### PR TITLE
fix: improve type safety for thoughtSignature extraction

### DIFF
--- a/src/api/gemini-client.ts
+++ b/src/api/gemini-client.ts
@@ -26,6 +26,7 @@ import { decodeHtmlEntities } from '../utils/html-entities';
  */
 interface PartWithThought extends Part {
 	thought?: boolean;
+	thoughtSignature?: string;
 }
 
 /**
@@ -453,7 +454,7 @@ export class GeminiClient implements ModelApi {
 		const toolCalls: ToolCall[] = [];
 		for (const part of parts) {
 			if ('functionCall' in part && part.functionCall && part.functionCall.name) {
-				const signature = (part as any).thoughtSignature;
+				const signature = (part as PartWithThought).thoughtSignature;
 
 				// Debug logging to verify extraction
 				this.plugin?.logger.debug(


### PR DESCRIPTION
## Summary

Fixes #235.

Adds `thoughtSignature?: string` to the existing `PartWithThought` interface and replaces `(part as any).thoughtSignature` with `(part as PartWithThought).thoughtSignature`. This follows the pattern already established in the file and eliminates the `any` cast.

## Test plan

- [x] `npm test` — all 718 tests pass
- [x] `npm run build` — production build succeeds
- [x] `npm run format-check` — Prettier clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Enhancements**
  * Improved AI response processing to better support advanced reasoning metadata extraction from API responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->