### PR TITLE
feat: Implement retry logic for model API requests

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -25,6 +25,8 @@ export interface ObsidianGeminiSettings {
 	historyFolder: string;
 	showModelPicker: boolean;
 	debugMode: boolean;
+	maxRetries: number;
+	initialBackoffDelay: number;
 }
 
 const DEFAULT_SETTINGS: ObsidianGeminiSettings = {
@@ -43,6 +45,8 @@ const DEFAULT_SETTINGS: ObsidianGeminiSettings = {
 	historyFolder: 'gemini-scribe',
 	showModelPicker: false,
 	debugMode: false,
+	maxRetries: 3,
+	initialBackoffDelay: 1000,
 };
 
 export default class ObsidianGemini extends Plugin {

--- a/src/api/api-factory.ts
+++ b/src/api/api-factory.ts
@@ -2,6 +2,7 @@ import ObsidianGemini from '../../main';
 import { ModelApi } from './interfaces/model-api';
 import { GeminiApiNew } from './implementations/gemini-api-new';
 import { OllamaApi } from './implementations/ollama-api';
+import { RetryModelApiDecorator } from './retry-model-api-decorator';
 
 /**
  * Enum for different API providers
@@ -26,12 +27,21 @@ export class ApiFactory {
         // Use the provider argument or get from settings
         const apiProvider = provider || (plugin.settings.apiProvider as ApiProvider) || ApiProvider.GEMINI;
         
+        let apiInstance: ModelApi;
+
         switch (apiProvider) {
             case ApiProvider.OLLAMA:
-                return new OllamaApi(plugin);
+                apiInstance = new OllamaApi(plugin);
+                break;
             case ApiProvider.GEMINI:
             default:
-                return new GeminiApiNew(plugin);
+                apiInstance = new GeminiApiNew(plugin);
+                break;
         }
+
+        // Wrap the created API instance with the RetryModelApiDecorator
+        const retryDecoratedApi = new RetryModelApiDecorator(apiInstance, plugin);
+
+        return retryDecoratedApi;
     }
 } 

--- a/src/api/retry-model-api-decorator.ts
+++ b/src/api/retry-model-api-decorator.ts
@@ -1,0 +1,44 @@
+import { ModelApi, BaseModelRequest, ExtendedModelRequest, ModelResponse } from './interfaces/model-api';
+import ObsidianGemini from '../../main';
+import { Notice } from 'obsidian';
+
+export class RetryModelApiDecorator implements ModelApi {
+    private decoratedApi: ModelApi;
+    private plugin: ObsidianGemini;
+
+    constructor(decoratedApi: ModelApi, plugin: ObsidianGemini) {
+        this.decoratedApi = decoratedApi;
+        this.plugin = plugin;
+    }
+
+    async generateModelResponse(request: BaseModelRequest | ExtendedModelRequest): Promise<ModelResponse> {
+        let attempts = 0;
+        const maxRetries = this.plugin.settings.maxRetries ?? 3; // Default to 3 if not set
+        const initialBackoffDelay = this.plugin.settings.initialBackoffDelay ?? 1000; // Default to 1000ms if not set
+
+        while (attempts < maxRetries) {
+            try {
+                // Add a small delay before the first attempt if it's a retry,
+                // but not for the very first attempt (attempts === 0)
+                if (attempts > 0) {
+                    const backoffDelay = initialBackoffDelay * (2 ** (attempts -1)); // Exponential backoff for subsequent retries
+                    new Notice(`Model request failed. Retrying in ${backoffDelay / 1000}s... (Attempt ${attempts + 1}/${maxRetries})`);
+                    await new Promise(resolve => setTimeout(resolve, backoffDelay));
+                }
+                const response = await this.decoratedApi.generateModelResponse(request);
+                return response;
+            } catch (error) {
+                attempts++;
+                if (attempts >= maxRetries) {
+                    new Notice(`Model request failed after ${maxRetries} attempts. Please try again later.`);
+                    throw error; // Re-throw the error after max retries
+                }
+                // Notice for the next retry is handled at the beginning of the loop if attempts > 0
+            }
+        }
+        // This part should ideally not be reached if maxRetries is >= 1,
+        // as the loop either returns a response or throws an error.
+        // However, to satisfy TypeScript's need for a return path:
+        throw new Error('Retry loop finished without success or definitive error.');
+    }
+}

--- a/src/ui/settings.ts
+++ b/src/ui/settings.ts
@@ -190,5 +190,33 @@ export default class ObsidianGeminiSettingTab extends PluginSettingTab {
 					await this.plugin.saveSettings();
 				})
 			);
+
+		new Setting(containerEl)
+			.setName('Maximum Retries')
+			.setDesc('Maximum number of retries when a model request fails.')
+			.addText((text) =>
+				text
+					.setPlaceholder('e.g., 3')
+					.setValue(this.plugin.settings.maxRetries.toString())
+					.onChange(async (value) => {
+						this.plugin.settings.maxRetries = parseInt(value);
+						await this.plugin.saveSettings();
+					})
+			);
+
+		new Setting(containerEl)
+			.setName('Initial Backoff Delay (ms)')
+			.setDesc(
+				'Initial delay in milliseconds before the first retry. Subsequent retries will use exponential backoff.'
+			)
+			.addText((text) =>
+				text
+					.setPlaceholder('e.g., 1000')
+					.setValue(this.plugin.settings.initialBackoffDelay.toString())
+					.onChange(async (value) => {
+						this.plugin.settings.initialBackoffDelay = parseInt(value);
+						await this.plugin.saveSettings();
+					})
+			);
 	}
 }


### PR DESCRIPTION
Adds a retry mechanism with exponential backoff when model API requests fail.

Key changes:
- Introduced `RetryModelApiDecorator` which wraps `ModelApi` instances.
- The decorator retries failed requests up to a configurable maximum number of attempts.
- Exponential backoff is used between retries, starting with a configurable initial delay.
- You are notified via Obsidian's `Notice` system when retries occur.
- New settings for "Maximum Retries" and "Initial Backoff Delay (ms)" have been added to the plugin settings UI.
- `ApiFactory` now automatically wraps all created API instances with this retry decorator.

This enhancement improves the resilience of model interactions by automatically handling transient network issues or temporary API unavailability.