### PR TITLE
Replace InstanceType with type imports for ObsidianGemini

### DIFF
--- a/src/agent/agent-factory.ts
+++ b/src/agent/agent-factory.ts
@@ -1,4 +1,4 @@
-import ObsidianGemini from '../main';
+import type ObsidianGemini from '../main';
 import { ModelApi } from '../api/interfaces/model-api';
 import { GeminiClientFactory } from '../api/simple-factory';
 import { SessionManager } from './session-manager';
@@ -30,7 +30,7 @@ export class AgentFactory {
 	 * @returns Agent components
 	 */
 	static createAgent(
-		plugin: InstanceType<typeof ObsidianGemini>,
+		plugin: ObsidianGemini,
 		_app: App
 	): {
 		sessionManager: SessionManager;
@@ -60,7 +60,7 @@ export class AgentFactory {
 	 * @param session The current chat session
 	 * @returns Configured ModelApi instance
 	 */
-	static createAgentModel(plugin: InstanceType<typeof ObsidianGemini>, session: ChatSession): ModelApi {
+	static createAgentModel(plugin: ObsidianGemini, session: ChatSession): ModelApi {
 		// Use session's model configuration if available
 		return GeminiClientFactory.createChatModel(plugin, session.modelConfig);
 	}
@@ -74,7 +74,7 @@ export class AgentFactory {
 	 * @returns Configured ModelApi instance
 	 */
 	static createAgentTaskModel(
-		plugin: InstanceType<typeof ObsidianGemini>,
+		plugin: ObsidianGemini,
 		config: AgentConfig,
 		_taskType?: 'summarize' | 'research' | 'code'
 	): ModelApi {
@@ -88,7 +88,7 @@ export class AgentFactory {
 	 *
 	 * @param plugin The plugin instance
 	 */
-	static async initializeAgent(plugin: InstanceType<typeof ObsidianGemini>): Promise<void> {
+	static async initializeAgent(plugin: ObsidianGemini): Promise<void> {
 		// This would be called during plugin load to set up agent infrastructure
 		const { sessionManager, toolRegistry, executionEngine } = this.createAgent(plugin, plugin.app);
 

--- a/src/agent/session-history.ts
+++ b/src/agent/session-history.ts
@@ -12,10 +12,10 @@ import historyEntryTemplate from '../history/templates/historyEntry.hbs';
  * Handles history for agent sessions stored in Agent-Sessions/ folder
  */
 export class SessionHistory {
-	private plugin: InstanceType<typeof ObsidianGemini>;
+	private plugin: ObsidianGemini;
 	private entryTemplate: Handlebars.TemplateDelegate;
 
-	constructor(plugin: InstanceType<typeof ObsidianGemini>) {
+	constructor(plugin: ObsidianGemini) {
 		this.plugin = plugin;
 
 		// Register Handlebars helpers (same as in markdownHistory)

--- a/src/agent/session-manager.ts
+++ b/src/agent/session-manager.ts
@@ -15,14 +15,14 @@ import { formatLocalDate } from '../utils/format-utils';
  * Manages chat sessions for both note-centric and agent modes
  */
 export class SessionManager {
-	private plugin: InstanceType<typeof ObsidianGemini>;
+	private plugin: ObsidianGemini;
 	private activeSessions = new Map<string, ChatSession>();
 
 	// Folder paths for different session types
 	private readonly HISTORY_FOLDER = 'History';
 	private readonly AGENT_SESSIONS_FOLDER = 'Agent-Sessions';
 
-	constructor(plugin: InstanceType<typeof ObsidianGemini>) {
+	constructor(plugin: ObsidianGemini) {
 		this.plugin = plugin;
 	}
 

--- a/src/completions.ts
+++ b/src/completions.ts
@@ -1,4 +1,4 @@
-import ObsidianGemini from './main';
+import type ObsidianGemini from './main';
 import { MarkdownView, Notice } from 'obsidian';
 import { forceableInlineSuggestion, Suggestion } from 'codemirror-companion-extension';
 import { BaseModelRequest } from './api/index';
@@ -6,12 +6,12 @@ import { GeminiPrompts } from './prompts';
 import { GeminiClientFactory } from './api/simple-factory';
 
 export class GeminiCompletions {
-	private plugin: InstanceType<typeof ObsidianGemini>;
+	private plugin: ObsidianGemini;
 	private prompts: GeminiPrompts;
 	private force_fetch: () => void = () => {};
 	private completionsOn: boolean = false;
 
-	constructor(plugin: InstanceType<typeof ObsidianGemini>) {
+	constructor(plugin: ObsidianGemini) {
 		this.plugin = plugin;
 		this.prompts = new GeminiPrompts(plugin);
 	}

--- a/src/files/index.ts
+++ b/src/files/index.ts
@@ -1,4 +1,4 @@
-import ObsidianGemini from '../main';
+import type ObsidianGemini from '../main';
 import { TFile } from 'obsidian';
 import { logDebugInfo } from '../api/utils/debug';
 import { GeminiPrompts } from '../prompts';

--- a/src/history/history.ts
+++ b/src/history/history.ts
@@ -1,4 +1,4 @@
-import ObsidianGemini from '../main';
+import type ObsidianGemini from '../main';
 import { TFile } from 'obsidian';
 import { GeminiConversationEntry } from '../types/conversation';
 import { SessionHistory } from '../agent/session-history';
@@ -11,10 +11,10 @@ import { ChatSession } from '../types/agent';
  * Note-based chat history has been removed in v4.0.
  */
 export class GeminiHistory {
-	private plugin: InstanceType<typeof ObsidianGemini>;
+	private plugin: ObsidianGemini;
 	private sessionHistory: SessionHistory;
 
-	constructor(plugin: InstanceType<typeof ObsidianGemini>) {
+	constructor(plugin: ObsidianGemini) {
 		this.plugin = plugin;
 		this.sessionHistory = new SessionHistory(plugin);
 	}

--- a/src/mcp/mcp-manager.ts
+++ b/src/mcp/mcp-manager.ts
@@ -110,12 +110,12 @@ function buildEnv(extra?: Record<string, string>): Record<string, string> | unde
  * tools are registered/unregistered in the plugin's ToolRegistry.
  */
 export class MCPManager {
-	private plugin: InstanceType<typeof ObsidianGemini>;
+	private plugin: ObsidianGemini;
 	private logger: Logger;
 	private connections = new Map<string, ServerConnection>();
 	private serverStates = new Map<string, MCPServerState>();
 
-	constructor(plugin: InstanceType<typeof ObsidianGemini>) {
+	constructor(plugin: ObsidianGemini) {
 		this.plugin = plugin;
 		this.logger = plugin.logger;
 	}

--- a/src/prompts/gemini-prompts.ts
+++ b/src/prompts/gemini-prompts.ts
@@ -1,7 +1,7 @@
 import * as Handlebars from 'handlebars';
 import { CustomPrompt } from './types';
 import { ToolDefinition } from '../api/interfaces/model-api';
-import ObsidianGemini from '../main';
+import type ObsidianGemini from '../main';
 
 import systemPromptContent from '../../prompts/systemPrompt.hbs';
 import completionPromptContent from '../../prompts/completionPrompt.hbs';
@@ -27,7 +27,7 @@ export class GeminiPrompts {
 	private examplePromptsPromptTemplate: Handlebars.TemplateDelegate;
 	private imagePromptGeneratorTemplate: Handlebars.TemplateDelegate;
 
-	constructor(private plugin?: InstanceType<typeof ObsidianGemini>) {
+	constructor(private plugin?: ObsidianGemini) {
 		this.completionsPromptTemplate = Handlebars.compile(completionPromptContent);
 		this.systemPromptTemplate = Handlebars.compile(systemPromptContent);
 		this.summaryPromptTemplate = Handlebars.compile(summaryPromptContent);

--- a/src/prompts/prompt-manager.ts
+++ b/src/prompts/prompt-manager.ts
@@ -1,5 +1,5 @@
 import { Vault, TFile, TFolder, normalizePath, Notice, Modal, App } from 'obsidian';
-import ObsidianGemini from '../main';
+import type ObsidianGemini from '../main';
 import { CustomPrompt, PromptInfo } from './types';
 
 export class PromptManager {

--- a/src/rewrite-selection.ts
+++ b/src/rewrite-selection.ts
@@ -1,4 +1,4 @@
-import ObsidianGemini from './main';
+import type ObsidianGemini from './main';
 import { Editor, Notice } from 'obsidian';
 import { ExtendedModelRequest } from './api/index';
 import { GeminiPrompts } from './prompts';
@@ -6,10 +6,10 @@ import { GeminiClientFactory } from './api/simple-factory';
 import { getErrorMessage } from './utils/error-utils';
 
 export class SelectionRewriter {
-	private plugin: InstanceType<typeof ObsidianGemini>;
+	private plugin: ObsidianGemini;
 	private prompts: GeminiPrompts;
 
-	constructor(plugin: InstanceType<typeof ObsidianGemini>) {
+	constructor(plugin: ObsidianGemini) {
 		this.plugin = plugin;
 		this.prompts = new GeminiPrompts(plugin);
 	}

--- a/src/services/agents-memory.ts
+++ b/src/services/agents-memory.ts
@@ -25,11 +25,11 @@ export interface AgentsMemoryData {
  * - Custom instructions specific to this vault
  */
 export class AgentsMemory {
-	private plugin: InstanceType<typeof ObsidianGemini>;
+	private plugin: ObsidianGemini;
 	private memoryFilePath: string;
 	private template: HandlebarsTemplateDelegate;
 
-	constructor(plugin: InstanceType<typeof ObsidianGemini>, templateContent: string) {
+	constructor(plugin: ObsidianGemini, templateContent: string) {
 		this.plugin = plugin;
 		this.memoryFilePath = normalizePath(`${plugin.settings.historyFolder}/AGENTS.md`);
 		this.template = Handlebars.compile(templateContent);

--- a/src/services/deep-research.ts
+++ b/src/services/deep-research.ts
@@ -44,7 +44,7 @@ export class DeepResearchService {
 	private currentInteractionId: string | null = null;
 	private retryConfig: RetryConfig;
 
-	constructor(private plugin: InstanceType<typeof ObsidianGemini>) {
+	constructor(private plugin: ObsidianGemini) {
 		this.reportGenerator = new ReportGenerator();
 		this.retryConfig = DEFAULT_RETRY_CONFIG;
 	}

--- a/src/services/example-prompts.ts
+++ b/src/services/example-prompts.ts
@@ -16,9 +16,9 @@ export interface ExamplePrompt {
  * This file stores UI-specific example prompts and is NOT sent to the AI agent
  */
 export class ExamplePromptsManager {
-	private plugin: InstanceType<typeof ObsidianGemini>;
+	private plugin: ObsidianGemini;
 
-	constructor(plugin: InstanceType<typeof ObsidianGemini>) {
+	constructor(plugin: ObsidianGemini) {
 		this.plugin = plugin;
 	}
 

--- a/src/services/folder-initializer.ts
+++ b/src/services/folder-initializer.ts
@@ -1,5 +1,5 @@
 import { TFolder, normalizePath } from 'obsidian';
-import ObsidianGemini from '../main';
+import type ObsidianGemini from '../main';
 import { ensureFolderExists } from '../utils/file-utils';
 
 /**

--- a/src/services/image-generation.ts
+++ b/src/services/image-generation.ts
@@ -1,15 +1,15 @@
-import ObsidianGemini from '../main';
+import type ObsidianGemini from '../main';
 import { Notice, App, Modal, Setting, TextAreaComponent } from 'obsidian';
 import { BaseModelRequest, GeminiClient, GeminiClientFactory } from '../api';
 import { GeminiPrompts } from '../prompts';
 import { getErrorMessage } from '../utils/error-utils';
 
 export class ImageGeneration {
-	private plugin: InstanceType<typeof ObsidianGemini>;
+	private plugin: ObsidianGemini;
 	private client: GeminiClient;
 	private prompts: GeminiPrompts;
 
-	constructor(plugin: InstanceType<typeof ObsidianGemini>) {
+	constructor(plugin: ObsidianGemini) {
 		this.plugin = plugin;
 		this.prompts = new GeminiPrompts(plugin);
 		this.client = new GeminiClient(
@@ -183,18 +183,13 @@ export class ImageGeneration {
  * Modal for prompting user to enter image description
  */
 class ImagePromptModal extends Modal {
-	private plugin: InstanceType<typeof ObsidianGemini>;
+	private plugin: ObsidianGemini;
 	private imageGeneration: ImageGeneration;
 	private onSubmit: (prompt: string) => void;
 	private prompt = '';
 	private textArea: TextAreaComponent | null = null;
 
-	constructor(
-		app: App,
-		plugin: InstanceType<typeof ObsidianGemini>,
-		imageGeneration: ImageGeneration,
-		onSubmit: (prompt: string) => void
-	) {
+	constructor(app: App, plugin: ObsidianGemini, imageGeneration: ImageGeneration, onSubmit: (prompt: string) => void) {
 		super(app);
 		this.plugin = plugin;
 		this.imageGeneration = imageGeneration;

--- a/src/services/model-discovery.ts
+++ b/src/services/model-discovery.ts
@@ -1,4 +1,4 @@
-import ObsidianGemini from '../main';
+import type ObsidianGemini from '../main';
 
 export interface GoogleModel {
 	name: string;

--- a/src/services/model-manager.ts
+++ b/src/services/model-manager.ts
@@ -1,4 +1,4 @@
-import ObsidianGemini from '../main';
+import type ObsidianGemini from '../main';
 import { GeminiModel, ModelUpdateResult, getUpdatedModelSettings, DEFAULT_GEMINI_MODELS } from '../models';
 import { ModelDiscoveryService, GoogleModel } from './model-discovery';
 import { ModelMapper } from './model-mapper';

--- a/src/services/project-manager.ts
+++ b/src/services/project-manager.ts
@@ -27,11 +27,11 @@ const PERMISSION_REVERSE_MAP: Record<ToolPermission, string> = {
  * A project is any Markdown file with the `gemini-scribe/project` tag.
  */
 export class ProjectManager {
-	private plugin: InstanceType<typeof ObsidianGemini>;
+	private plugin: ObsidianGemini;
 	private projectCache: Map<string, Project> = new Map();
 	private pendingTimers: Map<string, ReturnType<typeof setTimeout>> = new Map();
 
-	constructor(plugin: InstanceType<typeof ObsidianGemini>) {
+	constructor(plugin: ObsidianGemini) {
 		this.plugin = plugin;
 	}
 

--- a/src/services/skill-manager.ts
+++ b/src/services/skill-manager.ts
@@ -85,9 +85,9 @@ export function findFrontmatterEndOffset(content: string): number | undefined {
  *       scripts/       # Optional - read-only reference (no execution in Obsidian)
  */
 export class SkillManager {
-	private plugin: InstanceType<typeof ObsidianGemini>;
+	private plugin: ObsidianGemini;
 
-	constructor(plugin: InstanceType<typeof ObsidianGemini>) {
+	constructor(plugin: ObsidianGemini) {
 		this.plugin = plugin;
 	}
 

--- a/src/services/vault-analyzer.ts
+++ b/src/services/vault-analyzer.ts
@@ -21,7 +21,7 @@ export class VaultAnalyzer {
 	private vaultInfoCache: VaultInfoCache | null = null;
 	private readonly CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
 
-	constructor(private plugin: InstanceType<typeof ObsidianGemini>) {}
+	constructor(private plugin: ObsidianGemini) {}
 
 	/**
 	 * Helper to ensure minimum display time for each step

--- a/src/summary.ts
+++ b/src/summary.ts
@@ -1,4 +1,4 @@
-import ObsidianGemini from './main';
+import type ObsidianGemini from './main';
 import { GeminiPrompts } from './prompts';
 import { BaseModelRequest } from './api/index';
 import { GeminiClientFactory } from './api/simple-factory';
@@ -6,10 +6,10 @@ import { Notice } from 'obsidian';
 import { getErrorMessage } from './utils/error-utils';
 
 export class GeminiSummary {
-	private plugin: InstanceType<typeof ObsidianGemini>;
+	private plugin: ObsidianGemini;
 	private prompts: GeminiPrompts;
 
-	constructor(plugin: InstanceType<typeof ObsidianGemini>) {
+	constructor(plugin: ObsidianGemini) {
 		this.plugin = plugin;
 		this.prompts = new GeminiPrompts(plugin);
 	}

--- a/src/tools/deep-research-tool.ts
+++ b/src/tools/deep-research-tool.ts
@@ -66,7 +66,7 @@ export class DeepResearchTool implements Tool {
 		params: { topic: string; scope?: ResearchScope; outputFile?: string },
 		context: ToolExecutionContext
 	): Promise<ToolResult> {
-		const plugin = context.plugin as InstanceType<typeof ObsidianGemini>;
+		const plugin = context.plugin as ObsidianGemini;
 
 		try {
 			// Validate parameters

--- a/src/tools/execution-engine.ts
+++ b/src/tools/execution-engine.ts
@@ -18,12 +18,12 @@ import { shouldExcludePath } from '../utils/file-utils';
  * Handles execution of tools with permission checks and UI feedback
  */
 export class ToolExecutionEngine {
-	private plugin: InstanceType<typeof ObsidianGemini>;
+	private plugin: ObsidianGemini;
 	private registry: ToolRegistry;
 	private executionHistory: Map<string, ToolExecution[]> = new Map();
 	private loopDetector: ToolLoopDetector;
 
-	constructor(plugin: InstanceType<typeof ObsidianGemini>, registry: ToolRegistry) {
+	constructor(plugin: ObsidianGemini, registry: ToolRegistry) {
 		this.plugin = plugin;
 		this.registry = registry;
 		this.loopDetector = new ToolLoopDetector(
@@ -247,7 +247,7 @@ export class ToolExecutionEngine {
 	 * - edit_skill: originalContent = current SKILL.md body, proposedContent = parameters.content
 	 */
 	private async buildDiffContext(tool: Tool, parameters: any): Promise<DiffContext | undefined> {
-		const plugin = this.plugin as InstanceType<typeof ObsidianGemini>;
+		const plugin = this.plugin as ObsidianGemini;
 
 		if (tool.name === 'write_file' && parameters.path && parameters.content !== undefined) {
 			const normalizedPath = normalizePath(parameters.path);
@@ -340,7 +340,7 @@ export class ToolExecutionEngine {
 	 * Used for diff context display only.
 	 */
 	private getSkillFilePath(skillName: string): string {
-		const plugin = this.plugin as InstanceType<typeof ObsidianGemini>;
+		const plugin = this.plugin as ObsidianGemini;
 		if (plugin.skillManager) {
 			return normalizePath(`${plugin.skillManager.getSkillsFolderPath()}/${skillName}/SKILL.md`);
 		}
@@ -353,7 +353,7 @@ export class ToolExecutionEngine {
 	 */
 	private async safeReadFile(file: TFile): Promise<string> {
 		try {
-			return await (this.plugin as InstanceType<typeof ObsidianGemini>).app.vault.read(file);
+			return await (this.plugin as ObsidianGemini).app.vault.read(file);
 		} catch (error) {
 			(this.plugin as any).logger?.warn(`Failed to read file for diff context: ${file.path}`, error);
 			return '';

--- a/src/tools/google-search-tool.ts
+++ b/src/tools/google-search-tool.ts
@@ -37,7 +37,7 @@ export class GoogleSearchTool implements Tool {
 	}
 
 	async execute(params: { query: string }, context: ToolExecutionContext): Promise<ToolResult> {
-		const plugin = context.plugin as InstanceType<typeof ObsidianGemini>;
+		const plugin = context.plugin as ObsidianGemini;
 
 		try {
 			// Check if API key is available

--- a/src/tools/image-tools.ts
+++ b/src/tools/image-tools.ts
@@ -45,7 +45,7 @@ export class GenerateImageTool implements Tool {
 	}
 
 	async execute(params: any, context: ToolExecutionContext): Promise<ToolResult> {
-		const plugin = context.plugin as InstanceType<typeof ObsidianGemini>;
+		const plugin = context.plugin as ObsidianGemini;
 
 		try {
 			// Get the image generation service

--- a/src/tools/memory-tool.ts
+++ b/src/tools/memory-tool.ts
@@ -38,7 +38,7 @@ export class UpdateMemoryTool implements Tool {
 	}
 
 	async execute(params: { content: string }, context: ToolExecutionContext): Promise<ToolResult> {
-		const plugin = context.plugin as InstanceType<typeof ObsidianGemini>;
+		const plugin = context.plugin as ObsidianGemini;
 
 		try {
 			// Validate content
@@ -100,7 +100,7 @@ export class ReadMemoryTool implements Tool {
 	}
 
 	async execute(_params: any, context: ToolExecutionContext): Promise<ToolResult> {
-		const plugin = context.plugin as InstanceType<typeof ObsidianGemini>;
+		const plugin = context.plugin as ObsidianGemini;
 
 		try {
 			// Get the agents memory service

--- a/src/tools/rag-search-tool.ts
+++ b/src/tools/rag-search-tool.ts
@@ -139,7 +139,7 @@ export class RagSearchTool implements Tool {
 		params: { query: string; maxResults?: number; folder?: string; tags?: string[] },
 		context: ToolExecutionContext
 	): Promise<ToolResult> {
-		const plugin = context.plugin as InstanceType<typeof ObsidianGemini>;
+		const plugin = context.plugin as ObsidianGemini;
 
 		try {
 			// Validate query

--- a/src/tools/session-recall-tool.ts
+++ b/src/tools/session-recall-tool.ts
@@ -53,7 +53,7 @@ class RecallSessionsTool implements Tool {
 		params: { query?: string; filePath?: string; project?: string; limit?: number },
 		context: ToolExecutionContext
 	): Promise<ToolResult> {
-		const plugin = context.plugin as InstanceType<typeof ObsidianGemini>;
+		const plugin = context.plugin as ObsidianGemini;
 		const limit = Math.max(1, Math.min(50, Math.floor(params.limit || 10)));
 
 		try {

--- a/src/tools/skill-tools.ts
+++ b/src/tools/skill-tools.ts
@@ -42,7 +42,7 @@ export class ActivateSkillTool implements Tool {
 	}
 
 	async execute(params: { name: string; resource_path?: string }, context: ToolExecutionContext): Promise<ToolResult> {
-		const plugin = context.plugin as InstanceType<typeof ObsidianGemini>;
+		const plugin = context.plugin as ObsidianGemini;
 
 		try {
 			if (!plugin.skillManager) {
@@ -167,7 +167,7 @@ export class CreateSkillTool implements Tool {
 		params: { name: string; description: string; content: string; _userEdited?: boolean },
 		context: ToolExecutionContext
 	): Promise<ToolResult> {
-		const plugin = context.plugin as InstanceType<typeof ObsidianGemini>;
+		const plugin = context.plugin as ObsidianGemini;
 
 		try {
 			if (!plugin.skillManager) {
@@ -280,7 +280,7 @@ export class EditSkillTool implements Tool {
 		params: { name: string; description?: string; content?: string; _userEdited?: boolean },
 		context: ToolExecutionContext
 	): Promise<ToolResult> {
-		const plugin = context.plugin as InstanceType<typeof ObsidianGemini>;
+		const plugin = context.plugin as ObsidianGemini;
 
 		try {
 			if (!plugin.skillManager) {

--- a/src/tools/tool-registry.ts
+++ b/src/tools/tool-registry.ts
@@ -8,9 +8,9 @@ import type ObsidianGemini from '../main';
  */
 export class ToolRegistry {
 	private tools = new Map<string, Tool>();
-	private plugin: InstanceType<typeof ObsidianGemini>;
+	private plugin: ObsidianGemini;
 
-	constructor(plugin: InstanceType<typeof ObsidianGemini>) {
+	constructor(plugin: ObsidianGemini) {
 		this.plugin = plugin;
 	}
 

--- a/src/tools/vault-tools-extended.ts
+++ b/src/tools/vault-tools-extended.ts
@@ -63,7 +63,7 @@ export class UpdateFrontmatterTool implements Tool {
 	}
 
 	async execute(params: { path: string; key: string; value: any }, context: ToolExecutionContext): Promise<ToolResult> {
-		const plugin = context.plugin as InstanceType<typeof ObsidianGemini>;
+		const plugin = context.plugin as ObsidianGemini;
 		const { path, key, value } = params;
 
 		try {
@@ -184,7 +184,7 @@ export class AppendContentTool implements Tool {
 		params: { path: string; content: string; _replaceFullContent?: boolean; _userEdited?: boolean },
 		context: ToolExecutionContext
 	): Promise<ToolResult> {
-		const plugin = context.plugin as InstanceType<typeof ObsidianGemini>;
+		const plugin = context.plugin as ObsidianGemini;
 		const { path, content } = params;
 
 		try {

--- a/src/tools/vault/create-folder-tool.ts
+++ b/src/tools/vault/create-folder-tool.ts
@@ -40,7 +40,7 @@ export class CreateFolderTool implements Tool {
 	}
 
 	async execute(params: { path: string }, context: ToolExecutionContext): Promise<ToolResult> {
-		const plugin = context.plugin as InstanceType<typeof ObsidianGemini>;
+		const plugin = context.plugin as ObsidianGemini;
 
 		try {
 			const normalizedPath = normalizePath(params.path);

--- a/src/tools/vault/delete-file-tool.ts
+++ b/src/tools/vault/delete-file-tool.ts
@@ -41,7 +41,7 @@ export class DeleteFileTool implements Tool {
 	}
 
 	async execute(params: { path: string }, context: ToolExecutionContext): Promise<ToolResult> {
-		const plugin = context.plugin as InstanceType<typeof ObsidianGemini>;
+		const plugin = context.plugin as ObsidianGemini;
 
 		try {
 			const normalizedPath = normalizePath(params.path);

--- a/src/tools/vault/get-workspace-state-tool.ts
+++ b/src/tools/vault/get-workspace-state-tool.ts
@@ -31,7 +31,7 @@ export class GetWorkspaceStateTool implements Tool {
 	}
 
 	async execute(_params: any, context: ToolExecutionContext): Promise<ToolResult> {
-		const plugin = context.plugin as InstanceType<typeof ObsidianGemini>;
+		const plugin = context.plugin as ObsidianGemini;
 
 		try {
 			const activeFile = plugin.app.workspace.getActiveFile();

--- a/src/tools/vault/list-files-tool.ts
+++ b/src/tools/vault/list-files-tool.ts
@@ -40,7 +40,7 @@ export class ListFilesTool implements Tool {
 	}
 
 	async execute(params: { path: string; recursive?: boolean }, context: ToolExecutionContext): Promise<ToolResult> {
-		const plugin = context.plugin as InstanceType<typeof ObsidianGemini>;
+		const plugin = context.plugin as ObsidianGemini;
 
 		try {
 			// Default to project root when no path specified and project is active

--- a/src/tools/vault/move-file-tool.ts
+++ b/src/tools/vault/move-file-tool.ts
@@ -51,7 +51,7 @@ export class MoveFileTool implements Tool {
 		params: { sourcePath: string; targetPath: string },
 		context: ToolExecutionContext
 	): Promise<ToolResult> {
-		const plugin = context.plugin as InstanceType<typeof ObsidianGemini>;
+		const plugin = context.plugin as ObsidianGemini;
 
 		try {
 			const sourceNormalizedPath = normalizePath(params.sourcePath);

--- a/src/tools/vault/read-file-tool.ts
+++ b/src/tools/vault/read-file-tool.ts
@@ -44,7 +44,7 @@ export class ReadFileTool implements Tool {
 	}
 
 	async execute(params: { path: string }, context: ToolExecutionContext): Promise<ToolResult> {
-		const plugin = context.plugin as InstanceType<typeof ObsidianGemini>;
+		const plugin = context.plugin as ObsidianGemini;
 
 		try {
 			const normalizedPath = normalizePath(params.path);

--- a/src/tools/vault/search-file-contents-tool.ts
+++ b/src/tools/vault/search-file-contents-tool.ts
@@ -58,7 +58,7 @@ export class SearchFileContentsTool implements Tool {
 		},
 		context: ToolExecutionContext
 	): Promise<ToolResult> {
-		const plugin = context.plugin as InstanceType<typeof ObsidianGemini>;
+		const plugin = context.plugin as ObsidianGemini;
 
 		try {
 			const caseSensitive = params.caseSensitive ?? false;

--- a/src/tools/vault/search-files-tool.ts
+++ b/src/tools/vault/search-files-tool.ts
@@ -38,7 +38,7 @@ export class SearchFilesTool implements Tool {
 	}
 
 	async execute(params: { pattern: string; limit?: number }, context: ToolExecutionContext): Promise<ToolResult> {
-		const plugin = context.plugin as InstanceType<typeof ObsidianGemini>;
+		const plugin = context.plugin as ObsidianGemini;
 
 		try {
 			const allFiles = plugin.app.vault.getFiles();

--- a/src/tools/vault/utils.ts
+++ b/src/tools/vault/utils.ts
@@ -13,7 +13,7 @@ import { shouldExcludePathForPlugin as shouldExcludePath } from '../../utils/fil
  */
 export function resolvePathToFile(
 	path: string,
-	plugin: InstanceType<typeof ObsidianGemini>,
+	plugin: ObsidianGemini,
 	includeSuggestions: boolean = false
 ): { file: TFile | null; suggestions?: string[] } {
 	const normalizedPath = normalizePath(path);
@@ -108,7 +108,7 @@ export function resolvePathToFile(
  */
 export function resolvePathToFileOrFolder(
 	path: string,
-	plugin: InstanceType<typeof ObsidianGemini>,
+	plugin: ObsidianGemini,
 	includeSuggestions: boolean = false
 ): { item: TFile | TFolder | null; type: 'file' | 'folder' | null; suggestions?: string[] } {
 	const normalizedPath = normalizePath(path);

--- a/src/tools/vault/write-file-tool.ts
+++ b/src/tools/vault/write-file-tool.ts
@@ -54,7 +54,7 @@ export class WriteFileTool implements Tool {
 		params: { path: string; content: string; _userEdited?: boolean },
 		context: ToolExecutionContext
 	): Promise<ToolResult> {
-		const plugin = context.plugin as InstanceType<typeof ObsidianGemini>;
+		const plugin = context.plugin as ObsidianGemini;
 
 		try {
 			const normalizedPath = normalizePath(params.path);

--- a/src/tools/web-fetch-tool.ts
+++ b/src/tools/web-fetch-tool.ts
@@ -51,7 +51,7 @@ export class WebFetchTool implements Tool {
 	}
 
 	async execute(params: { url: string; query: string }, context: ToolExecutionContext): Promise<ToolResult> {
-		const plugin = context.plugin as InstanceType<typeof ObsidianGemini>;
+		const plugin = context.plugin as ObsidianGemini;
 
 		if (!plugin.apiKey) {
 			return {
@@ -201,10 +201,7 @@ export class WebFetchTool implements Tool {
 	/**
 	 * Fallback method using direct HTTP fetch
 	 */
-	private async fallbackFetch(
-		params: { url: string; query: string },
-		plugin: InstanceType<typeof ObsidianGemini>
-	): Promise<ToolResult> {
+	private async fallbackFetch(params: { url: string; query: string }, plugin: ObsidianGemini): Promise<ToolResult> {
 		try {
 			// Fetch the URL content directly with retry logic for transient errors
 			const response = await requestUrlWithRetry({

--- a/src/ui/agent-view/agent-view-attachments.ts
+++ b/src/ui/agent-view/agent-view-attachments.ts
@@ -13,7 +13,7 @@ import type ObsidianGemini from '../../main';
  * Provides access to shared state owned by the orchestrator.
  */
 export interface AttachmentsContext {
-	plugin: InstanceType<typeof ObsidianGemini>;
+	plugin: ObsidianGemini;
 	app: App;
 	getCurrentSession: () => ChatSession | null;
 	getShelf: () => AgentViewShelf;

--- a/src/ui/agent-view/agent-view-send.ts
+++ b/src/ui/agent-view/agent-view-send.ts
@@ -20,7 +20,7 @@ import type { ConfirmationResult, DiffContext } from '../../tools/types';
  * Provides access to shared state and components owned by the orchestrator.
  */
 export interface SendContext {
-	plugin: InstanceType<typeof ObsidianGemini>;
+	plugin: ObsidianGemini;
 	app: App;
 	getCurrentSession: () => ChatSession | null;
 	getShelf: () => AgentViewShelf;

--- a/src/ui/agent-view/agent-view.ts
+++ b/src/ui/agent-view/agent-view.ts
@@ -32,7 +32,7 @@ export const VIEW_TYPE_AGENT = 'gemini-agent-view';
  * It delegates functionality to specialized components and manages their interactions.
  */
 export class AgentView extends ItemView {
-	private plugin: InstanceType<typeof ObsidianGemini>;
+	private plugin: ObsidianGemini;
 
 	// UI components
 	private progress: AgentViewProgress;
@@ -57,7 +57,7 @@ export class AgentView extends ItemView {
 	private shelf!: AgentViewShelf;
 	private tokenUsageContainer!: HTMLElement;
 
-	constructor(leaf: WorkspaceLeaf, plugin: InstanceType<typeof ObsidianGemini>) {
+	constructor(leaf: WorkspaceLeaf, plugin: ObsidianGemini) {
 		super(leaf);
 		this.plugin = plugin;
 

--- a/src/ui/agent-view/file-mention-modal.ts
+++ b/src/ui/agent-view/file-mention-modal.ts
@@ -5,9 +5,9 @@ import type ObsidianGemini from '../../main';
 
 export class FileMentionModal extends FuzzySuggestModal<TAbstractFile> {
 	private onSelect: (file: TAbstractFile) => void;
-	private plugin: InstanceType<typeof ObsidianGemini>;
+	private plugin: ObsidianGemini;
 
-	constructor(app: any, onSelect: (file: TAbstractFile) => void, plugin: InstanceType<typeof ObsidianGemini>) {
+	constructor(app: any, onSelect: (file: TAbstractFile) => void, plugin: ObsidianGemini) {
 		super(app);
 		this.onSelect = onSelect;
 		this.plugin = plugin;

--- a/src/ui/agent-view/file-picker-modal.ts
+++ b/src/ui/agent-view/file-picker-modal.ts
@@ -12,17 +12,12 @@ interface SuggestModalChooser {
 export class FilePickerModal extends SuggestModal<TAbstractFile> {
 	private onSelect: (files: TFile[]) => void;
 	private selectedFiles: Set<TFile>;
-	private plugin: InstanceType<typeof ObsidianGemini>;
+	private plugin: ObsidianGemini;
 	private allItems: TAbstractFile[] = [];
 	private folderFilesCache: Map<TFolder, TFile[]> = new Map();
 	private lastSuggestions: TAbstractFile[] = [];
 
-	constructor(
-		app: App,
-		onSelect: (files: TFile[]) => void,
-		plugin: InstanceType<typeof ObsidianGemini>,
-		initialSelection: TFile[] = []
-	) {
+	constructor(app: App, onSelect: (files: TFile[]) => void, plugin: ObsidianGemini, initialSelection: TFile[] = []) {
 		super(app);
 		this.modalEl.addClass('gemini-context-file-picker');
 		this.onSelect = onSelect;

--- a/src/ui/agent-view/gemini-diff-view.ts
+++ b/src/ui/agent-view/gemini-diff-view.ts
@@ -16,12 +16,12 @@ export interface DiffViewState {
 }
 
 export class GeminiDiffView extends ItemView {
-	plugin: InstanceType<typeof ObsidianGemini>;
+	plugin: ObsidianGemini;
 	private editorView: EditorView | null = null;
 	private state: DiffViewState | null = null;
 	private resolved = false;
 
-	constructor(leaf: WorkspaceLeaf, plugin: InstanceType<typeof ObsidianGemini>) {
+	constructor(leaf: WorkspaceLeaf, plugin: ObsidianGemini) {
 		super(leaf);
 		this.plugin = plugin;
 	}

--- a/src/ui/agent-view/project-picker-modal.ts
+++ b/src/ui/agent-view/project-picker-modal.ts
@@ -11,13 +11,13 @@ interface ProjectPickerCallbacks {
  * Selecting null unlinks the session from any project.
  */
 export class ProjectPickerModal extends Modal {
-	private plugin: InstanceType<typeof ObsidianGemini>;
+	private plugin: ObsidianGemini;
 	private callbacks: ProjectPickerCallbacks;
 	private currentProjectPath: string | null;
 
 	constructor(
 		app: App,
-		plugin: InstanceType<typeof ObsidianGemini>,
+		plugin: ObsidianGemini,
 		callbacks: ProjectPickerCallbacks,
 		currentProjectPath: string | null = null
 	) {

--- a/src/ui/agent-view/session-list-modal.ts
+++ b/src/ui/agent-view/session-list-modal.ts
@@ -13,7 +13,7 @@ interface SessionListCallbacks {
 }
 
 export class SessionListModal extends Modal {
-	private plugin: InstanceType<typeof ObsidianGemini>;
+	private plugin: ObsidianGemini;
 	private callbacks: SessionListCallbacks;
 	private sessions: ChatSession[] = [];
 	private currentSessionId: string | null;
@@ -24,7 +24,7 @@ export class SessionListModal extends Modal {
 
 	constructor(
 		app: App,
-		plugin: InstanceType<typeof ObsidianGemini>,
+		plugin: ObsidianGemini,
 		callbacks: SessionListCallbacks,
 		currentSessionId: string | null = null
 	) {

--- a/src/ui/agent-view/session-settings-modal.ts
+++ b/src/ui/agent-view/session-settings-modal.ts
@@ -3,7 +3,7 @@ import { ChatSession, SessionModelConfig } from '../../types/agent';
 import type ObsidianGemini from '../../main';
 
 export class SessionSettingsModal extends Modal {
-	private plugin: InstanceType<typeof ObsidianGemini>;
+	private plugin: ObsidianGemini;
 	private onSave: (config: SessionModelConfig) => Promise<void>;
 	private modelConfig: SessionModelConfig;
 	private tempSlider: SliderComponent | null = null;
@@ -11,7 +11,7 @@ export class SessionSettingsModal extends Modal {
 
 	constructor(
 		app: any,
-		plugin: InstanceType<typeof ObsidianGemini>,
+		plugin: ObsidianGemini,
 		session: ChatSession,
 		onSave: (config: SessionModelConfig) => Promise<void>
 	) {

--- a/src/ui/settings-api.ts
+++ b/src/ui/settings-api.ts
@@ -1,4 +1,4 @@
-import ObsidianGemini from '../main';
+import type ObsidianGemini from '../main';
 import { Setting, Notice } from 'obsidian';
 import type { SettingsSectionContext } from './settings';
 
@@ -7,7 +7,7 @@ let topPDebounceTimer: NodeJS.Timeout | null = null;
 
 export async function renderApiSettings(
 	containerEl: HTMLElement,
-	plugin: InstanceType<typeof ObsidianGemini>,
+	plugin: ObsidianGemini,
 	context: SettingsSectionContext
 ): Promise<void> {
 	// File Logging
@@ -163,7 +163,7 @@ export async function renderApiSettings(
 	}
 }
 
-async function updateDiscoveryStatus(setting: Setting, plugin: InstanceType<typeof ObsidianGemini>): Promise<void> {
+async function updateDiscoveryStatus(setting: Setting, plugin: ObsidianGemini): Promise<void> {
 	try {
 		const status = await plugin.getModelManager().getDiscoveryStatus();
 
@@ -183,10 +183,7 @@ async function updateDiscoveryStatus(setting: Setting, plugin: InstanceType<type
 	}
 }
 
-async function createTemperatureSetting(
-	containerEl: HTMLElement,
-	plugin: InstanceType<typeof ObsidianGemini>
-): Promise<void> {
+async function createTemperatureSetting(containerEl: HTMLElement, plugin: ObsidianGemini): Promise<void> {
 	const modelManager = plugin.getModelManager();
 	const ranges = await modelManager.getParameterRanges();
 	const displayInfo = await modelManager.getParameterDisplayInfo();
@@ -231,7 +228,7 @@ async function createTemperatureSetting(
 		);
 }
 
-async function createTopPSetting(containerEl: HTMLElement, plugin: InstanceType<typeof ObsidianGemini>): Promise<void> {
+async function createTopPSetting(containerEl: HTMLElement, plugin: ObsidianGemini): Promise<void> {
 	const modelManager = plugin.getModelManager();
 	const ranges = await modelManager.getParameterRanges();
 	const displayInfo = await modelManager.getParameterDisplayInfo();

--- a/src/ui/settings-context.ts
+++ b/src/ui/settings-context.ts
@@ -1,7 +1,7 @@
-import ObsidianGemini from '../main';
+import type ObsidianGemini from '../main';
 import { Setting } from 'obsidian';
 
-export function renderContextSettings(containerEl: HTMLElement, plugin: InstanceType<typeof ObsidianGemini>): void {
+export function renderContextSettings(containerEl: HTMLElement, plugin: ObsidianGemini): void {
 	new Setting(containerEl).setName('Context Management').setHeading();
 
 	const thresholdSetting = new Setting(containerEl)

--- a/src/ui/settings-general.ts
+++ b/src/ui/settings-general.ts
@@ -1,13 +1,9 @@
-import ObsidianGemini from '../main';
+import type ObsidianGemini from '../main';
 import { App, Setting, SecretComponent } from 'obsidian';
 import { selectModelSetting } from './settings-helpers';
 import { FolderSuggest } from './folder-suggest';
 
-export async function renderGeneralSettings(
-	containerEl: HTMLElement,
-	plugin: InstanceType<typeof ObsidianGemini>,
-	app: App
-): Promise<void> {
+export async function renderGeneralSettings(containerEl: HTMLElement, plugin: ObsidianGemini, app: App): Promise<void> {
 	// Documentation button at the top
 	new Setting(containerEl)
 		.setName('Documentation')

--- a/src/ui/settings-helpers.ts
+++ b/src/ui/settings-helpers.ts
@@ -1,11 +1,11 @@
 import { Setting } from 'obsidian';
-import ObsidianGemini from '../main';
+import type ObsidianGemini from '../main';
 import { ObsidianGeminiSettings } from '../main';
 import { GEMINI_MODELS } from '../models';
 
 export async function selectModelSetting(
 	containerEl: HTMLElement,
-	plugin: InstanceType<typeof ObsidianGemini>,
+	plugin: ObsidianGemini,
 	settingName: keyof Pick<
 		ObsidianGeminiSettings,
 		{

--- a/src/ui/settings-mcp.ts
+++ b/src/ui/settings-mcp.ts
@@ -1,4 +1,4 @@
-import ObsidianGemini from '../main';
+import type ObsidianGemini from '../main';
 import { App, Setting, Notice, setIcon } from 'obsidian';
 import { sanitizeKeySegment } from '../mcp/mcp-oauth-provider';
 import { getErrorMessage } from '../utils/error-utils';
@@ -6,7 +6,7 @@ import type { SettingsSectionContext } from './settings';
 
 export async function renderMCPSettings(
 	containerEl: HTMLElement,
-	plugin: InstanceType<typeof ObsidianGemini>,
+	plugin: ObsidianGemini,
 	app: App,
 	context: SettingsSectionContext
 ): Promise<void> {
@@ -22,7 +22,7 @@ export async function renderMCPSettings(
 
 async function createMCPSettings(
 	containerEl: HTMLElement,
-	plugin: InstanceType<typeof ObsidianGemini>,
+	plugin: ObsidianGemini,
 	app: App,
 	context: SettingsSectionContext
 ): Promise<void> {

--- a/src/ui/settings-rag.ts
+++ b/src/ui/settings-rag.ts
@@ -1,11 +1,11 @@
-import ObsidianGemini from '../main';
+import type ObsidianGemini from '../main';
 import { App, Setting, Notice } from 'obsidian';
 import { getErrorMessage } from '../utils/error-utils';
 import type { SettingsSectionContext } from './settings';
 
 export async function renderRAGSettings(
 	containerEl: HTMLElement,
-	plugin: InstanceType<typeof ObsidianGemini>,
+	plugin: ObsidianGemini,
 	app: App,
 	context: SettingsSectionContext
 ): Promise<void> {

--- a/src/ui/settings-tools.ts
+++ b/src/ui/settings-tools.ts
@@ -1,4 +1,4 @@
-import ObsidianGemini from '../main';
+import type ObsidianGemini from '../main';
 import { App, Setting, SettingGroup } from 'obsidian';
 import {
 	ToolPermission,
@@ -14,7 +14,7 @@ import type { SettingsSectionContext } from './settings';
 
 export async function renderToolSettings(
 	containerEl: HTMLElement,
-	plugin: InstanceType<typeof ObsidianGemini>,
+	plugin: ObsidianGemini,
 	app: App,
 	context: SettingsSectionContext
 ): Promise<void> {
@@ -85,7 +85,7 @@ export async function renderToolSettings(
 
 async function createToolPermissionsSettings(
 	containerEl: HTMLElement,
-	plugin: InstanceType<typeof ObsidianGemini>,
+	plugin: ObsidianGemini,
 	app: App,
 	context: SettingsSectionContext
 ): Promise<void> {

--- a/src/ui/settings-ui.ts
+++ b/src/ui/settings-ui.ts
@@ -1,7 +1,7 @@
-import ObsidianGemini from '../main';
+import type ObsidianGemini from '../main';
 import { Setting } from 'obsidian';
 
-export function renderUISettings(containerEl: HTMLElement, plugin: InstanceType<typeof ObsidianGemini>): void {
+export function renderUISettings(containerEl: HTMLElement, plugin: ObsidianGemini): void {
 	new Setting(containerEl).setName('UI Settings').setHeading();
 
 	new Setting(containerEl)

--- a/src/ui/settings.ts
+++ b/src/ui/settings.ts
@@ -1,4 +1,4 @@
-import ObsidianGemini from '../main';
+import type ObsidianGemini from '../main';
 import { App, PluginSettingTab, Setting } from 'obsidian';
 import { renderGeneralSettings } from './settings-general';
 import { renderUISettings } from './settings-ui';
@@ -16,10 +16,10 @@ export interface SettingsSectionContext {
 }
 
 export default class ObsidianGeminiSettingTab extends PluginSettingTab {
-	plugin: InstanceType<typeof ObsidianGemini>;
+	plugin: ObsidianGemini;
 	private showDeveloperSettings = false;
 
-	constructor(app: App, plugin: InstanceType<typeof ObsidianGemini>) {
+	constructor(app: App, plugin: ObsidianGemini) {
 		super(app, plugin);
 		this.plugin = plugin;
 	}

--- a/src/utils/file-utils.ts
+++ b/src/utils/file-utils.ts
@@ -42,7 +42,7 @@ export function shouldExcludePath(path: string, excludeFolder?: string): boolean
  * @param plugin - The plugin instance
  * @returns true if the path should be excluded, false otherwise
  */
-export function shouldExcludePathForPlugin(path: string, plugin: InstanceType<typeof ObsidianGemini>): boolean {
+export function shouldExcludePathForPlugin(path: string, plugin: ObsidianGemini): boolean {
 	return shouldExcludePath(path, plugin.settings.historyFolder);
 }
 

--- a/test/prompts/gemini-prompts.test.ts
+++ b/test/prompts/gemini-prompts.test.ts
@@ -1,5 +1,5 @@
 import { GeminiPrompts } from '../../src/prompts/gemini-prompts';
-import ObsidianGemini from '../../src/main';
+import type ObsidianGemini from '../../src/main';
 
 // Mock window.localStorage
 const mockLocalStorage = {

--- a/test/prompts/prompt-manager.test.ts
+++ b/test/prompts/prompt-manager.test.ts
@@ -1,6 +1,6 @@
 import { PromptManager } from '../../src/prompts/prompt-manager';
 import { Vault, TFile } from 'obsidian';
-import ObsidianGemini from '../../src/main';
+import type ObsidianGemini from '../../src/main';
 
 // Mock obsidian module
 jest.mock('obsidian', () => {

--- a/test/services/model-manager-filter.test.ts
+++ b/test/services/model-manager-filter.test.ts
@@ -1,6 +1,6 @@
 import { ModelManager } from '../../src/services/model-manager';
 import { ModelDiscoveryService } from '../../src/services/model-discovery';
-import ObsidianGemini from '../../src/main';
+import type ObsidianGemini from '../../src/main';
 
 // Mock the model discovery service
 jest.mock('../../src/services/model-discovery');


### PR DESCRIPTION
## Summary

Refactors type annotations throughout the codebase to use TypeScript's `type` imports and direct type references instead of `InstanceType<typeof ObsidianGemini>`. This improves code clarity, reduces verbosity, and follows TypeScript best practices for type-only imports.

## Changes

- Changed all `import ObsidianGemini from '../main'` to `import type ObsidianGemini from '../main'` across 40+ files
- Replaced all instances of `InstanceType<typeof ObsidianGemini>` with `ObsidianGemini` in:
  - Constructor parameters
  - Property type annotations
  - Function parameters and return types
  - Type casts
- Simplified multi-line function signatures where applicable (e.g., `ImagePromptModal` constructor, `FilePickerModal` constructor)

## Benefits

- **Cleaner code**: Removes verbose `InstanceType<typeof>` pattern
- **Better tree-shaking**: Type-only imports are properly marked and can be eliminated at build time
- **TypeScript best practices**: Follows modern TypeScript conventions for type imports
- **Reduced cognitive load**: Direct type references are easier to read and understand

## Testing

All existing tests pass. This is a pure refactoring with no functional changes - the runtime behavior is identical.

https://claude.ai/code/session_01U6GE6NwpXRKbqeWom5Rikr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified TypeScript type system across the codebase by converting runtime imports to type-only imports.
  * Updated class constructors, fields, and function parameters to use direct type references instead of wrapper patterns.
  * Standardized type annotations in services, tools, UI components, and utilities for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->