### PR TITLE
fix: Change default chat model to Flash

### DIFF
--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -66,11 +66,11 @@ All models are selected from available Gemini models. The plugin supports dynami
 
 - **Setting**: `chatModelName`
 - **Type**: String
-- **Default**: `gemini-2.5-pro`
+- **Default**: `gemini-flash-latest`
 - **Description**: Model used for agent chat conversations
 - **Available Models**:
-  - `gemini-2.5-pro` - Gemini 2.5 Pro (most capable, default for chat)
-  - `gemini-flash-latest` - Gemini Flash Latest (fast and efficient)
+  - `gemini-flash-latest` - Gemini Flash Latest (fast and efficient, default for chat)
+  - `gemini-2.5-pro` - Gemini 2.5 Pro (most capable, requires billing)
   - `gemini-flash-lite-latest` - Gemini Flash Lite Latest (lightweight)
   - `gemini-3-pro-preview` - Gemini 3 Pro Preview (experimental)
 - **Note**: Model discovery automatically fetches the latest available models from Google's API

--- a/src/models.ts
+++ b/src/models.ts
@@ -8,8 +8,8 @@ export interface GeminiModel {
 }
 
 export const DEFAULT_GEMINI_MODELS: GeminiModel[] = [
-	{ value: 'gemini-2.5-pro', label: 'Gemini 2.5 Pro', defaultForRoles: ['chat'] },
-	{ value: 'gemini-flash-latest', label: 'Gemini Flash Latest', defaultForRoles: ['summary', 'rewrite'] },
+	{ value: 'gemini-2.5-pro', label: 'Gemini 2.5 Pro' },
+	{ value: 'gemini-flash-latest', label: 'Gemini Flash Latest', defaultForRoles: ['chat', 'summary', 'rewrite'] },
 	{ value: 'gemini-flash-lite-latest', label: 'Gemini Flash Lite Latest', defaultForRoles: ['completions'] },
 	{ value: 'gemini-3-pro-preview', label: 'Gemini 3 Pro Preview' },
 	{


### PR DESCRIPTION
## Summary

Change the default chat model from `gemini-2.5-pro` to `gemini-flash-latest` so new users on free API keys don't get errors on first use. Fixes #393.

## Changes

- Move `defaultForRoles: ['chat']` from `gemini-2.5-pro` to `gemini-flash-latest` in `src/models.ts`
- Update `docs/reference/settings.md` to reflect the new default and note that Pro requires billing
- `gemini-2.5-pro` remains in the model list — users with billing can still select it
- Existing users with Pro already saved in settings are not affected

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer — Fixes #393
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A, model default change only
- [x] Documentation has been updated (if applicable)
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated default AI model to a faster, more efficient option for better performance
  * Refreshed model descriptions to clarify billing requirements and reflect the new default model

<!-- end of auto-generated comment: release notes by coderabbit.ai -->