### PR TITLE
Always save RAG store name setting, add feedback for cleared value

### DIFF
--- a/src/ui/settings-rag.ts
+++ b/src/ui/settings-rag.ts
@@ -154,9 +154,10 @@ export async function renderRAGSettings(
 					.setValue('')
 					.onChange(async (value) => {
 						const trimmedValue = value.trim();
-						plugin.settings.ragIndexing.fileSearchStoreName = trimmedValue;
+						const normalizedStoreName = trimmedValue.length > 0 ? trimmedValue : null;
+						plugin.settings.ragIndexing.fileSearchStoreName = normalizedStoreName;
 						await plugin.saveSettings();
-						if (trimmedValue) {
+						if (normalizedStoreName) {
 							new Notice('Store name set. Will be used when indexing starts.');
 						} else {
 							new Notice('Store name cleared.');

--- a/src/ui/settings-rag.ts
+++ b/src/ui/settings-rag.ts
@@ -154,10 +154,12 @@ export async function renderRAGSettings(
 					.setValue('')
 					.onChange(async (value) => {
 						const trimmedValue = value.trim();
+						plugin.settings.ragIndexing.fileSearchStoreName = trimmedValue;
+						await plugin.saveSettings();
 						if (trimmedValue) {
-							plugin.settings.ragIndexing.fileSearchStoreName = trimmedValue;
-							await plugin.saveSettings();
 							new Notice('Store name set. Will be used when indexing starts.');
+						} else {
+							new Notice('Store name cleared.');
 						}
 					});
 			});


### PR DESCRIPTION
## Summary

Improves the RAG store name setting behavior by always persisting the value to settings (even when cleared) and providing user feedback when the store name is cleared.

## Changes

- Move settings save operation outside the conditional check so the store name is persisted whether it's set or cleared
- Add user-facing notice when store name is cleared to provide feedback for both set and clear actions
- Maintain existing notice for when store name is set

## Checklist

### Required

- [ ] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer
- [ ] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [ ] I have tested this change on Desktop
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards)
- [ ] Documentation has been updated (if applicable)
- [ ] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

https://claude.ai/code/session_01HQ1VxhsUo7DQPNxEqimHQo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The "Search index name" setting now always normalizes input, saves changes immediately (including when cleared), and shows appropriate feedback both when a name is set and when it is cleared.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->