### PR TITLE
Fix streaming request failures caused by empty systemInstruction

### DIFF
--- a/src/api/implementations/gemini-api-config.ts
+++ b/src/api/implementations/gemini-api-config.ts
@@ -11,7 +11,7 @@ interface GeminiRequestConfig {
 	model: string;
 	contents: Content[];
 	config: {
-		systemInstruction: string;
+		systemInstruction?: string;
 		temperature: number;
 		topP: number;
 		maxOutputTokens?: number;
@@ -64,7 +64,7 @@ export class GeminiApiConfig implements ModelApi {
 			model: this.config.model,
 			contents: await this.buildContents(request),
 			config: {
-				systemInstruction,
+				...(systemInstruction && { systemInstruction }),
 				temperature,
 				topP,
 				...(maxOutputTokens && { maxOutputTokens }),


### PR DESCRIPTION
## Summary

Fixes #139 - streaming request failures after 3.3.1 update

## Problem

After the 3.3.1 update (PR #138), users experienced:
- First query after opening vault returns an unexpected canned response regardless of actual query
- All subsequent queries fail with "streaming request failed" error
- Issue persists across all vaults, notes, models, and API keys until vault is reopened

## Root Cause

PR #138 introduced `systemInstruction` support to align with the Google Generative AI SDK v1.21.0. However, for regular chat requests (`BaseModelRequest`), the code was passing an empty string `''` as the system instruction to the Gemini API, causing the API to malfunction.

## Solution

1. Made `systemInstruction` optional in the `GeminiRequestConfig` interface
2. Only include `systemInstruction` in the API config when it has a non-empty value using conditional spread operator

This ensures that for `BaseModelRequest` (regular chat without custom prompts), no system instruction is sent to the API, preventing the unexpected behavior.

## Changes

- `src/api/implementations/gemini-api-config.ts`:
  - Line 14: Made `systemInstruction` optional in interface
  - Line 67: Only include `systemInstruction` when it has a value: `...(systemInstruction && { systemInstruction })`

## Testing

- Build passes successfully
- No TypeScript errors
- Changes are minimal and focused on the specific issue