### PR TITLE
Debounce settings saves to prevent excessive plugin lifecycle runs

### DIFF
--- a/__mocks__/obsidian.js
+++ b/__mocks__/obsidian.js
@@ -107,16 +107,28 @@ const MarkdownRenderer = {
 const setIcon = jest.fn();
 const Notice = jest.fn();
 const normalizePath = jest.fn((path) => path);
-// Minimal Obsidian `debounce` mock. Returns a callable Debouncer that invokes
-// the callback synchronously on each call and exposes cancel/run no-ops, so
-// settings modules importing `debounce` from 'obsidian' don't crash in tests.
+// Minimal Obsidian `debounce` mock. Queues the latest args on each call without
+// firing; `run()` drains the queue and invokes the callback; `cancel()` clears
+// it. This matches Obsidian's real debounce semantics (deferred firing) so
+// tests can assert coalescing behavior by driving `.run()` explicitly.
 const debounce = (cb, _timeout, _resetTimer) => {
+	let pendingArgs = null;
 	const debounced = (...args) => {
-		cb(...args);
+		pendingArgs = args;
 		return debounced;
 	};
-	debounced.cancel = () => debounced;
-	debounced.run = () => cb();
+	debounced.cancel = () => {
+		pendingArgs = null;
+		return debounced;
+	};
+	debounced.run = () => {
+		if (pendingArgs) {
+			const args = pendingArgs;
+			pendingArgs = null;
+			cb(...args);
+		}
+		return debounced;
+	};
 	return debounced;
 };
 const prepareFuzzySearch = jest.fn((query) => {

--- a/__mocks__/obsidian.js
+++ b/__mocks__/obsidian.js
@@ -107,6 +107,18 @@ const MarkdownRenderer = {
 const setIcon = jest.fn();
 const Notice = jest.fn();
 const normalizePath = jest.fn((path) => path);
+// Minimal Obsidian `debounce` mock. Returns a callable Debouncer that invokes
+// the callback synchronously on each call and exposes cancel/run no-ops, so
+// settings modules importing `debounce` from 'obsidian' don't crash in tests.
+const debounce = (cb, _timeout, _resetTimer) => {
+	const debounced = (...args) => {
+		cb(...args);
+		return debounced;
+	};
+	debounced.cancel = () => debounced;
+	debounced.run = () => cb();
+	return debounced;
+};
 const prepareFuzzySearch = jest.fn((query) => {
 	return (text) => {
 		if (!query || text.toLowerCase().includes(query.toLowerCase())) {
@@ -278,4 +290,5 @@ module.exports = {
 	prepareFuzzySearch,
 	SecretComponent,
 	SecretStorage,
+	debounce,
 };

--- a/src/ui/settings-api.ts
+++ b/src/ui/settings-api.ts
@@ -1,5 +1,5 @@
 import type ObsidianGemini from '../main';
-import { Setting, Notice } from 'obsidian';
+import { Setting, Notice, debounce } from 'obsidian';
 import type { SettingsSectionContext } from './settings';
 
 let temperatureDebounceTimer: NodeJS.Timeout | null = null;
@@ -12,6 +12,10 @@ export async function renderApiSettings(
 	plugin: ObsidianGemini,
 	context: SettingsSectionContext
 ): Promise<void> {
+	// Debounce saveSettings() for text inputs so typing doesn't trigger the plugin
+	// lifecycle on every keystroke. Settings are mutated immediately; only the save is delayed.
+	const debouncedSave = debounce(() => plugin.saveSettings(), 300, true);
+
 	// File Logging
 	new Setting(containerEl)
 		.setName('Log to file')
@@ -52,11 +56,11 @@ export async function renderApiSettings(
 			text
 				.setPlaceholder('e.g., 3')
 				.setValue(plugin.settings.maxRetries.toString())
-				.onChange(async (value) => {
+				.onChange((value) => {
 					const parsed = parseInt(value, 10);
 					if (!isNaN(parsed) && parsed >= 0) {
 						plugin.settings.maxRetries = parsed;
-						await plugin.saveSettings();
+						debouncedSave();
 					}
 				})
 		);
@@ -68,11 +72,11 @@ export async function renderApiSettings(
 			text
 				.setPlaceholder('e.g., 1000')
 				.setValue(plugin.settings.initialBackoffDelay.toString())
-				.onChange(async (value) => {
+				.onChange((value) => {
 					const parsed = parseInt(value, 10);
 					if (!isNaN(parsed) && parsed >= 0) {
 						plugin.settings.initialBackoffDelay = parsed;
-						await plugin.saveSettings();
+						debouncedSave();
 					}
 				})
 		);

--- a/src/ui/settings-api.ts
+++ b/src/ui/settings-api.ts
@@ -1,5 +1,6 @@
 import type ObsidianGemini from '../main';
 import { Setting, Notice, debounce } from 'obsidian';
+import { getErrorMessage } from '../utils/error-utils';
 import type { SettingsSectionContext } from './settings';
 
 let temperatureDebounceTimer: NodeJS.Timeout | null = null;
@@ -14,7 +15,20 @@ export async function renderApiSettings(
 ): Promise<void> {
 	// Debounce saveSettings() for text inputs so typing doesn't trigger the plugin
 	// lifecycle on every keystroke. Settings are mutated immediately; only the save is delayed.
-	const debouncedSave = debounce(() => plugin.saveSettings(), 300, true);
+	// The callback is async + wrapped in try/catch so rejections from saveSettings() don't
+	// become unhandled promise rejections.
+	const debouncedSave = debounce(
+		async () => {
+			try {
+				await plugin.saveSettings();
+			} catch (error) {
+				plugin.logger.error('Failed to save settings:', error);
+				new Notice(`Failed to save settings: ${getErrorMessage(error)}`);
+			}
+		},
+		300,
+		true
+	);
 
 	// File Logging
 	new Setting(containerEl)

--- a/src/ui/settings-general.ts
+++ b/src/ui/settings-general.ts
@@ -1,12 +1,26 @@
 import type ObsidianGemini from '../main';
-import { App, Setting, SecretComponent, debounce } from 'obsidian';
+import { App, Notice, Setting, SecretComponent, debounce } from 'obsidian';
 import { selectModelSetting } from './settings-helpers';
 import { FolderSuggest } from './folder-suggest';
+import { getErrorMessage } from '../utils/error-utils';
 
 export async function renderGeneralSettings(containerEl: HTMLElement, plugin: ObsidianGemini, app: App): Promise<void> {
 	// Debounce saveSettings() to avoid re-running the plugin lifecycle on every keystroke
 	// in text inputs. In-memory settings are mutated immediately so the UI stays responsive.
-	const debouncedSave = debounce(() => plugin.saveSettings(), 300, true);
+	// The callback is async + wrapped in try/catch so rejections from saveSettings() don't
+	// become unhandled promise rejections.
+	const debouncedSave = debounce(
+		async () => {
+			try {
+				await plugin.saveSettings();
+			} catch (error) {
+				plugin.logger.error('Failed to save settings:', error);
+				new Notice(`Failed to save settings: ${getErrorMessage(error)}`);
+			}
+		},
+		300,
+		true
+	);
 
 	// Documentation button at the top
 	new Setting(containerEl)

--- a/src/ui/settings-general.ts
+++ b/src/ui/settings-general.ts
@@ -1,9 +1,13 @@
 import type ObsidianGemini from '../main';
-import { App, Setting, SecretComponent } from 'obsidian';
+import { App, Setting, SecretComponent, debounce } from 'obsidian';
 import { selectModelSetting } from './settings-helpers';
 import { FolderSuggest } from './folder-suggest';
 
 export async function renderGeneralSettings(containerEl: HTMLElement, plugin: ObsidianGemini, app: App): Promise<void> {
+	// Debounce saveSettings() to avoid re-running the plugin lifecycle on every keystroke
+	// in text inputs. In-memory settings are mutated immediately so the UI stays responsive.
+	const debouncedSave = debounce(() => plugin.saveSettings(), 300, true);
+
 	// Documentation button at the top
 	new Setting(containerEl)
 		.setName('Documentation')
@@ -75,9 +79,9 @@ export async function renderGeneralSettings(containerEl: HTMLElement, plugin: Ob
 			text
 				.setPlaceholder('summary')
 				.setValue(plugin.settings.summaryFrontmatterKey)
-				.onChange(async (value) => {
+				.onChange((value) => {
 					plugin.settings.summaryFrontmatterKey = value;
-					await plugin.saveSettings();
+					debouncedSave();
 				})
 		);
 
@@ -88,9 +92,9 @@ export async function renderGeneralSettings(containerEl: HTMLElement, plugin: Ob
 			text
 				.setPlaceholder('Enter your name')
 				.setValue(plugin.settings.userName)
-				.onChange(async (value) => {
+				.onChange((value) => {
 					plugin.settings.userName = value;
-					await plugin.saveSettings();
+					debouncedSave();
 				})
 		);
 
@@ -101,9 +105,9 @@ export async function renderGeneralSettings(containerEl: HTMLElement, plugin: Ob
 			'Folder where plugin data is stored. Agent sessions are saved in Agent-Sessions/, custom prompts in Prompts/.'
 		)
 		.addText((text) => {
-			new FolderSuggest(app, text.inputEl, async (folder) => {
+			new FolderSuggest(app, text.inputEl, (folder) => {
 				plugin.settings.historyFolder = folder;
-				await plugin.saveSettings();
+				debouncedSave();
 			});
 			text.setValue(plugin.settings.historyFolder);
 		});

--- a/src/ui/settings-rag.ts
+++ b/src/ui/settings-rag.ts
@@ -164,6 +164,21 @@ export async function renderRAGSettings(
 		} else {
 			// No store yet - allow editing
 			storeNameSetting.addText((text) => {
+				// Bundle save + confirmation notice in a single debouncer so notices
+				// fire once per typing burst (not on every keystroke). The notice text
+				// depends on whether the store name is set or cleared at fire time.
+				const debouncedSaveAndNotify = debounce(
+					() => {
+						plugin.saveSettings();
+						if (plugin.settings.ragIndexing.fileSearchStoreName) {
+							new Notice('Store name set. Will be used when indexing starts.');
+						} else {
+							new Notice('Store name cleared.');
+						}
+					},
+					300,
+					true
+				);
 				text.inputEl.style.width = '30ch';
 				text
 					.setPlaceholder('Auto-generated if empty')
@@ -172,12 +187,7 @@ export async function renderRAGSettings(
 						const trimmedValue = value.trim();
 						const normalizedStoreName = trimmedValue.length > 0 ? trimmedValue : null;
 						plugin.settings.ragIndexing.fileSearchStoreName = normalizedStoreName;
-						debouncedSave();
-						if (normalizedStoreName) {
-							new Notice('Store name set. Will be used when indexing starts.');
-						} else {
-							new Notice('Store name cleared.');
-						}
+						debouncedSaveAndNotify();
 					});
 			});
 		}

--- a/src/ui/settings-rag.ts
+++ b/src/ui/settings-rag.ts
@@ -1,5 +1,5 @@
 import type ObsidianGemini from '../main';
-import { App, Setting, Notice } from 'obsidian';
+import { App, Setting, Notice, debounce } from 'obsidian';
 import { getErrorMessage } from '../utils/error-utils';
 import type { SettingsSectionContext } from './settings';
 
@@ -9,6 +9,10 @@ export async function renderRAGSettings(
 	app: App,
 	context: SettingsSectionContext
 ): Promise<void> {
+	// Debounce saveSettings() for text inputs so typing doesn't trigger the plugin
+	// lifecycle on every keystroke. Settings are mutated immediately; only the save is delayed.
+	const debouncedSave = debounce(() => plugin.saveSettings(), 300, true);
+
 	new Setting(containerEl).setName('Vault Search Index (Experimental)').setHeading();
 
 	// Privacy warning
@@ -164,11 +168,11 @@ export async function renderRAGSettings(
 				text
 					.setPlaceholder('Auto-generated if empty')
 					.setValue('')
-					.onChange(async (value) => {
+					.onChange((value) => {
 						const trimmedValue = value.trim();
 						const normalizedStoreName = trimmedValue.length > 0 ? trimmedValue : null;
 						plugin.settings.ragIndexing.fileSearchStoreName = normalizedStoreName;
-						await plugin.saveSettings();
+						debouncedSave();
 						if (normalizedStoreName) {
 							new Notice('Store name set. Will be used when indexing starts.');
 						} else {
@@ -212,13 +216,13 @@ export async function renderRAGSettings(
 				text
 					.setPlaceholder('Additional folders to exclude...')
 					.setValue(userFolders.join('\n'))
-					.onChange(async (value) => {
+					.onChange((value) => {
 						// Filter out system folders to prevent confusion
 						plugin.settings.ragIndexing.excludeFolders = value
 							.split('\n')
 							.map((f) => f.trim())
 							.filter((f) => f.length > 0 && !systemFolders.includes(f));
-						await plugin.saveSettings();
+						debouncedSave();
 					});
 			});
 	}

--- a/src/ui/settings-rag.ts
+++ b/src/ui/settings-rag.ts
@@ -11,7 +11,27 @@ export async function renderRAGSettings(
 ): Promise<void> {
 	// Debounce saveSettings() for text inputs so typing doesn't trigger the plugin
 	// lifecycle on every keystroke. Settings are mutated immediately; only the save is delayed.
-	const debouncedSave = debounce(() => plugin.saveSettings(), 300, true);
+	// The store-name field uses `pendingStoreNameMessage` to queue a confirmation
+	// notice that fires only after the save actually succeeds, so a failed save
+	// doesn't surface a misleading success toast.
+	let pendingStoreNameMessage: string | null = null;
+	const debouncedSave = debounce(
+		async () => {
+			const messageToShow = pendingStoreNameMessage;
+			pendingStoreNameMessage = null;
+			try {
+				await plugin.saveSettings();
+				if (messageToShow) {
+					new Notice(messageToShow);
+				}
+			} catch (error) {
+				plugin.logger.error('Failed to save RAG settings:', error);
+				new Notice(`Failed to save settings: ${getErrorMessage(error)}`);
+			}
+		},
+		300,
+		true
+	);
 
 	new Setting(containerEl).setName('Vault Search Index (Experimental)').setHeading();
 
@@ -164,21 +184,6 @@ export async function renderRAGSettings(
 		} else {
 			// No store yet - allow editing
 			storeNameSetting.addText((text) => {
-				// Bundle save + confirmation notice in a single debouncer so notices
-				// fire once per typing burst (not on every keystroke). The notice text
-				// depends on whether the store name is set or cleared at fire time.
-				const debouncedSaveAndNotify = debounce(
-					() => {
-						plugin.saveSettings();
-						if (plugin.settings.ragIndexing.fileSearchStoreName) {
-							new Notice('Store name set. Will be used when indexing starts.');
-						} else {
-							new Notice('Store name cleared.');
-						}
-					},
-					300,
-					true
-				);
 				text.inputEl.style.width = '30ch';
 				text
 					.setPlaceholder('Auto-generated if empty')
@@ -187,7 +192,13 @@ export async function renderRAGSettings(
 						const trimmedValue = value.trim();
 						const normalizedStoreName = trimmedValue.length > 0 ? trimmedValue : null;
 						plugin.settings.ragIndexing.fileSearchStoreName = normalizedStoreName;
-						debouncedSaveAndNotify();
+						// Queue the confirmation notice for the next save completion. Reusing
+						// the section-level debouncedSave keeps all RAG saves on a single 300 ms
+						// queue so rapid edits across fields collapse into one saveSettings call.
+						pendingStoreNameMessage = normalizedStoreName
+							? 'Store name set. Will be used when indexing starts.'
+							: 'Store name cleared.';
+						debouncedSave();
 					});
 			});
 		}

--- a/test/ui/settings-api.test.ts
+++ b/test/ui/settings-api.test.ts
@@ -75,9 +75,20 @@ jest.mock('obsidian', () => {
 		}
 	}
 
+	function debounce(cb: any, _timeout?: number, _resetTimer?: boolean) {
+		const debounced: any = (...args: any[]) => {
+			cb(...args);
+			return debounced;
+		};
+		debounced.cancel = () => debounced;
+		debounced.run = () => cb();
+		return debounced;
+	}
+
 	return {
 		Setting,
 		Notice: mockNotice,
+		debounce,
 	};
 });
 

--- a/test/ui/settings-api.test.ts
+++ b/test/ui/settings-api.test.ts
@@ -76,12 +76,23 @@ jest.mock('obsidian', () => {
 	}
 
 	function debounce(cb: any, _timeout?: number, _resetTimer?: boolean) {
+		let pendingArgs: any[] | null = null;
 		const debounced: any = (...args: any[]) => {
-			cb(...args);
+			pendingArgs = args;
 			return debounced;
 		};
-		debounced.cancel = () => debounced;
-		debounced.run = () => cb();
+		debounced.cancel = () => {
+			pendingArgs = null;
+			return debounced;
+		};
+		debounced.run = () => {
+			if (pendingArgs) {
+				const args = pendingArgs;
+				pendingArgs = null;
+				cb(...args);
+			}
+			return debounced;
+		};
 		return debounced;
 	}
 


### PR DESCRIPTION
## Summary

Implements debounced settings saves across the settings UI to prevent the plugin lifecycle from being triggered on every keystroke in text inputs. Settings are mutated immediately in memory for responsive UI feedback, while the actual save operation is debounced by 300ms.

## Changes

- Import `debounce` utility from Obsidian in settings modules
- Create a debounced `saveSettings()` function in each settings file with 300ms delay
- Replace all `await plugin.saveSettings()` calls in `onChange` handlers with `debouncedSave()` calls
- Remove `async` keyword from `onChange` callbacks since they no longer await the save operation
- Affected settings files:
  - `src/ui/settings-general.ts`: Summary frontmatter key, user name, and history folder inputs
  - `src/ui/settings-api.ts`: Max retries and initial backoff delay inputs
  - `src/ui/settings-rag.ts`: RAG store name and exclude folders inputs

## Checklist

### Required

- [ ] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer
- [ ] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [ ] I have tested this change on Desktop
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards)
- [ ] Documentation has been updated (if applicable)
- [ ] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

https://claude.ai/code/session_0162wTGV7iyVspkV4engn9Kk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Settings persistence for text inputs in API, General, and RAG panels is now debounced (edits are batched and saved after a short pause), reducing save frequency during typing. Immediate saves remain for toggles, sliders, and explicit actions (e.g., reindex/delete).

* **UX**
  * Search index name updates now show a single confirmation notice after typing pauses (e.g., "set" or "cleared"). Save failures are now surfaced to the user with an error notice.

* **Tests**
  * Test mocks updated to include debounce behavior for unit tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->