### PR TITLE
fix: Preserve newlines from Shift+Enter in agent chat input

### DIFF
--- a/src/ui/agent-view/agent-view-file-chips.ts
+++ b/src/ui/agent-view/agent-view-file-chips.ts
@@ -218,7 +218,8 @@ export class AgentViewFileChips {
 		});
 
 		// Get the formatted message with markdown links
-		const formattedMessage = clone.textContent?.trim() || '';
+		// Use innerText to preserve newlines from Shift+Enter (contenteditable creates <br>/<div>)
+		const formattedMessage = clone.innerText?.trim() || '';
 
 		// Now replace chips with file/folder names to get plain text
 		const plainClone = this.userInput.cloneNode(true) as HTMLElement;
@@ -247,7 +248,8 @@ export class AgentViewFileChips {
 				}
 			}
 		});
-		const text = plainClone.textContent?.trim() || '';
+		// Use innerText to preserve newlines from Shift+Enter
+		const text = plainClone.innerText?.trim() || '';
 
 		return {
 			text,


### PR DESCRIPTION
## Summary

Fixes #520 — newlines created with Shift+Enter in the agent chat input are now preserved in the displayed message and session history.

## Root Cause

`extractMessageContent()` used `.textContent` to extract text from the contenteditable input. `textContent` strips all HTML structure — including `<br>` and `<div>` elements that contenteditable creates for line breaks — collapsing everything to a flat string.

## Fix

Replace `.textContent` with `.innerText` in both extraction points (formatted message and plain text). `innerText` respects visual formatting and converts block elements and `<br>` to `\n`.

## Test plan

- [x] `npm test` passes
- [x] `npm run build` succeeds
- [ ] Manual: type multi-line message with Shift+Enter, submit, verify newlines preserved in chat and history file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed whitespace and line break preservation in text input, ensuring proper formatting is maintained when composing messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->