### PR TITLE
fix: Replace dynamic import('obsidian') with static import in createProject

### DIFF
--- a/src/services/project-manager.ts
+++ b/src/services/project-manager.ts
@@ -1,4 +1,4 @@
-import { TFile } from 'obsidian';
+import { TFile, normalizePath } from 'obsidian';
 import type ObsidianGemini from '../main';
 import { Project, ProjectConfig, ProjectSummary, PROJECT_TAG } from '../types/project';
 import { ToolPermission } from '../types/tool-policy';
@@ -147,7 +147,6 @@ export class ProjectManager {
 	 * Create a new project file with template frontmatter and instructions.
 	 */
 	async createProject(folderPath: string, name: string): Promise<TFile> {
-		const { normalizePath } = await import('obsidian');
 		const filePath = normalizePath(`${folderPath}/${name}.md`);
 
 		const content = `---


### PR DESCRIPTION
## Summary

Fixes #518 — `ProjectManager.createProject()` crashed with `TypeError: Failed to resolve module specifier 'obsidian'` because it used `await import('obsidian')` to get `normalizePath`.

## Root Cause

Dynamic `import('obsidian')` doesn't work at runtime in Obsidian's plugin environment. The `obsidian` module is provided by the host, not resolvable as a standard module specifier. This is different from dynamic imports of local files which work fine.

## Fix

Add `normalizePath` to the existing static import at the top of the file. Remove the dynamic import.

## Test plan

- [x] `npm test` passes
- [x] `npm run build` succeeds
- [ ] Manual: use "Create Project" command, verify file is created without error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved code organization and module loading efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->