### PR TITLE
Add status bar icons and status modal for RAG indexing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "4.2.0",
 			"license": "MIT",
 			"dependencies": {
-				"@allenhutchison/gemini-utils": "^0.2.0"
+				"@allenhutchison/gemini-utils": "^0.3.0"
 			},
 			"devDependencies": {
 				"@google/genai": "^1.29.0",
@@ -33,9 +33,9 @@
 			}
 		},
 		"node_modules/@allenhutchison/gemini-utils": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/@allenhutchison/gemini-utils/-/gemini-utils-0.2.0.tgz",
-			"integrity": "sha512-raGcPjpC/LD4pR2PzI3gcsc535zL1lsUIcLkbxQPxZPgp2CvLLOg/InMrh3S4YAB12j4Eryas2JHzKQB1ROYuA==",
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/@allenhutchison/gemini-utils/-/gemini-utils-0.3.0.tgz",
+			"integrity": "sha512-D8nY/r8o7mpL+x4FXwwApVIIxYGpXruSFhwdbXvNLJQcMHV1O033ChL5gtaRfOiFia75fs5UOzDbIh4MOh0dig==",
 			"license": "MIT",
 			"dependencies": {
 				"ignore": "^7.0.5"

--- a/package.json
+++ b/package.json
@@ -43,6 +43,6 @@
 		"typescript": "^5.9.3"
 	},
 	"dependencies": {
-		"@allenhutchison/gemini-utils": "^0.2.0"
+		"@allenhutchison/gemini-utils": "^0.3.0"
 	}
 }

--- a/src/ui/rag-status-modal.ts
+++ b/src/ui/rag-status-modal.ts
@@ -1,0 +1,180 @@
+import { App, Modal, Setting, setIcon } from 'obsidian';
+import type { RagIndexStatus } from '../services/rag-indexing';
+
+export interface RagStatusInfo {
+	status: RagIndexStatus;
+	indexedCount: number;
+	storeName: string | null;
+	lastSync: number | null;
+	progress?: { current: number; total: number };
+}
+
+/**
+ * Modal showing RAG indexing status and providing access to settings
+ */
+export class RagStatusModal extends Modal {
+	private statusInfo: RagStatusInfo;
+	private onOpenSettings: () => void;
+	private onReindex: () => void;
+
+	constructor(
+		app: App,
+		statusInfo: RagStatusInfo,
+		onOpenSettings: () => void,
+		onReindex: () => void
+	) {
+		super(app);
+		this.statusInfo = statusInfo;
+		this.onOpenSettings = onOpenSettings;
+		this.onReindex = onReindex;
+	}
+
+	onOpen() {
+		const { contentEl } = this;
+		contentEl.empty();
+		contentEl.addClass('rag-status-modal');
+
+		// Header with icon
+		const headerEl = contentEl.createDiv({ cls: 'rag-status-header' });
+		const iconEl = headerEl.createSpan({ cls: 'rag-status-header-icon' });
+		this.setStatusIcon(iconEl);
+		headerEl.createEl('h2', { text: 'RAG Index Status' });
+
+		// Status info
+		const infoEl = contentEl.createDiv({ cls: 'rag-status-info' });
+
+		// Status row
+		const statusRow = infoEl.createDiv({ cls: 'rag-status-row' });
+		statusRow.createSpan({ cls: 'rag-status-label', text: 'Status' });
+		const statusValue = statusRow.createSpan({ cls: 'rag-status-value' });
+		statusValue.setText(this.getStatusText());
+		statusValue.addClass(this.getStatusClass());
+
+		// Files indexed row
+		const filesRow = infoEl.createDiv({ cls: 'rag-status-row' });
+		filesRow.createSpan({ cls: 'rag-status-label', text: 'Files indexed' });
+		filesRow.createSpan({ cls: 'rag-status-value', text: `${this.statusInfo.indexedCount}` });
+
+		// Progress row (only during indexing)
+		if (this.statusInfo.status === 'indexing' && this.statusInfo.progress) {
+			const progressRow = infoEl.createDiv({ cls: 'rag-status-row' });
+			progressRow.createSpan({ cls: 'rag-status-label', text: 'Progress' });
+			const pct = Math.round((this.statusInfo.progress.current / this.statusInfo.progress.total) * 100);
+			progressRow.createSpan({
+				cls: 'rag-status-value',
+				text: `${this.statusInfo.progress.current}/${this.statusInfo.progress.total} (${pct}%)`
+			});
+		}
+
+		// Last sync row
+		if (this.statusInfo.lastSync) {
+			const syncRow = infoEl.createDiv({ cls: 'rag-status-row' });
+			syncRow.createSpan({ cls: 'rag-status-label', text: 'Last sync' });
+			syncRow.createSpan({
+				cls: 'rag-status-value',
+				text: this.formatDate(this.statusInfo.lastSync)
+			});
+		}
+
+		// Store name row
+		if (this.statusInfo.storeName) {
+			const storeRow = infoEl.createDiv({ cls: 'rag-status-row' });
+			storeRow.createSpan({ cls: 'rag-status-label', text: 'Store' });
+			const storeValue = storeRow.createSpan({ cls: 'rag-status-value rag-status-store' });
+			storeValue.setText(this.statusInfo.storeName);
+		}
+
+		// Actions
+		new Setting(contentEl)
+			.addButton((btn) =>
+				btn
+					.setButtonText('Reindex Vault')
+					.setDisabled(this.statusInfo.status === 'indexing')
+					.onClick(() => {
+						this.close();
+						this.onReindex();
+					})
+			)
+			.addButton((btn) =>
+				btn
+					.setButtonText('Open Settings')
+					.setCta()
+					.onClick(() => {
+						this.close();
+						this.onOpenSettings();
+					})
+			);
+	}
+
+	private setStatusIcon(el: HTMLElement): void {
+		switch (this.statusInfo.status) {
+			case 'idle':
+				setIcon(el, 'database');
+				break;
+			case 'indexing':
+				setIcon(el, 'upload-cloud');
+				break;
+			case 'error':
+				setIcon(el, 'alert-triangle');
+				break;
+			case 'paused':
+				setIcon(el, 'pause-circle');
+				break;
+			default:
+				setIcon(el, 'database');
+		}
+	}
+
+	private getStatusText(): string {
+		switch (this.statusInfo.status) {
+			case 'idle':
+				return 'Ready';
+			case 'indexing':
+				return 'Indexing...';
+			case 'error':
+				return 'Error';
+			case 'paused':
+				return 'Paused';
+			case 'disabled':
+				return 'Disabled';
+			default:
+				return 'Unknown';
+		}
+	}
+
+	private getStatusClass(): string {
+		switch (this.statusInfo.status) {
+			case 'idle':
+				return 'rag-status-ready';
+			case 'indexing':
+				return 'rag-status-indexing';
+			case 'error':
+				return 'rag-status-error';
+			case 'paused':
+				return 'rag-status-paused';
+			default:
+				return '';
+		}
+	}
+
+	private formatDate(timestamp: number): string {
+		const date = new Date(timestamp);
+		const now = new Date();
+		const diffMs = now.getTime() - date.getTime();
+		const diffMins = Math.floor(diffMs / 60000);
+		const diffHours = Math.floor(diffMs / 3600000);
+		const diffDays = Math.floor(diffMs / 86400000);
+
+		if (diffMins < 1) {
+			return 'Just now';
+		} else if (diffMins < 60) {
+			return `${diffMins} minute${diffMins === 1 ? '' : 's'} ago`;
+		} else if (diffHours < 24) {
+			return `${diffHours} hour${diffHours === 1 ? '' : 's'} ago`;
+		} else if (diffDays < 7) {
+			return `${diffDays} day${diffDays === 1 ? '' : 's'} ago`;
+		} else {
+			return date.toLocaleDateString();
+		}
+	}
+}

--- a/styles.css
+++ b/styles.css
@@ -3600,3 +3600,119 @@ If your plugin does not need CSS, delete this file.
 	color: var(--interactive-accent-hover);
 	text-decoration: underline;
 }
+
+/* ==================== RAG Status Bar ==================== */
+
+.rag-status-bar {
+	display: flex;
+	align-items: center;
+	gap: 4px;
+	cursor: pointer;
+}
+
+.rag-status-bar .rag-status-icon {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+}
+
+.rag-status-bar .rag-status-icon svg {
+	width: 14px;
+	height: 14px;
+}
+
+.rag-status-bar .rag-status-text {
+	font-size: var(--font-ui-smaller);
+}
+
+/* Animated pulse for indexing state */
+.rag-status-bar.rag-indexing .rag-status-icon svg {
+	animation: rag-pulse 1.5s ease-in-out infinite;
+}
+
+@keyframes rag-pulse {
+	0%, 100% {
+		opacity: 1;
+	}
+	50% {
+		opacity: 0.4;
+	}
+}
+
+/* RAG Status Modal */
+.rag-status-modal {
+	padding: 0;
+}
+
+.rag-status-header {
+	display: flex;
+	align-items: center;
+	gap: 12px;
+	margin-bottom: 16px;
+}
+
+.rag-status-header h2 {
+	margin: 0;
+}
+
+.rag-status-header-icon {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+}
+
+.rag-status-header-icon svg {
+	width: 24px;
+	height: 24px;
+	color: var(--text-accent);
+}
+
+.rag-status-info {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+	margin-bottom: 20px;
+	padding: 12px;
+	background: var(--background-secondary);
+	border-radius: var(--radius-m);
+}
+
+.rag-status-row {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+}
+
+.rag-status-label {
+	color: var(--text-muted);
+	font-size: var(--font-ui-small);
+}
+
+.rag-status-value {
+	font-weight: 500;
+}
+
+.rag-status-store {
+	font-family: var(--font-monospace);
+	font-size: var(--font-ui-smaller);
+	max-width: 200px;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.rag-status-ready {
+	color: var(--text-success);
+}
+
+.rag-status-indexing {
+	color: var(--text-accent);
+}
+
+.rag-status-error {
+	color: var(--text-error);
+}
+
+.rag-status-paused {
+	color: var(--text-warning);
+}


### PR DESCRIPTION
## Summary

- Replace text-only RAG status bar with Lucide icons for a more polished UI
- Add clickable status modal with detailed info and quick actions
- Upgrade gemini-utils to 0.3.0

## Changes

### Status Bar Icons
| State | Icon | Display |
|-------|------|---------|
| Idle | `database` | Icon + file count |
| Indexing | `upload-cloud` (pulsing) | Icon + percentage |
| Error | `alert-triangle` | Icon only |
| Paused | `pause-circle` | Icon only |

### Status Modal
Clicking the status bar opens a modal showing:
- Current status with icon
- Files indexed count
- Progress (during indexing)
- Last sync time (relative)
- Store name
- **Reindex Vault** button
- **Open Settings** button

### Other
- Tooltips now render above the status bar with proper callout arrow
- Upgraded `@allenhutchison/gemini-utils` to 0.3.0

## Test plan
- [x] Enable RAG indexing and verify status bar shows database icon with count
- [x] Trigger reindex and verify upload-cloud icon pulses
- [x] Hover over status bar to verify tooltip appears above
- [x] Click status bar to open modal
- [x] Verify modal shows correct status info
- [x] Click "Reindex Vault" to trigger reindexing
- [x] Click "Open Settings" to navigate to plugin settings

Fixes #250

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced status bar UI with real-time progress visualization during indexing
  * Added status modal displaying indexed file count, sync timestamps, and indexing progress
  * Improved visual feedback with animated icons for different indexing states

* **Chores**
  * Updated project dependency to latest version

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->