### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - '*'
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -22,6 +25,8 @@ jobs:
   build:
     needs: test
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Potential fix for [https://github.com/allenhutchison/obsidian-gemini/security/code-scanning/1](https://github.com/allenhutchison/obsidian-gemini/security/code-scanning/1)

In general, the fix is to add an explicit `permissions:` block to the workflow so the GITHUB_TOKEN used by jobs has only the minimal permissions required. We can define a restrictive default at the top of the workflow (applies to all jobs), and then override it for specific jobs that need additional access.

For this workflow, the `test` job only checks out code, installs dependencies, and runs tests, so it should only need read access to repository contents. The `build` job also checks out and builds, but the `Create release` step uses `gh release create`, which needs permission to write releases (a subset of repository contents write). The most precise and least-privilege setup is:
- At the workflow root: `permissions: contents: read` so both jobs default to read-only.
- For the `build` job specifically: add a `permissions:` block with `contents: write` so that `gh release create` can create a release while not granting any other unnecessary scopes.

This preserves existing behavior (releases can still be created) while constraining the token for all steps and documenting the needed scopes. All changes are confined to `.github/workflows/release.yml`, adding YAML keys in the appropriate locations; no imports or additional methods are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow permissions configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->