### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js
@@ -22,6 +24,8 @@ jobs:
   build:
     needs: test
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Potential fix for [https://github.com/allenhutchison/obsidian-gemini/security/code-scanning/3](https://github.com/allenhutchison/obsidian-gemini/security/code-scanning/3)

In general, to fix this issue you should explicitly specify a `permissions` block either at the workflow level or for each job, granting only the scopes actually needed. Jobs that only need to read repository contents (e.g., running tests) should get `contents: read`. Jobs that create releases should get the minimal write scopes required, such as `contents: write` (for release assets) and optionally `issues: write` or `pull-requests: write` if they truly need them.

For this specific workflow, the best minimal fix without changing functionality is:
- Add a `permissions` block to the `test` job that limits the token to `contents: read`, since it only checks out code and runs npm commands.
- Add a `permissions` block to the `build` job that allows creating a release. The GitHub CLI `gh release create` uses the GITHUB_TOKEN to talk to the Releases API, which is governed by `contents: write` (releases are tied to repo contents). We do not see any need for other write scopes in the snippet, so we restrict to `contents: write`.

Concretely:
- Edit `.github/workflows/release.yml`.
- Under `jobs.test:` add:

```yaml
    permissions:
      contents: read
```

- Under `jobs.build:` add:

```yaml
    permissions:
      contents: write
```

No imports or additional methods are required because this is a YAML workflow configuration change only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions release workflow with explicit permission configurations to enhance security and operational clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->