### PR TITLE
docs: Link bundled skills blog post from agent-skills guide

### DIFF
--- a/docs/guide/agent-skills.md
+++ b/docs/guide/agent-skills.md
@@ -27,6 +27,8 @@ Skills use **progressive disclosure** — the agent always knows which skills ar
 
 ## Built-in Skills
 
+For the design rationale behind bundled skills — why they exist, how progressive disclosure addresses the "lost in the middle" attention problem, and a walk-through of several of the built-ins — see the blog post [Bundled Skills in Gemini Scribe](https://allen.hutchison.org/2026/04/11/bundled-skills-in-gemini-scribe/).
+
 Gemini Scribe ships with built-in skills that are always available:
 
 - **gemini-scribe-help** — The agent can answer questions about the plugin itself by loading the relevant documentation on demand. Ask things like "How do I set up completions?" or "What settings are available?"
@@ -228,5 +230,6 @@ description: >-
 
 ## Further Reading
 
+- [Bundled Skills in Gemini Scribe](https://allen.hutchison.org/2026/04/11/bundled-skills-in-gemini-scribe/) — Blog post on why bundled skills exist, the progressive disclosure pattern, and a tour of several built-in skills
 - [agentskills.io Specification](https://agentskills.io) — The open standard for agent skills
 - [Agent Mode Guide](/guide/agent-mode) — Full agent documentation including skill tools


### PR DESCRIPTION
## Summary

Links the newly-published [Bundled Skills in Gemini Scribe](https://allen.hutchison.org/2026/04/11/bundled-skills-in-gemini-scribe/) blog post from `docs/guide/agent-skills.md`. The post explains the design rationale for bundled skills, how progressive disclosure addresses the "lost in the middle" attention problem, and walks through several of the built-in skills — all of which is useful context for users reading the skills guide.

Added in two places:

1. **Top of the "Built-in Skills" section** — a brief pointer framing the blog post as the "why" behind bundled skills. This is the most directly relevant placement since the post tours several of the built-ins listed immediately below.
2. **"Further Reading" section at the bottom** — the canonical home for external links alongside the agentskills.io spec.

Intentionally *not* linked from README, `docs/index.md`, or `docs/guide/agent-mode.md` to avoid linking the same post in five places.

## Changes

- `docs/guide/agent-skills.md`: +3 lines, two new links to the blog post.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A, docs-only link addition discussed with the maintainer in-session
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop — docs-only, verified locally
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — docs-only, no runtime impact
- [x] Documentation has been updated (if applicable) — this PR *is* the documentation update
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive reference documentation on bundled skills design principles and their implementation. The new material addresses progressive disclosure strategies and related optimization techniques, now available in both the "Built-in Skills" and "Further Reading" sections for enhanced guidance on the system's architectural decisions and design patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->