### PR TITLE
Update package-lock.json to specify exact version for svelte and add …

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
 				"obsidian-dataview": "^0.5.67",
 				"prettier": "^3.3.3",
 				"raw-loader": "^4.0.2",
-				"svelte": "^4.2.19",
+				"svelte": "4.2.19",
 				"ts-loader": "^9.5.1",
 				"tslib": "2.4.0",
 				"typescript": "4.7.4"
@@ -2853,6 +2853,16 @@
 				"obsidian-daily-notes-interface": "0.8.4",
 				"svelte": "3.35.0",
 				"tslib": "2.1.0"
+			}
+		},
+		"node_modules/obsidian-calendar-ui/node_modules/svelte": {
+			"version": "3.35.0",
+			"resolved": "https://registry.npmjs.org/svelte/-/svelte-3.35.0.tgz",
+			"integrity": "sha512-gknlZkR2sXheu/X+B7dDImwANVvK1R0QGQLd8CNIfxxGPeXBmePnxfzb6fWwTQRsYQG7lYkZXvpXJvxvpsoB7g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 8"
 			}
 		},
 		"node_modules/obsidian-calendar-ui/node_modules/tslib": {

--- a/src/models.ts
+++ b/src/models.ts
@@ -4,11 +4,11 @@ export interface GeminiModel {
 }
 
 export const GEMINI_MODELS: GeminiModel[] = [
-    { value: 'gemini-2.5-pro-exp-03-25', label: 'Gemini 2.5 Pro' },
+    { value: 'gemini-2.5-pro-preview-03-25', label: 'Gemini 2.5 Pro' },
+    { value: 'gemini-2.5-flash-preview-04-17', label: 'Gemini 2.5 Flash' },
     { value: 'gemini-2.0-pro-exp-02-05', label: 'Gemini 2.0 Pro' },
-    { value: 'gemini-2.0-flash-001', label: 'Gemini 2.0 Flash' },
-    { value: 'gemini-2.0-flash-lite-preview-02-05', label: 'Gemini 2.0 Flash Lite Preview' },
-    { value: 'gemini-2.0-flash-thinking-exp-01-21', label: 'Gemini 2.0 Flash Thinking' },
+    { value: 'gemini-2.0-flash', label: 'Gemini 2.0 Flash' },
+    { value: 'gemini-2.0-flash-lite', label: 'Gemini 2.0 Flash Lite' },
     { value: 'gemini-1.5-pro', label: 'gemini-1.5-pro' },
     { value: 'gemini-1.5-flash', label: 'gemini-1.5-flash' },
     { value: 'gemini-1.5-flash-8b', label: 'gemini-1.5-flash-8b' }

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -26,14 +26,12 @@ export class GeminiSearchTool {
 	private getTools(): any[] {
 		let tools: any[] = [];
 		switch (true) {
-			case (this.modelName.startsWith('gemini-2.0-flash-lite') ||
-				  this.modelName.startsWith('gemini-2.0-flash-thinking')):
+			case (this.modelName.startsWith('gemini-2.0-flash-lite')):
 				// Logic for flash-lite and flash-thinking don't currently support search			
 				tools = [];
 				break;
-			case (this.modelName.startsWith('gemini-2.0-flash') ||
-				  this.modelName.startsWith('gemini-2.0-pro')):
-				// Logic for gemini-2.0 models
+			case (this.modelName.startsWith('gemini-2.0') ||
+				  this.modelName.startsWith('gemini-2.5')):
 				tools = [
 					{
 						google_search: {},


### PR DESCRIPTION
…new svelte dependency for obsidian-calendar-ui. Modify GEMINI_MODELS in models.ts to reflect updated model values and streamline search logic in search.ts for gemini-2.0 and gemini-2.5 models.