### PR TITLE
docs: Add FAQ for reusing prompts in Agent mode

### DIFF
--- a/docs/guide/faq.md
+++ b/docs/guide/faq.md
@@ -109,6 +109,21 @@ The depth traversal setting was removed in v4.0 when Agent Mode became the defau
 
 If the agent is ignoring your custom prompt, check that your model's rate limits haven't been exceeded — rate limit errors can appear as generic "failed" messages. Also verify: (1) the prompt file exists in `[Plugin State Folder]/Prompts/`, and (2) the frontmatter reference uses correct wikilink syntax `[[Prompt Name]]`. ([#330](https://github.com/allenhutchison/obsidian-gemini/discussions/330))
 
+### How do I reuse prompts in Agent mode?
+
+Custom prompts are applied per-session, not executed as commands. To reuse a prompt:
+
+1. Open the agent panel and start or load a session
+2. Click the **gear icon** (session settings) in the session header
+3. Select your prompt from the **Prompt Template** dropdown
+4. The prompt is now active for that session — all messages will use it
+
+To apply the same prompt to different files, add the files as context (drag them in or use `@` to mention them) while the prompt is active.
+
+If you need a repeatable multi-step procedure rather than a behavioral style, consider creating a [skill](/guide/agent-skills) instead. Skills define step-by-step workflows the agent follows on demand.
+
+Custom prompts and skills both work on mobile (Android and iOS). ([#449](https://github.com/allenhutchison/obsidian-gemini/issues/449))
+
 ---
 
 Still have questions? Check the [GitHub Discussions](https://github.com/allenhutchison/obsidian-gemini/discussions) or [open an issue](https://github.com/allenhutchison/obsidian-gemini/issues).


### PR DESCRIPTION
## Summary

Fixes #449 — adds a FAQ entry answering the common question about how to reuse prompts in agent mode.

Clarifies:
- Custom prompts are session-level config (gear icon → Prompt Template dropdown), not executable commands
- How to apply the same prompt to different files (add context while prompt is active)
- When to use skills instead (repeatable multi-step procedures)
- Confirms mobile support (Android and iOS)

## Test plan

- [x] `npm run build` succeeds
- [x] Docs render correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added FAQ entry explaining how to reuse prompts in Agent mode, including step-by-step UI instructions for accessing prompt templates through session settings and guidance on reusing prompts across multiple files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->