### PR TITLE
Add Custom Prompt Settings and Refactor Prompt Handling

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -23,6 +23,15 @@ export interface ObsidianGeminiSettings {
 	chatHistory: boolean;
 	historyFolder: string;
 	showModelPicker: boolean;
+	promptMode: string;
+	customSystemPrompt: string;
+	customCompletionPrompt: string;
+	customGeneralPrompt: string;
+	customSummaryPrompt: string;
+	customRewritePrompt: string;
+	customDatePrompt: string;
+	customTimePrompt: string;
+	customContextPrompt: string;
 }
 
 const DEFAULT_SETTINGS: ObsidianGeminiSettings = {
@@ -40,6 +49,15 @@ const DEFAULT_SETTINGS: ObsidianGeminiSettings = {
 	chatHistory: false,
 	historyFolder: 'gemini-scribe',
 	showModelPicker: false,
+	promptMode: 'default',
+	customSystemPrompt: '',
+	customCompletionPrompt: '',
+	customGeneralPrompt: '',
+	customSummaryPrompt: '',
+	customRewritePrompt: '',
+	customDatePrompt: '',
+	customTimePrompt: '',
+	customContextPrompt: '',
 };
 
 export default class ObsidianGemini extends Plugin {

--- a/src/api.ts
+++ b/src/api.ts
@@ -46,7 +46,7 @@ export class GeminiApi {
 
 	constructor(plugin: ObsidianGemini) {
 		this.plugin = plugin;
-		this.prompts = new GeminiPrompts();
+		this.prompts = new GeminiPrompts(this.plugin.settings);
 		this.gemini = new GoogleGenerativeAI(this.plugin.settings.apiKey);
 	}
 

--- a/src/completions.ts
+++ b/src/completions.ts
@@ -14,7 +14,7 @@ export class GeminiCompletions {
 
 	constructor(plugin: ObsidianGemini) {
 		this.plugin = plugin;
-		this.prompts = new GeminiPrompts();
+		this.prompts = new GeminiPrompts(this.plugin.settings);
 		this.debouncedComplete = debounce(() => this.force_fetch(), this.TYPING_DELAY, true);
 	}
 

--- a/src/files/file-context.ts
+++ b/src/files/file-context.ts
@@ -28,7 +28,7 @@ export class FileContextTree {
 		this.maxDepth = depth ?? this.plugin.settings.maxContextDepth;
 		this.fileHelper = new ScribeFile(plugin);
 		this.dataViewHelper = new ScribeDataView(this.fileHelper, this.plugin);
-		this.prompts = new GeminiPrompts();
+		this.prompts = new GeminiPrompts(this.plugin.settings);
 	}
 
 	async buildStructure(

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -1,4 +1,5 @@
 import * as Handlebars from 'handlebars';
+import { ObsidianGeminiSettings } from '../main';
 
 // @ts-ignore
 import systemPromptContent from '../prompts/systemPrompt.txt';
@@ -17,6 +18,17 @@ import timePromptContent from '../prompts/timePrompt.txt';
 // @ts-ignore
 import contextPromptContent from '../prompts/contextPrompt.txt';
 
+export const DEFAULT_PROMPTS = {
+	system: systemPromptContent,
+	completion: completionPromptContent,
+	general: generalPromptContent,
+	summary: summaryPromptContent,
+	rewrite: rewritePromptContent,
+	date: datePromptContent,
+	time: timePromptContent,
+	context: contextPromptContent,
+};
+
 export class GeminiPrompts {
 	private completionsPromptTemplate: Handlebars.TemplateDelegate;
 	private systemPromptTemplate: Handlebars.TemplateDelegate;
@@ -27,15 +39,61 @@ export class GeminiPrompts {
 	private timePromptTemplate: Handlebars.TemplateDelegate;
 	private contextPromptTemplate: Handlebars.TemplateDelegate;
 
-	constructor() {
-		this.completionsPromptTemplate = Handlebars.compile(completionPromptContent);
-		this.systemPromptTemplate = Handlebars.compile(systemPromptContent);
-		this.generalPromptTemplate = Handlebars.compile(generalPromptContent);
-		this.summaryPromptTemplate = Handlebars.compile(summaryPromptContent);
-		this.rewritePromptTemplate = Handlebars.compile(rewritePromptContent);
-		this.datePromptTemplate = Handlebars.compile(datePromptContent);
-		this.timePromptTemplate = Handlebars.compile(timePromptContent);
-		this.contextPromptTemplate = Handlebars.compile(contextPromptContent);
+	constructor(userSettings?: Partial<ObsidianGeminiSettings>) {
+		const getPromptText = (customPrompt: string | undefined, defaultPrompt: string): string => {
+			return userSettings?.promptMode === 'custom' && customPrompt
+				? customPrompt
+				: defaultPrompt;
+		};
+
+		const systemPromptText = getPromptText(
+			userSettings?.customSystemPrompt,
+			DEFAULT_PROMPTS.system
+		);
+
+		const completionPromptText = getPromptText(
+			userSettings?.customCompletionPrompt, 
+			DEFAULT_PROMPTS.completion
+		);
+
+		const generalPromptText = getPromptText(
+			userSettings?.customGeneralPrompt,
+			DEFAULT_PROMPTS.general
+		);
+
+		const summaryPromptText = getPromptText(
+			userSettings?.customSummaryPrompt,
+			DEFAULT_PROMPTS.summary
+		);
+
+		const rewritePromptText = getPromptText(
+			userSettings?.customRewritePrompt,
+			DEFAULT_PROMPTS.rewrite
+		);
+
+		const datePromptText = getPromptText(
+			userSettings?.customDatePrompt,
+			DEFAULT_PROMPTS.date
+		);
+
+		const timePromptText = getPromptText(
+			userSettings?.customTimePrompt,
+			DEFAULT_PROMPTS.time
+		);
+
+		const contextPromptText = getPromptText(
+			userSettings?.customContextPrompt,
+			DEFAULT_PROMPTS.context
+		);
+
+		this.systemPromptTemplate = Handlebars.compile(systemPromptText);
+		this.completionsPromptTemplate = Handlebars.compile(completionPromptText);
+		this.generalPromptTemplate = Handlebars.compile(generalPromptText);
+		this.summaryPromptTemplate = Handlebars.compile(summaryPromptText);
+		this.rewritePromptTemplate = Handlebars.compile(rewritePromptText);
+		this.datePromptTemplate = Handlebars.compile(datePromptText);
+		this.timePromptTemplate = Handlebars.compile(timePromptText);
+		this.contextPromptTemplate = Handlebars.compile(contextPromptText);
 	}
 
 	completionsPrompt(variables: { [key: string]: string }): string {

--- a/src/rewrite.ts
+++ b/src/rewrite.ts
@@ -8,7 +8,7 @@ export class ModelRewriteMode {
 
 	constructor(plugin: ObsidianGemini) {
 		this.plugin = plugin;
-		this.prompts = new GeminiPrompts();
+		this.prompts = new GeminiPrompts(this.plugin.settings);
 	}
 
 	async generateRewriteResponse(userMessage: string, conversationHistory: any[]) {

--- a/src/summary.ts
+++ b/src/summary.ts
@@ -8,7 +8,7 @@ export class GeminiSummary {
 
 	constructor(plugin: ObsidianGemini) {
 		this.plugin = plugin;
-		this.prompts = new GeminiPrompts();
+		this.prompts = new GeminiPrompts(this.plugin.settings);
 	}
 
 	async summarizeActiveFile() {

--- a/src/ui/gemini-view.ts
+++ b/src/ui/gemini-view.ts
@@ -27,7 +27,7 @@ export class GeminiView extends ItemView {
 		super(leaf);
 		this.plugin = plugin;
 		this.rewriteMode = new ModelRewriteMode(plugin);
-		this.prompts = new GeminiPrompts();
+		this.prompts = new GeminiPrompts(this.plugin.settings);
 		this.registerLinkClickHandler();
 		this.registerSettingsListener();
 		


### PR DESCRIPTION
This pull request introduces several improvements to the Gemini Scribe plugin, enhancing the flexibility and configurability of prompt management. The following changes have been implemented:

- Introduced new settings to allow users to select between default and custom prompt values, enabling a more personalized experience.
- Updated the GeminiPrompts class to utilize the new user-defined settings, ensuring custom prompts override the defaults when specified.
- Enhanced the settings UI by adding options for editing custom prompts, along with a dropdown to choose between default and custom prompt modes.
- Refactored prompt initialization across the plugin components to ensure that all prompt handling respects user settings.