### PR TITLE
fix: Start RAG indexing when toggled without requiring plugin reload

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -919,8 +919,14 @@ export default class ObsidianGemini extends Plugin {
 		if (this.isGeminiInitialized && this.app.workspace.layoutReady) {
 			const ragStateChanged = this.previousRagEnabled !== this.settings.ragIndexing.enabled;
 			if (ragStateChanged) {
-				this.previousRagEnabled = this.settings.ragIndexing.enabled;
+				const nextRagEnabled = this.settings.ragIndexing.enabled;
 				await this.initializeRagIndexing();
+
+				// Advance tracker only if runtime state now matches requested state
+				const transitioned = nextRagEnabled ? this.ragIndexing !== null : this.ragIndexing === null;
+				if (transitioned) {
+					this.previousRagEnabled = nextRagEnabled;
+				}
 			}
 		}
 


### PR DESCRIPTION
## Summary

On a fresh install, after linking an API key and then enabling RAG indexing in settings, RAG doesn't start until the plugin is manually reloaded. This tracks the RAG enabled state change in `saveSettings()` so `initializeRagIndexing()` is called independently of the full `setupGeminiScribe()` re-initialization path.

Fixes #381

## Changes

- Add `previousRagEnabled` field to track RAG enabled state across settings saves (mirrors existing `previousApiKey` pattern)
- Initialize `previousRagEnabled` after successful setup in `onload()` and after API-key-triggered re-initialization
- Detect RAG state changes in `saveSettings()` and call `initializeRagIndexing()` directly when the toggle changes, without requiring a full plugin teardown/rebuild

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards)
- [x] Documentation has been updated (if applicable)
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * RAG indexing settings now apply immediately without requiring a full plugin restart.
  * Toggling RAG indexing is more responsive and takes effect after initial load or when settings are saved.
  * State changes are handled only when the system is initialized and layout is ready, keeping behavior stable.
  * Reapplying settings keeps RAG indexing state synchronized without a full reinitialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->