### PR TITLE
refactor: Move accessed files tracking to toolChainComplete subscriber

### DIFF
--- a/src/services/lifecycle-service.ts
+++ b/src/services/lifecycle-service.ts
@@ -5,6 +5,7 @@ import { AgentEventBus } from '../agent/agent-event-bus';
 import { HandlerPriority } from '../types/agent-events';
 import { ToolExecutionLogger } from './tool-execution-logger';
 import { ToolRegistrar } from './tool-registrar';
+import { extractAccessedPaths } from '../utils/accessed-files';
 import { GeminiPrompts, PromptManager } from '../prompts';
 import { ScribeFile } from '../files';
 import { ModelManager } from './model-manager';
@@ -321,6 +322,41 @@ export class LifecycleService {
 			};
 			plugin.agentEventBus.on('sessionCreated', resetContext, HandlerPriority.INTERNAL);
 			plugin.agentEventBus.on('sessionLoaded', resetContext, HandlerPriority.INTERNAL);
+
+			// Track accessed files after each tool chain
+			plugin.agentEventBus.on(
+				'toolChainComplete',
+				async (payload) => {
+					const session = payload.session;
+					const accessedPaths = extractAccessedPaths(
+						payload.toolResults as Array<{
+							toolName: string;
+							toolArguments: any;
+							result: import('../tools/types').ToolResult;
+						}>
+					);
+					if (accessedPaths.length === 0) return;
+
+					if (!session.accessedFiles) {
+						session.accessedFiles = new Set<string>();
+					}
+					let hasNew = false;
+					for (const p of accessedPaths) {
+						if (!session.accessedFiles.has(p)) {
+							session.accessedFiles.add(p);
+							hasNew = true;
+						}
+					}
+					if (hasNew) {
+						try {
+							await plugin.sessionHistory.updateSessionMetadata(session);
+						} catch (error) {
+							plugin.logger.error('Failed to persist accessed_files:', error);
+						}
+					}
+				},
+				HandlerPriority.INTERNAL
+			);
 		}
 
 		plugin.prompts = new GeminiPrompts(plugin);

--- a/src/ui/agent-view/agent-view-tools.ts
+++ b/src/ui/agent-view/agent-view-tools.ts
@@ -8,7 +8,6 @@ import { CustomPrompt } from '../../prompts/types';
 import { AgentFactory } from '../../agent/agent-factory';
 import { generateToolDescription } from '../../utils/text-generation';
 import { formatFileSize } from '../../utils/format-utils';
-import { extractAccessedPaths } from '../../utils/accessed-files';
 
 // Tool execution result messages
 const TOOL_EXECUTION_FAILED_DEFAULT_MSG = 'Tool execution failed (no error message provided)';
@@ -335,27 +334,7 @@ export class AgentViewTools {
 			}
 		}
 
-		// Track accessed files for this tool batch
-		const accessedPaths = extractAccessedPaths(toolResults);
-		if (accessedPaths.length > 0 && currentSession) {
-			if (!currentSession.accessedFiles) {
-				currentSession.accessedFiles = new Set<string>();
-			}
-			let hasNew = false;
-			for (const p of accessedPaths) {
-				if (!currentSession.accessedFiles.has(p)) {
-					currentSession.accessedFiles.add(p);
-					hasNew = true;
-				}
-			}
-			if (hasNew) {
-				try {
-					await this.plugin.sessionHistory.updateSessionMetadata(currentSession);
-				} catch (error) {
-					this.plugin.logger.error('Failed to persist accessed_files:', error);
-				}
-			}
-		}
+		// Accessed files tracking is handled by the toolChainComplete event bus subscriber
 
 		// Emit toolChainComplete hook
 		if (currentSession) {


### PR DESCRIPTION
## Summary

Fixes #477 — moves accessed files tracking from inline code in `agent-view-tools.ts` to a `toolChainComplete` event bus subscriber in `lifecycle-service.ts`. Part of #413.

## Changes

- **`src/services/lifecycle-service.ts`** — Register `toolChainComplete` subscriber that extracts file paths from tool results, updates `session.accessedFiles` Set, and persists to frontmatter
- **`src/ui/agent-view/agent-view-tools.ts`** — Remove ~20 lines of inline tracking code and unused `extractAccessedPaths` import

Same logic, same behavior — just decoupled from the tool execution UI flow. Follows the same pattern as `ToolExecutionLogger` (#426).

## Test plan

- [x] `npm test` passes (1120 tests)
- [x] `npm run build` succeeds
- [x] `npm run format-check` passes
- [ ] Manual: have agent read/write files, verify `accessed_files` appears in session frontmatter

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal file access tracking to a more centralized approach, improving code modularity and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->