### PR TITLE
fix: preserve HTML markup in saved chat history

### DIFF
--- a/src/history/templates/historyEntry.hbs
+++ b/src/history/templates/historyEntry.hbs
@@ -35,7 +35,7 @@
 > [!assistant]+
 {{/if}}
 {{#each messageLines}}
-> {{this}}
+> {{{this}}}
 {{/each}}
 
 --- 


### PR DESCRIPTION
## Summary

Fixes #112.

The Handlebars history template was using `{{this}}` for message lines, which auto-escapes HTML. This caused inline HTML markup (e.g., `<font color="#ff0000">red</font>`) to be saved as escaped entities (`&lt;font color=&quot;#ff0000&quot;&gt;`) in history files, even though it rendered correctly in the live chat UI.

Changed to `{{{this}}}` (triple-stash / unescaped output) so HTML in model responses is preserved as-is when writing to history files.

Combined with #331 (decoding HTML entities from Gemini API responses), this fully addresses the issue reported in #112 — colored text and other HTML markup now renders correctly in both the chat interface and saved history files.

## Test plan

- [x] `npm test` — all 718 tests pass
- [x] `npm run build` — production build succeeds
- [x] `npm run format-check` — Prettier clean
- [x] Manual: asked model to output colored text, verified it renders in chat and is preserved in saved history file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message display in history entries to render content as intended.
  * Updated history entry prefix indicator from "->" to "+>" for better visual distinction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->