### PR TITLE
fix(ui): prevent message submission during IME composition

### DIFF
--- a/src/ui/agent-view/agent-view-ui.ts
+++ b/src/ui/agent-view/agent-view-ui.ts
@@ -54,7 +54,7 @@ export class AgentViewUI {
 	constructor(
 		private app: App,
 		private plugin: ObsidianGemini
-	) {}
+	) { }
 
 	/**
 	 * Creates the main agent interface
@@ -335,6 +335,11 @@ export class AgentViewUI {
 
 		// Event listeners
 		userInput.addEventListener('keydown', (e) => {
+			// Prevent submission if IME composition is active (for Chinese/Japanese/etc)
+			if (e.isComposing) {
+				return;
+			}
+
 			if (e.key === 'Enter' && !e.shiftKey) {
 				e.preventDefault();
 				callbacks.sendMessage();


### PR DESCRIPTION
## Summary
Fixes an issue where pressing `Enter` during IME composition (e.g., when typing Chinese, Japanese using Pinyin/Kana) would prematurely submit the message to the agent.
## Changes
- Added a check for `e.isComposing` in the input field's `keydown` handler.
- Prevents `callbacks.sendMessage()` triggers while the user is still composing text via IME.
## Test Plan
- Type in the chat input using an IME (e.g., MacOS Pinyin).
- Press `Enter` to select a candidate word.
- Verify that the message is NOT sent.
- Press `Enter` again after composition is finished.
- Verify that the message IS sent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed unintended input submission when using IME (Input Method Editor) input methods during text composition in input fields.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->