### PR TITLE
feat: Add sessionCreated and sessionLoaded lifecycle hooks

### DIFF
--- a/src/services/lifecycle-service.ts
+++ b/src/services/lifecycle-service.ts
@@ -314,6 +314,13 @@ export class LifecycleService {
 				},
 				HandlerPriority.INTERNAL
 			);
+
+			// Reset context manager on session changes
+			const resetContext = async () => {
+				plugin.contextManager?.reset();
+			};
+			plugin.agentEventBus.on('sessionCreated', resetContext, HandlerPriority.INTERNAL);
+			plugin.agentEventBus.on('sessionLoaded', resetContext, HandlerPriority.INTERNAL);
 		}
 
 		plugin.prompts = new GeminiPrompts(plugin);

--- a/src/types/agent-events.ts
+++ b/src/types/agent-events.ts
@@ -56,6 +56,16 @@ export interface AgentEventMap {
 	apiResponseReceived: Readonly<{
 		usageMetadata?: UsageMetadata;
 	}>;
+
+	/** After a new agent session is created */
+	sessionCreated: Readonly<{
+		session: ChatSession;
+	}>;
+
+	/** After an existing session is loaded from history */
+	sessionLoaded: Readonly<{
+		session: ChatSession;
+	}>;
 }
 
 /** Union of all valid event names */

--- a/src/ui/agent-view/agent-view-session.ts
+++ b/src/ui/agent-view/agent-view-session.ts
@@ -131,13 +131,6 @@ export class AgentViewSession {
 
 			// Focus on input
 			this.uiCallbacks.focusInput();
-
-			// Notify subscribers that a new session was created
-			if (this.currentSession) {
-				await this.plugin.agentEventBus?.emit('sessionCreated', {
-					session: this.currentSession,
-				});
-			}
 		} catch (error) {
 			this.plugin.logger.error('Failed to create agent session:', error);
 			new Notice('Failed to create agent session');
@@ -207,11 +200,6 @@ export class AgentViewSession {
 			// Update UI
 			this.uiCallbacks.updateSessionHeader();
 			this.uiCallbacks.updateContextPanel();
-
-			// Notify subscribers that a session was loaded
-			await this.plugin.agentEventBus?.emit('sessionLoaded', {
-				session: this.currentSession,
-			});
 		} catch (error) {
 			this.plugin.logger.error('Failed to load session:', error);
 			new Notice('Failed to load session');

--- a/src/ui/agent-view/agent-view-session.ts
+++ b/src/ui/agent-view/agent-view-session.ts
@@ -131,6 +131,13 @@ export class AgentViewSession {
 
 			// Focus on input
 			this.uiCallbacks.focusInput();
+
+			// Notify subscribers that a new session was created
+			if (this.currentSession) {
+				await this.plugin.agentEventBus?.emit('sessionCreated', {
+					session: this.currentSession,
+				});
+			}
 		} catch (error) {
 			this.plugin.logger.error('Failed to create agent session:', error);
 			new Notice('Failed to create agent session');
@@ -200,6 +207,11 @@ export class AgentViewSession {
 			// Update UI
 			this.uiCallbacks.updateSessionHeader();
 			this.uiCallbacks.updateContextPanel();
+
+			// Notify subscribers that a session was loaded
+			await this.plugin.agentEventBus?.emit('sessionLoaded', {
+				session: this.currentSession,
+			});
 		} catch (error) {
 			this.plugin.logger.error('Failed to load session:', error);
 			new Notice('Failed to load session');

--- a/src/ui/agent-view/agent-view.ts
+++ b/src/ui/agent-view/agent-view.ts
@@ -949,8 +949,10 @@ To reference an attachment in your response, use the path shown above.`;
 		// Re-render header now that currentSession is updated — the header
 		// rendered inside createNewSession() used the stale reference.
 		this.updateSessionHeader();
-		// contextManager.reset() and updateTokenUsage() are handled by
-		// sessionCreated event bus subscribers
+		// Emit after this.currentSession is updated so subscribers see the correct session
+		if (this.currentSession) {
+			await this.plugin.agentEventBus?.emit('sessionCreated', { session: this.currentSession });
+		}
 	}
 
 	/**
@@ -960,8 +962,10 @@ To reference an attachment in your response, use the path shown above.`;
 		await this.session.loadSession(session);
 		this.currentSession = this.session.getCurrentSession();
 		this.updateSessionHeader();
-		// contextManager.reset() and refreshTokenUsageFromHistory() are handled by
-		// sessionLoaded event bus subscribers
+		// Emit after this.currentSession is updated so subscribers see the correct session
+		if (this.currentSession) {
+			await this.plugin.agentEventBus?.emit('sessionLoaded', { session: this.currentSession });
+		}
 	}
 
 	/**

--- a/src/ui/agent-view/agent-view.ts
+++ b/src/ui/agent-view/agent-view.ts
@@ -7,6 +7,7 @@ import { ExtendedModelRequest } from '../../api/interfaces/model-api';
 import { CustomPrompt } from '../../prompts/types';
 import { AgentFactory } from '../../agent/agent-factory';
 import { getErrorMessage } from '../../utils/error-utils';
+import { HandlerPriority } from '../../types/agent-events';
 
 // Import all component modules
 import { AgentViewProgress } from './agent-view-progress';
@@ -55,6 +56,7 @@ export class AgentView extends ItemView {
 	private isExecuting: boolean = false;
 	private turnToolCallCount: number = 0;
 	private cancellationRequested: boolean = false;
+	private eventBusUnsubscribers: (() => void)[] = [];
 	private allowedWithoutConfirmation: Set<string> = new Set(); // Session-level allowed tools
 	private activeFileChangeHandler: () => void;
 	private pendingAttachments: InlineAttachment[] = [];
@@ -189,6 +191,25 @@ export class AgentView extends ItemView {
 		};
 
 		this.session = new AgentViewSession(this.app, this.plugin, sessionCallbacks, sessionState);
+
+		// Register session lifecycle event bus subscribers for token display
+		const createdUnsub = this.plugin.agentEventBus?.on(
+			'sessionCreated',
+			async () => {
+				await this.updateTokenUsage();
+			},
+			HandlerPriority.NORMAL
+		);
+		if (createdUnsub) this.eventBusUnsubscribers.push(createdUnsub);
+
+		const loadedUnsub = this.plugin.agentEventBus?.on(
+			'sessionLoaded',
+			async () => {
+				await this.refreshTokenUsageFromHistory();
+			},
+			HandlerPriority.NORMAL
+		);
+		if (loadedUnsub) this.eventBusUnsubscribers.push(loadedUnsub);
 
 		// Create the header and context panel
 		this.ui.createCompactHeader(this.sessionHeader, this.contextPanel, this.currentSession, callbacks);
@@ -925,12 +946,11 @@ To reference an attachment in your response, use the path shown above.`;
 	private async createNewSession() {
 		await this.session.createNewSession();
 		this.currentSession = this.session.getCurrentSession();
-		// Reset context manager for the new session and update display
-		this.plugin.contextManager?.reset();
 		// Re-render header now that currentSession is updated — the header
 		// rendered inside createNewSession() used the stale reference.
 		this.updateSessionHeader();
-		await this.updateTokenUsage();
+		// contextManager.reset() and updateTokenUsage() are handled by
+		// sessionCreated event bus subscribers
 	}
 
 	/**
@@ -939,10 +959,9 @@ To reference an attachment in your response, use the path shown above.`;
 	private async loadSession(session: ChatSession) {
 		await this.session.loadSession(session);
 		this.currentSession = this.session.getCurrentSession();
-		// Reset cache and refresh token usage for the loaded session
-		this.plugin.contextManager?.reset();
 		this.updateSessionHeader();
-		await this.refreshTokenUsageFromHistory();
+		// contextManager.reset() and refreshTokenUsageFromHistory() are handled by
+		// sessionLoaded event bus subscribers
 	}
 
 	/**
@@ -1215,8 +1234,12 @@ To reference an attachment in your response, use the path shown above.`;
 	}
 
 	async onClose() {
-		// Cleanup session event bus subscriptions
+		// Cleanup event bus subscriptions
 		this.session?.destroy();
+		for (const unsub of this.eventBusUnsubscribers) {
+			unsub();
+		}
+		this.eventBusUnsubscribers = [];
 
 		// Cleanup components
 		if (this.messages) {


### PR DESCRIPTION
## Summary

Fixes #476 — adds session-level hooks to the agent event bus. Part of #413.

## Changes

### New events
- **`sessionCreated`** — emitted after new session is created and UI updated. Payload: `{ session }`
- **`sessionLoaded`** — emitted after existing session is loaded from history. Payload: `{ session }`

### Subscribers
- `contextManager.reset()` registered in lifecycle service for both events (INTERNAL priority)
- `updateTokenUsage()` registered in AgentView for `sessionCreated` (NORMAL priority)
- `refreshTokenUsageFromHistory()` registered in AgentView for `sessionLoaded` (NORMAL priority)

### Removed inline calls
- `this.plugin.contextManager?.reset()` from createNewSession wrapper (agent-view.ts)
- `this.plugin.contextManager?.reset()` from loadSession wrapper (agent-view.ts)
- `await this.updateTokenUsage()` from createNewSession wrapper
- `await this.refreshTokenUsageFromHistory()` from loadSession wrapper

### Cleanup
- AgentView stores event bus unsubscribers and cleans them up in `onClose()`

## Why this matters for Projects (#456)
These hooks enable Phase 2 project activation — when a session loads, a subscriber can check if it's associated with a project and activate the project context automatically.

## Test plan

- [x] `npm test` passes (1120 tests)
- [x] `npm run build` succeeds
- [x] `npm run format-check` passes
- [ ] Manual: create new session, verify token display resets correctly
- [ ] Manual: load existing session, verify token count shows correct value from history

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved session lifecycle management with event-driven architecture for context reset during session creation and loading.
  * Enhanced UI synchronization with session state changes for more reliable token usage updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->