### PR TITLE
Reuse API client in RAG search tool (#261)

### DIFF
--- a/src/services/rag-indexing.ts
+++ b/src/services/rag-indexing.ts
@@ -289,6 +289,13 @@ export class RagIndexingService {
 	}
 
 	/**
+	 * Get the GoogleGenAI client for reuse by other components
+	 */
+	getClient(): GoogleGenAI | null {
+		return this.ai;
+	}
+
+	/**
 	 * Check if the service is enabled and ready
 	 */
 	isReady(): boolean {

--- a/src/tools/rag-search-tool.ts
+++ b/src/tools/rag-search-tool.ts
@@ -1,6 +1,5 @@
 import { Tool, ToolResult, ToolExecutionContext } from './types';
 import { ToolCategory } from '../types/agent';
-import { GoogleGenAI } from '@google/genai';
 import type ObsidianGemini from '../main';
 
 /**
@@ -84,8 +83,14 @@ export class RagSearchTool implements Tool {
 			// Validate and clamp maxResults
 			const maxResults = Math.min(Math.max(params.maxResults || 5, 1), 20);
 
-			// Create API client
-			const ai = new GoogleGenAI({ apiKey: plugin.settings.apiKey });
+			// Reuse API client from RAG indexing service
+			const ai = plugin.ragIndexing.getClient();
+			if (!ai) {
+				return {
+					success: false,
+					error: 'RAG API client not available. Please wait for service initialization.'
+				};
+			}
 
 			// Perform search using generateContent with File Search tool
 			// Use the configured chat model for consistency


### PR DESCRIPTION
## Summary
- Reuse the `GoogleGenAI` client from `RagIndexingService` instead of creating a new one per search request
- Add `getClient()` method to expose the shared client

## Changes
- `src/services/rag-indexing.ts`: Add `getClient(): GoogleGenAI | null` method
- `src/tools/rag-search-tool.ts`: Use `plugin.ragIndexing.getClient()` instead of `new GoogleGenAI()`

## Benefits
- Reduced object allocation on each search
- Better connection reuse
- Consistent with other API usage patterns in codebase

## Test plan
- [x] Build passes
- [x] All tests pass
- [ ] Manual: Verify semantic search still works after change

Closes #261

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal client management by consolidating shared resource initialization across services, improving code efficiency and maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->