### PR TITLE
Document in-chat confirmation system

### DIFF
--- a/docs/agent-mode-guide.md
+++ b/docs/agent-mode-guide.md
@@ -170,7 +170,7 @@ When the agent needs to perform operations that require your approval (like crea
 
 Instead of popup modals, confirmation requests appear as interactive messages in the chat:
 
-```
+```text
 🔒 Permission Required
 
 📝 Write File
@@ -206,13 +206,13 @@ Parameters:
 
 Once you click a button, the confirmation request updates to show the result:
 
-```
+```text
 ✓ Permission granted: Write File was allowed
 ```
 
 or
 
-```
+```text
 ✗ Permission denied: Write File was cancelled
 ```
 
@@ -238,7 +238,7 @@ When you check "Don't ask again this session" and click Allow:
    - Restart Obsidian
 
 **Use case example:**
-```
+```text
 User: Organize my daily notes into monthly folders
 
 [Agent requests permission to move first file]
@@ -257,7 +257,7 @@ Before clicking Allow, always review:
 3. **File Paths**: Ensure paths are correct and won't overwrite important files
 4. **Content Preview**: Check the content looks reasonable (for write operations)
 **Example - Be careful with destructive operations:**
-```
+```text
 🔒 Permission Required
 
 🗑️ Delete File


### PR DESCRIPTION
Addresses #234

## Overview

Comprehensive documentation update for the in-chat confirmation system that replaced modal dialogs in PR #232. This adds detailed user guidance on how confirmations work, what the buttons do, and best practices for safe usage.

## Changes

### New Section: "Tool Confirmations"

Added major new section (125+ lines) between "Session Configuration" and "Best Practices" covering:

**How Confirmations Work:**
- Visual example of in-chat confirmation request
- Explanation of the three action buttons (Allow, Cancel, "Don't ask again")
- Before/after state examples

**Confirmation Actions:**
- ✓ Allow - What happens when you approve
- ✗ Cancel - What happens when you decline  
- ☑ Don't ask again this session - Session-level permissions explained

**What Operations Require Confirmation:**
- List of operations requiring confirmation by default
- Reference to settings configuration

**Session-Level Permissions:**
- Detailed explanation of "Don't ask again" checkbox behavior
- When permissions are cleared (new session, restart, etc.)
- Practical use case example

**Reviewing Confirmation Details:**
- Checklist of what to review before approving
- Warning example for destructive operations

**Best Practices for Confirmations:**
- 6 practical guidelines for safe confirmation usage

### Updated Existing Sections

**"Configure Permissions" (Getting Started):**
- Now mentions in-chat confirmation requests
- References detailed Tool Confirmations section

**"Review Before Confirming" (Best Practices):**
- Updated from modal-based to in-chat workflow
- Added specific checklist items
- Cross-references Tool Confirmations section

**"Confirmation System" (Safety Features):**
- Expanded from 3 vague bullet points to 6 detailed points
- Describes in-chat system specifically
- Cross-references Tool Confirmations section

**"Permissions" (Session Configuration):**
- Already referenced session-level permissions (no change needed)

## Documentation Quality

### Comprehensive Coverage
- ✅ Explains the visual UI elements
- ✅ Documents all three button actions
- ✅ Covers session-level permission lifecycle
- ✅ Includes practical examples
- ✅ Provides safety best practices
- ✅ Cross-references throughout guide

### User-Focused
- Clear visual examples of confirmation UI
- Step-by-step workflow explanation
- Warning examples for risky operations
- Practical use cases

### Accurate
- Matches PR #232 implementation
- Correctly describes button behavior
- Accurate session lifecycle documentation

## Screenshots Recommended

While the text documentation is complete, adding screenshots would enhance understanding:

1. **In-chat confirmation request** (before user clicks)
   - Shows the full UI with all three buttons
   - Example: write_file operation

2. **Permission granted message** (after clicking Allow)
   - Shows the updated message state

3. **Permission denied message** (after clicking Cancel)
   - Shows the cancellation state

4. **"Don't ask again" checkbox checked**
   - Shows checkbox in checked state before clicking Allow

5. **Settings → Gemini Scribe → Agent Permissions**
   - Shows where to configure which operations require confirmation

These screenshots can be added in a follow-up PR when available.

## Impact

- **+133 lines** of detailed confirmation documentation
- **-8 lines** of vague or outdated references
- **Net: +125 lines** of user guidance

Users now have comprehensive documentation for:
- Understanding what in-chat confirmations are
- How to respond to them safely
- When to use "Don't ask again this session"
- Best practices for avoiding mistakes

## Testing

- [x] Build passes (`npm run build`)
- [x] All internal documentation links work
- [x] Cross-references point to correct sections
- [x] Examples match PR #232 implementation

## Related

Closes #234  
Documents feature from PR #232

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Agent Mode guide to center on in-chat confirmation workflows and a new "Tool Confirmations" reference.
  * Added explicit confirmation actions (Allow, Cancel, "Don’t ask again this session"), interactive message examples, parameter display, and after-response behavior.
  * Expanded list of operations requiring confirmation and linked Settings → Gemini Scribe → Agent Permissions guidance.
  * Reworked best practices, reviewing guidance, and cautionary notes to align with the in-chat confirmation model.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->