### PR TITLE
fix: Stabilize system prompt for Gemini implicit caching

### DIFF
--- a/prompts/systemPrompt.hbs
+++ b/prompts/systemPrompt.hbs
@@ -5,8 +5,9 @@ writing based on this context. You have memory across sessions — use the
 recall_sessions tool to maintain continuity with past conversations, especially
 when working on files or topics we've discussed before.
 
-Today's date is: {{date}}
-The current time is: {{time}}
+{{#if sessionStartedAt}}
+This conversation started on {{sessionStartedAt}}.
+{{/if}}
 
 Assume that I am the author of all content unless specified otherwise, and you
 can refer to me as {{userName}}.

--- a/src/agent/session-history.ts
+++ b/src/agent/session-history.ts
@@ -51,9 +51,20 @@ export class SessionHistory {
 	}
 
 	/**
-	 * Add an entry to agent session history
+	 * Add an entry to agent session history.
+	 *
+	 * When `explicitTimestamp` is provided, it is used for both the persisted
+	 * `| Time |` metadata row and `entry.created_at`. This lets callers (e.g.
+	 * the agent send path) write the exact turn timestamp the model saw into
+	 * the per-turn preamble, so rehydrated history is bit-identical to what
+	 * was originally sent — a prerequisite for Gemini implicit-cache alignment
+	 * across resumes.
 	 */
-	async addEntryToSession(session: ChatSession, entry: GeminiConversationEntry): Promise<void> {
+	async addEntryToSession(
+		session: ChatSession,
+		entry: GeminiConversationEntry,
+		explicitTimestamp?: Date
+	): Promise<void> {
 		if (!this.plugin.settings.chatHistory) return;
 
 		const historyPath = session.historyPath;
@@ -85,11 +96,14 @@ export class SessionHistory {
 		const userDisplayName = (this.plugin.settings.userName ?? '').trim();
 		const displayName = entry.role === 'user' ? userDisplayName || 'User' : role;
 
+		const entryTimestamp = explicitTimestamp ?? new Date();
+		entry.created_at = entryTimestamp;
+
 		const entryContent = this.entryTemplate({
 			role: role,
 			displayName: displayName,
 			messageLines: messageLines,
-			timestamp: formatLocalTimestamp(),
+			timestamp: formatLocalTimestamp(entryTimestamp),
 			pluginVersion: this.plugin.manifest.version,
 			model: entry.model,
 			temperature: entry.metadata?.temperature,

--- a/src/api/gemini-client.ts
+++ b/src/api/gemini-client.ts
@@ -245,7 +245,8 @@ export class GeminiClient implements ModelApi {
 				agentsMemory,
 				availableSkills,
 				extReq.projectInstructions,
-				extReq.perTurnContext ?? extReq.prompt
+				extReq.perTurnContext ?? extReq.prompt,
+				extReq.sessionStartedAt
 			);
 		} else {
 			// For BaseModelRequest, prompt is the full input

--- a/src/api/interfaces/model-api.ts
+++ b/src/api/interfaces/model-api.ts
@@ -82,6 +82,14 @@ export interface ExtendedModelRequest extends BaseModelRequest {
 	availableTools?: ToolDefinition[];
 	/** Per-turn context injected into the system instruction: context file list, attachment paths, rendered file contents. */
 	perTurnContext?: string;
+	/**
+	 * Canonical, byte-stable string describing when the session started
+	 * (e.g. the raw `frontmatter.created` value). Rendered verbatim into the
+	 * system prompt's "This conversation started on ..." anchor. Must not be
+	 * re-formatted per request — doing so would break Gemini's implicit
+	 * prefix cache across tool-loop iterations and resumes.
+	 */
+	sessionStartedAt?: string;
 	inlineAttachments?: InlineDataPart[];
 	/** @deprecated Use inlineAttachments instead */
 	imageAttachments?: InlineDataPart[];

--- a/src/history/history.ts
+++ b/src/history/history.ts
@@ -42,10 +42,16 @@ export class GeminiHistory {
 	}
 
 	/**
-	 * Add entry to agent session history
+	 * Add entry to agent session history.
+	 *
+	 * See `SessionHistory.addEntryToSession` for the role of `explicitTimestamp`.
 	 */
-	async addEntryToSession(session: ChatSession, entry: GeminiConversationEntry): Promise<void> {
-		await this.sessionHistory.addEntryToSession(session, entry);
+	async addEntryToSession(
+		session: ChatSession,
+		entry: GeminiConversationEntry,
+		explicitTimestamp?: Date
+	): Promise<void> {
+		await this.sessionHistory.addEntryToSession(session, entry, explicitTimestamp);
 	}
 
 	/**

--- a/src/prompts/gemini-prompts.ts
+++ b/src/prompts/gemini-prompts.ts
@@ -131,7 +131,8 @@ export class GeminiPrompts {
 		agentsMemory?: string | null,
 		availableSkills?: { name: string; description: string }[],
 		projectInstructions?: string,
-		perTurnContext?: string
+		perTurnContext?: string,
+		sessionStartedAt?: string
 	): string {
 		// If custom prompt with override is provided, return only that
 		if (customPrompt?.overrideSystemPrompt) {
@@ -161,15 +162,13 @@ export class GeminiPrompts {
 		// template variable — the systemPrompt.hbs template handles the heading.
 		const additionalInstructions = customPrompt && !customPrompt.overrideSystemPrompt ? customPrompt.content : '';
 
-		// Capture a single timestamp so the date and time fields in the system
-		// prompt are always derived from the same instant (avoids split around
-		// midnight boundaries).
-		const now = new Date();
-
+		// sessionStartedAt must be a canonical, byte-stable string the caller
+		// persisted once. Do NOT re-format via Date/toLocaleString here — doing so
+		// would break Gemini's implicit prefix cache across resumes and across
+		// tool-loop iterations.
 		return this.systemPrompt({
 			userName: this.plugin?.settings.userName || 'User',
-			date: now.toLocaleDateString(),
-			time: now.toLocaleTimeString(),
+			sessionStartedAt: sessionStartedAt || '',
 			agentsMemory: agentsMemory || '',
 			projectInstructions: projectInstructions || '',
 			agentRulesSection,

--- a/src/ui/agent-view/agent-view-messages.ts
+++ b/src/ui/agent-view/agent-view-messages.ts
@@ -3,6 +3,7 @@ import { ChatSession } from '../../types/agent';
 import { GeminiConversationEntry } from '../../types/conversation';
 import type ObsidianGemini from '../../main';
 import { formatModelMessage } from '../../utils/markdown-formatting';
+import { stripTurnPreamble } from '../../utils/turn-preamble';
 import { Tool, DiffContext, ConfirmationResult } from '../../tools/types';
 
 // Documentation and help content
@@ -98,19 +99,22 @@ export class AgentViewMessages {
 
 		const content = messageDiv.createDiv({ cls: 'gemini-agent-message-content' });
 
+		// User turns carry a time preamble for the model; strip it for UI/copy.
+		const renderMessage = entry.role === 'user' ? stripTurnPreamble(entry.message) : entry.message;
+
 		// Check if this is a tool execution message from history
-		const isToolExecution = entry.metadata?.toolName || entry.message.includes('Tool Execution Results:');
+		const isToolExecution = entry.metadata?.toolName || renderMessage.includes('Tool Execution Results:');
 
 		// Convert single newlines to double newlines for proper markdown rendering
 		// while preserving table formatting
-		let formattedMessage = entry.message;
+		let formattedMessage = renderMessage;
 		if (entry.role === 'model') {
-			formattedMessage = formatModelMessage(entry.message);
+			formattedMessage = formatModelMessage(renderMessage);
 
 			// Debug logging for table formatting
 			if (formattedMessage.includes('|')) {
 				this.plugin.logger.log('Table formatting debug:');
-				this.plugin.logger.log('Original message:', entry.message);
+				this.plugin.logger.log('Original message:', renderMessage);
 				this.plugin.logger.log('Formatted message:', formattedMessage);
 			}
 		}
@@ -119,7 +123,7 @@ export class AgentViewMessages {
 		const sourcePath = currentSession?.historyPath || '';
 
 		// Special handling for tool execution messages
-		if (isToolExecution && entry.message.includes('Tool Execution Results:')) {
+		if (isToolExecution && renderMessage.includes('Tool Execution Results:')) {
 			// Extract tool execution sections and make them collapsible
 			const toolSections = formattedMessage.split(/### ([^\n]+)/);
 
@@ -208,9 +212,9 @@ export class AgentViewMessages {
 			setIcon(copyButton, 'copy');
 
 			copyButton.addEventListener('click', () => {
-				// Use the original message text to preserve formatting
+				// Copy the user-visible text (preamble stripped for user turns)
 				navigator.clipboard
-					.writeText(entry.message)
+					.writeText(renderMessage)
 					.then(() => {
 						new Notice('Message copied to clipboard.');
 					})

--- a/src/ui/agent-view/agent-view-send.ts
+++ b/src/ui/agent-view/agent-view-send.ts
@@ -6,6 +6,8 @@ import { ExtendedModelRequest } from '../../api/interfaces/model-api';
 import { CustomPrompt } from '../../prompts/types';
 import { AgentFactory } from '../../agent/agent-factory';
 import { getErrorMessage } from '../../utils/error-utils';
+import { formatLocalTimestamp } from '../../utils/format-utils';
+import { buildTurnPreamble } from '../../utils/turn-preamble';
 import { InlineAttachment } from './inline-attachment';
 import { AgentViewProgress } from './agent-view-progress';
 import { AgentViewMessages } from './agent-view-messages';
@@ -74,12 +76,22 @@ export class AgentViewSend {
 		const sendButton = this.ctx.getSendButton();
 
 		// Get message text directly from input (no chips to process)
-		const message = userInput.innerText?.trim() || '';
-		const formattedMessage = message;
+		const rawMessage = userInput.innerText?.trim() || '';
 		// Allow sending with only attachments (no text)
 		const shelfTextFiles = shelf.getTextFiles();
 		const attachments = shelf.getPendingAttachments();
-		if (!message && shelfTextFiles.length === 0 && attachments.length === 0) return;
+		if (!rawMessage && shelfTextFiles.length === 0 && attachments.length === 0) return;
+
+		// Prepend a per-turn time preamble. This is written into both the
+		// outgoing model message and the persisted history entry so replay is
+		// bit-identical. The UI render path strips it before display. Freezing
+		// the timestamp here (rather than at write time) lets Gemini's implicit
+		// prefix cache align across tool-loop iterations within the turn and
+		// across session resumes.
+		const turnTimestamp = new Date();
+		const turnPreamble = buildTurnPreamble(formatLocalTimestamp(turnTimestamp));
+		const message = turnPreamble + rawMessage;
+		const formattedMessage = message;
 
 		// Mark binary shelf items as sent
 		shelf.markBinarySent();
@@ -192,7 +204,9 @@ export class AgentViewSend {
 
 			// Save user message to history once, before the API call.
 			// Tools use in-memory updatedHistory, not the file, so early save is safe.
-			await this.ctx.plugin.sessionHistory.addEntryToSession(currentSession, userEntry);
+			// Pass the frozen turn timestamp so the persisted `| Time |` row matches
+			// the preamble the model saw — required for cache alignment on resume.
+			await this.ctx.plugin.sessionHistory.addEntryToSession(currentSession, userEntry, turnTimestamp);
 
 			// Build context for AI request including mentioned files
 			const contextInfo = await this.ctx.plugin.gfile.buildFileContext(
@@ -326,6 +340,10 @@ To reference an attachment in your response, use the path shown above.`;
 					projectSkills: activeProject?.config.skills, // Filter skills to project scope
 					renderContent: false, // We already rendered content above
 					availableTools: availableTools,
+					// Session-start anchor for the system prompt. Derived from the
+					// session's immutable `created` date so it's stable across every
+					// tool-loop iteration within this turn.
+					sessionStartedAt: formatLocalTimestamp(currentSession.created),
 					inlineAttachments: attachments.map((a: InlineAttachment) => ({ base64: a.base64, mimeType: a.mimeType })),
 				};
 

--- a/src/utils/turn-preamble.ts
+++ b/src/utils/turn-preamble.ts
@@ -1,0 +1,20 @@
+/**
+ * Per-turn time preamble prepended to outgoing user messages so the model
+ * has accurate "now" awareness without embedding a volatile timestamp in the
+ * (cached) system prompt. The preamble is persisted in history verbatim so
+ * replay is bit-identical to what the model originally saw — a prerequisite
+ * for Gemini implicit-cache alignment on session resume.
+ *
+ * The regex requires the literal `[Current date and time: ...]` header
+ * followed by the exact `\n\n` separator the sender writes. This keeps
+ * benign bracketed text a user might paste from being mistakenly stripped.
+ */
+const TURN_PREAMBLE_REGEX = /^\[Current date and time: [^\]\n]+\]\n\n/;
+
+export function buildTurnPreamble(timestamp: string): string {
+	return `[Current date and time: ${timestamp}]\n\n`;
+}
+
+export function stripTurnPreamble(text: string): string {
+	return text.replace(TURN_PREAMBLE_REGEX, '');
+}

--- a/test/prompts/gemini-prompts.test.ts
+++ b/test/prompts/gemini-prompts.test.ts
@@ -17,6 +17,7 @@ describe('GeminiPrompts', () => {
 		mockPlugin = {
 			settings: {
 				userName: 'Test User',
+				ragIndexing: { enabled: false },
 			},
 			logger: {
 				warn: jest.fn(),
@@ -81,5 +82,43 @@ describe('GeminiPrompts', () => {
 			agentsMemory: '',
 		});
 		expect(prompt).toContain('My user interface is set to the language code: en');
+	});
+
+	describe('getSystemPromptWithCustom (implicit-cache stability)', () => {
+		const baseArgs = [
+			undefined, // availableTools
+			undefined, // customPrompt
+			null, // agentsMemory
+			undefined, // availableSkills
+			undefined, // projectInstructions
+			undefined, // perTurnContext
+		] as const;
+
+		it('returns byte-identical output across calls with the same sessionStartedAt', () => {
+			const anchor = '2026-04-12T14:23:45.123-07:00';
+			const first = geminiPrompts.getSystemPromptWithCustom(...baseArgs, anchor);
+			const second = geminiPrompts.getSystemPromptWithCustom(...baseArgs, anchor);
+			expect(second).toBe(first);
+		});
+
+		it('includes the session-start anchor line when sessionStartedAt is provided', () => {
+			const anchor = '2026-04-12T14:23:45.123-07:00';
+			const prompt = geminiPrompts.getSystemPromptWithCustom(...baseArgs, anchor);
+			expect(prompt).toContain(`This conversation started on ${anchor}.`);
+		});
+
+		it('omits the anchor line entirely when sessionStartedAt is empty/undefined', () => {
+			const prompt = geminiPrompts.getSystemPromptWithCustom(...baseArgs, undefined);
+			expect(prompt).not.toContain('This conversation started on');
+		});
+
+		it('does not inject volatile date or time fields into the prompt', () => {
+			// Regression guard: the pre-fix template had `Today's date is:` and
+			// `The current time is:` lines that changed per call and broke the
+			// implicit prefix cache. They must stay out.
+			const prompt = geminiPrompts.getSystemPromptWithCustom(...baseArgs, '2026-04-12T14:23:45.123-07:00');
+			expect(prompt).not.toContain("Today's date is:");
+			expect(prompt).not.toContain('The current time is:');
+		});
 	});
 });

--- a/test/utils/turn-preamble.test.ts
+++ b/test/utils/turn-preamble.test.ts
@@ -1,0 +1,44 @@
+import { buildTurnPreamble, stripTurnPreamble } from '../../src/utils/turn-preamble';
+
+describe('turn-preamble', () => {
+	describe('buildTurnPreamble', () => {
+		it('wraps the timestamp in the canonical preamble format', () => {
+			const preamble = buildTurnPreamble('2026-04-12T14:23:45.123-07:00');
+			expect(preamble).toBe('[Current date and time: 2026-04-12T14:23:45.123-07:00]\n\n');
+		});
+	});
+
+	describe('stripTurnPreamble', () => {
+		it('strips a well-formed preamble from the start of the message', () => {
+			const message = '[Current date and time: 2026-04-12T14:23:45.123-07:00]\n\nHello, can you summarize my notes?';
+			expect(stripTurnPreamble(message)).toBe('Hello, can you summarize my notes?');
+		});
+
+		it('is a no-op when the message has no preamble', () => {
+			const message = 'Hello, can you summarize my notes?';
+			expect(stripTurnPreamble(message)).toBe(message);
+		});
+
+		it('leaves malformed preambles intact — never over-strips', () => {
+			const cases = [
+				// Missing closing bracket
+				'[Current date and time: 2026-04-12T14:23:45.123-07:00\n\nHello',
+				// Wrong header text
+				'[Timestamp: 2026-04-12T14:23:45.123-07:00]\n\nHello',
+				// Preamble buried inside the message, not at the start
+				'Hello [Current date and time: 2026-04-12T14:23:45.123-07:00]\n\nWorld',
+				// Single newline separator instead of the required blank line
+				'[Current date and time: 2026-04-12T14:23:45.123-07:00]\nHello',
+			];
+			for (const msg of cases) {
+				expect(stripTurnPreamble(msg)).toBe(msg);
+			}
+		});
+
+		it('build then strip round-trips to the original message', () => {
+			const original = 'What did I write about caching last week?';
+			const preamble = buildTurnPreamble('2026-04-12T14:23:45.123-07:00');
+			expect(stripTurnPreamble(preamble + original)).toBe(original);
+		});
+	});
+});


### PR DESCRIPTION
## Summary

The system prompt rebuilt itself with fresh `toLocaleDateString()` / `toLocaleTimeString()` on every call (`prompts/systemPrompt.hbs:8-9`), so every tool-loop iteration and every session resume produced a new prompt suffix and defeated Gemini's implicit prefix cache. In agent mode — where a single user turn triggers 5-20+ inner model calls sharing the same system prompt — the cost impact is substantial. This change stabilizes the prompt so the cache can actually do its job.

Prerequisite for #619 (eval harness), #621 (thinking budgets), and #622 (turn budgets) — without cache stability, cost measurements are noise.

Fixes #618

## Changes

- **System prompt anchor**: `prompts/systemPrompt.hbs` replaces the volatile `{{date}}`/`{{time}}` lines with a guarded `{{sessionStartedAt}}` anchor — "This conversation started on ...", sourced from `session.created`, stable for the life of the session.
- **`getSystemPromptWithCustom`** takes `sessionStartedAt?: string` instead of deriving from `new Date()`. Caller is responsible for byte-stable input; a comment warns against re-formatting.
- **Per-turn preamble**: `agent-view-send.ts` freezes a single `turnTimestamp` per turn, builds `[Current date and time: ISO]\n\n`, and prepends it to both the API-bound `message` and the history-bound `displayMessage`. Same timestamp, no drift.
- **`addEntryToSession`** accepts an optional `explicitTimestamp: Date` so the persisted `| Time |` metadata row matches the preamble the model saw — required for bit-identical rehydration.
- **`ExtendedModelRequest`** gains `sessionStartedAt?: string`, plumbed through `gemini-client.ts`.
- **UI strip**: `agent-view-messages.ts::displayMessage` strips the preamble for user-role entries before rendering and clipboard copy, via a new `src/utils/turn-preamble.ts` helper (`buildTurnPreamble` / `stripTurnPreamble`).
- **Tests**: new coverage for byte-identical prompt output, anchor inclusion/omission, a regression guard against the old `Today's date is:` line, and the strip helper (happy path, no-op, malformed preambles, round-trip).
- **Persistence**: no schema change. Existing `frontmatter.created` is the anchor; existing `| Time |` metadata row now honors the explicit timestamp when provided. Old sessions continue to work — cache alignment starts fresh from the first new turn after merge.

## Screenshots / Screencast

Not applicable — no visible UI change for users. Agent messages render identically (preamble is stripped); only the system-prompt bytes and history file contents change.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer (#618)
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop (in-progress — manual verification running)
- [ ] I have verified this change does not break Mobile (no platform-specific code touched; all changes are in plugin-wide paths shared by mobile and desktop)
- [x] Documentation has been updated (if applicable) — N/A, no user-facing behavior change
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Conversations now track and display when a session started.
  * Each message turn includes a timestamp to mark when it occurred.
  * System prompts are now deterministic and cache-optimized, eliminating volatile per-request date/time calculations.

* **Tests**
  * Added comprehensive test coverage for session start time handling and per-turn timestamp utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->