### PR TITLE
fix: Resolve plugin startup crash due to folder creation timing (fixes #107)

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -122,14 +122,6 @@ export default class ObsidianGemini extends Plugin {
 
 		// Initialize prompt manager
 		this.promptManager = new PromptManager(this, this.app.vault);
-		
-		// Only setup prompts if the feature is enabled
-		if (this.settings.enableCustomPrompts) {
-			await this.promptManager.ensurePromptsDirectory();
-			await this.promptManager.createDefaultPrompts();
-			// Setup prompt commands
-			this.promptManager.setupPromptCommands();
-		}
 
 		this.geminiApi = ApiFactory.createApi(this);
 		this.gfile = new ScribeFile(this);
@@ -187,6 +179,14 @@ export default class ObsidianGemini extends Plugin {
 	}
 
 	async onLayoutReady() {
+		// Setup prompts directory and commands after layout is ready
+		if (this.settings.enableCustomPrompts && this.promptManager) {
+			await this.promptManager.ensurePromptsDirectory();
+			await this.promptManager.createDefaultPrompts();
+			// Setup prompt commands
+			this.promptManager.setupPromptCommands();
+		}
+		
 		await this.history.onLayoutReady();
 	}
 

--- a/src/history/markdownHistory.test.ts
+++ b/src/history/markdownHistory.test.ts
@@ -213,7 +213,11 @@ describe('MarkdownHistory', () => {
 				message: 'test message',
 			};
 
-			mockPlugin.app.vault.adapter.exists.mockResolvedValue(false);
+			// Mock that folders don't exist
+			mockPlugin.app.vault.adapter.exists
+				.mockResolvedValueOnce(false) // base folder doesn't exist
+				.mockResolvedValueOnce(false) // history subfolder doesn't exist
+				.mockResolvedValueOnce(false); // history file doesn't exist
 
 			await markdownHistory.appendHistoryForFile(mockFile, entry);
 
@@ -226,7 +230,8 @@ describe('MarkdownHistory', () => {
 	describe('clearHistory', () => {
 		it('should only clear History subfolder, not entire state folder', async () => {
 			const historySubfolder = 'gemini-scribe/History';
-			mockPlugin.app.vault.adapter.exists.mockResolvedValue(true);
+			mockPlugin.app.vault.adapter.exists
+				.mockResolvedValueOnce(true); // History subfolder exists (for rmdir check)
 
 			await markdownHistory.clearHistory();
 

--- a/src/history/markdownHistory.ts
+++ b/src/history/markdownHistory.ts
@@ -391,7 +391,7 @@ export class MarkdownHistory {
 			}
 			// Recreate the History subfolder
 			await this.plugin.app.vault.createFolder(historyFolder).catch(() => {}); // Ensure base folder exists
-			await this.plugin.app.vault.createFolder(historySubfolder);
+			await this.plugin.app.vault.createFolder(historySubfolder).catch(() => {});
 			new Notice('Chat history cleared.');
 		} catch (error) {
 			console.error('Failed to clear all history', error);

--- a/src/prompts/prompt-manager.test.ts
+++ b/src/prompts/prompt-manager.test.ts
@@ -120,15 +120,29 @@ describe('PromptManager', () => {
 		it('should not create prompts directory if it exists', async () => {
 			// Create a mock that is an instance of TFolder
 			const MockTFolder = jest.requireMock('obsidian').TFolder;
-			const mockFolder = Object.create(MockTFolder.prototype);
-			mockFolder.path = 'gemini-scribe/Prompts';
-			mockVault.getAbstractFileByPath.mockReturnValue(mockFolder);
+			const mockPromptsFolder = Object.create(MockTFolder.prototype);
+			mockPromptsFolder.path = 'gemini-scribe/Prompts';
+			
+			mockVault.getAbstractFileByPath
+				.mockReturnValueOnce(mockPromptsFolder); // Prompts folder exists
 
 			await promptManager.ensurePromptsDirectory();
 
-			// Should still create base folder first, but not the prompts folder since it exists
+			// Should create base folder but not prompts folder (since it exists)
 			expect(mockVault.createFolder).toHaveBeenCalledWith('gemini-scribe');
 			expect(mockVault.createFolder).toHaveBeenCalledTimes(1);
+		});
+		
+		it('should create both directories if neither exists', async () => {
+			mockVault.getAbstractFileByPath
+				.mockReturnValueOnce(null); // Prompts folder doesn't exist
+
+			await promptManager.ensurePromptsDirectory();
+
+			// Should create both folders
+			expect(mockVault.createFolder).toHaveBeenCalledWith('gemini-scribe');
+			expect(mockVault.createFolder).toHaveBeenCalledWith('gemini-scribe/Prompts');
+			expect(mockVault.createFolder).toHaveBeenCalledTimes(2);
 		});
 	});
 


### PR DESCRIPTION
## Summary
Fixes #107 - Plugin was crashing on startup with "Folder already exists" error when Custom Prompts was enabled.

## Root Cause
The plugin was attempting to create folders during `onload()` before Obsidian's vault was fully initialized, causing errors when folders already existed.

## Solution
- **Timing Fix**: Move prompt directory creation from `setupGeminiScribe()` to `onLayoutReady()` to wait for vault initialization
- **Consistency Fix**: Ensure all `createFolder` calls use the `.catch(() => {})` pattern consistently
- **Test Updates**: Update test mocks to match the corrected folder creation behavior

## Changes Made
- `main.ts`: Move prompt setup from `onload` phase to `onLayoutReady` phase
- `src/history/markdownHistory.ts`: Fix one missing `.catch(() => {})` on folder creation
- Test files: Update mocks to reflect the timing changes

## Test Plan
- [x] All existing tests pass
- [x] Plugin builds successfully
- [x] Manual testing shows plugin loads without startup errors
- [x] Disable/re-enable functionality still works correctly

The plugin now waits for Obsidian's vault to be ready before creating any folders, preventing startup crashes while maintaining simple, consistent code.

🤖 Generated with [Claude Code](https://claude.ai/code)