### PR TITLE
Fix paste and @ mentions in Agent mode popout windows

### DIFF
--- a/src/utils/dom-context.ts
+++ b/src/utils/dom-context.ts
@@ -69,12 +69,14 @@ export function insertTextAtCursor(element: HTMLElement, text: string): void {
 		// No selection, append to end
 		element.appendChild(doc.createTextNode(text));
 
-		// Move cursor to end
-		const range = doc.createRange();
-		range.selectNodeContents(element);
-		range.collapse(false);
-		selection?.removeAllRanges();
-		selection?.addRange(range);
+		// Move cursor to end - only if we have a selection object
+		if (selection) {
+			const range = doc.createRange();
+			range.selectNodeContents(element);
+			range.collapse(false);
+			selection.removeAllRanges();
+			selection.addRange(range);
+		}
 		return;
 	}
 
@@ -117,6 +119,15 @@ export function insertNodeAtCursor(element: HTMLElement, node: Node): void {
 	if (!selection || selection.rangeCount === 0) {
 		// No selection, append to end
 		element.appendChild(node);
+
+		// Move cursor after the inserted node
+		if (selection && node.parentNode) {
+			const range = doc.createRange();
+			range.setStartAfter(node);
+			range.collapse(true);
+			selection.removeAllRanges();
+			selection.addRange(range);
+		}
 	} else {
 		const range = selection.getRangeAt(0);
 
@@ -132,17 +143,16 @@ export function insertNodeAtCursor(element: HTMLElement, node: Node): void {
 		} else {
 			// Selection is outside our element, append to end
 			element.appendChild(node);
-		}
-	}
 
-	// Move cursor after the inserted node
-	const newSelection = win.getSelection();
-	if (newSelection && node.parentNode) {
-		const range = doc.createRange();
-		range.setStartAfter(node);
-		range.collapse(true);
-		newSelection.removeAllRanges();
-		newSelection.addRange(range);
+			// Move cursor after the inserted node
+			if (node.parentNode) {
+				const range = doc.createRange();
+				range.setStartAfter(node);
+				range.collapse(true);
+				selection.removeAllRanges();
+				selection.addRange(range);
+			}
+		}
 	}
 }
 

--- a/src/utils/dom-context.ts
+++ b/src/utils/dom-context.ts
@@ -1,0 +1,172 @@
+/**
+ * Utility functions for handling DOM operations in both main and popout windows.
+ *
+ * In Obsidian, when a view is popped out to a separate window, the global
+ * `document` and `window` objects still refer to the main app's context.
+ * This can cause issues with DOM operations like selection, range manipulation,
+ * and element creation.
+ *
+ * These utilities ensure DOM operations use the correct document/window context
+ * based on where the element actually lives.
+ */
+
+/**
+ * Get the correct document and window context for a DOM element.
+ * This handles both main window and popout window scenarios.
+ */
+export function getDOMContext(element: HTMLElement) {
+	const doc = element.ownerDocument;
+	const win = doc.defaultView || window;
+
+	return { doc, win };
+}
+
+/**
+ * Get the current selection for an element's context.
+ * Returns null if no selection is available.
+ */
+export function getContextSelection(element: HTMLElement): Selection | null {
+	const { win } = getDOMContext(element);
+	return win.getSelection();
+}
+
+/**
+ * Create a new Range in the correct document context.
+ */
+export function createContextRange(element: HTMLElement): Range {
+	const { doc } = getDOMContext(element);
+	return doc.createRange();
+}
+
+/**
+ * Create a new DOM element in the correct document context.
+ */
+export function createContextElement<K extends keyof HTMLElementTagNameMap>(
+	contextElement: HTMLElement,
+	tagName: K
+): HTMLElementTagNameMap[K] {
+	const { doc } = getDOMContext(contextElement);
+	return doc.createElement(tagName);
+}
+
+/**
+ * Create a text node in the correct document context.
+ */
+export function createContextTextNode(contextElement: HTMLElement, text: string): Text {
+	const { doc } = getDOMContext(contextElement);
+	return doc.createTextNode(text);
+}
+
+/**
+ * Insert text at the current cursor position within an element.
+ * Handles both main window and popout window contexts.
+ */
+export function insertTextAtCursor(element: HTMLElement, text: string): void {
+	const { doc, win } = getDOMContext(element);
+	const selection = win.getSelection();
+
+	if (!selection || selection.rangeCount === 0) {
+		// No selection, append to end
+		element.appendChild(doc.createTextNode(text));
+
+		// Move cursor to end
+		const range = doc.createRange();
+		range.selectNodeContents(element);
+		range.collapse(false);
+		selection?.removeAllRanges();
+		selection?.addRange(range);
+		return;
+	}
+
+	const range = selection.getRangeAt(0);
+
+	// Ensure the range is within our element
+	if (element.contains(range.commonAncestorContainer)) {
+		range.deleteContents();
+
+		// Insert text node
+		const textNode = doc.createTextNode(text);
+		range.insertNode(textNode);
+
+		// Move cursor to end of inserted text
+		range.setStartAfter(textNode);
+		range.setEndAfter(textNode);
+		selection.removeAllRanges();
+		selection.addRange(range);
+	} else {
+		// Selection is outside our element, append to end
+		element.appendChild(doc.createTextNode(text));
+
+		// Move cursor to end
+		const range = doc.createRange();
+		range.selectNodeContents(element);
+		range.collapse(false);
+		selection.removeAllRanges();
+		selection.addRange(range);
+	}
+}
+
+/**
+ * Insert a node at the current cursor position within an element.
+ * Handles both main window and popout window contexts.
+ */
+export function insertNodeAtCursor(element: HTMLElement, node: Node): void {
+	const { doc, win } = getDOMContext(element);
+	const selection = win.getSelection();
+
+	if (!selection || selection.rangeCount === 0) {
+		// No selection, append to end
+		element.appendChild(node);
+	} else {
+		const range = selection.getRangeAt(0);
+
+		// Ensure the range is within our element
+		if (element.contains(range.commonAncestorContainer)) {
+			range.insertNode(node);
+
+			// Move cursor after the node
+			range.setStartAfter(node);
+			range.collapse(true);
+			selection.removeAllRanges();
+			selection.addRange(range);
+		} else {
+			// Selection is outside our element, append to end
+			element.appendChild(node);
+		}
+	}
+
+	// Move cursor after the inserted node
+	const newSelection = win.getSelection();
+	if (newSelection && node.parentNode) {
+		const range = doc.createRange();
+		range.setStartAfter(node);
+		range.collapse(true);
+		newSelection.removeAllRanges();
+		newSelection.addRange(range);
+	}
+}
+
+/**
+ * Move cursor to the end of an element's content.
+ */
+export function moveCursorToEnd(element: HTMLElement): void {
+	const { doc, win } = getDOMContext(element);
+	const selection = win.getSelection();
+
+	if (selection) {
+		const range = doc.createRange();
+		range.selectNodeContents(element);
+		range.collapse(false);
+		selection.removeAllRanges();
+		selection.addRange(range);
+	}
+}
+
+/**
+ * Execute a command in the correct document context.
+ * Useful for commands like 'paste', 'copy', etc.
+ */
+export function execContextCommand(element: HTMLElement, command: string, value?: string): boolean {
+	const { doc } = getDOMContext(element);
+	return doc.execCommand(command, false, value);
+}


### PR DESCRIPTION
## Summary
- Fixes paste functionality in Agent mode popout/detached windows
- Fixes @ mention file chip insertion in popout windows
- Adds reusable DOM context utilities for better popout window support

## Problem
As reported in #133, when the Agent view is popped out to a separate window:
- **Paste operations** (Ctrl+V/Cmd+V) didn't work - text was pasted to the main window instead
- **@ mentions** showed the file picker dialog but didn't insert chips into the input field

## Root Cause
In Obsidian popout windows, the global `document` and `window` objects refer to the main app's context, not the popout window's context. This caused DOM operations like selection, range manipulation, and element creation to fail or target the wrong window.

## Solution

### 1. Created DOM Context Utility Module
Added `src/utils/dom-context.ts` with reusable functions:
- `getDOMContext()` - Gets correct document/window for an element
- `createContextElement()` - Creates elements in the right document
- `insertNodeAtCursor()` - Inserts nodes with proper context
- `insertTextAtCursor()` - Handles text insertion
- And more utilities for common DOM operations

### 2. Refactored Agent View
Updated `src/ui/agent-view.ts` to use the new utilities for:
- **Chip creation and insertion** (@ mentions)
- **Paste handling** with multiple fallback methods
- **Cursor positioning** after operations

### 3. Enhanced Paste Handler
Implements three-tier fallback approach:
1. Standard `clipboardData` API (main window)
2. Async Clipboard API (may work in popout)
3. `execCommand` with cleanup (last resort)

## Testing
- ✅ Paste works in main window (with format stripping)
- ✅ Paste works in popout window
- ✅ @ mentions insert chips in main window
- ✅ @ mentions insert chips in popout window
- ✅ All existing tests pass

## Related Issues
- Fixes #133

## Future Benefits
The new DOM context utilities can be used to add popout window support to other views that may have similar issues.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes paste and @-mention chip insertion in Agent popout windows by using new DOM context utilities and a multi-strategy paste handler.
> 
> - **Agent View (`src/ui/agent-view.ts`)**:
>   - Refactors chip creation/insertion to use context-aware helpers: `insertNodeAtCursor`, `createContextElement`, `createContextTextNode`, `getDOMContext`.
>   - Enhances paste handling with fallbacks: `clipboardData`, async `navigator.clipboard.readText()`, and `execContextCommand('paste')`, then normalizes to plain text and restores cursor.
>   - Replaces direct `document/window` range/selection usage with context-aware equivalents; adds `moveCursorToEnd` usage.
> - **Utilities (`src/utils/dom-context.ts`)**:
>   - Adds DOM helpers for popout-safe operations: `getDOMContext`, `getContextSelection`, `createContextRange`, `createContextElement`, `createContextTextNode`, `insertTextAtCursor`, `insertNodeAtCursor`, `moveCursorToEnd`, `execContextCommand`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d8b1ec88b8d4cffb4757bffaa6cd55312ef4d8dd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->