### PR TITLE
Fix TypeScript errors in codebase

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,8 @@ npm run format       # Format code with Prettier
 npm run format-check # Check formatting without changes
 ```
 
+**IMPORTANT**: Always run `npm install` first if you encounter TypeScript errors or missing module errors during build. The build requires all dependencies in `node_modules` to be present. If you get errors about missing modules like `obsidian`, `@google/genai`, `handlebars`, or `tslib`, run `npm install` before attempting `npm run build` again.
+
 ### Testing
 
 - Run single test: `npm test -- path/to/test.ts`


### PR DESCRIPTION
Add prominent instruction to run npm install before npm run build to prevent TypeScript errors from missing dependencies.