### PR TITLE
feat: enable model discovery by default

### DIFF
--- a/docs/settings-reference.md
+++ b/docs/settings-reference.md
@@ -163,7 +163,7 @@ Dynamic model discovery automatically fetches the latest available Gemini models
 #### Enable Model Discovery
 - **Setting**: `modelDiscovery.enabled`
 - **Type**: Boolean
-- **Default**: `false`
+- **Default**: `true`
 - **Description**: Automatically discover and update available Gemini models
 
 #### Auto-Update Interval

--- a/src/main.ts
+++ b/src/main.ts
@@ -66,7 +66,7 @@ const DEFAULT_SETTINGS: ObsidianGeminiSettings = {
 	initialBackoffDelay: 1000,
 	streamingEnabled: true,
 	modelDiscovery: {
-		enabled: false, // Start disabled by default
+		enabled: true, // Automatically discover latest Gemini models
 		autoUpdateInterval: 24, // Check daily
 		lastUpdate: 0,
 		fallbackToStatic: true,


### PR DESCRIPTION
## Summary

Enables dynamic model discovery by default so users automatically get the latest Gemini models without needing to manually enable the feature in developer settings.

## Changes

### Code Changes
- Changed `modelDiscovery.enabled` default from `false` to `true` in `src/main.ts`
- Updated comment to clarify behavior

### Documentation Changes
- Updated `docs/settings-reference.md` to reflect new default value

## Benefits

1. **Better UX**: Users automatically see new Gemini models as Google releases them
2. **No Manual Configuration**: Users don't need to dig into developer settings
3. **Always Up-to-Date**: Model list stays current with Google's API
4. **Graceful Fallback**: Still falls back to static models if API fails (existing behavior)

## Testing
- ✅ TypeScript compilation successful
- ✅ All tests passing (21 suites, 288 tests)
- ✅ Existing fallback behavior preserved

## Migration Impact

For existing users:
- Users who previously had it disabled will get it enabled on next plugin update
- Users who explicitly disabled it won't be affected (user preference is preserved)
- Fallback to static models remains enabled by default for reliability

## Closes
Closes #104