### PR TITLE
Fix race condition in temperature/topP slider validation (issue #601)

### DIFF
--- a/src/ui/settings-api.ts
+++ b/src/ui/settings-api.ts
@@ -3,7 +3,9 @@ import { Setting, Notice } from 'obsidian';
 import type { SettingsSectionContext } from './settings';
 
 let temperatureDebounceTimer: NodeJS.Timeout | null = null;
+let temperatureRunId = 0;
 let topPDebounceTimer: NodeJS.Timeout | null = null;
+let topPRunId = 0;
 
 export async function renderApiSettings(
 	containerEl: HTMLElement,
@@ -212,20 +214,39 @@ async function createTemperatureSetting(
 					// Set immediate value for responsive UI
 					plugin.settings.temperature = value;
 
+					// Capture the run ID upfront so we can discard stale async results.
+					const runId = ++temperatureRunId;
+
 					// Debounce validation and saving
 					temperatureDebounceTimer = setTimeout(async () => {
-						// Validate the value against model capabilities
-						const validation = await modelManager.validateParameters(value, plugin.settings.topP);
+						try {
+							// Validate the current value against model capabilities. Read from
+							// settings rather than the captured `value` so the validation always
+							// matches the most recent user input.
+							const validation = await modelManager.validateParameters(
+								plugin.settings.temperature,
+								plugin.settings.topP
+							);
 
-						if (!validation.temperature.isValid && validation.temperature.adjustedValue !== undefined) {
-							slider.setValue(validation.temperature.adjustedValue);
-							plugin.settings.temperature = validation.temperature.adjustedValue;
-							if (validation.temperature.warning) {
-								new Notice(validation.temperature.warning);
+							// A newer slider change has superseded this run — discard the
+							// stale result instead of clobbering the current slider/value.
+							if (runId !== temperatureRunId) {
+								return;
 							}
-						}
 
-						await plugin.saveSettings();
+							if (!validation.temperature.isValid && validation.temperature.adjustedValue !== undefined) {
+								slider.setValue(validation.temperature.adjustedValue);
+								plugin.settings.temperature = validation.temperature.adjustedValue;
+								if (validation.temperature.warning) {
+									new Notice(validation.temperature.warning);
+								}
+							}
+
+							await plugin.saveSettings();
+						} catch (error) {
+							plugin.logger.error('Failed to validate/save temperature setting:', error);
+							new Notice('Failed to save temperature setting. See console for details.');
+						}
 					}, 300);
 				})
 		);
@@ -257,20 +278,39 @@ async function createTopPSetting(containerEl: HTMLElement, plugin: InstanceType<
 					// Set immediate value for responsive UI
 					plugin.settings.topP = value;
 
+					// Capture the run ID upfront so we can discard stale async results.
+					const runId = ++topPRunId;
+
 					// Debounce validation and saving
 					topPDebounceTimer = setTimeout(async () => {
-						// Validate the value against model capabilities
-						const validation = await modelManager.validateParameters(plugin.settings.temperature, value);
+						try {
+							// Validate the current value against model capabilities. Read from
+							// settings rather than the captured `value` so the validation always
+							// matches the most recent user input.
+							const validation = await modelManager.validateParameters(
+								plugin.settings.temperature,
+								plugin.settings.topP
+							);
 
-						if (!validation.topP.isValid && validation.topP.adjustedValue !== undefined) {
-							slider.setValue(validation.topP.adjustedValue);
-							plugin.settings.topP = validation.topP.adjustedValue;
-							if (validation.topP.warning) {
-								new Notice(validation.topP.warning);
+							// A newer slider change has superseded this run — discard the
+							// stale result instead of clobbering the current slider/value.
+							if (runId !== topPRunId) {
+								return;
 							}
-						}
 
-						await plugin.saveSettings();
+							if (!validation.topP.isValid && validation.topP.adjustedValue !== undefined) {
+								slider.setValue(validation.topP.adjustedValue);
+								plugin.settings.topP = validation.topP.adjustedValue;
+								if (validation.topP.warning) {
+									new Notice(validation.topP.warning);
+								}
+							}
+
+							await plugin.saveSettings();
+						} catch (error) {
+							plugin.logger.error('Failed to validate/save topP setting:', error);
+							new Notice('Failed to save Top P setting. See console for details.');
+						}
 					}, 300);
 				})
 		);

--- a/src/ui/settings-api.ts
+++ b/src/ui/settings-api.ts
@@ -244,6 +244,11 @@ async function createTemperatureSetting(
 
 							await plugin.saveSettings();
 						} catch (error) {
+							// If a newer run has superseded us, drop this stale failure silently —
+							// surfacing it would contradict whatever the current run is doing.
+							if (runId !== temperatureRunId) {
+								return;
+							}
 							plugin.logger.error('Failed to validate/save temperature setting:', error);
 							new Notice('Failed to save temperature setting. See console for details.');
 						}
@@ -308,6 +313,11 @@ async function createTopPSetting(containerEl: HTMLElement, plugin: InstanceType<
 
 							await plugin.saveSettings();
 						} catch (error) {
+							// If a newer run has superseded us, drop this stale failure silently —
+							// surfacing it would contradict whatever the current run is doing.
+							if (runId !== topPRunId) {
+								return;
+							}
 							plugin.logger.error('Failed to validate/save topP setting:', error);
 							new Notice('Failed to save Top P setting. See console for details.');
 						}

--- a/test/ui/settings-api.test.ts
+++ b/test/ui/settings-api.test.ts
@@ -233,6 +233,48 @@ describe('settings-api slider debounce (issue #601)', () => {
 			expect(mockNotice).toHaveBeenCalledWith(expect.stringContaining('Failed to save temperature setting'));
 		});
 
+		it('suppresses errors from stale validation runs that reject after a newer change', async () => {
+			let rejectFirst!: (e: any) => void;
+			const firstPending = new Promise((_res, rej) => {
+				rejectFirst = rej;
+			});
+
+			const validateParameters = jest
+				.fn()
+				.mockImplementationOnce(() => firstPending)
+				.mockImplementationOnce(() =>
+					Promise.resolve({
+						temperature: { isValid: true },
+						topP: { isValid: true },
+					})
+				);
+
+			const { plugin } = await setup(validateParameters);
+			const slider = mockSliderRegistry['Temperature'];
+
+			// First change: fire timer so the async body starts and awaits validation.
+			slider._handler(0.5);
+			await jest.advanceTimersByTimeAsync(300);
+			expect(validateParameters).toHaveBeenCalledTimes(1);
+
+			// Second change supersedes the in-flight run.
+			slider._handler(0.9);
+
+			// The stale run's validation now rejects.
+			rejectFirst(new Error('stale validation error'));
+			await flushMicrotasks();
+
+			// Stale rejection must NOT surface to the user: no logger.error, no Notice.
+			expect(plugin.logger.error).not.toHaveBeenCalled();
+			expect(mockNotice).not.toHaveBeenCalledWith(expect.stringContaining('Failed to save temperature setting'));
+
+			// The current run still completes cleanly.
+			await jest.advanceTimersByTimeAsync(300);
+			await flushMicrotasks();
+			expect(plugin.settings.temperature).toBe(0.9);
+			expect(plugin.saveSettings).toHaveBeenCalled();
+		});
+
 		it('saves settings after a clean validation without re-adjusting the slider', async () => {
 			const { plugin } = await setup();
 			const slider = mockSliderRegistry['Temperature'];
@@ -309,6 +351,43 @@ describe('settings-api slider debounce (issue #601)', () => {
 
 			expect(plugin.logger.error).toHaveBeenCalledWith('Failed to validate/save topP setting:', err);
 			expect(mockNotice).toHaveBeenCalledWith(expect.stringContaining('Failed to save Top P setting'));
+		});
+
+		it('suppresses errors from stale validation runs that reject after a newer change', async () => {
+			let rejectFirst!: (e: any) => void;
+			const firstPending = new Promise((_res, rej) => {
+				rejectFirst = rej;
+			});
+
+			const validateParameters = jest
+				.fn()
+				.mockImplementationOnce(() => firstPending)
+				.mockImplementationOnce(() =>
+					Promise.resolve({
+						temperature: { isValid: true },
+						topP: { isValid: true },
+					})
+				);
+
+			const { plugin } = await setup(validateParameters);
+			const slider = mockSliderRegistry['Top P'];
+
+			slider._handler(0.5);
+			await jest.advanceTimersByTimeAsync(300);
+			expect(validateParameters).toHaveBeenCalledTimes(1);
+
+			slider._handler(0.9);
+
+			rejectFirst(new Error('stale validation error'));
+			await flushMicrotasks();
+
+			expect(plugin.logger.error).not.toHaveBeenCalled();
+			expect(mockNotice).not.toHaveBeenCalledWith(expect.stringContaining('Failed to save Top P setting'));
+
+			await jest.advanceTimersByTimeAsync(300);
+			await flushMicrotasks();
+			expect(plugin.settings.topP).toBe(0.9);
+			expect(plugin.saveSettings).toHaveBeenCalled();
 		});
 	});
 });

--- a/test/ui/settings-api.test.ts
+++ b/test/ui/settings-api.test.ts
@@ -1,0 +1,314 @@
+/**
+ * Regression tests for settings-api temperature/topP slider debounce handlers.
+ *
+ * Covers issue #601:
+ *  - Stale async validation results must not overwrite current slider state
+ *    when a newer change has already been made (run-ID race condition).
+ *  - Validation / save rejections must surface through plugin.logger.error
+ *    and a user-facing Notice, not silent unhandled promise rejections.
+ */
+
+// `var` (not `const`) so that jest.mock hoisting can reference these below.
+// jest.mock is hoisted to the top of the file, while `const` would hit the
+// Temporal Dead Zone when the factory runs during module evaluation.
+// eslint-disable-next-line no-var
+var mockSliderRegistry: Record<string, any>;
+// eslint-disable-next-line no-var
+var mockNotice: jest.Mock;
+
+jest.mock('../../src/main');
+
+jest.mock('obsidian', () => {
+	mockSliderRegistry = {};
+	mockNotice = jest.fn();
+
+	class Setting {
+		private _name = '';
+		constructor(public containerEl: any) {}
+		setName(name: string) {
+			this._name = name;
+			return this;
+		}
+		setDesc(_desc: string) {
+			return this;
+		}
+		setHeading() {
+			return this;
+		}
+		addToggle(cb: (c: any) => void) {
+			const component: any = {};
+			component.setValue = () => component;
+			component.onChange = () => component;
+			cb(component);
+			return this;
+		}
+		addText(cb: (c: any) => void) {
+			const component: any = {};
+			component.setPlaceholder = () => component;
+			component.setValue = () => component;
+			component.onChange = () => component;
+			cb(component);
+			return this;
+		}
+		addSlider(cb: (c: any) => void) {
+			const component: any = {};
+			component.setValue = jest.fn(() => component);
+			component.setLimits = () => component;
+			component.setDynamicTooltip = () => component;
+			component._handler = null;
+			component.onChange = (handler: any) => {
+				component._handler = handler;
+				return component;
+			};
+			cb(component);
+			mockSliderRegistry[this._name] = component;
+			return this;
+		}
+		addButton(cb: (c: any) => void) {
+			const component: any = {};
+			component.setButtonText = () => component;
+			component.setTooltip = () => component;
+			component.setDisabled = () => component;
+			component.onClick = () => component;
+			cb(component);
+			return this;
+		}
+	}
+
+	return {
+		Setting,
+		Notice: mockNotice,
+	};
+});
+
+import { renderApiSettings } from '../../src/ui/settings-api';
+
+interface FakePlugin {
+	settings: any;
+	saveSettings: jest.Mock;
+	logger: {
+		error: jest.Mock;
+		warn: jest.Mock;
+		log: jest.Mock;
+		debug: jest.Mock;
+	};
+	getModelManager: () => any;
+}
+
+function buildPlugin(): FakePlugin {
+	return {
+		settings: {
+			temperature: 0.7,
+			topP: 1.0,
+			fileLogging: false,
+			allowSystemPromptOverride: false,
+			maxRetries: 3,
+			initialBackoffDelay: 1000,
+			modelDiscovery: { enabled: false, autoUpdateInterval: 24, fallbackToStatic: true },
+		},
+		saveSettings: jest.fn().mockResolvedValue(undefined),
+		logger: {
+			error: jest.fn(),
+			warn: jest.fn(),
+			log: jest.fn(),
+			debug: jest.fn(),
+		},
+		getModelManager: () => ({}),
+	};
+}
+
+async function setup(validateImpl?: jest.Mock) {
+	const plugin = buildPlugin();
+	const modelManager = {
+		getParameterRanges: jest.fn().mockResolvedValue({
+			temperature: { min: 0, max: 2, step: 0.1 },
+			topP: { min: 0, max: 1, step: 0.05 },
+		}),
+		getParameterDisplayInfo: jest.fn().mockResolvedValue({
+			hasModelData: false,
+			temperature: '',
+			topP: '',
+		}),
+		validateParameters:
+			validateImpl ||
+			jest.fn().mockResolvedValue({
+				temperature: { isValid: true },
+				topP: { isValid: true },
+			}),
+	};
+	plugin.getModelManager = () => modelManager;
+
+	const containerEl = {} as HTMLElement;
+	const context = { redisplay: jest.fn(), showDeveloperSettings: false };
+	await renderApiSettings(containerEl, plugin as any, context);
+	return { plugin, modelManager };
+}
+
+/** Run a few rounds of microtask flushes so awaited chains settle. */
+async function flushMicrotasks() {
+	for (let i = 0; i < 5; i++) {
+		await Promise.resolve();
+	}
+}
+
+describe('settings-api slider debounce (issue #601)', () => {
+	beforeEach(() => {
+		for (const key of Object.keys(mockSliderRegistry)) {
+			delete mockSliderRegistry[key];
+		}
+		mockNotice.mockClear();
+		jest.clearAllMocks();
+		jest.useFakeTimers();
+	});
+
+	afterEach(() => {
+		jest.useRealTimers();
+	});
+
+	describe('temperature slider', () => {
+		it('discards stale validation results when the slider changes mid-validation', async () => {
+			let resolveFirst!: (v: any) => void;
+			const firstPending = new Promise((res) => {
+				resolveFirst = res;
+			});
+
+			const validateParameters = jest
+				.fn()
+				.mockImplementationOnce(() => firstPending)
+				.mockImplementationOnce(() =>
+					Promise.resolve({
+						temperature: { isValid: true },
+						topP: { isValid: true },
+					})
+				);
+
+			const { plugin } = await setup(validateParameters);
+			const slider = mockSliderRegistry['Temperature'];
+			expect(slider).toBeDefined();
+
+			// User moves the slider to 0.5; advance past the debounce so the
+			// async body starts and awaits validation.
+			slider._handler(0.5);
+			await jest.advanceTimersByTimeAsync(300);
+			expect(validateParameters).toHaveBeenCalledTimes(1);
+
+			// User moves the slider again to 0.9 while validation is still pending.
+			slider._handler(0.9);
+			expect(plugin.settings.temperature).toBe(0.9);
+
+			// The first (now-stale) validation resolves with an "adjusted" value.
+			// Without the run-ID guard this would overwrite the current 0.9 slider.
+			resolveFirst({
+				temperature: { isValid: false, adjustedValue: 0.1, warning: 'out of range' },
+				topP: { isValid: true },
+			});
+			await flushMicrotasks();
+
+			expect(slider.setValue).not.toHaveBeenCalledWith(0.1);
+			expect(plugin.settings.temperature).toBe(0.9);
+			// The stale Notice warning must not leak through either.
+			expect(mockNotice).not.toHaveBeenCalledWith('out of range');
+
+			// The second debounce fires and validates the current value.
+			await jest.advanceTimersByTimeAsync(300);
+			await flushMicrotasks();
+			expect(validateParameters).toHaveBeenCalledTimes(2);
+			expect(validateParameters).toHaveBeenLastCalledWith(0.9, 1.0);
+			expect(plugin.saveSettings).toHaveBeenCalled();
+			expect(plugin.settings.temperature).toBe(0.9);
+			expect(slider.setValue).not.toHaveBeenCalledWith(0.1);
+		});
+
+		it('logs and surfaces a Notice when validation rejects', async () => {
+			const err = new Error('validate failed');
+			const validateParameters = jest.fn().mockRejectedValue(err);
+			const { plugin } = await setup(validateParameters);
+
+			const slider = mockSliderRegistry['Temperature'];
+			slider._handler(0.5);
+			await jest.advanceTimersByTimeAsync(300);
+			await flushMicrotasks();
+
+			expect(plugin.logger.error).toHaveBeenCalledWith('Failed to validate/save temperature setting:', err);
+			expect(mockNotice).toHaveBeenCalledWith(expect.stringContaining('Failed to save temperature setting'));
+		});
+
+		it('saves settings after a clean validation without re-adjusting the slider', async () => {
+			const { plugin } = await setup();
+			const slider = mockSliderRegistry['Temperature'];
+			// Ignore the initial setValue(plugin.settings.temperature) from setup.
+			slider.setValue.mockClear();
+
+			slider._handler(0.6);
+			await jest.advanceTimersByTimeAsync(300);
+			await flushMicrotasks();
+
+			expect(plugin.settings.temperature).toBe(0.6);
+			expect(plugin.saveSettings).toHaveBeenCalled();
+			// A clean validation result must not call setValue (no re-adjustment).
+			expect(slider.setValue).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('topP slider', () => {
+		it('discards stale validation results when the slider changes mid-validation', async () => {
+			let resolveFirst!: (v: any) => void;
+			const firstPending = new Promise((res) => {
+				resolveFirst = res;
+			});
+
+			const validateParameters = jest
+				.fn()
+				.mockImplementationOnce(() => firstPending)
+				.mockImplementationOnce(() =>
+					Promise.resolve({
+						temperature: { isValid: true },
+						topP: { isValid: true },
+					})
+				);
+
+			const { plugin } = await setup(validateParameters);
+			const slider = mockSliderRegistry['Top P'];
+			expect(slider).toBeDefined();
+
+			slider._handler(0.5);
+			await jest.advanceTimersByTimeAsync(300);
+			expect(validateParameters).toHaveBeenCalledTimes(1);
+
+			slider._handler(0.9);
+			expect(plugin.settings.topP).toBe(0.9);
+
+			resolveFirst({
+				temperature: { isValid: true },
+				topP: { isValid: false, adjustedValue: 0.1, warning: 'stale' },
+			});
+			await flushMicrotasks();
+
+			expect(slider.setValue).not.toHaveBeenCalledWith(0.1);
+			expect(plugin.settings.topP).toBe(0.9);
+			expect(mockNotice).not.toHaveBeenCalledWith('stale');
+
+			await jest.advanceTimersByTimeAsync(300);
+			await flushMicrotasks();
+
+			expect(validateParameters).toHaveBeenCalledTimes(2);
+			expect(validateParameters).toHaveBeenLastCalledWith(0.7, 0.9);
+			expect(plugin.saveSettings).toHaveBeenCalled();
+			expect(plugin.settings.topP).toBe(0.9);
+		});
+
+		it('logs and surfaces a Notice when validation rejects', async () => {
+			const err = new Error('validate failed');
+			const validateParameters = jest.fn().mockRejectedValue(err);
+			const { plugin } = await setup(validateParameters);
+
+			const slider = mockSliderRegistry['Top P'];
+			slider._handler(0.5);
+			await jest.advanceTimersByTimeAsync(300);
+			await flushMicrotasks();
+
+			expect(plugin.logger.error).toHaveBeenCalledWith('Failed to validate/save topP setting:', err);
+			expect(mockNotice).toHaveBeenCalledWith(expect.stringContaining('Failed to save Top P setting'));
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Fixes #601

Resolves a race condition in the temperature and topP slider debounce handlers where stale async validation results could overwrite the current slider state when a newer change was made mid-validation. Also adds proper error handling to surface validation/save failures through the logger and user-facing notices instead of silent unhandled promise rejections.

## Changes

- Added run-ID tracking (`temperatureRunId` and `topPRunId`) to each slider's debounce handler to detect and discard stale validation results
- Wrapped async validation/save logic in try-catch blocks to handle validation rejections gracefully
- Updated validation calls to read from `plugin.settings` instead of captured values, ensuring validation always matches the most recent user input
- Added error logging via `plugin.logger.error()` and user-facing `Notice` when validation or save operations fail
- Added comprehensive regression tests covering the race condition and error handling scenarios

## Test Plan

Added 314 lines of regression tests in `test/ui/settings-api.test.ts` covering:
- Stale validation result discarding when slider changes mid-validation (temperature and topP)
- Error logging and Notice display when validation rejects
- Clean validation without unnecessary slider re-adjustment

All tests use fake timers and mock the Obsidian API to verify the debounce and validation flow in isolation.

https://claude.ai/code/session_01C2rfCELucr54Zqo2dFmVnY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a race condition in temperature and topP slider validation where stale validation results could overwrite recently adjusted values
  * Improved error handling to notify users when settings fail to save, providing clear feedback when setting updates encounter issues

<!-- end of auto-generated comment: release notes by coderabbit.ai -->