### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Potential fix for [https://github.com/allenhutchison/obsidian-gemini/security/code-scanning/2](https://github.com/allenhutchison/obsidian-gemini/security/code-scanning/2)

In general, the fix is to add an explicit `permissions` block that grants only the minimal required scopes for each job. For jobs that only need to read repository contents (e.g., for checking out code, running tests, and uploading artifacts) you can typically set `permissions: contents: read` or even `permissions: read-all`. For jobs that must push to branches (like deploying to `gh-pages`), you grant `contents: write` as already done for `deploy-coverage-report`.

For this workflow, the minimal change that aligns with existing behavior and keeps functionality intact is to add a `permissions` block to the `test` job. The `test` job only checks out the code, sets up Node, installs dependencies, runs shell commands, runs tests, and uploads an artifact. None of these steps require write access to the repository; `actions/upload-artifact` stores artifacts in the Actions storage backend and does not need `contents: write`. Therefore, we can safely set `permissions: contents: read` for the `test` job. We will insert this block directly under `runs-on: ubuntu-latest` for the `test` job in `.github/workflows/ci.yml`, leaving the existing `deploy-coverage-report` job and its `permissions: contents: write` unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced security configuration in the continuous integration workflow by updating access control permissions to align with best practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->