### PR TITLE
fix: Improve context token tracking reliability and display

### DIFF
--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -142,7 +142,8 @@ Context management automatically monitors and controls conversation size to prev
 - **Type**: Boolean
 - **Default**: `false`
 - **Description**: Display estimated token count in the agent input area
-- **Display format**: `Tokens: ~N / M (X%)` showing current usage, model limit, and percentage
+- **Display format**: `Tokens: ~N (Y new) / M (X%)` showing total prompt tokens, uncached (new) tokens, model limit, and percentage used
+- **How it works**: Token counts update live after each API response, including during tool call chains. Gemini's implicit caching means repeated content (system prompt, tool definitions) is served from cache — the "new" count shows tokens that aren't cached
 - **Visual indicators**:
   - Normal (muted text) — well under threshold
   - Yellow — approaching compaction threshold (≥80% of threshold)

--- a/src/api/gemini-client.ts
+++ b/src/api/gemini-client.ts
@@ -151,7 +151,16 @@ export class GeminiClient implements ModelApi {
 					// Capture usageMetadata from chunks (usually present in last chunk)
 					if (chunk.usageMetadata) {
 						lastUsageMetadata = chunk.usageMetadata;
+						this.plugin?.logger.debug(
+							`[GeminiClient] Captured usageMetadata from streaming chunk: ` +
+								`prompt=${(chunk.usageMetadata as any).promptTokenCount}, ` +
+								`total=${(chunk.usageMetadata as any).totalTokenCount}`
+						);
 					}
+				}
+
+				if (!lastUsageMetadata) {
+					this.plugin?.logger.debug('[GeminiClient] No usageMetadata received from any streaming chunk');
 				}
 
 				return {

--- a/src/services/context-manager.ts
+++ b/src/services/context-manager.ts
@@ -53,12 +53,16 @@ export interface TokenUsageInfo {
 	inputTokenLimit: number;
 	/** Percentage of limit used */
 	percentUsed: number;
+	/** Tokens served from Gemini's implicit cache */
+	cachedTokens: number;
 }
 
 export interface UsageMetadata {
 	promptTokenCount?: number;
 	candidatesTokenCount?: number;
 	totalTokenCount?: number;
+	cachedContentTokenCount?: number;
+	thoughtsTokenCount?: number;
 }
 
 /**
@@ -67,6 +71,7 @@ export interface UsageMetadata {
  */
 export class ContextManager {
 	private lastUsageMetadata: UsageMetadata | null = null;
+	private acceptNextLowerUpdate = false;
 	private ai: GoogleGenAI;
 
 	constructor(
@@ -77,14 +82,48 @@ export class ContextManager {
 	}
 
 	/**
+	 * Signal the start of a new turn. The next updateUsageMetadata call
+	 * will accept a lower value (resetting the counter to the new turn's
+	 * actual prompt size). Subsequent updates within the turn still use
+	 * high-water mark so the counter only goes up during tool calls.
+	 */
+	beginTurn(): void {
+		this.acceptNextLowerUpdate = true;
+		this.logger.debug('[ContextManager] Begin turn — will accept next lower update');
+	}
+
+	/**
 	 * Update the cached usage metadata from an API response.
-	 * This is essentially free — metadata comes with every response.
+	 * Uses high-water mark within a turn: only accepts higher promptTokenCount
+	 * unless beginTurn() was called (which allows one lower update to reset the baseline).
+	 * Use setUsageMetadata() to unconditionally force a value (e.g. after compaction).
 	 */
 	updateUsageMetadata(metadata: UsageMetadata): void {
+		if (!metadata) return;
+
+		const newPrompt = metadata.promptTokenCount ?? 0;
+		const cachedPrompt = this.lastUsageMetadata?.promptTokenCount ?? 0;
+
+		if (newPrompt >= cachedPrompt || this.acceptNextLowerUpdate) {
+			this.lastUsageMetadata = { ...metadata };
+			this.acceptNextLowerUpdate = false;
+			this.logger.log(
+				`[ContextManager] Updated usage metadata: prompt=${metadata.promptTokenCount}, total=${metadata.totalTokenCount}`
+			);
+		} else {
+			this.logger.debug(`[ContextManager] Skipped lower metadata: prompt=${newPrompt} < cached=${cachedPrompt}`);
+		}
+	}
+
+	/**
+	 * Force-set usage metadata, bypassing the high-water mark check.
+	 * Used after compaction or when counting tokens from history.
+	 */
+	setUsageMetadata(metadata: UsageMetadata): void {
 		if (metadata) {
 			this.lastUsageMetadata = { ...metadata };
 			this.logger.log(
-				`[ContextManager] Updated usage metadata: prompt=${metadata.promptTokenCount}, total=${metadata.totalTokenCount}`
+				`[ContextManager] Force-set usage metadata: prompt=${metadata.promptTokenCount}, total=${metadata.totalTokenCount}`
 			);
 		}
 	}
@@ -134,10 +173,12 @@ export class ContextManager {
 	async getTokenUsage(modelName: string): Promise<TokenUsageInfo> {
 		const inputTokenLimit = await this.getInputTokenLimit(modelName);
 		const estimatedTokens = this.lastUsageMetadata?.promptTokenCount ?? 0;
+		const cachedTokens = this.lastUsageMetadata?.cachedContentTokenCount ?? 0;
 		return {
 			estimatedTokens,
 			inputTokenLimit,
 			percentUsed: inputTokenLimit > 0 ? Math.round((estimatedTokens / inputTokenLimit) * 100 * 10) / 10 : 0,
+			cachedTokens,
 		};
 	}
 
@@ -295,10 +336,10 @@ export class ContextManager {
 
 		// Ensure we don't split in the middle of a tool exchange (functionCall/functionResponse pair)
 		// Scan backward to find a safe boundary at the start of a user turn
+		// History entries may use parts[].text (API format) or message (stored format)
 		while (splitIndex > 0 && splitIndex < totalTurns) {
 			const entry = conversationHistory[splitIndex];
-			// Safe to split if this entry is a user message (starts a new turn)
-			if (entry.role === 'user' && entry.parts?.[0]?.text) {
+			if (entry.role === 'user' && (entry.parts?.[0]?.text || entry.message || entry.text)) {
 				break;
 			}
 			splitIndex--;
@@ -408,5 +449,6 @@ export class ContextManager {
 	 */
 	reset(): void {
 		this.lastUsageMetadata = null;
+		this.logger.debug('[ContextManager] Usage metadata reset');
 	}
 }

--- a/src/ui/agent-view/agent-view.ts
+++ b/src/ui/agent-view/agent-view.ts
@@ -162,7 +162,10 @@ export class AgentView extends ItemView {
 			hideProgress: () => this.progress.hide(),
 			displayMessage: (entry: GeminiConversationEntry) => this.displayMessage(entry),
 			autoLabelSessionIfNeeded: () => this.autoLabelSessionIfNeeded(),
-			onUsageMetadata: (metadata) => this.plugin.contextManager?.updateUsageMetadata(metadata),
+			onUsageMetadata: (metadata) => {
+				this.plugin.contextManager?.updateUsageMetadata(metadata);
+				this.updateTokenUsage();
+			},
 		};
 		this.tools = new AgentViewTools(this.app, this.chatContainer, this.plugin, toolsContext);
 
@@ -405,11 +408,21 @@ To reference an attachment in your response, use the path shown above.`;
 				const modelConfig = this.currentSession?.modelConfig || {};
 				const modelName = modelConfig.model || this.plugin.settings.chatModelName;
 
+				// Signal new turn so the token counter accepts the fresh prompt size
+				this.plugin.contextManager.beginTurn();
+
 				// Prepare history through context manager (may compact if over threshold)
 				const compactionResult = await this.plugin.contextManager.prepareHistory(conversationHistory, modelName);
 
 				// If compaction occurred, show notification and save summary to transcript
 				if (compactionResult.wasCompacted && compactionResult.summaryText) {
+					// Force-set the lower post-compaction token count (bypasses high-water mark)
+					this.plugin.contextManager.setUsageMetadata({
+						promptTokenCount: compactionResult.estimatedTokens,
+						totalTokenCount: compactionResult.estimatedTokens,
+					});
+					await this.updateTokenUsage();
+
 					const compactionEntry: GeminiConversationEntry = {
 						role: 'model',
 						message: `> [!info] Context Compacted\n> Older conversation turns have been summarized to maintain performance.\n\n${compactionResult.summaryText}`,
@@ -489,9 +502,12 @@ To reference an attachment in your response, use the path shown above.`;
 						const response = await streamResponse.complete;
 						this.currentStreamingResponse = null;
 
-						// Update context manager with usage metadata from response
+						// Update context manager and display with usage metadata from response
 						if (response.usageMetadata) {
 							this.plugin.contextManager.updateUsageMetadata(response.usageMetadata);
+							await this.updateTokenUsage();
+						} else {
+							this.plugin.logger.debug('[AgentView] Streaming response had no usageMetadata');
 						}
 
 						// Check if the model requested tool calls
@@ -592,9 +608,12 @@ To reference an attachment in your response, use the path shown above.`;
 					this.plugin.logger.log('Agent view using non-streaming API');
 					const response = await modelApi.generateModelResponse(request);
 
-					// Update context manager with usage metadata from response
+					// Update context manager and display with usage metadata from response
 					if (response.usageMetadata) {
 						this.plugin.contextManager.updateUsageMetadata(response.usageMetadata);
+						await this.updateTokenUsage();
+					} else {
+						this.plugin.logger.debug('[AgentView] Non-streaming response had no usageMetadata');
 					}
 
 					// Update progress to show response received
@@ -1075,7 +1094,10 @@ To reference an attachment in your response, use the path shown above.`;
 			hideProgress: () => this.progress.hide(),
 			displayMessage: (entry: GeminiConversationEntry) => this.displayMessage(entry),
 			autoLabelSessionIfNeeded: () => this.autoLabelSessionIfNeeded(),
-			onUsageMetadata: (metadata) => this.plugin.contextManager?.updateUsageMetadata(metadata),
+			onUsageMetadata: (metadata) => {
+				this.plugin.contextManager?.updateUsageMetadata(metadata);
+				this.updateTokenUsage();
+			},
 		};
 
 		this.tools = new AgentViewTools(this.app, this.chatContainer, this.plugin, toolsContext);
@@ -1084,6 +1106,7 @@ To reference an attachment in your response, use the path shown above.`;
 	/**
 	 * Updates the token usage display if the setting is enabled.
 	 * Uses cached usageMetadata from the latest API response for fast, reliable updates.
+	 * Falls back to countTokens API if no cached metadata is available.
 	 */
 	private async updateTokenUsage(): Promise<void> {
 		if (!this.plugin.contextManager || !this.plugin.settings.showTokenUsage || !this.tokenUsageContainer) {
@@ -1095,9 +1118,25 @@ To reference an attachment in your response, use the path shown above.`;
 
 		try {
 			const modelName = this.currentSession?.modelConfig?.model || this.plugin.settings.chatModelName;
-			const usage = await this.plugin.contextManager.getTokenUsage(modelName);
+			let usage = await this.plugin.contextManager.getTokenUsage(modelName);
 
-			// If no cached data yet (e.g., new session, first load), hide the display
+			// If no cached data, try counting from conversation history as fallback
+			if (usage.estimatedTokens === 0 && this.currentSession) {
+				const conversationHistory = await this.plugin.sessionHistory.getHistoryForSession(this.currentSession);
+				if (conversationHistory && conversationHistory.length > 0) {
+					this.plugin.logger.debug('[AgentView] No cached token usage, falling back to countTokens API');
+					const tokenCount = await this.plugin.contextManager.countTokens(modelName, conversationHistory);
+					if (tokenCount > 0) {
+						this.plugin.contextManager.setUsageMetadata({
+							promptTokenCount: tokenCount,
+							totalTokenCount: tokenCount,
+						});
+						usage = await this.plugin.contextManager.getTokenUsage(modelName);
+					}
+				}
+			}
+
+			// Still no data (e.g., new session with no messages)
 			if (usage.estimatedTokens === 0) {
 				this.tokenUsageContainer.style.display = 'none';
 				return;
@@ -1107,7 +1146,12 @@ To reference an attachment in your response, use the path shown above.`;
 			this.tokenUsageContainer.empty();
 
 			const tokenText = this.tokenUsageContainer.createSpan({ cls: 'gemini-agent-token-text' });
-			tokenText.textContent = `Tokens: ~${usage.estimatedTokens.toLocaleString()} / ${usage.inputTokenLimit.toLocaleString()} (${usage.percentUsed}%)`;
+			const uncached = usage.estimatedTokens - usage.cachedTokens;
+			if (usage.cachedTokens > 0) {
+				tokenText.textContent = `Tokens: ~${usage.estimatedTokens.toLocaleString()} (${uncached.toLocaleString()} new) / ${usage.inputTokenLimit.toLocaleString()} (${usage.percentUsed}%)`;
+			} else {
+				tokenText.textContent = `Tokens: ~${usage.estimatedTokens.toLocaleString()} / ${usage.inputTokenLimit.toLocaleString()} (${usage.percentUsed}%)`;
+			}
 
 			// Add warning class if approaching threshold
 			const threshold = this.plugin.settings.contextCompactionThreshold;
@@ -1142,7 +1186,7 @@ To reference an attachment in your response, use the path shown above.`;
 			if (conversationHistory && conversationHistory.length > 0) {
 				const tokenCount = await this.plugin.contextManager.countTokens(modelName, conversationHistory);
 				if (tokenCount > 0) {
-					this.plugin.contextManager.updateUsageMetadata({
+					this.plugin.contextManager.setUsageMetadata({
 						promptTokenCount: tokenCount,
 						totalTokenCount: tokenCount,
 					});

--- a/styles.css
+++ b/styles.css
@@ -2198,6 +2198,7 @@ If your plugin does not need CSS, delete this file.
 	font-weight: 500;
 	white-space: nowrap;
 	flex-shrink: 0;
+	margin-left: auto;
 }
 
 .gemini-tool-row-status-running {

--- a/test/services/context-manager.test.ts
+++ b/test/services/context-manager.test.ts
@@ -81,6 +81,53 @@ describe('ContextManager', () => {
 			contextManager.updateUsageMetadata(null as any);
 			// Should not throw
 		});
+
+		test('should use high-water mark and reject lower promptTokenCount within a turn', async () => {
+			contextManager.updateUsageMetadata({ promptTokenCount: 10000, totalTokenCount: 12000 });
+			contextManager.updateUsageMetadata({ promptTokenCount: 5000, totalTokenCount: 6000 });
+
+			const usage = await contextManager.getTokenUsage('gemini-2.5-flash');
+			expect(usage.estimatedTokens).toBe(10000);
+			expect(mockLogger.debug).toHaveBeenCalledWith(expect.stringContaining('Skipped lower metadata'));
+		});
+
+		test('should accept equal promptTokenCount', async () => {
+			contextManager.updateUsageMetadata({ promptTokenCount: 10000, totalTokenCount: 12000 });
+			contextManager.updateUsageMetadata({ promptTokenCount: 10000, totalTokenCount: 13000 });
+
+			const usage = await contextManager.getTokenUsage('gemini-2.5-flash');
+			expect(usage.estimatedTokens).toBe(10000);
+		});
+
+		test('should accept lower value after beginTurn', async () => {
+			contextManager.updateUsageMetadata({ promptTokenCount: 30000, totalTokenCount: 35000 });
+			contextManager.beginTurn();
+			contextManager.updateUsageMetadata({ promptTokenCount: 20000, totalTokenCount: 22000 });
+
+			const usage = await contextManager.getTokenUsage('gemini-2.5-flash');
+			expect(usage.estimatedTokens).toBe(20000);
+		});
+
+		test('should re-enable high-water mark after first update in new turn', async () => {
+			contextManager.updateUsageMetadata({ promptTokenCount: 30000, totalTokenCount: 35000 });
+			contextManager.beginTurn();
+			contextManager.updateUsageMetadata({ promptTokenCount: 20000, totalTokenCount: 22000 });
+			// Now high-water mark should be back in effect
+			contextManager.updateUsageMetadata({ promptTokenCount: 15000, totalTokenCount: 16000 });
+
+			const usage = await contextManager.getTokenUsage('gemini-2.5-flash');
+			expect(usage.estimatedTokens).toBe(20000);
+		});
+	});
+
+	describe('setUsageMetadata', () => {
+		test('should force-set metadata even if lower than cached', async () => {
+			contextManager.updateUsageMetadata({ promptTokenCount: 50000, totalTokenCount: 60000 });
+			contextManager.setUsageMetadata({ promptTokenCount: 5000, totalTokenCount: 6000 });
+
+			const usage = await contextManager.getTokenUsage('gemini-2.5-flash');
+			expect(usage.estimatedTokens).toBe(5000);
+		});
 	});
 
 	describe('getTokenUsage', () => {
@@ -239,6 +286,26 @@ describe('ContextManager', () => {
 			const history = Array.from({ length: 20 }, (_, i) => ({
 				role: i % 2 === 0 ? 'user' : 'model',
 				parts: [{ text: `Message ${i}` }],
+			}));
+
+			const result = await contextManager.prepareHistory(history, 'gemini-2.5-flash');
+
+			expect(result.wasCompacted).toBe(true);
+			expect(result.summaryText).toBeTruthy();
+			expect(result.compactedHistory.length).toBeLessThan(history.length);
+		});
+
+		test('should compact history entries with message format (stored sessions)', async () => {
+			contextManager.updateUsageMetadata({
+				promptTokenCount: 250_000,
+				totalTokenCount: 300_000,
+			});
+			mockCountTokens.mockResolvedValue({ totalTokens: 50_000 });
+
+			// Simulate stored session format: entries use 'message' field, not 'parts'
+			const history = Array.from({ length: 20 }, (_, i) => ({
+				role: i % 2 === 0 ? 'user' : 'model',
+				message: `Message ${i}`,
 			}));
 
 			const result = await contextManager.prepareHistory(history, 'gemini-2.5-flash');


### PR DESCRIPTION
## Summary

Fixes multiple issues with the token usage counter in the agent view that prevented it from updating reliably between turns and during tool execution. Also fixes a critical bug where context compaction produced empty summaries due to a format mismatch.

Follows up on #402 and #405.

## Changes

- **countTokens fallback**: When streaming responses lack `usageMetadata`, falls back to the countTokens API using stored conversation history
- **Live token updates**: Counter now refreshes after each tool call response, not just at turn end — gives real-time feedback during tool chains
- **High-water mark with turn boundaries**: Within a turn, the counter only increases (avoids confusing drops from ephemeral tool context). At the start of each new turn, `beginTurn()` resets the baseline so the counter reflects the actual prompt size
- **Cached token breakdown**: Display now shows `Tokens: ~N (Y new) / M (X%)` separating Gemini's implicit cache hits from new tokens, making context growth more visible
- **Fix compaction split boundary**: The split logic checked `entry.parts?.[0]?.text` but stored session history uses `entry.message` — this caused `splitIndex` to decrement to 0, producing an empty summary. Now checks both formats
- **Fix tool row badge alignment**: Added `margin-left: auto` to `.gemini-tool-row-status` so Completed/Failed badges align to the right edge regardless of parameter text presence
- **Diagnostic logging**: Added debug logs throughout the pipeline (streaming metadata capture, skipped updates, turn boundaries, fallback triggers)

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A: debug display feature, no mobile-specific code paths
- [x] Documentation has been updated (if applicable)
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced token usage display to show uncached tokens separately when applicable in the format "Tokens: ~N (Y new) / M (X%)".
  * Improved token counting with support for tracking cached tokens and better accuracy in usage estimates.

* **Documentation**
  * Updated token usage explanatory notes describing live updates, implicit caching behavior, and the new uncached token indicator.

* **Bug Fixes**
  * Fixed token counting fallback logic to ensure accurate metrics when cached data is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->