### PR TITLE
chore: remove old @google/generative-ai dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
 	"license": "MIT",
 	"devDependencies": {
 		"@google/genai": "latest",
-		"@google/generative-ai": "latest",
 		"@types/jest": "^29.5.14",
 		"@types/node": "^16.11.6",
 		"@typescript-eslint/eslint-plugin": "5.29.0",


### PR DESCRIPTION
Remove the deprecated @google/generative-ai package from devDependencies as it has been replaced by @google/genai.

Fixes #94

Generated with [Claude Code](https://claude.ai/code)