### PR TITLE
fix: Clear session title when creating new session

### DIFF
--- a/src/ui/agent-view/agent-view.ts
+++ b/src/ui/agent-view/agent-view.ts
@@ -911,6 +911,9 @@ To reference an attachment in your response, use the path shown above.`;
 		this.currentSession = this.session.getCurrentSession();
 		// Reset context manager for the new session and update display
 		this.plugin.contextManager?.reset();
+		// Re-render header now that currentSession is updated — the header
+		// rendered inside createNewSession() used the stale reference.
+		this.updateSessionHeader();
 		await this.updateTokenUsage();
 	}
 
@@ -922,6 +925,7 @@ To reference an attachment in your response, use the path shown above.`;
 		this.currentSession = this.session.getCurrentSession();
 		// Reset cache and refresh token usage for the loaded session
 		this.plugin.contextManager?.reset();
+		this.updateSessionHeader();
 		await this.refreshTokenUsageFromHistory();
 	}
 


### PR DESCRIPTION
## Summary

Fixes #448 — when clicking the "New Session" button, the title from the previous session was not cleared.

**Root cause**: `createNewSession()` and `loadSession()` in agent-view delegate to the session component, which internally calls `updateSessionHeader()`. But that callback renders the header using `this.currentSession` from agent-view — which still holds the **old** session reference. The assignment `this.currentSession = this.session.getCurrentSession()` happens *after* the header is already rendered with the stale title.

## Changes

- Add `updateSessionHeader()` call after `this.currentSession` is updated in both `createNewSession()` and `loadSession()`, so the header reflects the correct session title

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A, no mobile-specific code changed
- [x] Documentation has been updated (if applicable) — N/A, internal bug fix
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed session header not updating properly when creating or loading sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->