### PR TITLE
feat: Surface Gemini cached-token metrics in UI and debug logs

### DIFF
--- a/src/api/gemini-client.ts
+++ b/src/api/gemini-client.ts
@@ -156,10 +156,12 @@ export class GeminiClient implements ModelApi {
 					// Capture usageMetadata from chunks (usually present in last chunk)
 					if (chunk.usageMetadata) {
 						lastUsageMetadata = chunk.usageMetadata;
+						const meta = chunk.usageMetadata as any;
 						this.plugin?.logger.debug(
 							`[GeminiClient] Captured usageMetadata from streaming chunk: ` +
-								`prompt=${(chunk.usageMetadata as any).promptTokenCount}, ` +
-								`total=${(chunk.usageMetadata as any).totalTokenCount}`
+								`prompt=${meta.promptTokenCount}, ` +
+								`total=${meta.totalTokenCount}, ` +
+								`cached=${meta.cachedContentTokenCount ?? 0}`
 						);
 					}
 				}
@@ -425,6 +427,7 @@ export class GeminiClient implements ModelApi {
 					promptTokenCount: (response.usageMetadata as any).promptTokenCount,
 					candidatesTokenCount: (response.usageMetadata as any).candidatesTokenCount,
 					totalTokenCount: (response.usageMetadata as any).totalTokenCount,
+					cachedContentTokenCount: (response.usageMetadata as any).cachedContentTokenCount,
 				},
 			}),
 		};

--- a/src/api/interfaces/model-api.ts
+++ b/src/api/interfaces/model-api.ts
@@ -20,6 +20,13 @@ export interface ModelResponse {
 		promptTokenCount?: number;
 		candidatesTokenCount?: number;
 		totalTokenCount?: number;
+		/**
+		 * Portion of `promptTokenCount` served from Gemini's implicit or explicit
+		 * content cache. Present on responses where the request matched a cached
+		 * prefix; omitted otherwise. Used to surface caching effectiveness in the
+		 * token readout UI and debug logs.
+		 */
+		cachedContentTokenCount?: number;
 	};
 }
 

--- a/src/services/context-manager.ts
+++ b/src/services/context-manager.ts
@@ -107,9 +107,7 @@ export class ContextManager {
 		if (newPrompt >= cachedPrompt || this.acceptNextLowerUpdate) {
 			this.lastUsageMetadata = { ...metadata };
 			this.acceptNextLowerUpdate = false;
-			this.logger.log(
-				`[ContextManager] Updated usage metadata: prompt=${metadata.promptTokenCount}, total=${metadata.totalTokenCount}`
-			);
+			this.logger.log(`[ContextManager] Updated usage metadata: ${this.formatUsageForLog(metadata)}`);
 		} else {
 			this.logger.debug(`[ContextManager] Skipped lower metadata: prompt=${newPrompt} < cached=${cachedPrompt}`);
 		}
@@ -122,10 +120,20 @@ export class ContextManager {
 	setUsageMetadata(metadata: UsageMetadata): void {
 		if (metadata) {
 			this.lastUsageMetadata = { ...metadata };
-			this.logger.log(
-				`[ContextManager] Force-set usage metadata: prompt=${metadata.promptTokenCount}, total=${metadata.totalTokenCount}`
-			);
+			this.logger.log(`[ContextManager] Force-set usage metadata: ${this.formatUsageForLog(metadata)}`);
 		}
+	}
+
+	/**
+	 * Format usage metadata for a one-line debug log, including cached-prefix
+	 * share so cache effectiveness is observable per request.
+	 */
+	private formatUsageForLog(metadata: UsageMetadata): string {
+		const prompt = metadata.promptTokenCount ?? 0;
+		const total = metadata.totalTokenCount ?? 0;
+		const cached = metadata.cachedContentTokenCount ?? 0;
+		const ratio = prompt > 0 ? Math.round((cached / prompt) * 100) : 0;
+		return `prompt=${prompt}, total=${total}, cached=${cached} (${ratio}%)`;
 	}
 
 	/**

--- a/src/ui/agent-view/agent-view.ts
+++ b/src/ui/agent-view/agent-view.ts
@@ -643,11 +643,15 @@ export class AgentView extends ItemView {
 			this.tokenUsageContainer.empty();
 
 			const tokenText = this.tokenUsageContainer.createSpan({ cls: 'gemini-agent-token-text' });
-			const uncached = usage.estimatedTokens - usage.cachedTokens;
-			if (usage.cachedTokens > 0) {
-				tokenText.textContent = `Tokens: ~${usage.estimatedTokens.toLocaleString()} (${uncached.toLocaleString()} new) / ${usage.inputTokenLimit.toLocaleString()} (${usage.percentUsed}%)`;
+			const base = `Tokens: ~${usage.estimatedTokens.toLocaleString()} / ${usage.inputTokenLimit.toLocaleString()} (${usage.percentUsed}%)`;
+			if (usage.cachedTokens > 0 && usage.estimatedTokens > 0) {
+				// Cached ratio reflects how much of the current prompt was served
+				// from Gemini's implicit/explicit cache — a positive signal that
+				// rewards stable prefixes (system prompt, pinned history).
+				const cachedPercent = Math.round((usage.cachedTokens / usage.estimatedTokens) * 100);
+				tokenText.textContent = `${base} · ${cachedPercent}% cached`;
 			} else {
-				tokenText.textContent = `Tokens: ~${usage.estimatedTokens.toLocaleString()} / ${usage.inputTokenLimit.toLocaleString()} (${usage.percentUsed}%)`;
+				tokenText.textContent = base;
 			}
 
 			// Add warning class if approaching threshold

--- a/test/services/context-manager.test.ts
+++ b/test/services/context-manager.test.ts
@@ -116,6 +116,36 @@ describe('ContextManager', () => {
 			const usage = await contextManager.getTokenUsage('gemini-2.5-flash');
 			expect(usage.estimatedTokens).toBe(20000);
 		});
+
+		test('should preserve cachedContentTokenCount on updates', async () => {
+			contextManager.updateUsageMetadata({
+				promptTokenCount: 10000,
+				totalTokenCount: 11000,
+				cachedContentTokenCount: 8000,
+			});
+
+			const usage = await contextManager.getTokenUsage('gemini-2.5-flash');
+			expect(usage.cachedTokens).toBe(8000);
+		});
+
+		test('should log cached ratio alongside prompt/total', () => {
+			contextManager.updateUsageMetadata({
+				promptTokenCount: 10000,
+				totalTokenCount: 11000,
+				cachedContentTokenCount: 8000,
+			});
+
+			expect(mockLogger.log).toHaveBeenCalledWith(expect.stringContaining('cached=8000 (80%)'));
+		});
+
+		test('should report zero cached tokens when field is absent', () => {
+			contextManager.updateUsageMetadata({
+				promptTokenCount: 5000,
+				totalTokenCount: 6000,
+			});
+
+			expect(mockLogger.log).toHaveBeenCalledWith(expect.stringContaining('cached=0 (0%)'));
+		});
 	});
 
 	describe('setUsageMetadata', () => {


### PR DESCRIPTION
## Summary

Adds observability for Gemini's cache hits so we can measure the impact of #618 and the upcoming agent-loop work in #619, #622, and #623. Previously `ModelResponse.usageMetadata` silently dropped `cachedContentTokenCount` from the non-streaming extractor, and the token readout only showed total usage — we had no way to tell whether implicit caching was working.

Related to #618 (cache hits only start showing up once the system-prompt prefix is stable).

## Changes

- **Interface**: `ModelResponse.usageMetadata` gains `cachedContentTokenCount?: number`.
- **GeminiClient**: non-streaming extractor now forwards the field; streaming already passed the whole metadata object through. Streaming debug log also includes `cached=...`.
- **ContextManager**: `updateUsageMetadata` and `setUsageMetadata` log one-liners now include cached tokens and ratio via a shared `formatUsageForLog` helper, e.g. `prompt=98000, total=101000, cached=80000 (82%)`.
- **Agent view token readout**: replaces the prior \"(N new)\" uncached count with a cleaner cached-percentage suffix. Example:
  - Before: `Tokens: ~98,000 (18,000 new) / 1,000,000 (9.8%)`
  - After: `Tokens: ~98,000 / 1,000,000 (9.8%) · 82% cached`
  - When no cache hit, the readout stays as today — `Tokens: ~98,000 / 1,000,000 (9.8%)`.
- **Tests**: `context-manager.test.ts` gains coverage for cached-token preservation on update, the cached-ratio log format, and the zero-cached fallback.

## Rationale for Option B

We discussed three display options:

| Option | Shows | Tradeoff |
|---|---|---|
| A (keep total only) | `98k / 1M` | Hides the caching win |
| B (total + cached ratio) — **this PR** | `98k / 1M · 82% cached` | Transparent, doesn't lie about context usage |
| C (effective cost) | `24k effective / 1M` | Breaks compaction math, misleading |

The total-against-budget stays truthful because the context window enforces actual token count (cached tokens still occupy window space). Surfacing the cached ratio is pure signal — users see sessions getting cheaper over long conversations without us fabricating an \"effective\" number.

## Screenshots / Screencast

No visual diff beyond the token-usage line in the agent view footer. Format change is described above.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer (follow-up to #618; observability plumbing for #619 / #622 / #623)
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop (plugin reloaded, clean; cached percentage will light up once #618 lands and cache hits begin)
- [ ] I have verified this change does not break Mobile (no platform-specific code; changes are in shared paths)
- [x] Documentation has been updated (if applicable) — N/A, debug logging + minor UI text change
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Token usage metrics now display cached content information, showing the percentage of tokens served from cache alongside estimated token usage and limits.
  * Enhanced usage logging to include cached token statistics for better visibility into token consumption patterns.

* **Tests**
  * Added test coverage for cached token handling and reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->