### PR TITLE
Add error handling for dynamic modal imports in settings

### DIFF
--- a/src/ui/settings-mcp.ts
+++ b/src/ui/settings-mcp.ts
@@ -94,40 +94,45 @@ async function createMCPSettings(
 				.addButton((btn) =>
 					btn.setButtonText('Edit').onClick(async () => {
 						if (!mcpManager) return;
-						const { MCPServerModal } = await import('./mcp-server-modal');
-						const oldName = server.name;
-						const modal = new MCPServerModal(app, mcpManager, server, async (updated) => {
-							plugin.settings.mcpServers = plugin.settings.mcpServers || [];
+						try {
+							const { MCPServerModal } = await import('./mcp-server-modal');
+							const oldName = server.name;
+							const modal = new MCPServerModal(app, mcpManager, server, async (updated) => {
+								plugin.settings.mcpServers = plugin.settings.mcpServers || [];
 
-							// Reject duplicate names (allow keeping the same name)
-							if (updated.name !== oldName && plugin.settings.mcpServers.some((s) => s.name === updated.name)) {
-								new Notice(`A server named "${updated.name}" already exists`);
-								return;
-							}
+								// Reject duplicate names (allow keeping the same name)
+								if (updated.name !== oldName && plugin.settings.mcpServers.some((s) => s.name === updated.name)) {
+									new Notice(`A server named "${updated.name}" already exists`);
+									return;
+								}
 
-							const idx = plugin.settings.mcpServers.findIndex((s) => s.name === oldName);
-							if (idx >= 0) {
-								plugin.settings.mcpServers[idx] = updated;
-							}
-							await plugin.saveSettings();
+								const idx = plugin.settings.mcpServers.findIndex((s) => s.name === oldName);
+								if (idx >= 0) {
+									plugin.settings.mcpServers[idx] = updated;
+								}
+								await plugin.saveSettings();
 
-							// Disconnect old name first if it was connected (handles renames)
-							if (mcpManager?.isConnected(oldName)) {
-								await mcpManager.disconnectServer(oldName);
-								if (updated.enabled) {
-									try {
-										await mcpManager.connectServer(updated);
-									} catch (error) {
-										new Notice(
-											`Failed to reconnect "${updated.name}": ${error instanceof Error ? error.message : error}`
-										);
+								// Disconnect old name first if it was connected (handles renames)
+								if (mcpManager?.isConnected(oldName)) {
+									await mcpManager.disconnectServer(oldName);
+									if (updated.enabled) {
+										try {
+											await mcpManager.connectServer(updated);
+										} catch (error) {
+											new Notice(
+												`Failed to reconnect "${updated.name}": ${error instanceof Error ? error.message : error}`
+											);
+										}
 									}
 								}
-							}
 
-							context.redisplay();
-						});
-						modal.open();
+								context.redisplay();
+							});
+							modal.open();
+						} catch (error) {
+							plugin.logger.error('Failed to load MCP server modal:', error);
+							new Notice(`Failed to open server editor: ${getErrorMessage(error)}`);
+						}
 					})
 				)
 				.addButton((btn) =>
@@ -153,29 +158,34 @@ async function createMCPSettings(
 			.setCta()
 			.onClick(async () => {
 				if (!plugin.mcpManager) return;
-				const { MCPServerModal } = await import('./mcp-server-modal');
-				const modal = new MCPServerModal(app, plugin.mcpManager, null, async (config) => {
-					plugin.settings.mcpServers = plugin.settings.mcpServers || [];
-					// Check for duplicate name
-					if (plugin.settings.mcpServers.some((s) => s.name === config.name)) {
-						new Notice(`A server named "${config.name}" already exists`);
-						return;
-					}
-					plugin.settings.mcpServers.push(config);
-					await plugin.saveSettings();
-
-					// Connect if enabled
-					if (config.enabled && plugin.mcpManager) {
-						try {
-							await plugin.mcpManager.connectServer(config);
-						} catch (error) {
-							new Notice(`Server saved but failed to connect: ${getErrorMessage(error)}`);
+				try {
+					const { MCPServerModal } = await import('./mcp-server-modal');
+					const modal = new MCPServerModal(app, plugin.mcpManager, null, async (config) => {
+						plugin.settings.mcpServers = plugin.settings.mcpServers || [];
+						// Check for duplicate name
+						if (plugin.settings.mcpServers.some((s) => s.name === config.name)) {
+							new Notice(`A server named "${config.name}" already exists`);
+							return;
 						}
-					}
+						plugin.settings.mcpServers.push(config);
+						await plugin.saveSettings();
 
-					context.redisplay();
-				});
-				modal.open();
+						// Connect if enabled
+						if (config.enabled && plugin.mcpManager) {
+							try {
+								await plugin.mcpManager.connectServer(config);
+							} catch (error) {
+								new Notice(`Server saved but failed to connect: ${getErrorMessage(error)}`);
+							}
+						}
+
+						context.redisplay();
+					});
+					modal.open();
+				} catch (error) {
+					plugin.logger.error('Failed to load MCP server modal:', error);
+					new Notice(`Failed to open Add Server dialog: ${getErrorMessage(error)}`);
+				}
 			})
 	);
 }

--- a/src/ui/settings-rag.ts
+++ b/src/ui/settings-rag.ts
@@ -32,16 +32,23 @@ export async function renderRAGSettings(
 					toggle.setValue(true);
 
 					// Show cleanup modal when disabling
-					const { RagCleanupModal } = await import('./rag-cleanup-modal');
-					const modal = new RagCleanupModal(app, async (deleteData) => {
-						if (deleteData && plugin.ragIndexing) {
-							await plugin.ragIndexing.deleteFileSearchStore();
-						}
-						plugin.settings.ragIndexing.enabled = false;
-						await plugin.saveSettings();
-						context.redisplay();
-					});
-					modal.open();
+					try {
+						const { RagCleanupModal } = await import('./rag-cleanup-modal');
+						const modal = new RagCleanupModal(app, async (deleteData) => {
+							if (deleteData && plugin.ragIndexing) {
+								await plugin.ragIndexing.deleteFileSearchStore();
+							}
+							plugin.settings.ragIndexing.enabled = false;
+							await plugin.saveSettings();
+							context.redisplay();
+						});
+						modal.open();
+					} catch (error) {
+						plugin.logger.error('Failed to load RAG cleanup modal:', error);
+						new Notice(`Failed to open cleanup dialog: ${getErrorMessage(error)}`);
+						// Toggle was already reverted to `true` above and settings.enabled
+						// was never changed, so UI and settings remain consistent.
+					}
 				} else {
 					plugin.settings.ragIndexing.enabled = value;
 					await plugin.saveSettings();
@@ -96,25 +103,30 @@ export async function renderRAGSettings(
 						}
 
 						// Show confirmation modal
-						const { RagCleanupModal } = await import('./rag-cleanup-modal');
-						const modal = new RagCleanupModal(app, async (deleteData) => {
-							if (deleteData && plugin.ragIndexing) {
-								button.setButtonText('Deleting...');
-								button.setDisabled(true);
+						try {
+							const { RagCleanupModal } = await import('./rag-cleanup-modal');
+							const modal = new RagCleanupModal(app, async (deleteData) => {
+								if (deleteData && plugin.ragIndexing) {
+									button.setButtonText('Deleting...');
+									button.setDisabled(true);
 
-								try {
-									await plugin.ragIndexing.deleteFileSearchStore();
-									new Notice('Index deleted. Use "Reindex Vault" to rebuild.');
-									context.redisplay();
-								} catch (error) {
-									new Notice(`Failed to delete index: ${getErrorMessage(error)}`);
-								} finally {
-									button.setButtonText('Delete Index');
-									button.setDisabled(false);
+									try {
+										await plugin.ragIndexing.deleteFileSearchStore();
+										new Notice('Index deleted. Use "Reindex Vault" to rebuild.');
+										context.redisplay();
+									} catch (error) {
+										new Notice(`Failed to delete index: ${getErrorMessage(error)}`);
+									} finally {
+										button.setButtonText('Delete Index');
+										button.setDisabled(false);
+									}
 								}
-							}
-						});
-						modal.open();
+							});
+							modal.open();
+						} catch (error) {
+							plugin.logger.error('Failed to load RAG cleanup modal:', error);
+							new Notice(`Failed to open delete confirmation: ${getErrorMessage(error)}`);
+						}
 					})
 			);
 

--- a/src/ui/settings-tools.ts
+++ b/src/ui/settings-tools.ts
@@ -1,5 +1,5 @@
 import type ObsidianGemini from '../main';
-import { App, Setting, SettingGroup } from 'obsidian';
+import { App, Setting, SettingGroup, Notice } from 'obsidian';
 import {
 	ToolPermission,
 	ToolClassification,
@@ -10,6 +10,7 @@ import {
 	PRESET_PERMISSIONS,
 	DEFAULT_TOOL_POLICY,
 } from '../types/tool-policy';
+import { getErrorMessage } from '../utils/error-utils';
 import type { SettingsSectionContext } from './settings';
 
 export async function renderToolSettings(
@@ -123,7 +124,8 @@ async function createToolPermissionsSettings(
 					try {
 						confirmed = await showYoloConfirmation(app);
 					} catch (error) {
-						plugin.logger.error('Failed to load YOLO confirmation modal', error);
+						plugin.logger.error('Failed to load YOLO confirmation modal:', error);
+						new Notice(`Failed to open YOLO confirmation: ${getErrorMessage(error)}`);
 					}
 					if (!confirmed) {
 						dropdown.setValue(policy.activePreset);


### PR DESCRIPTION
## Summary

Adds comprehensive error handling for dynamic modal imports across settings UI modules. When modal imports fail (e.g., due to module loading issues), users now receive clear error notifications instead of silent failures or unhandled exceptions.

## Changes

- Wrapped dynamic `import()` statements in try-catch blocks in `settings-mcp.ts`, `settings-rag.ts`, and `settings-tools.ts`
- Added user-facing error notifications via `Notice` when modal loading fails
- Added server-side logging via `plugin.logger.error()` for debugging
- Imported `Notice` and `getErrorMessage` utility where needed
- Improved error message clarity for "Edit Server", "Add Server", "RAG Cleanup", and "YOLO Confirmation" dialogs

## Testing

Existing functionality remains unchanged for successful modal loads. Error handling is defensive and non-breaking—if a modal fails to load, users see a clear error message rather than the UI becoming unresponsive.

https://claude.ai/code/session_0144GQ7PEpZTKv5exGExx3St

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * MCP server configuration modals now show clear error notifications and log failures if the modal fails to load or open.
  * RAG indexing cleanup dialogs now display informative error messages and log failures when modal initialization or opening fails.
  * Tool confirmation flows (YOLO/other confirmations) now surface user-facing error notices and improved logging on failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->