### PR TITLE
Add detailed RAG status modal with tabs and file lists (#246)

### DIFF
--- a/src/services/rag-indexing.ts
+++ b/src/services/rag-indexing.ts
@@ -283,6 +283,7 @@ export class RagIndexingService {
 		this.fileUploader = null;
 		this.vaultAdapter = null;
 		this.cache = null;
+		this.failedFiles = [];
 		this.status = 'disabled';
 	}
 
@@ -1165,9 +1166,12 @@ export class RagIndexingService {
 
 							// Track failed file with error details
 							if (event.currentFile) {
+								const errorMessage = event.error instanceof Error
+									? event.error.message
+									: String(event.error || 'Unknown error');
 								this.failedFiles.push({
 									path: event.currentFile,
-									error: event.error?.message || 'Unknown error',
+									error: errorMessage,
 									timestamp: Date.now(),
 								});
 							}

--- a/styles.css
+++ b/styles.css
@@ -3808,6 +3808,7 @@ If your plugin does not need CSS, delete this file.
 	align-items: center;
 	padding: 8px 12px;
 	border-bottom: 1px solid var(--background-modifier-border);
+	transition: background 0.15s ease;
 }
 
 .rag-status-file-item:last-child {


### PR DESCRIPTION
## Summary

Enhances the RAG status modal to provide comprehensive visibility into indexing operations:

- **Tabbed interface** with Overview, Files, and Failures tabs
- **Overview tab**: Shows status, file counts, pending changes, last sync, and store info with Sync Now/Reindex All/Settings buttons
- **Files tab**: Searchable list of indexed files sorted by last indexed time (newest first), with "Show all" for large vaults
- **Failures tab**: List of failed files with error messages (only shown when failures exist)

### Technical Changes

- Added `FailedFileEntry` interface to track file failures with error details
- Added `getDetailedStatus()` method returning indexed files list and failure details
- Added `syncPendingChanges()` for immediate sync (bypasses debounce)
- Added `getPendingCount()` helper
- Track failed files during indexing in `file_error` progress handler
- Complete rewrite of `RagStatusModal` with tab system and search functionality
- New CSS styles for tabs, file lists, search input, and failure items

## Test Plan

- [x] Click status bar icon when not indexing to open detailed modal
- [x] Verify tabs switch correctly between Overview, Files, Failures
- [x] Test search filtering in Files tab
- [x] Verify "Show all X files" appears for large vaults (>200 files)
- [x] Test Sync Now button (should be disabled when no pending changes)
- [x] Trigger a file failure (e.g., file too large) and verify it appears in Failures tab
- [x] Verify modal width constraints work properly

Closes #246

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * RAG indexing now tracks failed files with per-file error details and timestamps
  * "Sync Now" button to immediately process pending changes
  * Enhanced status modal with tabbed interface (Overview, Files, Failures)
  * Search, filter, and incremental loading for indexed files; view indexed file timestamps
  * View pending and failed change counts, last sync, store name, and rate-limited status



<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->