### PR TITLE
Fix duplicate user message writes to session history

### DIFF
--- a/src/ui/agent-view/agent-view.ts
+++ b/src/ui/agent-view/agent-view.ts
@@ -340,11 +340,6 @@ export class AgentView extends ItemView {
 		};
 		await this.displayMessage(userEntry);
 
-		// Save user message to history once, before the API call.
-		// Tools use in-memory updatedHistory, not the file, so early save is safe.
-		// addEntryToSession checks settings.chatHistory internally.
-		await this.plugin.sessionHistory.addEntryToSession(this.currentSession, userEntry);
-
 		try {
 			// Start with session context files (active file is already included if present)
 			const allContextFiles = [...this.currentSession.context.contextFiles];


### PR DESCRIPTION
The user message was being saved to history twice in sendMessage() - once
before the try block and once inside it after the history snapshot. Removed
the first call so the message is only saved once, after the pre-turn
history snapshot.

https://claude.ai/code/session_01FFJCEUtSrpoH3P56KxPX6n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal message handling flow to prevent data duplication and improve processing efficiency. No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->