### PR TITLE
docs: Add FAQ for Folder Notes plugin conflict

### DIFF
--- a/docs/guide/faq.md
+++ b/docs/guide/faq.md
@@ -91,6 +91,14 @@ This command requires: (1) a markdown file actively open in the editor, and (2) 
 
 The vault index uses Google's File Search API to enable semantic (meaning-based) search of your vault. Files are stored in an index private to your GCP project, tied to your API key. Your data is not shared or used for model training. The feature is experimental and located under Advanced Settings. ([#297](https://github.com/allenhutchison/obsidian-gemini/discussions/297))
 
+## Plugin Conflicts
+
+### RAG indexing creates runaway "Untitled" notes in the plugin state folder
+
+This is caused by a conflict with the **Folder Notes** plugin, not Gemini Scribe itself. Folder Notes automatically creates notes when it detects new folders or file activity, and the rapid file operations during RAG indexing can trigger it repeatedly.
+
+**To fix:** Disable the Folder Notes plugin, or configure it to ignore the Gemini Scribe state folder (default: `gemini-scribe/`). ([#463](https://github.com/allenhutchison/obsidian-gemini/discussions/463))
+
 ## Miscellaneous
 
 ### What happened to the "Context Depth" setting?


### PR DESCRIPTION
## Summary

Adds a new FAQ entry documenting the known conflict between the Folder Notes plugin and Gemini Scribe's RAG indexing, which causes runaway "Untitled" notes to be created in the plugin state folder.

Based on the investigation in #463.

## Changes

- Added new "Plugin Conflicts" section to `docs/guide/faq.md`
- Documented the Folder Notes conflict, root cause, and workaround

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A, docs-only change
- [x] Documentation has been updated (if applicable)
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added FAQ section addressing plugin conflicts, documenting how rapid RAG indexing operations can create unwanted untitled notes when used alongside certain plugins. Includes troubleshooting guidance with options to disable conflicting plugins or configure them to ignore the application's state folder.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->