### PR TITLE
feat: Add prompt guidance for recall_sessions tool

### DIFF
--- a/prompts/agentToolsPrompt.txt
+++ b/prompts/agentToolsPrompt.txt
@@ -119,3 +119,7 @@ You have access to the following skills. Use the `activate_skill` tool to load a
 - **{{this.name}}**: {{this.description}}
 {{/each}}
 {{/if}}
+
+## Session Memory
+
+When the user asks about prior conversations, past decisions, or previous work on specific files, use the `recall_sessions` tool to find relevant past sessions. It searches by file path, project, or title. Use `read_file` on the returned historyPath to see full conversation details from a past session.


### PR DESCRIPTION
## Summary

Fixes #507 — adds a "Session Memory" section to `agentToolsPrompt.txt` so the agent knows when and how to use the `recall_sessions` tool.

## Changes

Added to `prompts/agentToolsPrompt.txt` after the Skills section:

> ## Session Memory
> When the user asks about prior conversations, past decisions, or previous work on specific files, use the `recall_sessions` tool to find relevant past sessions. It searches by file path, project, or title. Use `read_file` on the returned historyPath to see full conversation details from a past session.

## Test plan

- [x] `npm test` passes
- [x] `npm run build` succeeds
- [ ] Manual: ask agent about prior work, verify it proactively calls recall_sessions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The agent can now recall and reference prior conversations, previous decisions, and earlier work on specific files when you ask about them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->