### PR TITLE
Add PDF and attachment indexing support

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -43,6 +43,7 @@ export interface RagIndexingSettings {
 	fileSearchStoreName: string | null;
 	excludeFolders: string[];
 	autoSync: boolean;
+	includeAttachments: boolean;
 }
 
 export interface ObsidianGeminiSettings {
@@ -114,6 +115,7 @@ const DEFAULT_SETTINGS: ObsidianGeminiSettings = {
 		fileSearchStoreName: null,
 		excludeFolders: [],
 		autoSync: true,
+		includeAttachments: false,
 	},
 };
 

--- a/src/services/rag-indexing.ts
+++ b/src/services/rag-indexing.ts
@@ -116,6 +116,7 @@ export class RagIndexingService {
 				metadataCache: this.plugin.app.metadataCache,
 				excludeFolders: this.plugin.settings.ragIndexing.excludeFolders,
 				historyFolder: this.plugin.settings.historyFolder,
+				includeAttachments: this.plugin.settings.ragIndexing.includeAttachments,
 				logError: (msg, ...args) => this.plugin.logger.error(msg, ...args),
 			});
 


### PR DESCRIPTION
## Summary
- Adds support for indexing PDFs and other file types supported by Google's File Search API
- Adds ability to delete and rebuild the index

## Changes
- Add `includeAttachments` setting to `RagIndexingSettings` interface
- Update `ObsidianVaultAdapter` to support multiple file types:
  - Use `getMimeTypeWithFallback()` from gemini-utils for MIME type detection
  - Handle binary files (PDFs) with `vault.readBinary()`
  - Check supported extensions via `isExtensionSupportedWithFallback()`
- Pass `includeAttachments` setting to adapter in `RagIndexingService`
- Add "Include attachments" toggle in settings UI
- Add "Delete Index" button to allow users to rebuild index from scratch

## Supported File Types
Leverages gemini-utils MIME type support including:
- **PDF** (application/pdf)
- **Markdown, HTML, plain text**
- **Programming languages**: Python, Java, Go, Kotlin, C/C++, and many more
- **Text files via fallback**: JavaScript, TypeScript, JSON, YAML, shell scripts, etc.

## Test Plan
- [x] Build passes
- [x] All 553 tests pass
- [ ] Enable RAG indexing and toggle "Include attachments"
- [ ] Reindex vault and verify PDFs are indexed
- [ ] Test "Delete Index" button with confirmation modal
- [ ] Verify search returns results from PDFs

Fixes #245

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * "Include attachments" toggle in Vault Search Index (RAG) settings to opt into indexing PDFs and other non‑Markdown files (requires reindexing).
  * Delete Index button to clear and reset the search index.

* **Improvements**
  * MIME-aware file handling with safer reading of short/empty files and more accurate metadata for indexed attachments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->