### PR TITLE
Drag drop context files 11739064744453761558

### DIFF
--- a/docs/agent-mode-guide.md
+++ b/docs/agent-mode-guide.md
@@ -60,29 +60,49 @@ Agent: I'll help you find and summarize your meeting notes. Let me:
 [Executes write_file tool to create summary]
 ```
 
-### Image Support
+### File Attachments & Drag-and-Drop
 
-You can include images in your chat for multimodal AI analysis:
+You can include images, audio, video, PDFs, and text files in your chat. Files are automatically classified and routed:
 
-**Adding Images:**
+**Adding Files:**
 
 - **Paste** images directly from your clipboard (Ctrl/Cmd+V)
-- **Drag and drop** image files into the input box
-- Multiple images can be attached to a single message
+- **Drag and drop** files from your vault's file explorer into the input box
+- **Drag and drop** files from your OS file manager (if they're inside the vault)
+- **Drag and drop** folders to include all contained files
+- Multiple files can be attached to a single message
 
-**Supported Formats:**
+**How Files Are Routed:**
 
-- PNG, JPEG, GIF, WebP
+When you drop a file, the plugin classifies it based on its extension:
+
+| Category                      | Extensions                                                                    | Action                                                             |
+| ----------------------------- | ----------------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| **Text**                      | `.md`, `.txt`, `.ts`, `.js`, `.json`, `.html`, `.css`, `.py`, etc.            | Added as context chips (the AI reads the file content)             |
+| **Binary (Gemini-supported)** | `.png`, `.jpg`, `.gif`, `.webp`, `.pdf`, `.mp3`, `.wav`, `.mp4`, `.mov`, etc. | Sent as inline data (the AI processes the binary content directly) |
+| **Unsupported**               | `.zip`, `.exe`, `.dmg`, etc.                                                  | Skipped with a notification                                        |
+
+**Supported Binary Formats:**
+
+- **Images**: PNG, JPEG, GIF, WebP, HEIC, HEIF
+- **Audio**: WAV, MP3, AIFF, AAC, OGG, FLAC
+- **Video**: MP4, MPEG, MOV, AVI, FLV, WebM, WMV, 3GP
+- **Documents**: PDF
 
 **How It Works:**
 
-1. When you paste or drop an image, a thumbnail preview appears above the input
-2. Click the × button on any thumbnail to remove it before sending
-3. When you send the message, images are saved to your vault's attachment folder
-4. The AI receives both the image content and its vault path for referencing
-5. Images appear in the chat with wikilink embeds (e.g., `![[attachments/pasted-image.png]]`)
+1. When you add a binary file, a preview appears above the input (thumbnail for images, icon for other types)
+2. Click the × button on any preview to remove it before sending
+3. Pasted/external images are saved to your vault's attachment folder; vault files are referenced in place
+4. The AI receives both the file content and its vault path for referencing
+5. Files appear in the chat with wikilink embeds (e.g., `![[attachments/pasted-image.png]]`)
 
-> **Privacy Note**: Images are sent to the Gemini API for analysis. Avoid pasting images containing sensitive, confidential, or personal information.
+**Size Limits:**
+
+- Cumulative inline data is limited to **20 MB** per message
+- Files exceeding the limit are skipped with a notification
+
+> **Privacy Note**: Attached files are sent to the Gemini API for analysis. Avoid attaching files containing sensitive, confidential, or personal information.
 
 **Usage Examples:**
 
@@ -93,24 +113,31 @@ Agent: I can see a TypeScript error in your screenshot. The issue is...
 ```
 
 ```text
-User: [drops multiple images] Compare these two diagrams and summarize the differences
+User: [drops a PDF] Summarize the key points from this document
 
-Agent: Looking at both images, I can see the following differences...
+Agent: Based on the PDF, here are the main points...
+```
+
+```text
+User: [drops a folder with mixed files] Review these project files
+
+Agent: I can see the markdown notes in context and the attached images...
 ```
 
 **Combining with Context Files:**
 
-Images work alongside @ mentions and context files. You can:
+Attachments work alongside @ mentions and context files. You can:
 
-- Reference images in context files: "Look at the screenshot and update @ProjectNotes with the solution"
+- Reference attached files in context: "Look at the screenshot and update @ProjectNotes with the solution"
 - Ask the agent to embed images in notes it creates
-- Use image paths in wikilinks: `![[path/to/image.png]]`
+- Use file paths in wikilinks: `![[path/to/image.png]]`
 
 **Edge Cases:**
 
-- Large images are sent as-is (no automatic compression)
-- Unsupported formats (non-PNG/JPEG/GIF/WebP) are ignored with a notification
-- If image processing fails, you'll see a notification
+- Large files are sent as-is (no automatic compression)
+- Unsupported file types are skipped with a notification
+- If file processing fails, you'll see a notification
+- Dropping a folder recursively includes all child files
 
 ### Context Files
 

--- a/src/api/gemini-client.ts
+++ b/src/api/gemini-client.ts
@@ -327,16 +327,15 @@ export class GeminiClient implements ModelApi {
 			userParts.push({ text: extReq.userMessage });
 		}
 
-		// Add image attachments as inlineData parts
-		if (extReq.imageAttachments && extReq.imageAttachments.length > 0) {
-			for (const img of extReq.imageAttachments) {
-				userParts.push({
-					inlineData: {
-						mimeType: img.mimeType,
-						data: img.base64,
-					},
-				});
-			}
+		// Add inline data attachments (images, audio, video, PDF)
+		const allAttachments = [...(extReq.inlineAttachments || []), ...(extReq.imageAttachments || [])];
+		for (const attachment of allAttachments) {
+			userParts.push({
+				inlineData: {
+					mimeType: attachment.mimeType,
+					data: attachment.base64,
+				},
+			});
 		}
 
 		// Add current user message with all parts (only if there are parts)

--- a/src/api/interfaces/model-api.ts
+++ b/src/api/interfaces/model-api.ts
@@ -41,12 +41,15 @@ export interface BaseModelRequest {
 }
 
 /**
- * Represents an image attachment for multimodal input
+ * Represents an inline data attachment for multimodal input (images, audio, video, PDF)
  */
-export interface ImagePart {
+export interface InlineDataPart {
 	base64: string;
 	mimeType: string;
 }
+
+/** Backward-compatible alias */
+export type ImagePart = InlineDataPart;
 
 /**
  * Represents an extended model request with conversation history and a user message.
@@ -58,7 +61,8 @@ export interface ImagePart {
  * @property renderContent - Whether to render the content in responses (default: true)
  * @property customPrompt - Optional custom prompt to modify system behavior
  * @property availableTools - Optional array of tool definitions for function calling
- * @property imageAttachments - Optional array of image attachments for multimodal input
+ * @property inlineAttachments - Optional array of inline data attachments for multimodal input
+ * @property imageAttachments - Deprecated alias for inlineAttachments
  */
 export interface ExtendedModelRequest extends BaseModelRequest {
 	conversationHistory: any[];
@@ -66,7 +70,9 @@ export interface ExtendedModelRequest extends BaseModelRequest {
 	renderContent?: boolean;
 	customPrompt?: CustomPrompt;
 	availableTools?: ToolDefinition[];
-	imageAttachments?: ImagePart[];
+	inlineAttachments?: InlineDataPart[];
+	/** @deprecated Use inlineAttachments instead */
+	imageAttachments?: InlineDataPart[];
 }
 
 /**

--- a/src/ui/agent-view/agent-view-ui.ts
+++ b/src/ui/agent-view/agent-view-ui.ts
@@ -1,4 +1,4 @@
-import { App, TFile, TFolder, Notice, setIcon, normalizePath } from 'obsidian';
+import { App, TFile, TFolder, Notice, setIcon } from 'obsidian';
 import type ObsidianGemini from '../../main';
 import { FilePickerModal } from './file-picker-modal';
 import { SessionListModal } from './session-list-modal';
@@ -8,12 +8,18 @@ import { ChatSession } from '../../types/agent';
 import { insertTextAtCursor, moveCursorToEnd, execContextCommand } from '../../utils/dom-context';
 import { shouldExcludePathForPlugin } from '../../utils/file-utils';
 import {
-	ImageAttachment,
+	InlineAttachment,
 	generateAttachmentId,
 	fileToBase64,
 	getMimeType,
 	isSupportedImageType,
-} from './image-attachment';
+} from './inline-attachment';
+import {
+	classifyFile,
+	FileCategory,
+	arrayBufferToBase64,
+	GEMINI_INLINE_DATA_LIMIT,
+} from '../../utils/file-classification';
 
 /**
  * Callbacks interface for UI interactions
@@ -32,10 +38,10 @@ export interface UICallbacks {
 	updateSessionMetadata: () => Promise<void>;
 	loadSession: (session: ChatSession) => Promise<void>;
 	isCurrentSession: (session: ChatSession) => boolean;
-	addImageAttachment: (attachment: ImageAttachment) => void;
-	removeImageAttachment: (id: string) => void;
-	getImageAttachments: () => ImageAttachment[];
-	handleDroppedFiles: (files: (TFile | TFolder)[]) => void;
+	addAttachment: (attachment: InlineAttachment) => void;
+	removeAttachment: (id: string) => void;
+	getAttachments: () => InlineAttachment[];
+	handleDroppedFiles: (files: TFile[]) => void;
 }
 
 /**
@@ -398,18 +404,17 @@ export class AgentViewUI {
 			if (e.dataTransfer?.files?.length) {
 				const adapter = this.app.vault.adapter;
 				if (adapter && 'basePath' in adapter) {
-					// (adapter as any).basePath is a private Obsidian API, but standard for accessing the file system path
 					const basePath = (adapter as any).basePath;
-					// Note: normalizePath is intended for vault-relative paths but is used here to normalize slashes
-					// on absolute OS paths for consistency across platforms (Windows backslashes vs POSIX slashes)
-					const normalizedBase = normalizePath(basePath);
+					// Normalize slashes for cross-platform consistency (Windows backslashes vs POSIX)
+					// Using explicit replace instead of normalizePath which is intended for vault-relative paths
+					const normalizedBase = basePath.replace(/\\/g, '/');
 
 					for (const file of Array.from(e.dataTransfer.files)) {
 						// (file as any).path is an Electron extension that provides the full filesystem path
 						const rawPath = (file as any).path;
 
 						if (rawPath && typeof rawPath === 'string') {
-							const normalizedRaw = normalizePath(rawPath);
+							const normalizedRaw = rawPath.replace(/\\/g, '/');
 
 							if (normalizedRaw.startsWith(normalizedBase)) {
 								let relPath = normalizedRaw.substring(normalizedBase.length);
@@ -473,7 +478,7 @@ export class AgentViewUI {
 				}
 			}
 
-			// If valid vault files were found, add them and stop
+			// If valid vault files were found, classify and route them
 			if (droppedFiles.length > 0) {
 				e.preventDefault();
 				e.stopPropagation();
@@ -491,24 +496,118 @@ export class AgentViewUI {
 					return;
 				}
 
-				callbacks.handleDroppedFiles(filteredFiles);
+				// Expand folders → collect all child TFiles recursively
+				const allTFiles: TFile[] = [];
+				for (const file of filteredFiles) {
+					if (file instanceof TFolder) {
+						const children = this.collectFilesFromFolder(file);
+						allTFiles.push(...children.filter((f) => !shouldExcludePathForPlugin(f.path, this.plugin)));
+					} else if (file instanceof TFile) {
+						allTFiles.push(file);
+					}
+				}
 
-				new Notice(`Added ${filteredFiles.length} file${filteredFiles.length === 1 ? '' : 's'} to context`, 2000);
+				// Deduplicate again after folder expansion
+				const dedupedFiles = [...new Map(allTFiles.map((f) => [f.path, f])).values()];
+
+				// Classify each file
+				const textFiles: TFile[] = [];
+				const binaryFiles: TFile[] = [];
+				const unsupportedExts: string[] = [];
+
+				for (const file of dedupedFiles) {
+					const result = classifyFile(file.extension);
+					switch (result.category) {
+						case FileCategory.TEXT:
+							textFiles.push(file);
+							break;
+						case FileCategory.GEMINI_BINARY:
+							binaryFiles.push(file);
+							break;
+						case FileCategory.UNSUPPORTED:
+							unsupportedExts.push(`.${file.extension}`);
+							break;
+					}
+				}
+
+				// Route text files → context chips
+				if (textFiles.length > 0) {
+					callbacks.handleDroppedFiles(textFiles);
+				}
+
+				// Route binary files → inline attachments
+				let binaryCount = 0;
+				let cumulativeSize = 0;
+				const sizeLimitExceeded: string[] = [];
+
+				for (const file of binaryFiles) {
+					try {
+						const buffer = await this.app.vault.readBinary(file);
+						cumulativeSize += buffer.byteLength;
+
+						if (cumulativeSize > GEMINI_INLINE_DATA_LIMIT) {
+							sizeLimitExceeded.push(file.name);
+							cumulativeSize -= buffer.byteLength;
+							continue;
+						}
+
+						const base64 = arrayBufferToBase64(buffer);
+						const classification = classifyFile(file.extension);
+						const attachment: InlineAttachment = {
+							base64,
+							mimeType: classification.mimeType,
+							id: generateAttachmentId(),
+							vaultPath: file.path,
+							fileName: file.name,
+						};
+						callbacks.addAttachment(attachment);
+						binaryCount++;
+					} catch (err) {
+						this.plugin.logger.error(`Failed to read binary file ${file.path}:`, err);
+						new Notice(`Failed to attach ${file.name}`);
+					}
+				}
+
+				// Show notices
+				const parts: string[] = [];
+				if (textFiles.length > 0) {
+					parts.push(`${textFiles.length} text file${textFiles.length === 1 ? '' : 's'} added to context`);
+				}
+				if (binaryCount > 0) {
+					parts.push(`${binaryCount} file${binaryCount === 1 ? '' : 's'} attached`);
+				}
+				if (parts.length > 0) {
+					new Notice(parts.join(', '), 3000);
+				}
+
+				if (sizeLimitExceeded.length > 0) {
+					new Notice(
+						`Skipped ${sizeLimitExceeded.length} file${sizeLimitExceeded.length === 1 ? '' : 's'} (exceeds 20MB cumulative limit): ${sizeLimitExceeded.join(', ')}`,
+						5000
+					);
+				}
+
+				if (unsupportedExts.length > 0) {
+					const uniqueExts = [...new Set(unsupportedExts)];
+					new Notice(
+						`Skipped unsupported file type${uniqueExts.length === 1 ? '' : 's'}: ${uniqueExts.join(', ')}`,
+						4000
+					);
+				}
+
 				return;
 			}
 			// --- End Vault File Drops ---
 
-			// First check if there are any supported images in the drop
+			// Non-vault drops: handle images from external sources (browser, desktop)
 			const files = e.dataTransfer?.files;
 			const fileArray = files?.length ? Array.from(files) : [];
 			const hasImages = fileArray.some((file) => isSupportedImageType(file.type));
 
 			// Only prevent default behavior if we have images to handle
-			// This allows text/URL drops to work normally
 			if (!hasImages) {
-				// Check if there were unsupported image formats
 				const unsupportedImages = fileArray.filter(
-					(file) => file.type.startsWith('image/') && !isSupportedImageType(file.type)
+					(file) => file.type?.startsWith('image/') && !isSupportedImageType(file.type)
 				);
 				if (unsupportedImages.length > 0) {
 					new Notice('Unsupported image format. Please use PNG, JPEG, GIF, or WebP.');
@@ -519,19 +618,19 @@ export class AgentViewUI {
 			e.preventDefault();
 			e.stopPropagation();
 
-			// Process all supported images
+			// Process all supported images from non-vault sources
 			let imagesProcessed = 0;
 			let unsupportedCount = 0;
 			for (const file of fileArray) {
 				if (isSupportedImageType(file.type)) {
 					try {
 						const base64 = await fileToBase64(file);
-						const attachment: ImageAttachment = {
+						const attachment: InlineAttachment = {
 							base64,
 							mimeType: getMimeType(file),
 							id: generateAttachmentId(),
 						};
-						callbacks.addImageAttachment(attachment);
+						callbacks.addAttachment(attachment);
 						imagesProcessed++;
 					} catch (err) {
 						this.plugin.logger.error('Failed to process dropped image:', err);
@@ -564,12 +663,12 @@ export class AgentViewUI {
 						}
 						try {
 							const base64 = await fileToBase64(file);
-							const attachment: ImageAttachment = {
+							const attachment: InlineAttachment = {
 								base64,
 								mimeType: getMimeType(file),
 								id: generateAttachmentId(),
 							};
-							callbacks.addImageAttachment(attachment);
+							callbacks.addAttachment(attachment);
 							imagesProcessed++;
 						} catch (err) {
 							this.plugin.logger.error('Failed to process pasted image:', err);
@@ -769,9 +868,13 @@ export class AgentViewUI {
 	}
 
 	/**
-	 * Updates the image preview container with thumbnails
+	 * Updates the attachment preview container with thumbnails or file icons
 	 */
-	updateImagePreview(container: HTMLElement, attachments: ImageAttachment[], onRemove: (id: string) => void): void {
+	updateAttachmentPreview(
+		container: HTMLElement,
+		attachments: InlineAttachment[],
+		onRemove: (id: string) => void
+	): void {
 		container.empty();
 
 		if (attachments.length === 0) {
@@ -784,24 +887,71 @@ export class AgentViewUI {
 		for (const attachment of attachments) {
 			const thumbWrapper = container.createDiv({ cls: 'gemini-agent-image-thumb' });
 
-			// Create image element
-			const img = thumbWrapper.createEl('img', {
-				attr: {
-					src: `data:${attachment.mimeType};base64,${attachment.base64}`,
-					alt: 'Attached image',
-				},
-			});
+			if (attachment.mimeType.startsWith('image/')) {
+				// Image: show thumbnail
+				thumbWrapper.createEl('img', {
+					attr: {
+						src: `data:${attachment.mimeType};base64,${attachment.base64}`,
+						alt: attachment.fileName || 'Attached image',
+					},
+				});
+			} else {
+				// Non-image binary: show icon + filename
+				thumbWrapper.addClass('gemini-agent-attachment-file');
+
+				const iconEl = thumbWrapper.createDiv({ cls: 'gemini-agent-attachment-icon' });
+				const iconName = this.getIconForMimeType(attachment.mimeType);
+				setIcon(iconEl, iconName);
+
+				if (attachment.fileName) {
+					thumbWrapper.createDiv({
+						cls: 'gemini-agent-attachment-label',
+						text: attachment.fileName,
+						attr: { title: attachment.fileName },
+					});
+				}
+			}
 
 			// Create remove button
 			const removeBtn = thumbWrapper.createEl('button', {
 				text: '×',
 				cls: 'gemini-agent-image-remove',
-				attr: { title: 'Remove image', 'aria-label': 'Remove image' },
+				attr: { title: 'Remove attachment', 'aria-label': 'Remove attachment' },
 			});
 
 			removeBtn.addEventListener('click', () => {
 				onRemove(attachment.id);
 			});
 		}
+	}
+
+	/** Backward-compatible alias */
+	updateImagePreview(container: HTMLElement, attachments: InlineAttachment[], onRemove: (id: string) => void): void {
+		this.updateAttachmentPreview(container, attachments, onRemove);
+	}
+
+	/**
+	 * Recursively collect all TFile children from a folder
+	 */
+	private collectFilesFromFolder(folder: TFolder): TFile[] {
+		const files: TFile[] = [];
+		for (const child of folder.children) {
+			if (child instanceof TFile) {
+				files.push(child);
+			} else if (child instanceof TFolder) {
+				files.push(...this.collectFilesFromFolder(child));
+			}
+		}
+		return files;
+	}
+
+	/**
+	 * Get a Lucide icon name for a MIME type
+	 */
+	private getIconForMimeType(mimeType: string): string {
+		if (mimeType === 'application/pdf') return 'file-text';
+		if (mimeType.startsWith('audio/')) return 'music';
+		if (mimeType.startsWith('video/')) return 'video';
+		return 'file';
 	}
 }

--- a/src/ui/agent-view/agent-view.ts
+++ b/src/ui/agent-view/agent-view.ts
@@ -16,7 +16,7 @@ import { AgentViewContext } from './agent-view-context';
 import { AgentViewSession, SessionUICallbacks, SessionState } from './agent-view-session';
 import { AgentViewTools, AgentViewContext as ToolsContext } from './agent-view-tools';
 import { AgentViewUI, UICallbacks } from './agent-view-ui';
-import { ImageAttachment } from './image-attachment';
+import { InlineAttachment } from './inline-attachment';
 
 // Import modals from agent-view directory
 import { FilePickerModal } from './file-picker-modal';
@@ -60,7 +60,7 @@ export class AgentView extends ItemView {
 	private cancellationRequested: boolean = false;
 	private allowedWithoutConfirmation: Set<string> = new Set(); // Session-level allowed tools
 	private activeFileChangeHandler: () => void;
-	private pendingImageAttachments: ImageAttachment[] = [];
+	private pendingAttachments: InlineAttachment[] = [];
 	private imagePreviewContainer: HTMLElement;
 
 	constructor(leaf: WorkspaceLeaf, plugin: InstanceType<typeof ObsidianGemini>) {
@@ -123,10 +123,10 @@ export class AgentView extends ItemView {
 			updateSessionMetadata: () => this.updateSessionMetadata(),
 			loadSession: (session: ChatSession) => this.loadSession(session),
 			isCurrentSession: (session: ChatSession) => this.isCurrentSession(session),
-			addImageAttachment: (attachment: ImageAttachment) => this.addImageAttachment(attachment),
-			removeImageAttachment: (id: string) => this.removeImageAttachment(id),
-			getImageAttachments: () => this.pendingImageAttachments,
-			handleDroppedFiles: (files: (TFile | TFolder)[]) => this.handleDroppedFiles(files),
+			addAttachment: (attachment: InlineAttachment) => this.addAttachment(attachment),
+			removeAttachment: (id: string) => this.removeAttachment(id),
+			getAttachments: () => this.pendingAttachments,
+			handleDroppedFiles: (files: TFile[]) => this.handleDroppedFiles(files),
 		};
 
 		// Create the main interface using AgentViewUI
@@ -207,35 +207,40 @@ export class AgentView extends ItemView {
 		}
 
 		const { text: message, files, formattedMessage } = this.fileChips.extractMessageContent();
-		// Allow sending with only images (no text)
-		if (!message && files.length === 0 && this.pendingImageAttachments.length === 0) return;
+		// Allow sending with only attachments (no text)
+		if (!message && files.length === 0 && this.pendingAttachments.length === 0) return;
 
-		// Capture pending images and clear them
-		const imageAttachments = [...this.pendingImageAttachments];
-		this.pendingImageAttachments = [];
-		this.ui.updateImagePreview(this.imagePreviewContainer, [], (id) => this.removeImageAttachment(id));
+		// Capture pending attachments and clear them
+		const attachments = [...this.pendingAttachments];
+		this.pendingAttachments = [];
+		this.ui.updateAttachmentPreview(this.imagePreviewContainer, [], (id) => this.removeAttachment(id));
 
-		// Save images to vault and get their paths
-		const savedImagePaths: string[] = [];
+		// Save attachments to vault (skip those already saved, e.g. from drag-drop)
+		const savedPaths: string[] = [];
 		const failedSaves: number[] = [];
-		for (let i = 0; i < imageAttachments.length; i++) {
-			const attachment = imageAttachments[i];
+		for (let i = 0; i < attachments.length; i++) {
+			const attachment = attachments[i];
+			if (attachment.vaultPath) {
+				// Already in vault (from drag-drop), skip saving
+				savedPaths.push(attachment.vaultPath);
+				continue;
+			}
 			try {
-				const { saveImageToVault } = await import('./image-attachment');
-				const path = await saveImageToVault(this.app, attachment);
+				const { saveAttachmentToVault } = await import('./inline-attachment');
+				const path = await saveAttachmentToVault(this.app, attachment);
 				attachment.vaultPath = path;
-				savedImagePaths.push(path);
+				savedPaths.push(path);
 			} catch (err) {
-				this.plugin.logger.error('Failed to save image to vault:', err);
+				this.plugin.logger.error('Failed to save attachment to vault:', err);
 				failedSaves.push(i + 1);
 			}
 		}
 
-		// Notify user of any save failures (images will still be sent to AI)
+		// Notify user of any save failures (attachments will still be sent to AI)
 		if (failedSaves.length > 0) {
 			const failedList = failedSaves.join(', ');
 			new Notice(
-				`Failed to save ${failedSaves.length === 1 ? 'image' : 'images'} #${failedList} to vault. ` +
+				`Failed to save ${failedSaves.length === 1 ? 'attachment' : 'attachments'} #${failedList} to vault. ` +
 					`${failedSaves.length === 1 ? 'It' : 'They'} will still be sent to the AI but won't be stored locally.`,
 				5000
 			);
@@ -259,10 +264,10 @@ export class AgentView extends ItemView {
 
 		// Build message with image thumbnails for display (use wikilinks for saved images)
 		let displayMessage = formattedMessage;
-		if (savedImagePaths.length > 0) {
-			const imageLinks = savedImagePaths.map((path) => `![[${path}]]`).join('\n');
+		if (savedPaths.length > 0) {
+			const imageLinks = savedPaths.map((path) => `![[${path}]]`).join('\n');
 			// Explicitly show the path context to ensure AI reliability (User preference: reliability > hidden)
-			const contextNote = `\n> [!info] Image Source\n> ${savedImagePaths.map((p) => `\`${p}\``).join('\n> ')}`;
+			const contextNote = `\n> [!info] Image Source\n> ${savedPaths.map((p) => `\`${p}\``).join('\n> ')}`;
 			displayMessage = displayMessage + '\n\n' + imageLinks + contextNote;
 		}
 
@@ -342,9 +347,9 @@ The mentioned files are included in the context below for reference.`;
 			}
 
 			// Add image path information if images were attached
-			if (savedImagePaths.length > 0) {
-				const pathList = savedImagePaths.map((p) => `- ${p}`).join('\n');
-				additionalInstructions += `\n\nIMAGE ATTACHMENTS: The user has attached ${savedImagePaths.length} image(s) to this message. The images have been saved to the vault at these paths:
+			if (savedPaths.length > 0) {
+				const pathList = savedPaths.map((p) => `- ${p}`).join('\n');
+				additionalInstructions += `\n\nIMAGE ATTACHMENTS: The user has attached ${savedPaths.length} image(s) to this message. The images have been saved to the vault at these paths:
 ${pathList}
 To embed any of these images in a note, use the wikilink format: ![[path/to/image.png]]
 To reference an image in your response, use the path shown above.`;
@@ -382,7 +387,7 @@ To reference an image in your response, use the path shown above.`;
 					customPrompt: customPrompt, // Custom prompt template (if configured)
 					renderContent: false, // We already rendered content above
 					availableTools: availableTools,
-					imageAttachments: imageAttachments.map((a) => ({ base64: a.base64, mimeType: a.mimeType })),
+					inlineAttachments: attachments.map((a: InlineAttachment) => ({ base64: a.base64, mimeType: a.mimeType })),
 				};
 
 				// Create model API for this session
@@ -917,43 +922,39 @@ To reference an image in your response, use the path shown above.`;
 			updateSessionMetadata: () => this.updateSessionMetadata(),
 			loadSession: (session: ChatSession) => this.loadSession(session),
 			isCurrentSession: (session: ChatSession) => this.isCurrentSession(session),
-			addImageAttachment: (attachment: ImageAttachment) => this.addImageAttachment(attachment),
-			removeImageAttachment: (id: string) => this.removeImageAttachment(id),
-			getImageAttachments: () => this.pendingImageAttachments,
-			handleDroppedFiles: (files: (TFile | TFolder)[]) => this.handleDroppedFiles(files),
+			addAttachment: (attachment: InlineAttachment) => this.addAttachment(attachment),
+			removeAttachment: (id: string) => this.removeAttachment(id),
+			getAttachments: () => this.pendingAttachments,
+			handleDroppedFiles: (files: TFile[]) => this.handleDroppedFiles(files),
 		};
 	}
 
 	/**
-	 * Handle dropped files by inserting chips
+	 * Handle dropped text files by inserting context chips
 	 */
-	private handleDroppedFiles(files: (TFile | TFolder)[]) {
+	private handleDroppedFiles(files: TFile[]) {
 		for (const file of files) {
-			if (file instanceof TFile) {
-				this.insertFileChip(file);
-			} else if (file instanceof TFolder) {
-				this.insertFolderChip(file);
-			}
+			this.insertFileChip(file);
 		}
 	}
 
 	/**
-	 * Add an image attachment to pending list
+	 * Add an attachment to pending list
 	 */
-	private addImageAttachment(attachment: ImageAttachment): void {
-		this.pendingImageAttachments.push(attachment);
-		this.ui.updateImagePreview(this.imagePreviewContainer, this.pendingImageAttachments, (id) =>
-			this.removeImageAttachment(id)
+	private addAttachment(attachment: InlineAttachment): void {
+		this.pendingAttachments.push(attachment);
+		this.ui.updateAttachmentPreview(this.imagePreviewContainer, this.pendingAttachments, (id) =>
+			this.removeAttachment(id)
 		);
 	}
 
 	/**
-	 * Remove an image attachment from pending list
+	 * Remove an attachment from pending list
 	 */
-	private removeImageAttachment(id: string): void {
-		this.pendingImageAttachments = this.pendingImageAttachments.filter((a) => a.id !== id);
-		this.ui.updateImagePreview(this.imagePreviewContainer, this.pendingImageAttachments, (id) =>
-			this.removeImageAttachment(id)
+	private removeAttachment(id: string): void {
+		this.pendingAttachments = this.pendingAttachments.filter((a) => a.id !== id);
+		this.ui.updateAttachmentPreview(this.imagePreviewContainer, this.pendingAttachments, (id) =>
+			this.removeAttachment(id)
 		);
 	}
 

--- a/src/utils/file-classification.ts
+++ b/src/utils/file-classification.ts
@@ -1,0 +1,112 @@
+/**
+ * File classification utility for routing dropped files to the correct handler.
+ *
+ * Classifies files as TEXT (context chips), GEMINI_BINARY (inline attachments),
+ * or UNSUPPORTED based on their extension.
+ */
+
+import { EXTENSION_TO_MIME, TEXT_FALLBACK_EXTENSIONS } from '@allenhutchison/gemini-utils';
+
+/** Maximum size for inline data sent to Gemini (20 MB) */
+export const GEMINI_INLINE_DATA_LIMIT = 20 * 1024 * 1024;
+
+/**
+ * MIME types for binary files that Gemini can consume as inline data.
+ * Maps file extension (without dot) to MIME type.
+ */
+export const GEMINI_INLINE_BINARY_MIMES: Record<string, string> = {
+	// Images
+	png: 'image/png',
+	jpg: 'image/jpeg',
+	jpeg: 'image/jpeg',
+	gif: 'image/gif',
+	webp: 'image/webp',
+	heic: 'image/heic',
+	heif: 'image/heif',
+
+	// Audio
+	wav: 'audio/wav',
+	mp3: 'audio/mp3',
+	aiff: 'audio/aiff',
+	aac: 'audio/aac',
+	ogg: 'audio/ogg',
+	flac: 'audio/flac',
+
+	// Video
+	mp4: 'video/mp4',
+	mpeg: 'video/mpeg',
+	mov: 'video/mov',
+	avi: 'video/x-msvideo',
+	flv: 'video/x-flv',
+	mpg: 'video/mpeg',
+	webm: 'video/webm',
+	wmv: 'video/x-ms-wmv',
+	'3gp': 'video/3gpp',
+
+	// Documents
+	pdf: 'application/pdf',
+};
+
+export enum FileCategory {
+	TEXT = 'text',
+	GEMINI_BINARY = 'gemini_binary',
+	UNSUPPORTED = 'unsupported',
+}
+
+export interface FileClassification {
+	category: FileCategory;
+	mimeType: string;
+	reason?: string;
+}
+
+/**
+ * Classify a file extension into TEXT, GEMINI_BINARY, or UNSUPPORTED.
+ *
+ * @param extension - File extension without leading dot (e.g. "md", "png", "zip")
+ */
+export function classifyFile(extension: string): FileClassification {
+	const ext = extension.toLowerCase();
+
+	// Check binary types first (more specific match)
+	if (ext in GEMINI_INLINE_BINARY_MIMES) {
+		return {
+			category: FileCategory.GEMINI_BINARY,
+			mimeType: GEMINI_INLINE_BINARY_MIMES[ext],
+		};
+	}
+
+	// Check text types via gemini-utils EXTENSION_TO_MIME (uses dot-prefixed keys)
+	const dotExt = `.${ext}`;
+	if (dotExt in EXTENSION_TO_MIME) {
+		return {
+			category: FileCategory.TEXT,
+			mimeType: EXTENSION_TO_MIME[dotExt],
+		};
+	}
+
+	// Check text fallback extensions
+	if (TEXT_FALLBACK_EXTENSIONS.has(dotExt)) {
+		return {
+			category: FileCategory.TEXT,
+			mimeType: 'text/plain',
+		};
+	}
+
+	return {
+		category: FileCategory.UNSUPPORTED,
+		mimeType: '',
+		reason: `Unsupported file type: .${ext}`,
+	};
+}
+
+/**
+ * Convert an ArrayBuffer to a base64 string.
+ */
+export function arrayBufferToBase64(buffer: ArrayBuffer): string {
+	const bytes = new Uint8Array(buffer);
+	let binary = '';
+	for (let i = 0; i < bytes.byteLength; i++) {
+		binary += String.fromCharCode(bytes[i]);
+	}
+	return btoa(binary);
+}

--- a/styles.css
+++ b/styles.css
@@ -4200,6 +4200,43 @@ If your plugin does not need CSS, delete this file.
 	background-color: var(--text-error);
 }
 
+/* Non-image attachment preview (PDF, audio, video) */
+.gemini-agent-attachment-file {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	background-color: var(--background-secondary);
+	width: auto;
+	min-width: 60px;
+	max-width: 100px;
+	height: 60px;
+	padding: 4px 8px;
+	gap: 2px;
+}
+
+.gemini-agent-attachment-icon {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	color: var(--text-muted);
+}
+
+.gemini-agent-attachment-icon svg {
+	width: 20px;
+	height: 20px;
+}
+
+.gemini-agent-attachment-label {
+	font-size: 9px;
+	color: var(--text-muted);
+	text-overflow: ellipsis;
+	overflow: hidden;
+	white-space: nowrap;
+	max-width: 100%;
+	text-align: center;
+}
+
 .gemini-agent-input-dragover {
 	background-color: var(--background-modifier-hover) !important;
 	border-color: var(--interactive-accent) !important;

--- a/test/ui/agent-view-ui.test.ts
+++ b/test/ui/agent-view-ui.test.ts
@@ -1,12 +1,11 @@
 import { AgentViewUI, UICallbacks } from '../../src/ui/agent-view/agent-view-ui';
-import { App, TFile, TFolder, WorkspaceLeaf, Notice, normalizePath } from 'obsidian';
+import { App, TFile, TFolder, WorkspaceLeaf, Notice } from 'obsidian';
 import ObsidianGemini from '../../src/main';
 import { shouldExcludePathForPlugin } from '../../src/utils/file-utils';
 
 // Mock dependencies
 jest.mock('obsidian', () => ({
 	...jest.requireActual('../../__mocks__/obsidian.js'),
-	normalizePath: jest.fn((p: string) => p),
 }));
 jest.mock('../../src/main');
 jest.mock('../../src/ui/agent-view/file-picker-modal');
@@ -21,6 +20,13 @@ jest.mock('@allenhutchison/gemini-utils', () => ({
 	ResearchManager: class {},
 	ReportGenerator: class {},
 	Interaction: class {},
+	EXTENSION_TO_MIME: {
+		'.md': 'text/markdown',
+		'.txt': 'text/plain',
+		'.html': 'text/html',
+		'.pdf': 'application/pdf',
+	},
+	TEXT_FALLBACK_EXTENSIONS: new Set(['.ts', '.js', '.json', '.css']),
 }));
 jest.mock('@google/genai', () => ({
 	GoogleGenAI: class {},
@@ -51,6 +57,7 @@ describe('AgentViewUI', () => {
 				adapter: {
 					basePath: '/Users/test/vault',
 				},
+				readBinary: jest.fn().mockResolvedValue(new ArrayBuffer(100)),
 			},
 			metadataCache: {
 				getFirstLinkpathDest: jest.fn(),
@@ -84,9 +91,9 @@ describe('AgentViewUI', () => {
 			updateSessionMetadata: jest.fn().mockResolvedValue(undefined),
 			loadSession: jest.fn().mockResolvedValue(undefined),
 			isCurrentSession: jest.fn(),
-			addImageAttachment: jest.fn(),
-			removeImageAttachment: jest.fn(),
-			getImageAttachments: jest.fn(),
+			addAttachment: jest.fn(),
+			removeAttachment: jest.fn(),
+			getAttachments: jest.fn(),
 			handleDroppedFiles: jest.fn(),
 		};
 
@@ -192,52 +199,46 @@ describe('AgentViewUI', () => {
 			const event = await triggerDrop(dataTransfer);
 
 			expect(event.preventDefault).toHaveBeenCalled();
+			// .md is classified as TEXT → handleDroppedFiles
 			expect(callbacks.handleDroppedFiles).toHaveBeenCalledWith([mockFile]);
 			expect(app.vault.getAbstractFileByPath).toHaveBeenCalledWith('folder/note.md');
 		});
 
 		it('should normalize Windows paths correctly', async () => {
-			// Override normalizePath mock for this test to simulate Windows behavior
-			(normalizePath as jest.Mock).mockImplementation((path) => path.replace(/\\/g, '/'));
+			// Mock Windows-style paths
+			(app.vault.adapter as any).basePath = 'C:\\Users\\test\\vault';
 
-			try {
-				// Mock Windows-style paths
-				(app.vault.adapter as any).basePath = 'C:\\Users\\test\\vault';
+			const mockFile = {
+				path: 'folder/note.md',
+				extension: 'md',
+			} as unknown as TFile;
+			Object.setPrototypeOf(mockFile, TFile.prototype);
 
-				const mockFile = {
-					path: 'folder/note.md',
-				} as unknown as TFile;
-				Object.setPrototypeOf(mockFile, TFile.prototype);
+			(app.vault.getAbstractFileByPath as jest.Mock).mockReturnValue(mockFile);
 
-				(app.vault.getAbstractFileByPath as jest.Mock).mockReturnValue(mockFile);
+			// Simulate Windows file path with backslashes
+			const droppedFile = {
+				path: 'C:\\Users\\test\\vault\\folder\\note.md',
+			};
 
-				// Simulate Windows file path
-				const droppedFile = {
-					path: 'C:\\Users\\test\\vault\\folder\\note.md',
-				};
+			const dataTransfer = {
+				files: [droppedFile],
+				types: ['Files'],
+			};
+			Object.defineProperty(dataTransfer.files, 'length', { value: 1 });
+			(dataTransfer.files as any)[Symbol.iterator] = function* () {
+				yield droppedFile;
+			};
 
-				const dataTransfer = {
-					files: [droppedFile],
-					types: ['Files'],
-				};
-				Object.defineProperty(dataTransfer.files, 'length', { value: 1 });
-				(dataTransfer.files as any)[Symbol.iterator] = function* () {
-					yield droppedFile;
-				};
+			await triggerDrop(dataTransfer);
 
-				await triggerDrop(dataTransfer);
-
-				expect(callbacks.handleDroppedFiles).toHaveBeenCalledWith([mockFile]);
-				// normalizePath replaces backslashes with forward slashes in 'folder/note.md'
-				expect(app.vault.getAbstractFileByPath).toHaveBeenCalledWith('folder/note.md');
-			} finally {
-				// Reset mock
-				(normalizePath as jest.Mock).mockImplementation((path) => path);
-			}
+			expect(callbacks.handleDroppedFiles).toHaveBeenCalledWith([mockFile]);
+			// Backslashes normalized to forward slashes for vault path resolution
+			expect(app.vault.getAbstractFileByPath).toHaveBeenCalledWith('folder/note.md');
 		});
 
 		it('should handle internal Wikilink drops', async () => {
-			const mockFile = { path: 'My Note.md' } as unknown as TFile;
+			const mockFile = { path: 'My Note.md', extension: 'md' } as unknown as TFile;
 			Object.setPrototypeOf(mockFile, TFile.prototype);
 
 			(app.vault.getAbstractFileByPath as jest.Mock).mockReturnValue(mockFile);
@@ -255,7 +256,7 @@ describe('AgentViewUI', () => {
 		});
 
 		it('should handle internal Markdown link drops', async () => {
-			const mockFile = { path: 'My Note.md' } as unknown as TFile;
+			const mockFile = { path: 'My Note.md', extension: 'md' } as unknown as TFile;
 			Object.setPrototypeOf(mockFile, TFile.prototype);
 
 			(app.vault.getAbstractFileByPath as jest.Mock).mockReturnValue(mockFile);
@@ -273,7 +274,7 @@ describe('AgentViewUI', () => {
 		});
 
 		it('should deduplicate files', async () => {
-			const mockFile = { path: 'note.md' } as unknown as TFile;
+			const mockFile = { path: 'note.md', extension: 'md' } as unknown as TFile;
 			Object.setPrototypeOf(mockFile, TFile.prototype);
 
 			(app.vault.getAbstractFileByPath as jest.Mock).mockReturnValue(mockFile);
@@ -293,7 +294,7 @@ describe('AgentViewUI', () => {
 		});
 
 		it('should exclude system folders', async () => {
-			const mockFile = { path: '.obsidian/config' } as unknown as TFile;
+			const mockFile = { path: '.obsidian/config', extension: 'config' } as unknown as TFile;
 			Object.setPrototypeOf(mockFile, TFile.prototype);
 
 			(app.vault.getAbstractFileByPath as jest.Mock).mockReturnValue(mockFile);
@@ -327,10 +328,210 @@ describe('AgentViewUI', () => {
 
 			const event = await triggerDrop(dataTransfer);
 
-			// Should verify image processing or just return
-			// Since we mock isSupportedImageType to false implicitly (undefined), it might show "Unsupported" or do nothing
-			// But critically, it should NOT call handleDroppedFiles
+			// Should NOT call handleDroppedFiles for non-vault files
 			expect(callbacks.handleDroppedFiles).not.toHaveBeenCalled();
+		});
+
+		it('should route vault .png files as inline attachments (not context chips)', async () => {
+			const mockFile = {
+				path: 'images/photo.png',
+				name: 'photo.png',
+				extension: 'png',
+			} as unknown as TFile;
+			Object.setPrototypeOf(mockFile, TFile.prototype);
+
+			(app.vault.getAbstractFileByPath as jest.Mock).mockReturnValue(mockFile);
+			(app.vault.readBinary as jest.Mock).mockResolvedValue(new ArrayBuffer(100));
+
+			const droppedFile = {
+				path: '/Users/test/vault/images/photo.png',
+				name: 'photo.png',
+			};
+
+			const dataTransfer = {
+				files: [droppedFile],
+				types: ['Files'],
+			};
+			Object.defineProperty(dataTransfer.files, 'length', { value: 1 });
+			(dataTransfer.files as any)[Symbol.iterator] = function* () {
+				yield droppedFile;
+			};
+
+			await triggerDrop(dataTransfer);
+
+			// Should NOT be added as context chip (text)
+			expect(callbacks.handleDroppedFiles).not.toHaveBeenCalled();
+			// Should be added as inline attachment
+			expect(callbacks.addAttachment).toHaveBeenCalledTimes(1);
+			expect(callbacks.addAttachment).toHaveBeenCalledWith(
+				expect.objectContaining({
+					mimeType: 'image/png',
+					vaultPath: 'images/photo.png',
+					fileName: 'photo.png',
+				})
+			);
+		});
+
+		it('should route vault .md files as context chips (not attachments)', async () => {
+			const mockFile = {
+				path: 'notes/test.md',
+				name: 'test.md',
+				extension: 'md',
+			} as unknown as TFile;
+			Object.setPrototypeOf(mockFile, TFile.prototype);
+
+			(app.vault.getAbstractFileByPath as jest.Mock).mockReturnValue(mockFile);
+
+			const droppedFile = {
+				path: '/Users/test/vault/notes/test.md',
+				name: 'test.md',
+			};
+
+			const dataTransfer = {
+				files: [droppedFile],
+				types: ['Files'],
+			};
+			Object.defineProperty(dataTransfer.files, 'length', { value: 1 });
+			(dataTransfer.files as any)[Symbol.iterator] = function* () {
+				yield droppedFile;
+			};
+
+			await triggerDrop(dataTransfer);
+
+			// Should be added as context chip
+			expect(callbacks.handleDroppedFiles).toHaveBeenCalledWith([mockFile]);
+			// Should NOT be an inline attachment
+			expect(callbacks.addAttachment).not.toHaveBeenCalled();
+		});
+
+		it('should show Notice for unsupported file types like .zip', async () => {
+			const mockFile = {
+				path: 'files/archive.zip',
+				name: 'archive.zip',
+				extension: 'zip',
+			} as unknown as TFile;
+			Object.setPrototypeOf(mockFile, TFile.prototype);
+
+			(app.vault.getAbstractFileByPath as jest.Mock).mockReturnValue(mockFile);
+
+			const droppedFile = {
+				path: '/Users/test/vault/files/archive.zip',
+				name: 'archive.zip',
+			};
+
+			const dataTransfer = {
+				files: [droppedFile],
+				types: ['Files'],
+			};
+			Object.defineProperty(dataTransfer.files, 'length', { value: 1 });
+			(dataTransfer.files as any)[Symbol.iterator] = function* () {
+				yield droppedFile;
+			};
+
+			await triggerDrop(dataTransfer);
+
+			// Neither context chip nor attachment
+			expect(callbacks.handleDroppedFiles).not.toHaveBeenCalled();
+			expect(callbacks.addAttachment).not.toHaveBeenCalled();
+			// Should show unsupported notice
+			expect(Notice).toHaveBeenCalledWith(expect.stringContaining('unsupported'), expect.any(Number));
+		});
+
+		it('should handle mixed file types from folder expansion', async () => {
+			const mdFile = {
+				path: 'folder/note.md',
+				name: 'note.md',
+				extension: 'md',
+			} as unknown as TFile;
+			Object.setPrototypeOf(mdFile, TFile.prototype);
+
+			const pngFile = {
+				path: 'folder/image.png',
+				name: 'image.png',
+				extension: 'png',
+			} as unknown as TFile;
+			Object.setPrototypeOf(pngFile, TFile.prototype);
+
+			const zipFile = {
+				path: 'folder/archive.zip',
+				name: 'archive.zip',
+				extension: 'zip',
+			} as unknown as TFile;
+			Object.setPrototypeOf(zipFile, TFile.prototype);
+
+			// Create a mock folder with children
+			const mockFolder = {
+				path: 'folder',
+				children: [mdFile, pngFile, zipFile],
+			} as unknown as TFolder;
+			Object.setPrototypeOf(mockFolder, TFolder.prototype);
+
+			(app.vault.getAbstractFileByPath as jest.Mock).mockReturnValue(mockFolder);
+			(app.vault.readBinary as jest.Mock).mockResolvedValue(new ArrayBuffer(100));
+
+			const droppedFile = {
+				path: '/Users/test/vault/folder',
+				name: 'folder',
+			};
+
+			const dataTransfer = {
+				files: [droppedFile],
+				types: ['Files'],
+			};
+			Object.defineProperty(dataTransfer.files, 'length', { value: 1 });
+			(dataTransfer.files as any)[Symbol.iterator] = function* () {
+				yield droppedFile;
+			};
+
+			await triggerDrop(dataTransfer);
+
+			// Text file should be context chip
+			expect(callbacks.handleDroppedFiles).toHaveBeenCalledWith([mdFile]);
+			// PNG should be inline attachment
+			expect(callbacks.addAttachment).toHaveBeenCalledTimes(1);
+			expect(callbacks.addAttachment).toHaveBeenCalledWith(expect.objectContaining({ mimeType: 'image/png' }));
+			// Unsupported notice for .zip
+			expect(Notice).toHaveBeenCalledWith(expect.stringContaining('unsupported'), expect.any(Number));
+		});
+
+		it('should enforce cumulative size limit for binary attachments', async () => {
+			// Create a file that's just under the limit
+			const bigBuffer = new ArrayBuffer(21 * 1024 * 1024); // 21MB — over the 20MB limit
+
+			const bigFile = {
+				path: 'videos/big.mp4',
+				name: 'big.mp4',
+				extension: 'mp4',
+			} as unknown as TFile;
+			Object.setPrototypeOf(bigFile, TFile.prototype);
+
+			const smallFile = {
+				path: 'images/small.png',
+				name: 'small.png',
+				extension: 'png',
+			} as unknown as TFile;
+			Object.setPrototypeOf(smallFile, TFile.prototype);
+
+			// First file is small, second is big
+			(app.vault.getAbstractFileByPath as jest.Mock).mockReturnValueOnce(smallFile).mockReturnValueOnce(bigFile);
+
+			(app.vault.readBinary as jest.Mock)
+				.mockResolvedValueOnce(new ArrayBuffer(100)) // small file
+				.mockResolvedValueOnce(bigBuffer); // big file
+
+			// Drop small file first (via text links since we need both resolved)
+			const dataTransfer = {
+				files: [],
+				getData: jest.fn().mockReturnValue('[[images/small.png]]\n[[videos/big.mp4]]'),
+				types: ['text/plain'],
+			};
+
+			await triggerDrop(dataTransfer);
+
+			// Small file should be attached
+			expect(callbacks.addAttachment).toHaveBeenCalledTimes(1);
+			// Big file should be skipped, notice shown
+			expect(Notice).toHaveBeenCalledWith(expect.stringContaining('20MB'), expect.any(Number));
 		});
 	});
 });

--- a/test/ui/agent-view.test.ts
+++ b/test/ui/agent-view.test.ts
@@ -12,6 +12,22 @@ jest.mock('../../src/tools/execution-engine');
 jest.mock('../../src/ui/agent-view/file-picker-modal');
 jest.mock('../../src/ui/agent-view/session-settings-modal');
 
+// Mock external ESM dependencies
+jest.mock('@allenhutchison/gemini-utils', () => ({
+	ResearchManager: class {},
+	ReportGenerator: class {},
+	Interaction: class {},
+	EXTENSION_TO_MIME: {
+		'.md': 'text/markdown',
+		'.txt': 'text/plain',
+		'.pdf': 'application/pdf',
+	},
+	TEXT_FALLBACK_EXTENSIONS: new Set(['.ts', '.js', '.json', '.css']),
+}));
+jest.mock('@google/genai', () => ({
+	GoogleGenAI: class {},
+}));
+
 // Mock Obsidian
 jest.mock('obsidian', () => {
 	const mock = jest.requireActual('../../__mocks__/obsidian.js');
@@ -1048,12 +1064,12 @@ describe('AgentView UI Tests', () => {
 				update: jest.fn(),
 			};
 
-			// Mock image attachment support (added in image-paste feature)
-			(agentView as any).pendingImageAttachments = [];
+			// Mock attachment support
+			(agentView as any).pendingAttachments = [];
 			(agentView as any).imagePreviewContainer = document.createElement('div');
 			(agentView as any).ui = {
 				...((agentView as any).ui || {}),
-				updateImagePreview: jest.fn(),
+				updateAttachmentPreview: jest.fn(),
 			};
 
 			// Set cancellation flag (simulating previous stop)

--- a/test/utils/file-classification.test.ts
+++ b/test/utils/file-classification.test.ts
@@ -1,0 +1,176 @@
+import {
+	classifyFile,
+	FileCategory,
+	arrayBufferToBase64,
+	GEMINI_INLINE_DATA_LIMIT,
+	GEMINI_INLINE_BINARY_MIMES,
+} from '../../src/utils/file-classification';
+
+// Mock the gemini-utils module
+jest.mock('@allenhutchison/gemini-utils', () => ({
+	EXTENSION_TO_MIME: {
+		'.md': 'text/markdown',
+		'.txt': 'text/plain',
+		'.html': 'text/html',
+		'.pdf': 'application/pdf',
+		'.py': 'text/x-python',
+		'.c': 'text/x-c',
+	},
+	TEXT_FALLBACK_EXTENSIONS: new Set(['.ts', '.js', '.json', '.css', '.yaml', '.tsx', '.jsx', '.csv']),
+}));
+
+describe('file-classification', () => {
+	describe('classifyFile', () => {
+		it('should classify markdown files as TEXT', () => {
+			const result = classifyFile('md');
+			expect(result.category).toBe(FileCategory.TEXT);
+			expect(result.mimeType).toBe('text/markdown');
+		});
+
+		it('should classify .txt files as TEXT', () => {
+			const result = classifyFile('txt');
+			expect(result.category).toBe(FileCategory.TEXT);
+			expect(result.mimeType).toBe('text/plain');
+		});
+
+		it('should classify TypeScript files as TEXT via fallback', () => {
+			const result = classifyFile('ts');
+			expect(result.category).toBe(FileCategory.TEXT);
+			expect(result.mimeType).toBe('text/plain');
+		});
+
+		it('should classify JSON files as TEXT via fallback', () => {
+			const result = classifyFile('json');
+			expect(result.category).toBe(FileCategory.TEXT);
+			expect(result.mimeType).toBe('text/plain');
+		});
+
+		it('should classify .png as GEMINI_BINARY', () => {
+			const result = classifyFile('png');
+			expect(result.category).toBe(FileCategory.GEMINI_BINARY);
+			expect(result.mimeType).toBe('image/png');
+		});
+
+		it('should classify .jpg as GEMINI_BINARY', () => {
+			const result = classifyFile('jpg');
+			expect(result.category).toBe(FileCategory.GEMINI_BINARY);
+			expect(result.mimeType).toBe('image/jpeg');
+		});
+
+		it('should classify .pdf as GEMINI_BINARY', () => {
+			const result = classifyFile('pdf');
+			expect(result.category).toBe(FileCategory.GEMINI_BINARY);
+			expect(result.mimeType).toBe('application/pdf');
+		});
+
+		it('should classify .mp3 as GEMINI_BINARY', () => {
+			const result = classifyFile('mp3');
+			expect(result.category).toBe(FileCategory.GEMINI_BINARY);
+			expect(result.mimeType).toBe('audio/mp3');
+		});
+
+		it('should classify .mp4 as GEMINI_BINARY', () => {
+			const result = classifyFile('mp4');
+			expect(result.category).toBe(FileCategory.GEMINI_BINARY);
+			expect(result.mimeType).toBe('video/mp4');
+		});
+
+		it('should classify .wav as GEMINI_BINARY', () => {
+			const result = classifyFile('wav');
+			expect(result.category).toBe(FileCategory.GEMINI_BINARY);
+			expect(result.mimeType).toBe('audio/wav');
+		});
+
+		it('should classify .webm as GEMINI_BINARY', () => {
+			const result = classifyFile('webm');
+			expect(result.category).toBe(FileCategory.GEMINI_BINARY);
+			expect(result.mimeType).toBe('video/webm');
+		});
+
+		it('should classify .zip as UNSUPPORTED', () => {
+			const result = classifyFile('zip');
+			expect(result.category).toBe(FileCategory.UNSUPPORTED);
+			expect(result.mimeType).toBe('');
+			expect(result.reason).toContain('zip');
+		});
+
+		it('should classify .exe as UNSUPPORTED', () => {
+			const result = classifyFile('exe');
+			expect(result.category).toBe(FileCategory.UNSUPPORTED);
+		});
+
+		it('should classify .dmg as UNSUPPORTED', () => {
+			const result = classifyFile('dmg');
+			expect(result.category).toBe(FileCategory.UNSUPPORTED);
+		});
+
+		it('should be case insensitive', () => {
+			expect(classifyFile('PNG').category).toBe(FileCategory.GEMINI_BINARY);
+			expect(classifyFile('MD').category).toBe(FileCategory.TEXT);
+			expect(classifyFile('Pdf').category).toBe(FileCategory.GEMINI_BINARY);
+		});
+
+		it('should handle extension without dot', () => {
+			// Extension passed without dot (as TFile.extension provides)
+			const result = classifyFile('md');
+			expect(result.category).toBe(FileCategory.TEXT);
+		});
+
+		it('should prioritize binary classification over text for PDF', () => {
+			// PDF is in both GEMINI_INLINE_BINARY_MIMES and EXTENSION_TO_MIME
+			// Binary should win since we check it first
+			const result = classifyFile('pdf');
+			expect(result.category).toBe(FileCategory.GEMINI_BINARY);
+		});
+	});
+
+	describe('arrayBufferToBase64', () => {
+		it('should convert empty buffer', () => {
+			const buffer = new ArrayBuffer(0);
+			expect(arrayBufferToBase64(buffer)).toBe('');
+		});
+
+		it('should convert simple byte array', () => {
+			const buffer = new Uint8Array([72, 101, 108, 108, 111]).buffer; // "Hello"
+			const base64 = arrayBufferToBase64(buffer);
+			expect(base64).toBe(btoa('Hello'));
+		});
+
+		it('should handle binary data with high bytes', () => {
+			const buffer = new Uint8Array([0, 128, 255]).buffer;
+			const result = arrayBufferToBase64(buffer);
+			// Verify it's valid base64
+			expect(() => atob(result)).not.toThrow();
+		});
+	});
+
+	describe('constants', () => {
+		it('should define 20MB inline data limit', () => {
+			expect(GEMINI_INLINE_DATA_LIMIT).toBe(20 * 1024 * 1024);
+		});
+
+		it('should include all expected image types', () => {
+			expect(GEMINI_INLINE_BINARY_MIMES['png']).toBe('image/png');
+			expect(GEMINI_INLINE_BINARY_MIMES['jpg']).toBe('image/jpeg');
+			expect(GEMINI_INLINE_BINARY_MIMES['jpeg']).toBe('image/jpeg');
+			expect(GEMINI_INLINE_BINARY_MIMES['gif']).toBe('image/gif');
+			expect(GEMINI_INLINE_BINARY_MIMES['webp']).toBe('image/webp');
+		});
+
+		it('should include audio types', () => {
+			expect(GEMINI_INLINE_BINARY_MIMES['mp3']).toBe('audio/mp3');
+			expect(GEMINI_INLINE_BINARY_MIMES['wav']).toBe('audio/wav');
+			expect(GEMINI_INLINE_BINARY_MIMES['flac']).toBe('audio/flac');
+		});
+
+		it('should include video types', () => {
+			expect(GEMINI_INLINE_BINARY_MIMES['mp4']).toBe('video/mp4');
+			expect(GEMINI_INLINE_BINARY_MIMES['webm']).toBe('video/webm');
+			expect(GEMINI_INLINE_BINARY_MIMES['mov']).toBe('video/mov');
+		});
+
+		it('should include PDF', () => {
+			expect(GEMINI_INLINE_BINARY_MIMES['pdf']).toBe('application/pdf');
+		});
+	});
+});


### PR DESCRIPTION
Implemented drag-and-drop functionality for the Scribe chat window. Users can now drag files or folders from the Obsidian vault (side pane or OS explorer) into the chat input to add them to the context as chips. 

- Handles drops of `File` objects by verifying they reside within the vault path.
- Handles internal drops (which provide text links) by parsing Wikilinks (`[[...]]`) and Markdown links (`[...](...)`).
- Supports dragging multiple files and folders.
- Integrates with the existing chip system (`insertFileChip`, `insertFolderChip`).
- Falls back to existing image attachment logic for non-vault external images.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Drag-and-drop now accepts vault files, folders, OS files and internal links; supports many file types with inline/attachment routing, previews (icons/thumbnails), size limits, deduplication, and per-file notices for exclusions or unsupported types.
* **Breaking Changes**
  * UI callbacks and flows moved from image-centric to attachment-centric (addAttachment, getAttachments, handleDroppedFiles).
* **Tests**
  * Comprehensive unit tests covering drops, path normalization, dedupe, exclusion rules, and classification.
* **Documentation**
  * User guide updated from image support to general file attachments and new size/privacy notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->