### PR TITLE
fix: Restore previously focused tab when diff view closes

### DIFF
--- a/src/ui/agent-view/agent-view-messages.ts
+++ b/src/ui/agent-view/agent-view-messages.ts
@@ -774,11 +774,9 @@ export class AgentViewMessages {
 		onDiffOpened?: (view: import('./gemini-diff-view').GeminiDiffView) => void,
 		onDiffClosed?: () => void
 	): Promise<void> {
-		const { GeminiDiffView } = await import('./gemini-diff-view');
-		const { VIEW_TYPE_DIFF } = await import('../../main');
-
 		// Remember the previously focused leaf so we can restore it when the diff closes
 		const previousLeaf = this.plugin.app.workspace.getMostRecentLeaf();
+		const leaf = this.plugin.app.workspace.getLeaf('tab');
 
 		const restorePreviousLeaf = () => {
 			if (previousLeaf && previousLeaf !== leaf) {
@@ -786,31 +784,39 @@ export class AgentViewMessages {
 			}
 		};
 
-		const leaf = this.plugin.app.workspace.getLeaf('tab');
-		await leaf.setViewState({ type: VIEW_TYPE_DIFF, active: true });
+		try {
+			const { GeminiDiffView } = await import('./gemini-diff-view');
+			const { VIEW_TYPE_DIFF } = await import('../../main');
+			await leaf.setViewState({ type: VIEW_TYPE_DIFF, active: true });
 
-		const view = leaf.view;
-		if (view instanceof GeminiDiffView) {
-			view.setDiffState({
-				filePath: diffContext.filePath,
-				originalContent: diffContext.originalContent,
-				proposedContent: diffContext.proposedContent,
-				isNewFile: diffContext.isNewFile,
-				onResolve: (result) => {
-					restorePreviousLeaf();
-					onDiffClosed?.();
-					handleResponse(result.approved, result.finalContent, result.userEdited);
-				},
-				onClose: () => {
-					restorePreviousLeaf();
-					onDiffClosed?.();
-				},
-			});
-			onDiffOpened?.(view);
-		} else {
-			this.plugin.logger?.error(
-				`[AgentViewMessages] Failed to open diff view for ${diffContext.filePath}: unexpected view type`
-			);
+			const view = leaf.view;
+			if (view instanceof GeminiDiffView) {
+				view.setDiffState({
+					filePath: diffContext.filePath,
+					originalContent: diffContext.originalContent,
+					proposedContent: diffContext.proposedContent,
+					isNewFile: diffContext.isNewFile,
+					onResolve: (result) => {
+						restorePreviousLeaf();
+						onDiffClosed?.();
+						handleResponse(result.approved, result.finalContent, result.userEdited);
+					},
+					onClose: () => {
+						restorePreviousLeaf();
+						onDiffClosed?.();
+					},
+				});
+				onDiffOpened?.(view);
+			} else {
+				this.plugin.logger?.error(
+					`[AgentViewMessages] Failed to open diff view for ${diffContext.filePath}: unexpected view type`
+				);
+				leaf.detach();
+				restorePreviousLeaf();
+				onDiffClosed?.();
+			}
+		} catch (error) {
+			this.plugin.logger?.error(`[AgentViewMessages] Failed to open diff view for ${diffContext.filePath}:`, error);
 			leaf.detach();
 			restorePreviousLeaf();
 			onDiffClosed?.();


### PR DESCRIPTION
## Summary

After viewing a diff for a file write, the user loses their previously focused tab. This fix captures the active leaf before opening the diff view and restores focus to it when the diff closes.

Fixes #437

## Changes

- Capture `workspace.getMostRecentLeaf()` before opening the diff tab
- Restore focus via `workspace.setActiveLeaf()` on resolve (approve/cancel), close (tab X), and error paths
- Uses non-deprecated `getMostRecentLeaf()` instead of `activeLeaf`

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A, desktop-only tab focus behavior
- [x] Documentation has been updated (if applicable) — N/A, internal UX fix
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace focus restoration when opening and interacting with the diff view. Your previously active workspace is now reliably reactivated after closing or navigating away from diffs.
  * Enhanced error handling around diff view setup so focus is restored even if the diff fails to open, preventing unexpected focus loss.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->