### PR TITLE
refactor: Consolidate token tracking into event bus subscribers

### DIFF
--- a/src/services/lifecycle-service.ts
+++ b/src/services/lifecycle-service.ts
@@ -2,6 +2,7 @@ import { TFile } from 'obsidian';
 import { Notice } from 'obsidian';
 import type ObsidianGemini from '../main';
 import { AgentEventBus } from '../agent/agent-event-bus';
+import { HandlerPriority } from '../types/agent-events';
 import { ToolExecutionLogger } from './tool-execution-logger';
 import { ToolRegistrar } from './tool-registrar';
 import { GeminiPrompts, PromptManager } from '../prompts';
@@ -294,6 +295,25 @@ export class LifecycleService {
 		// Event bus is created once and persists across re-initialization
 		if (!plugin.agentEventBus) {
 			plugin.agentEventBus = new AgentEventBus(plugin.logger);
+
+			// Register core token tracking subscribers
+			plugin.agentEventBus.on(
+				'turnStart',
+				async () => {
+					plugin.contextManager?.beginTurn();
+				},
+				HandlerPriority.INTERNAL
+			);
+
+			plugin.agentEventBus.on(
+				'apiResponseReceived',
+				async (payload) => {
+					if (payload.usageMetadata) {
+						plugin.contextManager?.updateUsageMetadata(payload.usageMetadata);
+					}
+				},
+				HandlerPriority.INTERNAL
+			);
 		}
 
 		plugin.prompts = new GeminiPrompts(plugin);

--- a/src/types/agent-events.ts
+++ b/src/types/agent-events.ts
@@ -1,5 +1,6 @@
 import { ChatSession } from './agent';
 import { ToolResult } from '../tools/types';
+import type { UsageMetadata } from '../services/context-manager';
 
 /**
  * Handler priority levels. Lower numbers execute first.
@@ -49,6 +50,11 @@ export interface AgentEventMap {
 			result: ToolResult;
 		}>;
 		toolCount: number;
+	}>;
+
+	/** After any API response (initial, follow-up, or retry) with usage metadata */
+	apiResponseReceived: Readonly<{
+		usageMetadata?: UsageMetadata;
 	}>;
 }
 

--- a/src/ui/agent-view/agent-view-tools.ts
+++ b/src/ui/agent-view/agent-view-tools.ts
@@ -8,7 +8,6 @@ import { CustomPrompt } from '../../prompts/types';
 import { AgentFactory } from '../../agent/agent-factory';
 import { generateToolDescription } from '../../utils/text-generation';
 import { formatFileSize } from '../../utils/format-utils';
-import type { UsageMetadata } from '../../services/context-manager';
 import { extractAccessedPaths } from '../../utils/accessed-files';
 
 // Tool execution result messages
@@ -39,7 +38,6 @@ export interface AgentViewContext {
 	hideProgress(): void;
 	displayMessage(entry: GeminiConversationEntry): Promise<void>;
 	autoLabelSessionIfNeeded(): Promise<void>;
-	onUsageMetadata?: (metadata: UsageMetadata) => void;
 	incrementToolCallCount?(count: number): void;
 }
 
@@ -482,9 +480,11 @@ export class AgentViewTools {
 
 			const followUpResponse = await modelApi.generateModelResponse(followUpRequest);
 
-			// Update context manager with usage metadata from follow-up response
+			// Emit usage metadata via event bus (contextManager subscribes)
 			if (followUpResponse.usageMetadata) {
-				this.context.onUsageMetadata?.(followUpResponse.usageMetadata);
+				await this.plugin.agentEventBus?.emit('apiResponseReceived', {
+					usageMetadata: followUpResponse.usageMetadata,
+				});
 			}
 
 			// Check if the follow-up response also contains tool calls
@@ -559,9 +559,11 @@ export class AgentViewTools {
 					const modelApi2 = AgentFactory.createAgentModel(this.plugin, currentSession);
 					const retryResponse = await modelApi2.generateModelResponse(retryRequest);
 
-					// Update context manager with usage metadata from retry response
+					// Emit usage metadata via event bus (contextManager subscribes)
 					if (retryResponse.usageMetadata) {
-						this.context.onUsageMetadata?.(retryResponse.usageMetadata);
+						await this.plugin.agentEventBus?.emit('apiResponseReceived', {
+							usageMetadata: retryResponse.usageMetadata,
+						});
 					}
 
 					if (retryResponse.markdown && retryResponse.markdown.trim()) {

--- a/src/ui/agent-view/agent-view.ts
+++ b/src/ui/agent-view/agent-view.ts
@@ -163,10 +163,6 @@ export class AgentView extends ItemView {
 			hideProgress: () => this.progress.hide(),
 			displayMessage: (entry: GeminiConversationEntry) => this.displayMessage(entry),
 			autoLabelSessionIfNeeded: () => this.autoLabelSessionIfNeeded(),
-			onUsageMetadata: (metadata) => {
-				this.plugin.contextManager?.updateUsageMetadata(metadata);
-				this.updateTokenUsage();
-			},
 			incrementToolCallCount: (count: number) => {
 				this.turnToolCallCount += count;
 			},
@@ -422,8 +418,7 @@ To reference an attachment in your response, use the path shown above.`;
 				const modelConfig = this.currentSession?.modelConfig || {};
 				const modelName = modelConfig.model || this.plugin.settings.chatModelName;
 
-				// Signal new turn so the token counter accepts the fresh prompt size
-				this.plugin.contextManager.beginTurn();
+				// beginTurn() is now handled by the turnStart event bus subscriber
 
 				// Prepare history through context manager (may compact if over threshold)
 				const compactionResult = await this.plugin.contextManager.prepareHistory(conversationHistory, modelName);
@@ -516,10 +511,11 @@ To reference an attachment in your response, use the path shown above.`;
 						const response = await streamResponse.complete;
 						this.currentStreamingResponse = null;
 
-						// Update context manager and display with usage metadata from response
+						// Emit usage metadata via event bus (contextManager subscribes)
 						if (response.usageMetadata) {
-							this.plugin.contextManager.updateUsageMetadata(response.usageMetadata);
-							await this.updateTokenUsage();
+							await this.plugin.agentEventBus?.emit('apiResponseReceived', {
+								usageMetadata: response.usageMetadata,
+							});
 						} else {
 							this.plugin.logger.debug('[AgentView] Streaming response had no usageMetadata');
 						}
@@ -622,10 +618,11 @@ To reference an attachment in your response, use the path shown above.`;
 					this.plugin.logger.log('Agent view using non-streaming API');
 					const response = await modelApi.generateModelResponse(request);
 
-					// Update context manager and display with usage metadata from response
+					// Emit usage metadata via event bus (contextManager subscribes)
 					if (response.usageMetadata) {
-						this.plugin.contextManager.updateUsageMetadata(response.usageMetadata);
-						await this.updateTokenUsage();
+						await this.plugin.agentEventBus?.emit('apiResponseReceived', {
+							usageMetadata: response.usageMetadata,
+						});
 					} else {
 						this.plugin.logger.debug('[AgentView] Non-streaming response had no usageMetadata');
 					}
@@ -1125,10 +1122,6 @@ To reference an attachment in your response, use the path shown above.`;
 			hideProgress: () => this.progress.hide(),
 			displayMessage: (entry: GeminiConversationEntry) => this.displayMessage(entry),
 			autoLabelSessionIfNeeded: () => this.autoLabelSessionIfNeeded(),
-			onUsageMetadata: (metadata) => {
-				this.plugin.contextManager?.updateUsageMetadata(metadata);
-				this.updateTokenUsage();
-			},
 			incrementToolCallCount: (count: number) => {
 				this.turnToolCallCount += count;
 			},


### PR DESCRIPTION
## Summary

Fixes #473 — consolidates scattered token tracking calls into centralized event bus subscribers. Part of #413.

## Changes

### New event
- **`apiResponseReceived`** added to `AgentEventMap` — emitted after every API response (streaming, non-streaming, tool follow-up, retry) with `usageMetadata`

### Subscribers registered in lifecycle service
- `turnStart` → `contextManager.beginTurn()` (resets high-water mark)
- `apiResponseReceived` → `contextManager.updateUsageMetadata()` (tracks token usage)

### Removed inline calls
- 6x `contextManager.updateUsageMetadata()` (agent-view.ts ×2, agent-view-tools.ts ×2, onUsageMetadata callback ×2)
- 1x `contextManager.beginTurn()` (agent-view.ts)
- 4x paired `updateTokenUsage()` UI refresh calls (now handled by finally block)
- `onUsageMetadata` callback removed from `AgentViewContext` interface and both toolsContext creation sites

**Net: 11 scattered calls → 2 centralized subscribers.**

### Kept as-is
- `updateTokenUsage()` at compaction, finally block, session create, session load (UI refresh, different concern)
- `contextManager.setUsageMetadata()` at compaction (different method)
- `contextManager.reset()` at session lifecycle (#476 scope)

## Test plan

- [x] `npm test` passes (1113 tests)
- [x] `npm run build` succeeds
- [x] `npm run format-check` passes
- [ ] Manual: send message, verify token count updates after response
- [ ] Manual: trigger tool calls, verify token count updates after follow-ups

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal event handling architecture by transitioning from direct callbacks to an event-driven pattern for usage metadata tracking. This modernizes the codebase for better maintainability and scalability without affecting end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->