### PR TITLE
feat: Add temperature and topP settings

### DIFF
--- a/main.test.ts
+++ b/main.test.ts
@@ -1,0 +1,45 @@
+import { ObsidianGeminiSettings } from './main';
+
+describe('ObsidianGeminiSettings', () => {
+	describe('temperature and topP settings', () => {
+		it('should have default temperature of 0.7', () => {
+			const defaultSettings: Partial<ObsidianGeminiSettings> = {
+				temperature: 0.7,
+			};
+			expect(defaultSettings.temperature).toBe(0.7);
+		});
+
+		it('should have default topP of 1', () => {
+			const defaultSettings: Partial<ObsidianGeminiSettings> = {
+				topP: 1,
+			};
+			expect(defaultSettings.topP).toBe(1);
+		});
+
+		it('should accept temperature values between 0 and 1', () => {
+			const settings: Partial<ObsidianGeminiSettings> = {
+				temperature: 0,
+			};
+			expect(settings.temperature).toBe(0);
+
+			settings.temperature = 1;
+			expect(settings.temperature).toBe(1);
+
+			settings.temperature = 0.5;
+			expect(settings.temperature).toBe(0.5);
+		});
+
+		it('should accept topP values between 0 and 1', () => {
+			const settings: Partial<ObsidianGeminiSettings> = {
+				topP: 0,
+			};
+			expect(settings.topP).toBe(0);
+
+			settings.topP = 1;
+			expect(settings.topP).toBe(1);
+
+			settings.topP = 0.8;
+			expect(settings.topP).toBe(0.8);
+		});
+	});
+});

--- a/main.ts
+++ b/main.ts
@@ -41,6 +41,8 @@ export interface ObsidianGeminiSettings {
 	modelDiscovery: ModelDiscoverySettings;
 	enableCustomPrompts: boolean;
 	allowSystemPromptOverride: boolean;
+	temperature: number;
+	topP: number;
 }
 
 const DEFAULT_SETTINGS: ObsidianGeminiSettings = {
@@ -70,6 +72,8 @@ const DEFAULT_SETTINGS: ObsidianGeminiSettings = {
 	},
 	enableCustomPrompts: false,
 	allowSystemPromptOverride: false,
+	temperature: 0.7,
+	topP: 1,
 };
 
 export default class ObsidianGemini extends Plugin {

--- a/src/api/implementations/gemini-api-new.test.ts
+++ b/src/api/implementations/gemini-api-new.test.ts
@@ -268,4 +268,104 @@ describe('GeminiApiNew', () => {
 			expect(receivedChunks).toEqual(['First chunk']);
 		});
 	});
+
+	describe('temperature and topP parameters', () => {
+		it('should use temperature from request if provided', async () => {
+			const mockApiResponse = {
+				text: () => 'Test response',
+			};
+			mockGenerateContent.mockResolvedValue(mockApiResponse);
+
+			const request: BaseModelRequest = {
+				prompt: 'Test prompt',
+				temperature: 0.3,
+			};
+
+			await geminiApiNew.generateModelResponse(request);
+
+			// Check that generateContent was called with the correct temperature
+			expect(mockGenerateContent).toHaveBeenCalledWith(
+				expect.objectContaining({
+					config: expect.objectContaining({
+						temperature: 0.3,
+					}),
+				})
+			);
+		});
+
+		it('should use topP from request if provided', async () => {
+			const mockApiResponse = {
+				text: () => 'Test response',
+			};
+			mockGenerateContent.mockResolvedValue(mockApiResponse);
+
+			const request: BaseModelRequest = {
+				prompt: 'Test prompt',
+				topP: 0.8,
+			};
+
+			await geminiApiNew.generateModelResponse(request);
+
+			// Check that generateContent was called with the correct topP
+			expect(mockGenerateContent).toHaveBeenCalledWith(
+				expect.objectContaining({
+					config: expect.objectContaining({
+						topP: 0.8,
+					}),
+				})
+			);
+		});
+
+		it('should use default temperature from settings if not provided in request', async () => {
+			const mockApiResponse = {
+				text: () => 'Test response',
+			};
+			mockGenerateContent.mockResolvedValue(mockApiResponse);
+
+			// Update mock settings to include temperature and topP
+			mockPluginInstance.settings.temperature = 0.7;
+			mockPluginInstance.settings.topP = 1;
+
+			const request: BaseModelRequest = {
+				prompt: 'Test prompt',
+			};
+
+			await geminiApiNew.generateModelResponse(request);
+
+			// Check that generateContent was called with the default temperature
+			expect(mockGenerateContent).toHaveBeenCalledWith(
+				expect.objectContaining({
+					config: expect.objectContaining({
+						temperature: 0.7,
+						topP: 1,
+					}),
+				})
+			);
+		});
+
+		it('should handle both temperature and topP together', async () => {
+			const mockApiResponse = {
+				text: () => 'Test response',
+			};
+			mockGenerateContent.mockResolvedValue(mockApiResponse);
+
+			const request: BaseModelRequest = {
+				prompt: 'Test prompt',
+				temperature: 0.5,
+				topP: 0.9,
+			};
+
+			await geminiApiNew.generateModelResponse(request);
+
+			// Check that generateContent was called with both parameters
+			expect(mockGenerateContent).toHaveBeenCalledWith(
+				expect.objectContaining({
+					config: expect.objectContaining({
+						temperature: 0.5,
+						topP: 0.9,
+					}),
+				})
+			);
+		});
+	});
 });

--- a/src/api/implementations/gemini-api-new.ts
+++ b/src/api/implementations/gemini-api-new.ts
@@ -60,6 +60,8 @@ export class GeminiApiNew implements ModelApi {
 						config: {
 							systemInstruction: systemInstruction,
 							tools: tools,
+							temperature: request.temperature ?? this.plugin.settings.temperature,
+							topP: request.topP ?? this.plugin.settings.topP,
 						},
 						contents: contents,
 					});
@@ -81,6 +83,10 @@ export class GeminiApiNew implements ModelApi {
 					const streamingResult = await this.ai.models.generateContentStream({
 						model: modelToUse,
 						contents: request.prompt,
+						config: {
+							temperature: request.temperature ?? this.plugin.settings.temperature,
+							topP: request.topP ?? this.plugin.settings.topP,
+						},
 					});
 
 					for await (const chunk of streamingResult) {
@@ -133,6 +139,8 @@ export class GeminiApiNew implements ModelApi {
 				config: {
 					systemInstruction: systemInstruction,
 					tools: tools,
+					temperature: request.temperature ?? this.plugin.settings.temperature,
+					topP: request.topP ?? this.plugin.settings.topP,
 				},
 				contents: contents,
 			});
@@ -142,6 +150,10 @@ export class GeminiApiNew implements ModelApi {
 			const result = await this.ai.models.generateContent({
 				model: modelToUse,
 				contents: request.prompt,
+				config: {
+					temperature: request.temperature ?? this.plugin.settings.temperature,
+					topP: request.topP ?? this.plugin.settings.topP,
+				},
 			});
 			response = this.parseModelResult(result);
 		}

--- a/src/api/interfaces/model-api.ts
+++ b/src/api/interfaces/model-api.ts
@@ -24,6 +24,8 @@ export interface ModelResponse {
 export interface BaseModelRequest {
 	model?: string;
 	prompt: string;
+	temperature?: number;
+	topP?: number;
 }
 
 /**

--- a/src/history/markdownHistory.ts
+++ b/src/history/markdownHistory.ts
@@ -16,6 +16,10 @@ export class MarkdownHistory {
 		Handlebars.registerHelper('eq', function (a, b) {
 			return a === b;
 		});
+		// Register isDefined helper to handle 0 values properly
+		Handlebars.registerHelper('isDefined', function (value) {
+			return value !== undefined;
+		});
 		this.entryTemplate = Handlebars.compile(historyEntryTemplate);
 	}
 
@@ -420,6 +424,7 @@ export class MarkdownHistory {
 			pluginVersion: this.plugin.manifest.version,
 			fileVersion,
 			temperature: entry.metadata?.temperature,
+			topP: entry.metadata?.topP,
 			customPrompt: entry.metadata?.customPrompt,
 			context: entry.metadata?.context,
 		});
@@ -466,6 +471,8 @@ export class MarkdownHistory {
 				// Extract metadata from the table in the metadata callout
 				const timeMatch = section.match(/\|\s*Time\s*\|\s*(.*?)\s*\|/m);
 				const modelMatch = section.match(/\|\s*Model\s*\|\s*(.*?)\s*\|/m);
+				const temperatureMatch = section.match(/\|\s*Temperature\s*\|\s*(.*?)\s*\|/m);
+				const topPMatch = section.match(/\|\s*Top P\s*\|\s*(.*?)\s*\|/m);
 				const customPromptMatch = section.match(/\|\s*Custom Prompt\s*\|\s*(.*?)\s*\|/m);
 				const timestamp = timeMatch ? new Date(timeMatch[1].trim()) : new Date();
 
@@ -483,6 +490,12 @@ export class MarkdownHistory {
 						const metadata: Record<string, any> = {};
 						if (customPromptMatch) {
 							metadata.customPrompt = customPromptMatch[1].trim();
+						}
+						if (temperatureMatch) {
+							metadata.temperature = parseFloat(temperatureMatch[1].trim());
+						}
+						if (topPMatch) {
+							metadata.topP = parseFloat(topPMatch[1].trim());
 						}
 
 						entries.push({

--- a/src/history/templates/historyEntry.hbs
+++ b/src/history/templates/historyEntry.hbs
@@ -15,8 +15,11 @@
 > | File Version | {{fileVersion}} |
 {{#if model}}
 > | Model | {{model}} |
-{{#if temperature}}
+{{#if (isDefined temperature)}}
 > | Temperature | {{temperature}} |
+{{/if}}
+{{#if (isDefined topP)}}
+> | Top P | {{topP}} |
 {{/if}}
 {{/if}}
 {{#if customPrompt}}

--- a/src/ui/gemini-view.ts
+++ b/src/ui/gemini-view.ts
@@ -541,7 +541,11 @@ export class GeminiView extends ItemView {
 								message: botResponse.markdown,
 								userMessage: userMessage,
 								model: this.plugin.settings.chatModelName,
-								metadata: customPromptInfo ? { customPrompt: customPromptInfo } : undefined,
+								metadata: {
+									...(customPromptInfo ? { customPrompt: customPromptInfo } : {}),
+									temperature: this.plugin.settings.temperature,
+									topP: this.plugin.settings.topP,
+								},
 							});
 
 							// No need to clear and reload - the streaming UI already shows the messages
@@ -580,7 +584,11 @@ export class GeminiView extends ItemView {
 							message: botResponse.markdown,
 							userMessage: userMessage,
 							model: this.plugin.settings.chatModelName,
-							metadata: customPromptInfo ? { customPrompt: customPromptInfo } : undefined,
+							metadata: {
+								...(customPromptInfo ? { customPrompt: customPromptInfo } : {}),
+								temperature: this.plugin.settings.temperature,
+								topP: this.plugin.settings.topP,
+							},
 						});
 
 						// Clear and reload the entire chat from history

--- a/src/ui/settings.ts
+++ b/src/ui/settings.ts
@@ -337,6 +337,34 @@ export default class ObsidianGeminiSettingTab extends PluginSettingTab {
 						})
 				);
 
+			new Setting(containerEl)
+				.setName('Temperature')
+				.setDesc('Controls randomness. Lower values are more deterministic. (Default: 0.7)')
+				.addSlider((slider) =>
+					slider
+						.setLimits(0, 1, 0.1)
+						.setValue(this.plugin.settings.temperature)
+						.setDynamicTooltip()
+						.onChange(async (value) => {
+							this.plugin.settings.temperature = value;
+							await this.plugin.saveSettings();
+						})
+				);
+
+			new Setting(containerEl)
+				.setName('Top P')
+				.setDesc('Controls diversity. Lower values are more focused. (Default: 1)')
+				.addSlider((slider) =>
+					slider
+						.setLimits(0, 1, 0.1)
+						.setValue(this.plugin.settings.topP)
+						.setDynamicTooltip()
+						.onChange(async (value) => {
+							this.plugin.settings.topP = value;
+							await this.plugin.saveSettings();
+						})
+				);
+
 			// Model Discovery Settings (only visible in debug mode)
 			new Setting(containerEl).setName('Model Discovery').setHeading();
 


### PR DESCRIPTION
This commit introduces settings for temperature and topP to control the creativity and randomness of the model's responses.

The following changes are included:
- Added temperature and topP sliders to the settings UI.
- Updated the Gemini API to pass these values to the model.
- Included temperature and topP in the chat history metadata.
- Added tests for the new settings and API parameters.

Relates to #105