### PR TITLE
fix: decode HTML entities in Gemini API responses

### DIFF
--- a/src/api/gemini-client.ts
+++ b/src/api/gemini-client.ts
@@ -19,6 +19,7 @@ import {
 import { GeminiPrompts } from '../prompts';
 import type ObsidianGemini from '../main';
 import { getDefaultModelForRole } from '../models';
+import { decodeHtmlEntities } from '../utils/html-entities';
 
 /**
  * Extends Part to include the optional thought property
@@ -371,6 +372,9 @@ export class GeminiClient implements ModelApi {
 			}
 		}
 
+		// Decode HTML entities that Gemini sometimes returns
+		markdown = decodeHtmlEntities(markdown);
+
 		// Extract tool calls
 		toolCalls = this.extractToolCallsFromResponse(response);
 
@@ -390,10 +394,11 @@ export class GeminiClient implements ModelApi {
 	 */
 	private extractTextFromChunk(chunk: any): string {
 		if (chunk.candidates?.[0]?.content?.parts) {
-			return chunk.candidates[0].content.parts
+			const text = chunk.candidates[0].content.parts
 				.filter((part: Part) => 'text' in part && part.text && !(part as PartWithThought).thought)
 				.map((part: Part) => (part as PartWithThought).text)
 				.join('');
+			return decodeHtmlEntities(text);
 		}
 		return '';
 	}

--- a/src/utils/html-entities.ts
+++ b/src/utils/html-entities.ts
@@ -1,0 +1,85 @@
+/**
+ * Utility for decoding HTML entities in Gemini API responses.
+ *
+ * Gemini models (especially Flash Lite) sometimes return HTML entities
+ * despite system prompt instructions not to. Entities can be double or
+ * triple-encoded (e.g., &amp;amp;quot; → &amp;quot; → &quot; → ").
+ */
+
+/** Named HTML entities we decode. */
+const NAMED_ENTITIES: Record<string, string> = {
+	'&amp;': '&',
+	'&lt;': '<',
+	'&gt;': '>',
+	'&quot;': '"',
+	'&apos;': "'",
+	'&nbsp;': '\u00A0',
+};
+
+/** Pattern matching any HTML entity we handle. */
+const ENTITY_PATTERN = /&(?:amp|lt|gt|quot|apos|nbsp|#\d{1,6}|#x[0-9a-fA-F]{1,6});/;
+
+/** Maximum decode iterations to prevent infinite loops on malformed input. */
+const MAX_ITERATIONS = 5;
+
+/**
+ * Decode a single pass of HTML entities in a string.
+ * Handles named, decimal numeric, and hex numeric entities.
+ */
+function decodeOnce(text: string): string {
+	return text.replace(/&(?:#x([0-9a-fA-F]{1,6})|#(\d{1,6})|([a-zA-Z]+));/g, (match, hex, dec, named) => {
+		if (hex) {
+			try {
+				return String.fromCodePoint(parseInt(hex, 16));
+			} catch {
+				return match; // Invalid code point, leave as-is
+			}
+		}
+		if (dec) {
+			try {
+				return String.fromCodePoint(parseInt(dec, 10));
+			} catch {
+				return match; // Invalid code point, leave as-is
+			}
+		}
+		if (named) {
+			const key = `&${named};`;
+			return NAMED_ENTITIES[key] ?? match;
+		}
+		return match;
+	});
+}
+
+/**
+ * Decode HTML entities in text, preserving content inside fenced code blocks.
+ *
+ * Iteratively decodes until no more entities remain or the iteration cap
+ * is reached. Code blocks (``` … ```) are left untouched since entities
+ * inside them may be intentional.
+ */
+export function decodeHtmlEntities(text: string): string {
+	if (!text) return text;
+
+	// Split on fenced code blocks, preserving the delimiters.
+	// Odd-indexed segments are inside code fences.
+	const parts = text.split(/(```[\s\S]*?```)/);
+
+	for (let i = 0; i < parts.length; i++) {
+		// Skip code blocks (odd indices)
+		if (i % 2 !== 0) continue;
+
+		let segment = parts[i];
+		let iterations = 0;
+
+		while (iterations < MAX_ITERATIONS && ENTITY_PATTERN.test(segment)) {
+			const decoded = decodeOnce(segment);
+			if (decoded === segment) break; // No progress — stop
+			segment = decoded;
+			iterations++;
+		}
+
+		parts[i] = segment;
+	}
+
+	return parts.join('');
+}

--- a/test/utils/html-entities.test.ts
+++ b/test/utils/html-entities.test.ts
@@ -1,0 +1,130 @@
+import { decodeHtmlEntities } from '../../src/utils/html-entities';
+
+describe('decodeHtmlEntities', () => {
+	// --- Basic named entities ---
+	it('decodes single-encoded named entities', () => {
+		expect(decodeHtmlEntities('&amp;')).toBe('&');
+		expect(decodeHtmlEntities('&lt;')).toBe('<');
+		expect(decodeHtmlEntities('&gt;')).toBe('>');
+		expect(decodeHtmlEntities('&quot;')).toBe('"');
+		expect(decodeHtmlEntities('&apos;')).toBe("'");
+		expect(decodeHtmlEntities('&nbsp;')).toBe('\u00A0');
+	});
+
+	it('decodes multiple entities in a sentence', () => {
+		expect(decodeHtmlEntities('He said &quot;hello&quot; &amp; goodbye')).toBe('He said "hello" & goodbye');
+	});
+
+	// --- Multi-layer encoding ---
+	it('decodes double-encoded entities', () => {
+		// &amp;quot; → &quot; → "
+		expect(decodeHtmlEntities('&amp;quot;')).toBe('"');
+		// &amp;amp; → &amp; → &
+		expect(decodeHtmlEntities('&amp;amp;')).toBe('&');
+		// &amp;lt; → &lt; → <
+		expect(decodeHtmlEntities('&amp;lt;')).toBe('<');
+	});
+
+	it('decodes triple-encoded entities', () => {
+		// &amp;amp;quot; → &amp;quot; → &quot; → "
+		expect(decodeHtmlEntities('&amp;amp;quot;')).toBe('"');
+		// &amp;amp;amp; → &amp;amp; → &amp; → &
+		expect(decodeHtmlEntities('&amp;amp;amp;')).toBe('&');
+	});
+
+	it('decodes a realistic triple-encoded sentence', () => {
+		const input = 'She said &amp;amp;quot;hello&amp;amp;quot; &amp;amp;amp; waved';
+		expect(decodeHtmlEntities(input)).toBe('She said "hello" & waved');
+	});
+
+	// --- Numeric entities ---
+	it('decodes decimal numeric entities', () => {
+		expect(decodeHtmlEntities('&#39;')).toBe("'");
+		expect(decodeHtmlEntities('&#34;')).toBe('"');
+		expect(decodeHtmlEntities('&#60;')).toBe('<');
+		expect(decodeHtmlEntities('&#62;')).toBe('>');
+		expect(decodeHtmlEntities('&#38;')).toBe('&');
+	});
+
+	it('decodes hex numeric entities', () => {
+		expect(decodeHtmlEntities('&#x27;')).toBe("'");
+		expect(decodeHtmlEntities('&#x22;')).toBe('"');
+		expect(decodeHtmlEntities('&#x3C;')).toBe('<');
+		expect(decodeHtmlEntities('&#x3E;')).toBe('>');
+		expect(decodeHtmlEntities('&#x26;')).toBe('&');
+	});
+
+	it('decodes double-encoded numeric entities', () => {
+		// &amp;#39; → &#39; → '
+		expect(decodeHtmlEntities('&amp;#39;')).toBe("'");
+		// &amp;#x27; → &#x27; → '
+		expect(decodeHtmlEntities('&amp;#x27;')).toBe("'");
+	});
+
+	// --- Code block preservation ---
+	it('preserves entities inside fenced code blocks', () => {
+		const input = 'Before &amp; ```const x = &amp;amp;``` After &amp;';
+		expect(decodeHtmlEntities(input)).toBe('Before & ```const x = &amp;amp;``` After &');
+	});
+
+	it('preserves entities inside multi-line code blocks', () => {
+		const input = 'Text &quot;here&quot;\n```\ncode &amp; more &lt;tag&gt;\n```\nEnd &amp;';
+		expect(decodeHtmlEntities(input)).toBe('Text "here"\n```\ncode &amp; more &lt;tag&gt;\n```\nEnd &');
+	});
+
+	it('handles multiple code blocks', () => {
+		const input = '&amp; ```&amp;``` middle &amp; ```&amp;``` &amp;';
+		expect(decodeHtmlEntities(input)).toBe('& ```&amp;``` middle & ```&amp;``` &');
+	});
+
+	// --- Edge cases ---
+	it('returns empty string unchanged', () => {
+		expect(decodeHtmlEntities('')).toBe('');
+	});
+
+	it('returns null/undefined unchanged', () => {
+		expect(decodeHtmlEntities(null as unknown as string)).toBe(null);
+		expect(decodeHtmlEntities(undefined as unknown as string)).toBe(undefined);
+	});
+
+	it('passes through text with no entities', () => {
+		const input = 'Hello, world! This is plain text with no entities.';
+		expect(decodeHtmlEntities(input)).toBe(input);
+	});
+
+	it('handles entities at string boundaries', () => {
+		expect(decodeHtmlEntities('&amp;start')).toBe('&start');
+		expect(decodeHtmlEntities('end&amp;')).toBe('end&');
+		expect(decodeHtmlEntities('&amp;')).toBe('&');
+	});
+
+	it('handles unknown named entities gracefully', () => {
+		expect(decodeHtmlEntities('&unknown;')).toBe('&unknown;');
+	});
+
+	it('does not loop infinitely on malformed input', () => {
+		// This should terminate even with deeply nested encoding
+		const input = '&amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;';
+		const result = decodeHtmlEntities(input);
+		// After 5 iterations the remaining entities are left as-is
+		expect(typeof result).toBe('string');
+	});
+
+	it('handles invalid Unicode code points gracefully', () => {
+		// Code point above U+10FFFF should be left as-is
+		expect(decodeHtmlEntities('&#x110000;')).toBe('&#x110000;');
+		// Extremely large decimal code point
+		expect(decodeHtmlEntities('&#999999999;')).toBe('&#999999999;');
+	});
+
+	// --- Mixed content ---
+	it('handles mixed entities and plain text', () => {
+		const input = 'The &lt;div&gt; element &amp; the &quot;class&quot; attribute';
+		expect(decodeHtmlEntities(input)).toBe('The <div> element & the "class" attribute');
+	});
+
+	it('handles entities mixed with markdown', () => {
+		const input = '**Bold** text with &quot;quotes&quot; and `inline &amp; code`';
+		expect(decodeHtmlEntities(input)).toBe('**Bold** text with "quotes" and `inline & code`');
+	});
+});


### PR DESCRIPTION
## Summary

We believe this addresses #327.

Gemini models (especially Flash Lite) sometimes return HTML entities (`&amp;`, `&quot;`, `&#x27;`, etc.) in their responses despite system prompt instructions not to. These entities are often double or triple-encoded (e.g., `&amp;amp;quot;` instead of `"`), causing users to see raw encoded text.

- **New utility** (`src/utils/html-entities.ts`): `decodeHtmlEntities()` iteratively decodes HTML entities (named, decimal, hex) while preserving content inside fenced code blocks. Caps at 5 iterations to handle multi-layer encoding safely.
- **Applied at the API layer** (`src/api/gemini-client.ts`): Decoding in both `extractModelResponse()` (non-streaming) and `extractTextFromChunk()` (streaming), covering all response paths — chat, agent, summary, rewrite, and completions.
- **20 unit tests** covering single/double/triple encoding, numeric entities, code block preservation, invalid Unicode code points, and edge cases.

## Test plan

- [x] `npm test` — all 718 tests pass (20 new)
- [x] `npm run build` — production build succeeds
- [x] `npm run format-check` — Prettier clean
- [ ] Manual: send chat messages that trigger Gemini to use entities, verify they render as plain characters

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed HTML entities in Gemini API responses being properly decoded and displayed as intended characters instead of encoded text (e.g., &amp; now displays as &).

* **Tests**
  * Added comprehensive test coverage for HTML entity decoding, including edge cases and various encoding scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->