### PR TITLE
Fix blank image model dropdown in settings

### DIFF
--- a/src/ui/settings-helpers.ts
+++ b/src/ui/settings-helpers.ts
@@ -62,10 +62,10 @@ export async function selectModelSetting(
 			if (!valueExists && availableModels.length > 0) {
 				const defaultValue = availableModels[0].value;
 				plugin.logger.warn(`${label}: Current value "${currentValue}" not found in available models. Defaulting to "${defaultValue}"`);
-				(plugin.settings as ObsidianGeminiSettings)[settingName] = defaultValue as string;
+				(plugin.settings as ObsidianGeminiSettings)[settingName] = defaultValue;
 				dropdown.setValue(defaultValue);
 				// Save the corrected setting
-				plugin.saveSettings();
+				plugin.saveSettings().catch((e) => plugin.logger.error(`Failed to save corrected ${label} setting:`, e));
 			} else {
 				dropdown.setValue(currentValue);
 			}


### PR DESCRIPTION
## Summary

Fixes issue where the image model dropdown in settings appears blank, requiring users to manually select a model every time they open settings.

## Problem

When the settings UI is rendered:
1. The dropdown loads the saved `imageModelName` value
2. The dropdown is populated with available image generation models
3. **If the saved value doesn't match any available option, the dropdown shows blank**

This happens when:
- A previously selected model is removed or renamed
- Model discovery returns a different set of models than expected
- The saved value is empty, undefined, or invalid
- Model availability changes between plugin versions

Users reported having to re-select the image model every time they open settings, which is frustrating and shouldn't be necessary.

## Solution

Added validation logic in `selectModelSetting()` function (`src/ui/settings-helpers.ts`):

1. **Check if saved value exists** in available models list
2. **Auto-select first model** if current value is invalid
3. **Auto-save corrected value** to persist the fix
4. **Log warning** for debugging when auto-correction occurs

### Code Changes

```typescript
// Get current setting value
const currentValue = String((plugin.settings as ObsidianGeminiSettings)[settingName]);

// Check if current value exists in available models
const valueExists = availableModels.some(m => m.value === currentValue);

// If value doesn't exist in options, use first available model
if (!valueExists && availableModels.length > 0) {
    const defaultValue = availableModels[0].value;
    plugin.logger.warn(`${label}: Current value "${currentValue}" not found in available models. Defaulting to "${defaultValue}"`);
    (plugin.settings as ObsidianGeminiSettings)[settingName] = defaultValue as string;
    dropdown.setValue(defaultValue);
    plugin.saveSettings();
} else {
    dropdown.setValue(currentValue);
}
```

## Impact

### Benefits
✅ **No more blank dropdowns** - Always shows a valid model selection  
✅ **Automatic recovery** - Self-heals invalid settings  
✅ **Better UX** - Users don't need to manually re-select models  
✅ **Applies to all models** - Fixes chat, summary, completions, and image dropdowns  
✅ **Debug friendly** - Logs warnings when corrections occur  

### Scope
- **Affects**: All model selection dropdowns in settings
- **Breaking changes**: None
- **Migration**: Automatic - invalid values are corrected on settings load

## Testing

✅ Build successful with no compilation errors  
✅ Fix applies generically to all model dropdowns via shared `selectModelSetting()` function  
✅ Handles edge cases:
   - Empty/undefined saved values
   - Removed/renamed models
   - Model discovery changes
   - Empty available models list (no change if list is empty)

## User Impact

Users will no longer experience:
- Blank image model dropdown requiring manual selection
- Need to re-select model every time settings are opened
- Confusion about which model is currently selected

The dropdown will always show a valid selection, even after plugin updates or model changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model-selection validation to prevent invalid configurations. If the currently configured model is no longer available, the app now automatically selects the first available model, updates the displayed choice, saves the corrected setting, and emits a warning to signal the adjustment. Existing manual-change behavior remains unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->