### PR TITLE
Refactor tests to run in parallel

### DIFF
--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -12,9 +12,8 @@ export default {
 		'\\.txt$': './text-transformer.mjs',
 		'\\.hbs$': './text-transformer.mjs',
 	},
-	// This pattern will find .test.ts or .spec.ts (and .js) files in any directory.
-	// It will correctly find your src/models.test.ts file.
-	testMatch: ['**/?(*.)+(spec|test).[tj]s'],
+	// This pattern will find .test.ts or .spec.ts (and .js) files in the test directory.
+	testMatch: ['<rootDir>/test/**/?(*.)+(spec|test).[tj]s'],
 	moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node', 'txt', 'hbs'],
 	// If you have path aliases in tsconfig.json (like "@/*"), configure moduleNameMapper here.
 	// For example:

--- a/test/agent/session-manager-integration.test.ts
+++ b/test/agent/session-manager-integration.test.ts
@@ -1,6 +1,6 @@
-import { SessionManager } from './session-manager';
-import { SessionHistory } from './session-history';
-import { SessionType, ToolCategory, DestructiveAction } from '../types/agent';
+import { SessionManager } from '../../src/agent/session-manager';
+import { SessionHistory } from '../../src/agent/session-history';
+import { SessionType, ToolCategory, DestructiveAction } from '../../src/types/agent';
 import { TFile, TFolder } from 'obsidian';
 
 // Mock Obsidian

--- a/test/agent/session-manager.test.ts
+++ b/test/agent/session-manager.test.ts
@@ -1,5 +1,5 @@
-import { SessionManager } from './session-manager';
-import { SessionType } from '../types/agent';
+import { SessionManager } from '../../src/agent/session-manager';
+import { SessionType } from '../../src/types/agent';
 
 // Import the mocked TFile class
 import { TFile } from 'obsidian';

--- a/test/api/gemini-api-tools.test.ts
+++ b/test/api/gemini-api-tools.test.ts
@@ -1,5 +1,5 @@
-import { Tool } from '../tools/types';
-import { ToolCategory } from '../types/agent';
+import { Tool } from '../../src/tools/types';
+import { ToolCategory } from '../../src/types/agent';
 
 describe('Gemini API Tools Formatting', () => {
 	test('should format tools correctly for Gemini API', () => {

--- a/test/api/utils/debug.test.ts
+++ b/test/api/utils/debug.test.ts
@@ -7,7 +7,7 @@ import {
 	stripFileContextNode,
 	stripLinkedFileContents,
 	redactLinkedFileSections,
-} from './debug';
+} from '../../../src/api/utils/debug';
 
 describe('isBaseModelRequest', () => {
 	it('should return true for a valid BaseModelRequest', () => {

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -1,4 +1,4 @@
-import { ObsidianGeminiSettings } from './main';
+import { ObsidianGeminiSettings } from '../src/main';
 
 describe('ObsidianGeminiSettings', () => {
 	describe('temperature and topP settings', () => {

--- a/test/models.test.ts
+++ b/test/models.test.ts
@@ -5,7 +5,7 @@ import {
 	GeminiModel,
 	getUpdatedModelSettings,
 	setGeminiModels,
-} from './models';
+} from '../src/models';
 
 // Helper to temporarily modify GEMINI_MODELS for specific tests
 const setTestModels = (models: GeminiModel[]) => {
@@ -67,7 +67,7 @@ describe('getDefaultModelForRole', () => {
 		// This test relies on the original state of GEMINI_MODELS before any test modifications
 		// If originalModels was captured from an already empty state, this test would be misleading.
 		// This is more of an assertion about your actual data.
-		const actualImportedModels = jest.requireActual<typeof import('./models')>('./models').GEMINI_MODELS;
+		const actualImportedModels = jest.requireActual<typeof import('../src/models')>('../src/models').GEMINI_MODELS;
 		expect(actualImportedModels.length).toBeGreaterThan(0);
 	});
 

--- a/test/prompts/prompt-manager.test.ts
+++ b/test/prompts/prompt-manager.test.ts
@@ -1,6 +1,6 @@
-import { PromptManager } from './prompt-manager';
+import { PromptManager } from '../../src/prompts/prompt-manager';
 import { Vault, TFile, TFolder } from 'obsidian';
-import ObsidianGemini from '../main';
+import ObsidianGemini from '../../src/main';
 
 // Mock obsidian module
 jest.mock('obsidian', () => {

--- a/test/services/agents-memory.test.ts
+++ b/test/services/agents-memory.test.ts
@@ -1,4 +1,4 @@
-import { AgentsMemory, AgentsMemoryData } from './agents-memory';
+import { AgentsMemory, AgentsMemoryData } from '../../src/services/agents-memory';
 import { TFile, normalizePath } from 'obsidian';
 
 // Mock obsidian

--- a/test/services/model-discovery.test.ts
+++ b/test/services/model-discovery.test.ts
@@ -1,4 +1,4 @@
-import { ModelDiscoveryService, GoogleModel, ModelDiscoveryResult } from './model-discovery';
+import { ModelDiscoveryService, GoogleModel, ModelDiscoveryResult } from '../../src/services/model-discovery';
 
 // Mock ObsidianGemini plugin
 const mockPlugin = {

--- a/test/services/model-manager-filter.test.ts
+++ b/test/services/model-manager-filter.test.ts
@@ -1,10 +1,10 @@
-import { ModelManager } from './model-manager';
-import { ModelDiscoveryService } from './model-discovery';
-import { GeminiModel } from '../models';
-import ObsidianGemini from '../main';
+import { ModelManager } from '../../src/services/model-manager';
+import { ModelDiscoveryService } from '../../src/services/model-discovery';
+import { GeminiModel } from '../../src/models';
+import ObsidianGemini from '../../src/main';
 
 // Mock the model discovery service
-jest.mock('./model-discovery');
+jest.mock('../../src/services/model-discovery');
 
 describe('ModelManager Version Filtering', () => {
 	let modelManager: ModelManager;

--- a/test/services/model-manager.test.ts
+++ b/test/services/model-manager.test.ts
@@ -1,9 +1,9 @@
-import { ModelManager, ModelUpdateOptions } from './model-manager';
-import { ModelDiscoveryService } from './model-discovery';
-import { GeminiModel } from '../models';
+import { ModelManager, ModelUpdateOptions } from '../../src/services/model-manager';
+import { ModelDiscoveryService } from '../../src/services/model-discovery';
+import { GeminiModel } from '../../src/models';
 
 // Mock the models module
-jest.mock('../models', () => ({
+jest.mock('../../src/models', () => ({
 	GEMINI_MODELS: [
 		{ value: 'gemini-2.5-pro', label: 'Gemini 2.5 Pro', defaultForRoles: ['chat'] },
 		{ value: 'gemini-2.5-flash', label: 'Gemini 2.5 Flash', defaultForRoles: ['summary'] },
@@ -17,13 +17,13 @@ jest.mock('../models', () => ({
 }));
 
 // Mock ModelDiscoveryService
-jest.mock('./model-discovery');
-jest.mock('./model-mapper');
+jest.mock('../../src/services/model-discovery');
+jest.mock('../../src/services/model-mapper');
 
-import { ModelMapper } from './model-mapper';
+import { ModelMapper } from '../../src/services/model-mapper';
 
 // Get the mocked function after import
-const { setGeminiModels } = require('../models');
+const { setGeminiModels } = require('../../src/models');
 const mockSetGeminiModels = setGeminiModels as jest.Mock;
 
 const mockPlugin = {

--- a/test/services/model-mapper.test.ts
+++ b/test/services/model-mapper.test.ts
@@ -1,6 +1,6 @@
-import { ModelMapper } from './model-mapper';
-import { GeminiModel } from '../models';
-import { GoogleModel } from './model-discovery';
+import { ModelMapper } from '../../src/services/model-mapper';
+import { GeminiModel } from '../../src/models';
+import { GoogleModel } from '../../src/services/model-discovery';
 
 describe('ModelMapper', () => {
 	const mockGoogleModels: GoogleModel[] = [

--- a/test/services/parameter-validation.test.ts
+++ b/test/services/parameter-validation.test.ts
@@ -1,5 +1,5 @@
-import { ParameterValidationService } from './parameter-validation';
-import { GoogleModel } from './model-discovery';
+import { ParameterValidationService } from '../../src/services/parameter-validation';
+import { GoogleModel } from '../../src/services/model-discovery';
 
 describe('ParameterValidationService', () => {
 	describe('getParameterRanges', () => {

--- a/test/tools/execution-engine.test.ts
+++ b/test/tools/execution-engine.test.ts
@@ -1,7 +1,7 @@
-import { ToolExecutionEngine } from './execution-engine';
-import { ToolRegistry } from './tool-registry';
-import { ReadFileTool, ListFilesTool, WriteFileTool } from './vault-tools';
-import { ToolCategory } from '../types/agent';
+import { ToolExecutionEngine } from '../../src/tools/execution-engine';
+import { ToolRegistry } from '../../src/tools/tool-registry';
+import { ReadFileTool, ListFilesTool, WriteFileTool } from '../../src/tools/vault-tools';
+import { ToolCategory } from '../../src/types/agent';
 import { Notice } from 'obsidian';
 
 // Mock Obsidian
@@ -24,7 +24,7 @@ jest.mock('obsidian', () => ({
 }));
 
 // Mock the confirmation modal
-jest.mock('../ui/tool-confirmation-modal', () => ({
+jest.mock('../../src/ui/tool-confirmation-modal', () => ({
 	ToolConfirmationModal: jest.fn()
 }));
 
@@ -119,7 +119,7 @@ describe('ToolExecutionEngine - Confirmation Requirements', () => {
 		} as any;
 
 		// Mock user declining confirmation
-		const { ToolConfirmationModal } = require('../ui/tool-confirmation-modal');
+		const { ToolConfirmationModal } = require('../../src/ui/tool-confirmation-modal');
 		ToolConfirmationModal.mockImplementation((app: any, tool: any, params: any, callback: Function) => ({
 			open: jest.fn(() => {
 				// Simulate user declining

--- a/test/tools/google-search-tool.test.ts
+++ b/test/tools/google-search-tool.test.ts
@@ -1,7 +1,7 @@
-import { GoogleSearchTool, getGoogleSearchTool } from './google-search-tool';
-import { ToolExecutionContext } from './types';
+import { GoogleSearchTool, getGoogleSearchTool } from '../../src/tools/google-search-tool';
+import { ToolExecutionContext } from '../../src/tools/types';
 import { GoogleGenAI } from '@google/genai';
-import { getDefaultModelForRole } from '../models';
+import { getDefaultModelForRole } from '../../src/models';
 
 // Mock Google Gen AI
 jest.mock('@google/genai', () => ({

--- a/test/tools/image-tools.test.ts
+++ b/test/tools/image-tools.test.ts
@@ -1,5 +1,5 @@
-import { GenerateImageTool, getImageTools } from './image-tools';
-import { ToolExecutionContext } from './types';
+import { GenerateImageTool, getImageTools } from '../../src/tools/image-tools';
+import { ToolExecutionContext } from '../../src/tools/types';
 
 // Mock the image generation service
 const mockImageGeneration = {

--- a/test/tools/loop-detector.test.ts
+++ b/test/tools/loop-detector.test.ts
@@ -1,5 +1,5 @@
-import { ToolLoopDetector } from './loop-detector';
-import { ToolCall } from './types';
+import { ToolLoopDetector } from '../../src/tools/loop-detector';
+import { ToolCall } from '../../src/tools/types';
 
 describe('ToolLoopDetector', () => {
 	let detector: ToolLoopDetector;

--- a/test/tools/memory-tool.test.ts
+++ b/test/tools/memory-tool.test.ts
@@ -1,6 +1,6 @@
-import { UpdateMemoryTool, ReadMemoryTool, getMemoryTools } from './memory-tool';
-import { ToolExecutionContext } from './types';
-import { ToolCategory } from '../types/agent';
+import { UpdateMemoryTool, ReadMemoryTool, getMemoryTools } from '../../src/tools/memory-tool';
+import { ToolExecutionContext } from '../../src/tools/types';
+import { ToolCategory } from '../../src/types/agent';
 
 // Mock AgentsMemory
 const mockAgentsMemory = {

--- a/test/tools/tool-integration.test.ts
+++ b/test/tools/tool-integration.test.ts
@@ -1,9 +1,9 @@
-import { ToolExecutionEngine } from './execution-engine';
-import { ToolRegistry } from './tool-registry';
-import { ReadFileTool, WriteFileTool, SearchFilesTool, DeleteFileTool, ListFilesTool } from './vault-tools';
-import { GoogleSearchTool } from './google-search-tool';
-import { WebFetchTool } from './web-fetch-tool';
-import { SessionType, ToolCategory } from '../types/agent';
+import { ToolExecutionEngine } from '../../src/tools/execution-engine';
+import { ToolRegistry } from '../../src/tools/tool-registry';
+import { ReadFileTool, WriteFileTool, SearchFilesTool, DeleteFileTool, ListFilesTool } from '../../src/tools/vault-tools';
+import { GoogleSearchTool } from '../../src/tools/google-search-tool';
+import { WebFetchTool } from '../../src/tools/web-fetch-tool';
+import { SessionType, ToolCategory } from '../../src/types/agent';
 import { TFile } from 'obsidian';
 
 // Mock dependencies
@@ -22,14 +22,14 @@ jest.mock('obsidian', () => ({
 jest.mock('@google/genai');
 
 // Mock ScribeFile and ScribeDataView
-jest.mock('../files', () => ({
+jest.mock('../../src/files', () => ({
 	ScribeFile: jest.fn().mockImplementation(() => ({
 		getUniqueLinks: jest.fn().mockReturnValue(new Set()),
 		getLinkText: jest.fn((file: any) => `[[${file.name || file.path}]]`)
 	}))
 }));
 
-jest.mock('../files/dataview-utils', () => ({
+jest.mock('../../src/files/dataview-utils', () => ({
 	ScribeDataView: jest.fn().mockImplementation(() => ({
 		getBacklinks: jest.fn().mockResolvedValue(new Set())
 	}))

--- a/test/tools/tool-registry.test.ts
+++ b/test/tools/tool-registry.test.ts
@@ -1,6 +1,6 @@
-import { ToolRegistry } from './tool-registry';
-import { Tool, ToolResult, ToolExecutionContext } from './types';
-import { ToolCategory } from '../types/agent';
+import { ToolRegistry } from '../../src/tools/tool-registry';
+import { Tool, ToolResult, ToolExecutionContext } from '../../src/tools/types';
+import { ToolCategory } from '../../src/types/agent';
 
 // Mock plugin
 const mockPlugin = {

--- a/test/tools/vault-tools.test.ts
+++ b/test/tools/vault-tools.test.ts
@@ -1,15 +1,15 @@
-import { ReadFileTool, WriteFileTool, ListFilesTool, SearchFilesTool, MoveFileTool, getVaultTools } from './vault-tools';
-import { ToolExecutionContext } from './types';
+import { ReadFileTool, WriteFileTool, ListFilesTool, SearchFilesTool, MoveFileTool, getVaultTools } from '../../src/tools/vault-tools';
+import { ToolExecutionContext } from '../../src/tools/types';
 
 // Mock ScribeFile and ScribeDataView
-jest.mock('../files', () => ({
+jest.mock('../../src/files', () => ({
 	ScribeFile: jest.fn().mockImplementation(() => ({
 		getUniqueLinks: jest.fn().mockReturnValue(new Set()),
 		getLinkText: jest.fn((file: any) => `[[${file.name || file.path}]]`)
 	}))
 }));
 
-jest.mock('../files/dataview-utils', () => ({
+jest.mock('../../src/files/dataview-utils', () => ({
 	ScribeDataView: jest.fn().mockImplementation(() => ({
 		getBacklinks: jest.fn().mockResolvedValue(new Set())
 	}))
@@ -428,7 +428,7 @@ describe('VaultTools', () => {
 		let tool: any;
 
 		beforeEach(() => {
-			const { GetActiveFileTool } = require('./vault-tools');
+			const { GetActiveFileTool } = require('../../src/tools/vault-tools');
 			tool = new GetActiveFileTool();
 		});
 

--- a/test/ui/agent-view.test.ts
+++ b/test/ui/agent-view.test.ts
@@ -1,16 +1,16 @@
-import { AgentView } from './agent-view';
-import { SessionManager } from '../agent/session-manager';
-import { ToolRegistry } from '../tools/tool-registry';
-import { ToolExecutionEngine } from '../tools/execution-engine';
-import { SessionType } from '../types/agent';
+import { AgentView } from '../../src/ui/agent-view';
+import { SessionManager } from '../../src/agent/session-manager';
+import { ToolRegistry } from '../../src/tools/tool-registry';
+import { ToolExecutionEngine } from '../../src/tools/execution-engine';
+import { SessionType } from '../../src/types/agent';
 import { ItemView, WorkspaceLeaf, Notice } from 'obsidian';
 
 // Mock dependencies
-jest.mock('../agent/session-history');
-jest.mock('../tools/tool-registry');
-jest.mock('../tools/execution-engine');
-jest.mock('../ui/file-picker-modal');
-jest.mock('../ui/session-settings-modal');
+jest.mock('../../src/agent/session-history');
+jest.mock('../../src/tools/tool-registry');
+jest.mock('../../src/tools/execution-engine');
+jest.mock('../../src/ui/file-picker-modal');
+jest.mock('../../src/ui/session-settings-modal');
 
 // Mock Obsidian
 jest.mock('obsidian', () => {

--- a/test/ui/update-notification-modal.test.ts
+++ b/test/ui/update-notification-modal.test.ts
@@ -2,7 +2,7 @@
  * Tests for UpdateNotificationModal
  */
 
-import { UpdateNotificationModal } from './update-notification-modal';
+import { UpdateNotificationModal } from '../../src/ui/update-notification-modal';
 import { App } from 'obsidian';
 
 // Mock Obsidian

--- a/test/utils/file-utils.test.ts
+++ b/test/utils/file-utils.test.ts
@@ -1,4 +1,4 @@
-import { shouldExcludePath, shouldExcludePathForPlugin, createFileFilter } from './file-utils';
+import { shouldExcludePath, shouldExcludePathForPlugin, createFileFilter } from '../../src/utils/file-utils';
 import { TFile, TFolder } from 'obsidian';
 
 describe('file-utils', () => {


### PR DESCRIPTION
- Create test/ directory structure mirroring src/
- Move all test files from src/ to test/
- Update all import paths in test files to reference ../src/
- Update jest.config.mjs to use new test directory location
- All tests passing (24 suites, 367 tests passed)

Resolves #187