### PR TITLE
fix: Allow typing literal @ symbol in agent chat

### DIFF
--- a/src/ui/agent-view/agent-view-ui.ts
+++ b/src/ui/agent-view/agent-view-ui.ts
@@ -383,9 +383,10 @@ export class AgentViewUI {
 				callbacks.sendMessage();
 			} else if (e.key === '@') {
 				// Trigger file mention — don't preventDefault so @ is typed.
+				// Defer to next microtask so the browser commits the @ character first.
 				// If user selects a file, the @ will be removed before inserting the chip.
 				// If user dismisses the picker, the @ stays as a literal character.
-				callbacks.showFileMention();
+				setTimeout(() => callbacks.showFileMention(), 0);
 			}
 		});
 

--- a/src/ui/agent-view/agent-view.ts
+++ b/src/ui/agent-view/agent-view.ts
@@ -884,7 +884,7 @@ To reference an attachment in your response, use the path shown above.`;
 	 * Remove a trailing @ character from the input, used when the file picker
 	 * replaces the @ trigger with a file chip.
 	 */
-	private removeTrailingAtSymbol() {
+	private removeTrailingAtSymbol(): void {
 		const input = this.userInput;
 		if (!input) return;
 
@@ -892,6 +892,10 @@ To reference an attachment in your response, use the path shown above.`;
 		if (!selection || selection.rangeCount === 0) return;
 
 		const range = selection.getRangeAt(0);
+
+		// Only proceed with a collapsed cursor (no text selected)
+		if (!range.collapsed) return;
+
 		const node = range.startContainer;
 
 		// Only mutate text nodes within the input element


### PR DESCRIPTION
## Summary

Fixes #499 — users can now type a literal `@` symbol in the agent chat input.

## Problem

The `@` keypress was intercepted with `e.preventDefault()`, consuming the character. When the file picker was dismissed without a selection, the `@` was gone with no way to type it.

## Solution

- Remove `e.preventDefault()` on `@` keypress — the character is typed naturally
- File picker still opens on `@`
- When a file is selected: `removeTrailingAtSymbol()` removes the `@` before inserting the chip
- When the picker is dismissed: `@` stays in the input as a literal character

## Test plan

- [x] `npm test` passes
- [x] `npm run build` succeeds
- [ ] Manual: type `user@example.com` in chat — @ should stay
- [ ] Manual: type `@` then select a file — chip should replace @
- [ ] Manual: type `@` then dismiss picker — @ should remain

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Typing "@" now inserts the character into the input immediately. When selecting a file/folder from the picker, the trailing "@" is automatically removed before the file chip is inserted; if the picker is dismissed, the "@" remains. This yields more natural typing and selection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->