### PR TITLE
fix: add thought_signature to tool calls for Gemini 3 support

### DIFF
--- a/src/api/gemini-client.ts
+++ b/src/api/gemini-client.ts
@@ -417,7 +417,8 @@ export class GeminiClient implements ModelApi {
 			if ('functionCall' in part && part.functionCall && part.functionCall.name) {
 				toolCalls.push({
 					name: part.functionCall.name,
-					arguments: part.functionCall.args || {}
+					arguments: part.functionCall.args || {},
+					thoughtSignature: (part as any).thoughtSignature
 				});
 			}
 		}

--- a/src/api/interfaces/model-api.ts
+++ b/src/api/interfaces/model-api.ts
@@ -24,6 +24,7 @@ export interface ModelResponse {
 export interface ToolCall {
 	name: string;
 	arguments: Record<string, any>;
+	thoughtSignature?: string;
 }
 
 /**

--- a/src/ui/agent-view/agent-view-tools.ts
+++ b/src/ui/agent-view/agent-view-tools.ts
@@ -166,7 +166,8 @@ export class AgentViewTools {
 					functionCall: {
 						name: tc.name,
 						args: tc.arguments || {}
-					}
+					},
+					thoughtSignature: tc.thoughtSignature
 				}))
 			},
 			// Tool results as functionResponse


### PR DESCRIPTION
This PR fixes an issue where Gemini 3 API calls would fail with a 'missing thought_signature' error when using tools. It captures the `thoughtSignature` from the API response and includes it in the conversation history when sending tool results back to the model.