### PR TITLE
fix: Align text properly after @file chips in input

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1578,9 +1578,7 @@ If your plugin does not need CSS, delete this file.
 	overflow-y: auto;
 	padding: var(--size-4-2);
 	position: relative;
-	display: flex;
-	align-items: center;
-	flex-wrap: wrap;
+	line-height: 1.6;
 }
 
 .gemini-agent-input-rich:focus {


### PR DESCRIPTION
## Summary

Fixes #375 — text after @file chips in the prompt textarea was vertically misaligned.

The contenteditable input used `display: flex` with `align-items: center`, which broke the natural inline flow. Chips (`inline-flex` elements with `vertical-align: middle`) and adjacent text nodes were treated as separate flex items with different alignment behavior, causing the text to shift vertically after a chip.

The fix switches to standard block/inline flow with `line-height: 1.6`, letting chips and text share the same baseline naturally.

## Changes

- Remove `display: flex`, `align-items: center`, and `flex-wrap: wrap` from `.gemini-agent-input-rich`
- Add `line-height: 1.6` for consistent vertical spacing with inline chips

## Screenshots / Screencast

CSS-only change to the input textarea — the chips' `inline-flex` + `vertical-align: middle` now works correctly in the inline flow context.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards)
- [x] Documentation has been updated (if applicable) — N/A, CSS-only fix
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated layout styling for input component to adjust element spacing and flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->