### PR TITLE
feat: list executed tools in empty response message

### DIFF
--- a/src/ui/agent-view/agent-view-tools.ts
+++ b/src/ui/agent-view/agent-view-tools.ts
@@ -334,11 +334,22 @@ export class AgentViewTools {
 						this.plugin.logger.warn('Model returned empty response after retry');
 						this.context.hideProgress();
 
-						// Show error message to user
+						// Show error message to user with executed tool names
+						const executedToolNames = toolResults
+							.filter((r) => r.result?.success !== false)
+							.map((r) => {
+								const tool = this.plugin.toolRegistry.getTool(r.toolName);
+								return tool?.displayName || r.toolName;
+							})
+							.join(', ');
+
+						const emptyResponseMessage = executedToolNames
+							? `I completed the requested actions (${executedToolNames}) but had trouble generating a summary. The operations were successful.`
+							: 'I completed the requested actions but had trouble generating a summary. The operations were successful.';
+
 						const errorEntry: GeminiConversationEntry = {
 							role: 'model',
-							message:
-								'I completed the requested actions but had trouble generating a summary. The tools were executed successfully.',
+							message: emptyResponseMessage,
 							notePath: '',
 							created_at: new Date(),
 						};


### PR DESCRIPTION
## Summary

Fixes #237.

When the agent executes tools but the model returns an empty response, the fallback message now lists which tools were successfully executed using their display names.

**Before:**
> I completed the requested actions but had trouble generating a summary. The operations were successful.

**After:**
> I completed the requested actions (Write File, Read File) but had trouble generating a summary. The operations were successful.

- Filters to only successfully executed tools
- Uses human-friendly `displayName` from the tool registry, falling back to the raw tool name
- Falls back to the original generic message if no successful tools are found

## Test plan

- [x] `npm test` — all 718 tests pass
- [x] `npm run build` — production build succeeds
- [x] `npm run format-check` — Prettier clean
- [x] CodeRabbit review — no findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error messaging to display executed tool names when the agent successfully completes actions but cannot generate a response summary, providing better visibility into completed operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->