### PR TITLE
fix: read_file returns success with exists:false for missing files

### DIFF
--- a/src/tools/vault-tools.ts
+++ b/src/tools/vault-tools.ts
@@ -184,13 +184,18 @@ export class ReadFileTool implements Tool {
 			const { item, type: _type, suggestions } = resolvePathToFileOrFolder(params.path, plugin, true);
 
 			if (!item) {
-				// Provide helpful error message with suggestions
-				const suggestion =
-					suggestions && suggestions.length > 0 ? `\n\nDid you mean one of these?\n${suggestions.join('\n')}` : '';
+				// File not existing is information, not an error — the agent asked
+				// "what's in this file?" and the answer is "it doesn't exist."
+				const suggestionList = suggestions && suggestions.length > 0 ? suggestions : [];
 
 				return {
-					success: false,
-					error: `File or folder not found: ${params.path}${suggestion}`,
+					success: true,
+					data: {
+						path: params.path,
+						exists: false,
+						message: `File or folder does not exist: ${params.path}`,
+						suggestions: suggestionList,
+					},
 				};
 			}
 

--- a/test/tools/execution-engine.test.ts
+++ b/test/tools/execution-engine.test.ts
@@ -95,9 +95,9 @@ describe('ToolExecutionEngine - Confirmation Requirements', () => {
 			context
 		);
 
-		// Tool should execute without confirmation
-		expect(readResult.success).toBe(false); // Will fail because file doesn't exist, but that's ok
-		expect(readResult.error).toBe('File or folder not found: test.md');
+		// Tool should execute without confirmation — returns success with exists: false
+		expect(readResult.success).toBe(true);
+		expect(readResult.data.exists).toBe(false);
 
 		// Test list_files - should not require confirmation
 		const listResult = await engine.executeTool(

--- a/test/tools/tool-integration.test.ts
+++ b/test/tools/tool-integration.test.ts
@@ -406,7 +406,8 @@ describe('Tool Integration Tests', () => {
 
 			expect(results).toHaveLength(3);
 			expect(results[0].success).toBe(true); // Search should succeed
-			expect(results[1].success).toBe(false); // Read should fail
+			expect(results[1].success).toBe(true); // Read returns success with exists: false
+			expect(results[1].data.exists).toBe(false);
 			expect(results[2].success).toBe(true); // List should succeed
 		});
 	});

--- a/test/tools/vault-tools.test.ts
+++ b/test/tools/vault-tools.test.ts
@@ -158,15 +158,17 @@ describe('VaultTools', () => {
 			});
 		});
 
-		it('should return error for non-existent file', async () => {
+		it('should return success with exists:false for non-existent file', async () => {
 			mockVault.getAbstractFileByPath.mockReturnValue(null);
 			mockVault.getFiles.mockReturnValue([]);
 			mockMetadataCache.getFirstLinkpathDest.mockReturnValue(null);
 
 			const result = await tool.execute({ path: 'nonexistent.md' }, mockContext);
 
-			expect(result.success).toBe(false);
-			expect(result.error).toBe('File or folder not found: nonexistent.md');
+			expect(result.success).toBe(true);
+			expect(result.data.exists).toBe(false);
+			expect(result.data.path).toBe('nonexistent.md');
+			expect(result.data.message).toContain('does not exist');
 		});
 
 		it('should not resolve to system folder files via case-insensitive fallback', async () => {
@@ -190,8 +192,8 @@ describe('VaultTools', () => {
 			// Try to resolve a path that would case-insensitively match the system files
 			const result = await tool.execute({ path: 'workspace.json' }, mockContext);
 
-			expect(result.success).toBe(false);
-			expect(result.error).toContain('not found');
+			expect(result.success).toBe(true);
+			expect(result.data.exists).toBe(false);
 		});
 
 		it('should not suggest system folder files', async () => {
@@ -213,11 +215,11 @@ describe('VaultTools', () => {
 			// "workspace" substring matches both filenames, but .obsidian should be excluded
 			const result = await tool.execute({ path: 'workspace' }, mockContext);
 
-			expect(result.success).toBe(false);
+			expect(result.success).toBe(true);
+			expect(result.data.exists).toBe(false);
 			// Suggestions should include the user file but not the .obsidian file
-			const suggestions = result.error!;
-			expect(suggestions).toContain('workspace-notes.md');
-			expect(suggestions).not.toContain('.obsidian');
+			expect(result.data.suggestions.join(' ')).toContain('workspace-notes.md');
+			expect(result.data.suggestions.join(' ')).not.toContain('.obsidian');
 		});
 
 		it('should list contents when given a folder path', async () => {


### PR DESCRIPTION
## Summary

Fixes #480 — `read_file` no longer returns a tool failure when a file doesn't exist. Instead it returns `success: true` with data indicating the file is missing. This prevents red error styling in the UI when automation skills probe for files.

## Changes

- **`src/tools/vault-tools.ts`** — ReadFileTool returns `{ success: true, data: { path, exists: false, message, suggestions } }` instead of `{ success: false, error: "File or folder not found" }`
- Updated tests in `vault-tools.test.ts`, `tool-integration.test.ts`, `execution-engine.test.ts`

## Before / After

**Before:** `🔧 read_file path="config.yaml" → error: File not found` (red error styling)

**After:** `🔧 read_file path="config.yaml" → success` (normal styling, agent sees `exists: false` in data)

## Design decisions

- Only `read_file` changed — `delete_file` and `move_file` still fail on missing files since those are mutation requests where non-existence is a real error
- Suggestions (similar file names) are still returned in `data.suggestions` to help the agent
- The `exists: false` field lets the agent programmatically distinguish "doesn't exist" from "exists but empty"

## Test plan

- [x] `npm test` passes (1113 tests, updated 5 existing tests)
- [x] `npm run build` succeeds
- [x] `npm run format-check` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting when reading non-existent files or folders: the tool now returns a structured response with an `exists: false` indicator and helpful message instead of a failure state, providing better diagnostics and file location suggestions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->