### PR TITLE
feat: Track all accessed files in session frontmatter

### DIFF
--- a/src/agent/session-history.ts
+++ b/src/agent/session-history.ts
@@ -2,6 +2,7 @@ import { TFile, normalizePath } from 'obsidian';
 import { ChatSession } from '../types/agent';
 import { GeminiConversationEntry } from '../types/conversation';
 import type ObsidianGemini from '../main';
+import { pathToWikilink } from '../utils/accessed-files';
 import * as Handlebars from 'handlebars';
 // @ts-ignore
 import historyEntryTemplate from '../history/templates/historyEntry.hbs';
@@ -302,6 +303,13 @@ export class SessionHistory {
 				frontmatter.context_files = session.context.contextFiles.map((f) => `[[${f.basename}]]`);
 			} else {
 				delete frontmatter.context_files;
+			}
+
+			// Accessed files - all files the agent interacted with during the session
+			if (session.accessedFiles?.size) {
+				frontmatter.accessed_files = Array.from(session.accessedFiles).map(pathToWikilink);
+			} else {
+				delete frontmatter.accessed_files;
 			}
 
 			if (session.context?.enabledTools?.length) {

--- a/src/agent/session-manager.ts
+++ b/src/agent/session-manager.ts
@@ -261,6 +261,20 @@ export class SessionManager {
 			metadata: frontmatter?.metadata,
 		};
 
+		// Restore accessed_files Set from frontmatter wikilinks
+		if (frontmatter?.accessed_files && Array.isArray(frontmatter.accessed_files)) {
+			session.accessedFiles = new Set<string>();
+			for (const ref of frontmatter.accessed_files) {
+				if (typeof ref === 'string' && ref.startsWith('[[') && ref.endsWith(']]')) {
+					const linkpath = ref.slice(2, -2);
+					const resolved = this.plugin.app.metadataCache.getFirstLinkpathDest(linkpath, '');
+					if (resolved instanceof TFile) {
+						session.accessedFiles.add(resolved.path);
+					}
+				}
+			}
+		}
+
 		this.activeSessions.set(session.id, session);
 		return session;
 	}

--- a/src/types/agent.ts
+++ b/src/types/agent.ts
@@ -102,6 +102,9 @@ export interface ChatSession {
 		autoLabeled?: boolean;
 		[key: string]: any;
 	};
+
+	/** In-memory set of file paths accessed during this session (not serialized directly) */
+	accessedFiles?: Set<string>;
 }
 
 /**

--- a/src/types/agent.ts
+++ b/src/types/agent.ts
@@ -103,7 +103,7 @@ export interface ChatSession {
 		[key: string]: any;
 	};
 
-	/** In-memory set of file paths accessed during this session (not serialized directly) */
+	/** In-memory set of file paths accessed during this session. Converted to wikilinks and persisted to frontmatter as accessed_files. */
 	accessedFiles?: Set<string>;
 }
 

--- a/src/ui/agent-view/agent-view-tools.ts
+++ b/src/ui/agent-view/agent-view-tools.ts
@@ -9,6 +9,7 @@ import { AgentFactory } from '../../agent/agent-factory';
 import { generateToolDescription } from '../../utils/text-generation';
 import { formatFileSize } from '../../utils/format-utils';
 import type { UsageMetadata } from '../../services/context-manager';
+import { extractAccessedPaths } from '../../utils/accessed-files';
 
 // Tool execution result messages
 const TOOL_EXECUTION_FAILED_DEFAULT_MSG = 'Tool execution failed (no error message provided)';
@@ -321,6 +322,28 @@ export class AgentViewTools {
 						error: error instanceof Error ? error.message : 'Unknown error',
 					},
 				});
+			}
+		}
+
+		// Track accessed files for this tool batch
+		const accessedPaths = extractAccessedPaths(toolResults);
+		if (accessedPaths.length > 0 && currentSession) {
+			if (!currentSession.accessedFiles) {
+				currentSession.accessedFiles = new Set<string>();
+			}
+			let hasNew = false;
+			for (const p of accessedPaths) {
+				if (!currentSession.accessedFiles.has(p)) {
+					currentSession.accessedFiles.add(p);
+					hasNew = true;
+				}
+			}
+			if (hasNew) {
+				try {
+					await this.plugin.sessionHistory.updateSessionMetadata(currentSession);
+				} catch (error) {
+					this.plugin.logger.error('Failed to persist accessed_files:', error);
+				}
 			}
 		}
 

--- a/src/utils/accessed-files.ts
+++ b/src/utils/accessed-files.ts
@@ -19,7 +19,8 @@ interface ToolResultEntry {
 
 /**
  * Extract accessed file paths from a batch of tool results.
- * Returns deduplicated paths for tools that represent targeted file access.
+ * Returns paths in encounter order (duplicates may remain); deduplication
+ * occurs in agent-view-tools.ts when paths are added to the session Set.
  * Search/list tools are excluded to avoid noise.
  */
 export function extractAccessedPaths(toolResults: ToolResultEntry[]): string[] {

--- a/src/utils/accessed-files.ts
+++ b/src/utils/accessed-files.ts
@@ -1,0 +1,51 @@
+import { ToolResult } from '../tools/types';
+
+/** Tools where result.data.path represents a targeted file access */
+const TRACKED_TOOLS = new Set([
+	'read_file',
+	'write_file',
+	'create_folder',
+	'delete_file',
+	'move_file',
+	'update_frontmatter',
+	'append_content',
+]);
+
+interface ToolResultEntry {
+	toolName: string;
+	toolArguments: any;
+	result: ToolResult;
+}
+
+/**
+ * Extract accessed file paths from a batch of tool results.
+ * Returns deduplicated paths for tools that represent targeted file access.
+ * Search/list tools are excluded to avoid noise.
+ */
+export function extractAccessedPaths(toolResults: ToolResultEntry[]): string[] {
+	const paths: string[] = [];
+
+	for (const tr of toolResults) {
+		if (!tr.result.success || !TRACKED_TOOLS.has(tr.toolName)) continue;
+
+		if (tr.toolName === 'move_file') {
+			if (tr.result.data?.sourcePath) paths.push(tr.result.data.sourcePath);
+			if (tr.result.data?.targetPath) paths.push(tr.result.data.targetPath);
+		} else {
+			if (tr.result.data?.path) paths.push(tr.result.data.path);
+		}
+	}
+
+	return paths;
+}
+
+/**
+ * Convert a file path to the wikilink basename format used in frontmatter.
+ * Matches the existing context_files format: [[basename]] without .md extension.
+ * Non-md files keep their extension: images/photo.png → [[photo.png]]
+ */
+export function pathToWikilink(path: string): string {
+	const filename = path.substring(path.lastIndexOf('/') + 1);
+	const basename = filename.endsWith('.md') ? filename.slice(0, -3) : filename;
+	return `[[${basename}]]`;
+}

--- a/test/agent/session-manager.test.ts
+++ b/test/agent/session-manager.test.ts
@@ -226,6 +226,106 @@ describe('SessionManager', () => {
 		});
 	});
 
+	describe('loadSessionFromFile - accessed_files', () => {
+		beforeEach(() => {
+			mockPlugin.app.metadataCache = {
+				getFirstLinkpathDest: jest.fn(),
+				getFileCache: jest.fn(),
+			};
+		});
+
+		it('should restore accessedFiles Set from frontmatter wikilinks', async () => {
+			const mockHistoryFile = {
+				path: 'gemini-scribe/Agent-Sessions/test.md',
+				basename: 'test',
+				stat: { ctime: Date.now(), mtime: Date.now() },
+			} as any;
+
+			const frontmatter = {
+				session_id: 'test-session',
+				type: 'agent-session',
+				title: 'Test Session',
+				accessed_files: ['[[Chapter 1]]', '[[Utils]]'],
+				created: new Date().toISOString(),
+				last_active: new Date().toISOString(),
+			};
+
+			mockPlugin.app.vault.read.mockResolvedValue('test content');
+			mockPlugin.app.metadataCache.getFileCache.mockReturnValue({ frontmatter });
+
+			const mockFile1 = new TFile();
+			(mockFile1 as any).path = 'chapters/Chapter 1.md';
+			(mockFile1 as any).basename = 'Chapter 1';
+			const mockFile2 = new TFile();
+			(mockFile2 as any).path = 'src/Utils.md';
+			(mockFile2 as any).basename = 'Utils';
+
+			mockPlugin.app.metadataCache.getFirstLinkpathDest.mockReturnValueOnce(mockFile1).mockReturnValueOnce(mockFile2);
+
+			const session = await (sessionManager as any).loadSessionFromFile(mockHistoryFile);
+
+			expect(session.accessedFiles).toBeInstanceOf(Set);
+			expect(session.accessedFiles.size).toBe(2);
+			expect(session.accessedFiles.has('chapters/Chapter 1.md')).toBe(true);
+			expect(session.accessedFiles.has('src/Utils.md')).toBe(true);
+		});
+
+		it('should handle missing accessed_files gracefully', async () => {
+			const mockHistoryFile = {
+				path: 'gemini-scribe/Agent-Sessions/test.md',
+				basename: 'test',
+				stat: { ctime: Date.now(), mtime: Date.now() },
+			} as any;
+
+			const frontmatter = {
+				session_id: 'test-session',
+				type: 'agent-session',
+				title: 'Test Session',
+				created: new Date().toISOString(),
+				last_active: new Date().toISOString(),
+			};
+
+			mockPlugin.app.vault.read.mockResolvedValue('test content');
+			mockPlugin.app.metadataCache.getFileCache.mockReturnValue({ frontmatter });
+
+			const session = await (sessionManager as any).loadSessionFromFile(mockHistoryFile);
+
+			expect(session.accessedFiles).toBeUndefined();
+		});
+
+		it('should skip unresolvable wikilinks in accessed_files', async () => {
+			const mockHistoryFile = {
+				path: 'gemini-scribe/Agent-Sessions/test.md',
+				basename: 'test',
+				stat: { ctime: Date.now(), mtime: Date.now() },
+			} as any;
+
+			const frontmatter = {
+				session_id: 'test-session',
+				type: 'agent-session',
+				title: 'Test Session',
+				accessed_files: ['[[Exists]]', '[[Deleted File]]'],
+				created: new Date().toISOString(),
+				last_active: new Date().toISOString(),
+			};
+
+			mockPlugin.app.vault.read.mockResolvedValue('test content');
+			mockPlugin.app.metadataCache.getFileCache.mockReturnValue({ frontmatter });
+
+			const mockFile = new TFile();
+			(mockFile as any).path = 'Exists.md';
+			(mockFile as any).basename = 'Exists';
+
+			// First link resolves, second returns null (deleted file)
+			mockPlugin.app.metadataCache.getFirstLinkpathDest.mockReturnValueOnce(mockFile).mockReturnValueOnce(null);
+
+			const session = await (sessionManager as any).loadSessionFromFile(mockHistoryFile);
+
+			expect(session.accessedFiles.size).toBe(1);
+			expect(session.accessedFiles.has('Exists.md')).toBe(true);
+		});
+	});
+
 	describe('getRecentAgentSessions', () => {
 		let mockFolder: any;
 		let mockSessionFiles: TFile[];

--- a/test/utils/accessed-files.test.ts
+++ b/test/utils/accessed-files.test.ts
@@ -1,0 +1,165 @@
+import { extractAccessedPaths, pathToWikilink } from '../../src/utils/accessed-files';
+
+describe('extractAccessedPaths', () => {
+	it('should extract path from read_file result', () => {
+		const results = [
+			{
+				toolName: 'read_file',
+				toolArguments: { path: 'notes/test.md' },
+				result: { success: true, data: { path: 'notes/test.md' } },
+			},
+		];
+		expect(extractAccessedPaths(results)).toEqual(['notes/test.md']);
+	});
+
+	it('should extract path from write_file result', () => {
+		const results = [
+			{
+				toolName: 'write_file',
+				toolArguments: { path: 'notes/new.md' },
+				result: { success: true, data: { path: 'notes/new.md', action: 'created' } },
+			},
+		];
+		expect(extractAccessedPaths(results)).toEqual(['notes/new.md']);
+	});
+
+	it('should extract path from delete_file result', () => {
+		const results = [
+			{
+				toolName: 'delete_file',
+				toolArguments: { path: 'old.md' },
+				result: { success: true, data: { path: 'old.md', action: 'deleted' } },
+			},
+		];
+		expect(extractAccessedPaths(results)).toEqual(['old.md']);
+	});
+
+	it('should extract path from create_folder result', () => {
+		const results = [
+			{
+				toolName: 'create_folder',
+				toolArguments: { path: 'new-folder' },
+				result: { success: true, data: { path: 'new-folder', action: 'created' } },
+			},
+		];
+		expect(extractAccessedPaths(results)).toEqual(['new-folder']);
+	});
+
+	it('should extract path from update_frontmatter result', () => {
+		const results = [
+			{
+				toolName: 'update_frontmatter',
+				toolArguments: { path: 'note.md' },
+				result: { success: true, data: { path: 'note.md', key: 'tags' } },
+			},
+		];
+		expect(extractAccessedPaths(results)).toEqual(['note.md']);
+	});
+
+	it('should extract path from append_content result', () => {
+		const results = [
+			{
+				toolName: 'append_content',
+				toolArguments: { path: 'log.md' },
+				result: { success: true, data: { path: 'log.md', action: 'appended' } },
+			},
+		];
+		expect(extractAccessedPaths(results)).toEqual(['log.md']);
+	});
+
+	it('should extract both paths from move_file result', () => {
+		const results = [
+			{
+				toolName: 'move_file',
+				toolArguments: { sourcePath: 'old/note.md', targetPath: 'new/note.md' },
+				result: { success: true, data: { sourcePath: 'old/note.md', targetPath: 'new/note.md', action: 'moved' } },
+			},
+		];
+		expect(extractAccessedPaths(results)).toEqual(['old/note.md', 'new/note.md']);
+	});
+
+	it('should skip failed results', () => {
+		const results = [
+			{
+				toolName: 'read_file',
+				toolArguments: { path: 'missing.md' },
+				result: { success: false, error: 'File not found' },
+			},
+		];
+		expect(extractAccessedPaths(results)).toEqual([]);
+	});
+
+	it('should skip non-tracked tools', () => {
+		const results = [
+			{
+				toolName: 'search_files',
+				toolArguments: { pattern: '*.md' },
+				result: { success: true, data: { matches: [] } },
+			},
+			{ toolName: 'list_files', toolArguments: { path: '/' }, result: { success: true, data: { files: [] } } },
+			{
+				toolName: 'search_file_contents',
+				toolArguments: { query: 'test' },
+				result: { success: true, data: { results: [] } },
+			},
+			{ toolName: 'list_folders', toolArguments: { path: '/' }, result: { success: true, data: { folders: [] } } },
+			{ toolName: 'get_active_file', toolArguments: {}, result: { success: true, data: { path: 'active.md' } } },
+			{ toolName: 'read_memory', toolArguments: {}, result: { success: true, data: { path: 'AGENTS.md' } } },
+			{
+				toolName: 'update_memory',
+				toolArguments: { content: 'test' },
+				result: { success: true, data: { path: 'AGENTS.md' } },
+			},
+		];
+		expect(extractAccessedPaths(results)).toEqual([]);
+	});
+
+	it('should handle missing data gracefully', () => {
+		const results = [
+			{ toolName: 'read_file', toolArguments: { path: 'test.md' }, result: { success: true } },
+			{ toolName: 'read_file', toolArguments: { path: 'test.md' }, result: { success: true, data: {} } },
+			{ toolName: 'read_file', toolArguments: { path: 'test.md' }, result: { success: true, data: null } },
+		];
+		expect(extractAccessedPaths(results)).toEqual([]);
+	});
+
+	it('should extract paths from a mixed batch', () => {
+		const results = [
+			{ toolName: 'read_file', toolArguments: { path: 'a.md' }, result: { success: true, data: { path: 'a.md' } } },
+			{
+				toolName: 'search_files',
+				toolArguments: { pattern: '*.md' },
+				result: { success: true, data: { matches: [] } },
+			},
+			{ toolName: 'write_file', toolArguments: { path: 'b.md' }, result: { success: true, data: { path: 'b.md' } } },
+			{ toolName: 'read_file', toolArguments: { path: 'c.md' }, result: { success: false, error: 'Not found' } },
+		];
+		expect(extractAccessedPaths(results)).toEqual(['a.md', 'b.md']);
+	});
+});
+
+describe('pathToWikilink', () => {
+	it('should convert markdown file path to wikilink', () => {
+		expect(pathToWikilink('folder/My Note.md')).toBe('[[My Note]]');
+	});
+
+	it('should handle root-level files', () => {
+		expect(pathToWikilink('Note.md')).toBe('[[Note]]');
+	});
+
+	it('should handle deeply nested paths', () => {
+		expect(pathToWikilink('a/b/c/Deep Note.md')).toBe('[[Deep Note]]');
+	});
+
+	it('should keep extension for non-md files', () => {
+		expect(pathToWikilink('images/photo.png')).toBe('[[photo.png]]');
+	});
+
+	it('should handle files without extension', () => {
+		expect(pathToWikilink('folder/README')).toBe('[[README]]');
+	});
+
+	it('should handle folder paths', () => {
+		expect(pathToWikilink('my-folder')).toBe('[[my-folder]]');
+	});
+});


### PR DESCRIPTION
## Summary

Fixes #457 — adds an `accessed_files` field to session frontmatter that records all files the agent reads or modifies via tools during a session. This is a prerequisite for #456 (Projects feature) which needs session→file associations.

## Changes

- **`src/utils/accessed-files.ts`** (new) — pure utility with `extractAccessedPaths()` to pull file paths from tool results, and `pathToWikilink()` for frontmatter formatting
- **`src/types/agent.ts`** — add `accessedFiles?: Set<string>` to `ChatSession` for in-memory deduplication
- **`src/ui/agent-view/agent-view-tools.ts`** — after each tool batch, extract accessed paths and persist to frontmatter if new paths found
- **`src/agent/session-history.ts`** — write `accessed_files` as top-level frontmatter key (mirrors `context_files` pattern)
- **`src/agent/session-manager.ts`** — restore `accessedFiles` Set from frontmatter wikilinks on session load

### Design decisions

- **Batch writes**: frontmatter written once per message turn (after all tools in a batch complete), not after every individual tool call
- **Tracked tools**: `read_file`, `write_file`, `create_folder`, `delete_file`, `move_file`, `update_frontmatter`, `append_content`
- **Skipped tools**: `search_files`, `list_files`, `list_folders`, etc. — too noisy, would pollute the list
- **Wikilink format**: matches existing `context_files` pattern (`[[basename]]`)
- **Dedup**: in-memory `Set<string>` ensures a file accessed 10 times appears once

### Frontmatter output

```yaml
accessed_files:
  - "[[Chapter 1]]"
  - "[[Chapter 2]]"
  - "[[Magic System]]"
```

## Test plan

- [x] `npm test` passes (1061 tests, including 20 new tests)
- [x] `npm run build` succeeds
- [x] `npm run format-check` passes
- [x] Unit tests for `extractAccessedPaths` — all tracked tools, skipped tools, failed results, missing data
- [x] Unit tests for `pathToWikilink` — md/non-md files, nested paths, folders
- [x] Session round-trip tests — accessedFiles Set restored from frontmatter, handles missing/unresolvable links
- [ ] Manual: open agent session, have agent read/write files, verify `accessed_files` in session frontmatter

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sessions now track and persist files accessed during a conversation and restore that file list when a session is loaded.

* **Tests**
  * Added tests covering file-access extraction and conversion utilities, plus session load/save behavior for persisted accessed-file metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->