### PR TITLE
fix: Project auto-detection not working on session creation

### DIFF
--- a/src/ui/agent-view/agent-view-session.ts
+++ b/src/ui/agent-view/agent-view-session.ts
@@ -26,7 +26,7 @@ export interface SessionUICallbacks {
 	showEmptyState: () => Promise<void>;
 
 	/** Add active file to context if available */
-	addActiveFileToContext: () => Promise<void>;
+	addActiveFileToContext: (session?: ChatSession) => Promise<void>;
 
 	/** Focus the input field */
 	focusInput: () => void;
@@ -121,8 +121,9 @@ export class AgentViewSession {
 			// Create new session with default context (no initial files)
 			this.currentSession = await this.plugin.sessionManager.createAgentSession();
 
-			// Add active file to context if there is one
-			await this.uiCallbacks.addActiveFileToContext();
+			// Add active file to context — pass session directly since
+			// the AgentView's currentSession reference isn't updated yet
+			await this.uiCallbacks.addActiveFileToContext(this.currentSession);
 
 			// Update UI (no history to load for new session)
 			this.uiCallbacks.updateSessionHeader();

--- a/src/ui/agent-view/agent-view.ts
+++ b/src/ui/agent-view/agent-view.ts
@@ -180,7 +180,8 @@ export class AgentView extends ItemView {
 			updateSessionHeader: () => this.updateSessionHeader(),
 			updateContextPanel: () => this.updateContextPanel(),
 			showEmptyState: () => this.showEmptyState(),
-			addActiveFileToContext: () => this.context.addActiveFileToContext(this.currentSession),
+			addActiveFileToContext: (session?: ChatSession) =>
+				this.context.addActiveFileToContext(session ?? this.currentSession),
 			focusInput: () => this.userInput.focus(),
 		};
 


### PR DESCRIPTION
## Summary

Fixes #523 — project auto-detection now works when creating a new session while the active file is inside a project folder.

## Root Cause

The `addActiveFileToContext` callback captured `AgentView.currentSession` via a closure. During `createNewSession()`, this reference was still `null` (or the previous session) because the AgentView's reference isn't updated until after `createNewSession()` returns:

```
session.createNewSession()       ← addActiveFileToContext uses AgentView.currentSession (STALE!)
  → createAgentSession()         ← new session created
  → addActiveFileToContext()     ← adds file to wrong/null session
this.currentSession = ...        ← AgentView reference updated (TOO LATE)
emit('sessionCreated')           ← subscriber finds empty context files
```

The active file was silently lost, so the `ProjectActivationSubscriber` found no context files to match against any project.

## Fix

Pass `AgentViewSession.currentSession` directly to the callback instead of relying on the stale AgentView closure:

```typescript
// Before: callback always uses AgentView's (stale) reference
addActiveFileToContext: () => this.context.addActiveFileToContext(this.currentSession)

// After: accepts optional session, falls back to current
addActiveFileToContext: (session?) => this.context.addActiveFileToContext(session ?? this.currentSession)
```

## Test plan

- [x] `npm test` passes
- [x] `npm run build` succeeds
- [x] Manual: open file inside a project folder → create new session → verify project badge appears in header
- [x] Manual: open the project file itself → create new session → verify project linked

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved session context handling in agent view callbacks to ensure consistent session reference management during context updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->