### PR TITLE
fix: Prevent header buttons from overflowing on narrow screens

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1009,12 +1009,15 @@ If your plugin does not need CSS, delete this file.
 	align-items: center;
 	gap: var(--size-4-2);
 	flex: 1;
+	min-width: 0;
+	overflow: hidden;
 }
 
 .gemini-agent-header-right {
 	display: flex;
 	align-items: center;
 	gap: var(--size-2-1);
+	flex-shrink: 0;
 }
 
 /* Toggle Button */
@@ -1044,7 +1047,7 @@ If your plugin does not need CSS, delete this file.
 .gemini-agent-title-container {
 	display: inline-flex;
 	align-items: center;
-	min-width: 200px;
+	min-width: 0;
 	max-width: 400px;
 }
 


### PR DESCRIPTION
## Summary

On mobile devices, the agent view header buttons (settings, new session, browse) on the right side were pushed off-screen, requiring horizontal scrolling to access them.

## Changes

- Remove `min-width: 200px` from `.gemini-agent-title-container`, replace with `min-width: 0` so the title truncates with ellipsis on narrow screens
- Add `min-width: 0` and `overflow: hidden` to `.gemini-agent-header-left` so the left section can shrink below its content size
- Add `flex-shrink: 0` to `.gemini-agent-header-right` so action buttons are never compressed

## Screenshots / Screencast

Tested on iOS — header title truncates gracefully and all buttons remain visible and tappable.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards)
- [x] Documentation has been updated (if applicable) — N/A, CSS-only fix
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed layout overflow issues in the compact agent header to ensure proper content display and sizing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->