### PR TITLE
Potential fix for code scanning alert no. 4: Bad HTML filtering regexp

### DIFF
--- a/src/tools/web-fetch-tool.ts
+++ b/src/tools/web-fetch-tool.ts
@@ -221,9 +221,9 @@ export class WebFetchTool implements Tool {
 			// Convert HTML to text (basic conversion)
 			let content = response.text;
 
-			// Remove script and style tags
-			content = content.replace(/<script[^>]*>[\s\S]*?<\/script>/gi, '');
-			content = content.replace(/<style[^>]*>[\s\S]*?<\/style>/gi, '');
+			// Remove script and style tags (handle tolerant HTML end tags like </script foo="bar">)
+			content = content.replace(/<script\b[^>]*>[\s\S]*?<\/script\b[^>]*>/gi, '');
+			content = content.replace(/<style\b[^>]*>[\s\S]*?<\/style\b[^>]*>/gi, '');
 
 			// Extract title
 			const titleMatch = content.match(/<title[^>]*>([^<]+)<\/title>/i);


### PR DESCRIPTION
Potential fix for [https://github.com/allenhutchison/obsidian-gemini/security/code-scanning/4](https://github.com/allenhutchison/obsidian-gemini/security/code-scanning/4)

**General approach**

Avoid hand-rolled HTML parsing with fragile regexes. When you must use regex, make it robust enough to handle common browser-tolerated syntax variations for the specific tag type, or better, use a real HTML parser/sanitizer.

**Best concrete fix here**

We want to keep functionality (strip script and style blocks before tag-stripping), but adjust the regexes so they match end tags with optional trailing attributes/whitespace, and are case-insensitive. We can:

- Keep the existing `gi` flags.
- For scripts, change `</script>` to something that matches:
  - optional whitespace after `/script`
  - optional attributes or junk before `>`
  
  Example: `</script\b[^>]*>`.

- Do the analogous change for styles: `</style\b[^>]*>`.

This keeps the basic approach (regex-based stripping) but aligns better with what browsers will treat as end tags. No new imports or libraries are required, and we stay within the shown code.

Concretely:

- In `src/tools/web-fetch-tool.ts`, lines:
  - `content = content.replace(/<script[^>]*>[\s\S]*?<\/script>/gi, '');`
  - `content = content.replace(/<style[^>]*>[\s\S]*?<\/style>/gi, '');`
- Update them to:
  - `content = content.replace(/<script\b[^>]*>[\s\S]*?<\/script\b[^>]*>/gi, '');`
  - `content = content.replace(/<style\b[^>]*>[\s\S]*?<\/style\b[^>]*>/gi, '');`

We also add `\b` after `script`/`style` on the opening tags to avoid accidentally matching tags like `<scripting>`.

No other code or imports need to change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTML cleanup to more reliably remove script and style blocks with varied end-tag formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->