### PR TITLE
Feat/background task infrastructure

### DIFF
--- a/docs/guide/background-tasks.md
+++ b/docs/guide/background-tasks.md
@@ -11,7 +11,7 @@ The status bar shows a single indicator for all background work. It reflects bot
 | Hidden                         | No background work running, RAG idle or disabled |
 | Spinning loader icon + count   | One or more background tasks running             |
 | Upload-cloud icon + percentage | RAG indexing in progress                         |
-| Database icon + number         | RAG idle, N files indexed                        |
+| Pause-circle icon              | RAG indexing paused                              |
 
 Click the indicator at any time to open the **Background Tasks** panel.
 

--- a/docs/guide/background-tasks.md
+++ b/docs/guide/background-tasks.md
@@ -1,0 +1,57 @@
+# Background Tasks
+
+Long-running operations — deep research and image generation — run in the background so they never block your editing session. Results are saved to your vault automatically and you're notified when they're ready.
+
+## Status Bar Indicator
+
+The status bar shows a single indicator for all background work. It reflects both active background tasks and the RAG indexing state in one place.
+
+| Appearance                     | Meaning                                          |
+| ------------------------------ | ------------------------------------------------ |
+| Hidden                         | No background work running, RAG idle or disabled |
+| Spinning loader icon + count   | One or more background tasks running             |
+| Upload-cloud icon + percentage | RAG indexing in progress                         |
+| Database icon + number         | RAG idle, N files indexed                        |
+
+Click the indicator at any time to open the **Background Tasks** panel.
+
+## Background Tasks Panel
+
+The panel (also available via **Command Palette → View Background Tasks**) shows:
+
+- **Running** — tasks currently in progress, with a Cancel button for each
+- **Recent** — the last 20 completed, failed, or cancelled tasks
+
+Completed tasks with output files show an **Open result** link that opens the file in Obsidian.
+
+## How Tasks Are Created
+
+Background tasks are created automatically when you trigger long-running operations:
+
+- **Deep Research** — starts a research task; result saved to `<history-folder>/background-tasks/<id>.md`
+- **Image Generation** — generates and saves an image; result path shown in the completion notice
+
+Both operations fire a completion notice with a clickable vault link when done. If a task fails, a notice explains the error.
+
+## Cancellation
+
+Click **Cancel** next to a running task in the panel. The task stops at the next safe checkpoint — it may not stop instantly if the underlying API call is already in flight.
+
+## Accessing Results
+
+When a task completes you'll see a notice in the bottom-right corner with an **Open result** link. You can also find the result by:
+
+1. Clicking the status bar indicator → **Open result** in the Recent section
+2. Navigating directly to `<history-folder>/background-tasks/` in the file explorer
+
+## Troubleshooting
+
+**Task shows as failed**
+Check the error shown in the Background Tasks panel. Common causes:
+
+- API key not configured or expired
+- Network timeout on long-running research queries
+- Vault path conflict for image output
+
+**Status bar indicator not visible**
+The indicator is hidden when there is nothing to show (no tasks running, RAG disabled or idle). Trigger a background task or enable RAG indexing in Settings.

--- a/src/main.ts
+++ b/src/main.ts
@@ -36,6 +36,8 @@ import { ProjectManager } from './services/project-manager';
 import { AgentEventBus } from './agent/agent-event-bus';
 import { ToolExecutionLogger } from './subscribers/tool-execution-logger';
 import { LifecycleService } from './services/lifecycle-service';
+import { BackgroundTaskManager } from './services/background-task-manager';
+import { BackgroundStatusBar } from './services/background-status-bar';
 import { getErrorMessage } from './utils/error-utils';
 
 export interface RagIndexingSettings {
@@ -182,6 +184,8 @@ export default class ObsidianGemini extends Plugin {
 	public projectManager!: ProjectManager;
 	public agentEventBus!: AgentEventBus;
 	public toolExecutionLogger: ToolExecutionLogger | null = null;
+	public backgroundTaskManager: BackgroundTaskManager | null = null;
+	public backgroundStatusBar: BackgroundStatusBar | null = null;
 
 	// Private members
 	private ribbonIcon!: HTMLElement;
@@ -289,6 +293,16 @@ export default class ObsidianGemini extends Plugin {
 			callback: () => {
 				if (!this.checkInitialized()) return;
 				this.activateAgentView();
+			},
+		});
+
+		// View background tasks
+		this.addCommand({
+			id: 'gemini-scribe-view-background-tasks',
+			name: 'View Background Tasks',
+			callback: async () => {
+				const { BackgroundTasksModal } = await import('./ui/background-tasks-modal');
+				new BackgroundTasksModal(this.app, this).open();
 			},
 		});
 

--- a/src/services/background-status-bar.ts
+++ b/src/services/background-status-bar.ts
@@ -77,7 +77,8 @@ export class BackgroundStatusBar {
 			tooltipParts.push(`${runningCount} background task${runningCount > 1 ? 's' : ''} running — click to view`);
 		} else {
 			// No tasks running — let RAG drive the icon
-			setIcon(iconEl, ragStatus === 'indexing' ? 'upload-cloud' : 'database');
+			const ragIcon = ragStatus === 'indexing' ? 'upload-cloud' : ragStatus === 'paused' ? 'pause-circle' : 'database';
+			setIcon(iconEl, ragIcon);
 			textEl.setText(
 				ragStatus === 'indexing'
 					? (() => {
@@ -91,11 +92,13 @@ export class BackgroundStatusBar {
 			);
 		}
 
-		// Append RAG state to tooltip when both are active
+		// Append RAG state to tooltip
 		if (ragStatus === 'indexing') {
 			const p = this.ragProvider!.getIndexingProgress();
 			const pctLabel = p.total > 0 ? ` (${p.current}/${p.total})` : '';
 			tooltipParts.push(`RAG: indexing${pctLabel}`);
+		} else if (ragStatus === 'paused') {
+			tooltipParts.push(`RAG: paused (${this.ragProvider!.getIndexedFileCount()} files indexed)`);
 		} else if (ragStatus === 'error') {
 			tooltipParts.push('RAG: error — check settings');
 		} else if (ragStatus === 'rate_limited') {

--- a/src/services/background-status-bar.ts
+++ b/src/services/background-status-bar.ts
@@ -104,8 +104,6 @@ export class BackgroundStatusBar {
 		} else if (ragStatus === 'rate_limited') {
 			const secs = this.ragProvider!.getRateLimitRemainingSeconds();
 			tooltipParts.push(`RAG: rate limited (${secs}s)`);
-		} else if (ragStatus === 'idle' && runningCount === 0) {
-			tooltipParts.push(`RAG: ${this.ragProvider!.getIndexedFileCount()} files indexed`);
 		}
 
 		setTooltip(this.statusBarItem, tooltipParts.join(' · '), { placement: 'top' });

--- a/src/services/background-status-bar.ts
+++ b/src/services/background-status-bar.ts
@@ -22,8 +22,9 @@ export class BackgroundStatusBar {
 		this.taskManager = taskManager;
 	}
 
-	/** Called after RAG is initialized so it can contribute to the shared indicator. */
-	setRagProvider(provider: RagStatusProvider): void {
+	/** Called after RAG is initialized so it can contribute to the shared indicator.
+	 *  Pass null to unregister (e.g. when RagIndexingService is torn down). */
+	setRagProvider(provider: RagStatusProvider | null): void {
 		this.ragProvider = provider;
 		this.update();
 	}

--- a/src/services/background-status-bar.ts
+++ b/src/services/background-status-bar.ts
@@ -1,0 +1,117 @@
+import { setIcon, setTooltip } from 'obsidian';
+import type ObsidianGemini from '../main';
+import type { BackgroundTaskManager } from './background-task-manager';
+import type { RagStatusProvider } from './rag-status-bar';
+
+/**
+ * A single coordinated status bar item that reflects both RAG indexing state
+ * and background task state. This is the canonical "things are happening in
+ * the background" surface — there should only ever be one icon, not two.
+ *
+ * Priority: if background tasks are running they take the icon; RAG state is
+ * included in the tooltip. When no tasks are running, RAG state drives the icon.
+ */
+export class BackgroundStatusBar {
+	private plugin: ObsidianGemini;
+	private taskManager: BackgroundTaskManager;
+	private ragProvider: RagStatusProvider | null = null;
+	private statusBarItem: HTMLElement | null = null;
+
+	constructor(plugin: ObsidianGemini, taskManager: BackgroundTaskManager) {
+		this.plugin = plugin;
+		this.taskManager = taskManager;
+	}
+
+	/** Called after RAG is initialized so it can contribute to the shared indicator. */
+	setRagProvider(provider: RagStatusProvider): void {
+		this.ragProvider = provider;
+		this.update();
+	}
+
+	/** Attach the status bar item to the Obsidian status bar. */
+	setup(): void {
+		if (this.statusBarItem) return;
+
+		this.statusBarItem = this.plugin.addStatusBarItem();
+		this.statusBarItem.addClass('gemini-bg-status-bar');
+
+		this.statusBarItem.createSpan({ cls: 'gemini-bg-status-icon' });
+		this.statusBarItem.createSpan({ cls: 'gemini-bg-status-text' });
+
+		this.statusBarItem.addEventListener('click', async () => {
+			const { BackgroundTasksModal } = await import('../ui/background-tasks-modal');
+			new BackgroundTasksModal(this.plugin.app, this.plugin).open();
+		});
+
+		this.update();
+	}
+
+	/** Re-render the status bar item to reflect current state. */
+	update(): void {
+		if (!this.statusBarItem) return;
+
+		const iconEl = this.statusBarItem.querySelector('.gemini-bg-status-icon') as HTMLElement | null;
+		const textEl = this.statusBarItem.querySelector('.gemini-bg-status-text') as HTMLElement | null;
+		if (!iconEl || !textEl) return;
+
+		const runningCount = this.taskManager.runningCount;
+		const ragStatus = this.ragProvider?.getStatus() ?? 'disabled';
+
+		// Nothing to show — hide entirely
+		if (runningCount === 0 && (ragStatus === 'disabled' || ragStatus === 'idle')) {
+			this.statusBarItem.style.display = 'none';
+			return;
+		}
+
+		this.statusBarItem.style.display = '';
+		this.statusBarItem.removeClass('gemini-bg-active');
+
+		const tooltipParts: string[] = [];
+
+		if (runningCount > 0) {
+			// Background tasks take visual priority
+			this.statusBarItem.addClass('gemini-bg-active');
+			setIcon(iconEl, 'loader');
+			textEl.setText(runningCount > 1 ? `${runningCount} tasks` : '1 task');
+			tooltipParts.push(`${runningCount} background task${runningCount > 1 ? 's' : ''} running — click to view`);
+		} else {
+			// No tasks running — let RAG drive the icon
+			setIcon(iconEl, ragStatus === 'indexing' ? 'upload-cloud' : 'database');
+			textEl.setText(
+				ragStatus === 'indexing'
+					? (() => {
+							const p = this.ragProvider!.getIndexingProgress();
+							if (p.total > 0) {
+								return `${Math.round((p.current / p.total) * 100)}%`;
+							}
+							return '…';
+						})()
+					: String(this.ragProvider?.getIndexedFileCount() ?? '')
+			);
+		}
+
+		// Append RAG state to tooltip when both are active
+		if (ragStatus === 'indexing') {
+			const p = this.ragProvider!.getIndexingProgress();
+			const pctLabel = p.total > 0 ? ` (${p.current}/${p.total})` : '';
+			tooltipParts.push(`RAG: indexing${pctLabel}`);
+		} else if (ragStatus === 'error') {
+			tooltipParts.push('RAG: error — check settings');
+		} else if (ragStatus === 'rate_limited') {
+			const secs = this.ragProvider!.getRateLimitRemainingSeconds();
+			tooltipParts.push(`RAG: rate limited (${secs}s)`);
+		} else if (ragStatus === 'idle' && runningCount === 0) {
+			tooltipParts.push(`RAG: ${this.ragProvider!.getIndexedFileCount()} files indexed`);
+		}
+
+		setTooltip(this.statusBarItem, tooltipParts.join(' · '), { placement: 'top' });
+	}
+
+	destroy(): void {
+		if (this.statusBarItem) {
+			this.statusBarItem.remove();
+			this.statusBarItem = null;
+		}
+		this.ragProvider = null;
+	}
+}

--- a/src/services/background-task-manager.ts
+++ b/src/services/background-task-manager.ts
@@ -165,10 +165,13 @@ export class BackgroundTaskManager {
 		} catch (error) {
 			// Don't overwrite cancelled status if cancel() raced with a throw.
 			// Use the cancellation flag rather than task.status to avoid a TypeScript narrowing issue.
-			if (!isCancelled()) {
+			// Always report 'Cancelled' for the cancelled path so subscribers see a consistent shape.
+			if (isCancelled()) {
+				task.error = 'Cancelled';
+			} else {
 				task.status = 'failed';
+				task.error = getErrorMessage(error);
 			}
-			task.error = getErrorMessage(error);
 			task.completedAt = new Date();
 
 			this.plugin.logger.error(`[BackgroundTaskManager] Task ${id} (${task.label}) failed:`, error);
@@ -224,11 +227,13 @@ export class BackgroundTaskManager {
 	}
 
 	destroy(): void {
-		// Cancel all running tasks so work functions can bail out
+		// Signal all running tasks to stop. The flags must outlive tasks.clear() so
+		// any in-flight run() that resumes after destroy can still see isCancelled() === true
+		// and skip emitting backgroundTaskComplete / showing a completion Notice.
+		// The existing finally { cancellationFlags.delete(id) } in run() handles cleanup.
 		for (const task of this.getActiveTasks()) {
 			this.cancellationFlags.set(task.id, true);
 		}
 		this.tasks.clear();
-		this.cancellationFlags.clear();
 	}
 }

--- a/src/services/background-task-manager.ts
+++ b/src/services/background-task-manager.ts
@@ -107,8 +107,9 @@ export class BackgroundTaskManager {
 			.sort((a, b) => {
 				const byCompleted = (b.completedAt?.getTime() ?? 0) - (a.completedAt?.getTime() ?? 0);
 				if (byCompleted !== 0) return byCompleted;
-				// Tiebreak by startedAt so tasks that began later sort first when they finish in the same millisecond.
-				return b.startedAt.getTime() - a.startedAt.getTime();
+				// Tiebreak by numeric task ID (monotonically increasing) so the task
+				// submitted later always sorts first regardless of timer resolution.
+				return Number(b.id) - Number(a.id);
 			})
 			.slice(0, limit);
 	}

--- a/src/services/background-task-manager.ts
+++ b/src/services/background-task-manager.ts
@@ -1,0 +1,228 @@
+import { Notice } from 'obsidian';
+import type ObsidianGemini from '../main';
+import type { AgentEventBus } from '../agent/agent-event-bus';
+import { getErrorMessage } from '../utils/error-utils';
+
+export type BackgroundTaskStatus = 'pending' | 'running' | 'complete' | 'failed' | 'cancelled';
+
+export interface BackgroundTask {
+	id: string;
+	type: string;
+	label: string;
+	status: BackgroundTaskStatus;
+	outputPath?: string;
+	error?: string;
+	startedAt: Date;
+	completedAt?: Date;
+}
+
+/**
+ * Manages fire-and-forget background tasks (e.g. deep research, image generation).
+ * Callers submit work and receive a task ID immediately — they never block.
+ *
+ * Events emitted on AgentEventBus:
+ *   backgroundTaskStarted  — when a task transitions pending → running
+ *   backgroundTaskComplete — when a task finishes successfully
+ *   backgroundTaskFailed   — when a task throws or is cancelled
+ */
+export class BackgroundTaskManager {
+	private plugin: ObsidianGemini;
+	private eventBus: AgentEventBus;
+	private tasks = new Map<string, BackgroundTask>();
+	private cancellationFlags = new Map<string, boolean>();
+	/** Maximum number of completed/failed tasks kept in memory for the monitoring modal. */
+	private static readonly MAX_RECENT = 20;
+	private nextId = 1;
+
+	constructor(plugin: ObsidianGemini, eventBus: AgentEventBus) {
+		this.plugin = plugin;
+		this.eventBus = eventBus;
+	}
+
+	/**
+	 * Submit a unit of work to run in the background.
+	 * The work function receives a `isCancelled` predicate it can poll
+	 * to abort early. It should return the vault path of its output file,
+	 * or undefined if there is no file output.
+	 *
+	 * @param type    Short machine-readable category (e.g. 'deep-research')
+	 * @param label   Human-readable description shown in the status bar / modal
+	 * @param work    Async function to execute; return value becomes outputPath
+	 * @returns       The task ID — callers can pass this to cancel() or getTask()
+	 */
+	submit(type: string, label: string, work: (isCancelled: () => boolean) => Promise<string | undefined>): string {
+		const id = String(this.nextId++);
+
+		const task: BackgroundTask = {
+			id,
+			type,
+			label,
+			status: 'pending',
+			startedAt: new Date(),
+		};
+
+		this.tasks.set(id, task);
+		this.cancellationFlags.set(id, false);
+
+		// Fire-and-forget — intentionally not awaited by the caller
+		this.run(id, work);
+
+		return id;
+	}
+
+	/**
+	 * Request cancellation of a running task.
+	 * The work function must cooperate by polling `isCancelled()`.
+	 * Has no effect if the task is already complete or failed.
+	 */
+	cancel(taskId: string): void {
+		const task = this.tasks.get(taskId);
+		if (!task) return;
+		if (task.status !== 'pending' && task.status !== 'running') return;
+
+		this.cancellationFlags.set(taskId, true);
+		task.status = 'cancelled';
+		task.completedAt = new Date();
+		this.plugin.logger.log(`[BackgroundTaskManager] Task ${taskId} (${task.label}) cancelled`);
+		this.notifyStatusChange();
+	}
+
+	/** Returns a live snapshot of a single task, or undefined. */
+	getTask(taskId: string): BackgroundTask | undefined {
+		return this.tasks.get(taskId);
+	}
+
+	/** Returns all currently running tasks. */
+	getActiveTasks(): BackgroundTask[] {
+		return [...this.tasks.values()].filter((t) => t.status === 'pending' || t.status === 'running');
+	}
+
+	/**
+	 * Returns the most recent completed/failed/cancelled tasks, newest first.
+	 * Capped at BackgroundTaskManager.MAX_RECENT entries.
+	 */
+	getRecentTasks(limit = BackgroundTaskManager.MAX_RECENT): BackgroundTask[] {
+		return [...this.tasks.values()]
+			.filter((t) => t.status === 'complete' || t.status === 'failed' || t.status === 'cancelled')
+			.sort((a, b) => (b.completedAt?.getTime() ?? 0) - (a.completedAt?.getTime() ?? 0))
+			.slice(0, limit);
+	}
+
+	/** Total number of currently running tasks (used by the status bar). */
+	get runningCount(): number {
+		return this.getActiveTasks().length;
+	}
+
+	// --- Private ---
+
+	private async run(id: string, work: (isCancelled: () => boolean) => Promise<string | undefined>): Promise<void> {
+		const task = this.tasks.get(id)!;
+		const isCancelled = () => this.cancellationFlags.get(id) === true;
+
+		// Transition to running
+		task.status = 'running';
+		this.plugin.logger.log(`[BackgroundTaskManager] Task ${id} (${task.label}) started`);
+
+		await this.eventBus.emit('backgroundTaskStarted', { taskId: id, type: task.type, label: task.label });
+		this.notifyStatusChange();
+
+		try {
+			const outputPath = await work(isCancelled);
+
+			// Check if it was cancelled while work was executing
+			if (isCancelled()) {
+				// cancel() already set status = 'cancelled'
+				await this.eventBus.emit('backgroundTaskFailed', {
+					taskId: id,
+					type: task.type,
+					label: task.label,
+					error: 'Cancelled',
+				});
+				this.notifyStatusChange();
+				return;
+			}
+
+			task.status = 'complete';
+			task.outputPath = outputPath;
+			task.completedAt = new Date();
+
+			this.plugin.logger.log(`[BackgroundTaskManager] Task ${id} (${task.label}) complete`);
+
+			await this.eventBus.emit('backgroundTaskComplete', {
+				taskId: id,
+				type: task.type,
+				label: task.label,
+				outputPath,
+			});
+
+			this.showCompletionNotice(task);
+		} catch (error) {
+			// Don't overwrite cancelled status if cancel() raced with a throw.
+			// Use the cancellation flag rather than task.status to avoid a TypeScript narrowing issue.
+			if (!isCancelled()) {
+				task.status = 'failed';
+			}
+			task.error = getErrorMessage(error);
+			task.completedAt = new Date();
+
+			this.plugin.logger.error(`[BackgroundTaskManager] Task ${id} (${task.label}) failed:`, error);
+
+			await this.eventBus.emit('backgroundTaskFailed', {
+				taskId: id,
+				type: task.type,
+				label: task.label,
+				error: task.error,
+			});
+
+			new Notice(`Background task failed: ${task.label}\n${task.error}`, 8000);
+		} finally {
+			this.cancellationFlags.delete(id);
+			this.pruneOldTasks();
+			this.notifyStatusChange();
+		}
+	}
+
+	private showCompletionNotice(task: BackgroundTask): void {
+		if (task.outputPath) {
+			const notice = new Notice(``, 8000);
+			const fragment = notice.noticeEl;
+			fragment.createSpan({ text: `✓ ${task.label} complete. ` });
+			const link = fragment.createEl('a', { text: 'Open result', href: '#' });
+			link.addEventListener('click', (e) => {
+				e.preventDefault();
+				this.plugin.app.workspace.openLinkText(task.outputPath!, '', false);
+				notice.hide();
+			});
+		} else {
+			new Notice(`✓ ${task.label} complete.`, 5000);
+		}
+	}
+
+	/** Keep memory bounded — only keep the last MAX_RECENT finished tasks. */
+	private pruneOldTasks(): void {
+		const finished = this.getRecentTasks(BackgroundTaskManager.MAX_RECENT + 1);
+		if (finished.length > BackgroundTaskManager.MAX_RECENT) {
+			const toRemove = finished.slice(BackgroundTaskManager.MAX_RECENT);
+			for (const t of toRemove) {
+				this.tasks.delete(t.id);
+			}
+		}
+	}
+
+	/**
+	 * Notify the status bar that counts have changed.
+	 * The status bar pulls state via runningCount, so just triggering a re-render is enough.
+	 */
+	private notifyStatusChange(): void {
+		this.plugin.backgroundStatusBar?.update();
+	}
+
+	destroy(): void {
+		// Cancel all running tasks so work functions can bail out
+		for (const task of this.getActiveTasks()) {
+			this.cancellationFlags.set(task.id, true);
+		}
+		this.tasks.clear();
+		this.cancellationFlags.clear();
+	}
+}

--- a/src/services/background-task-manager.ts
+++ b/src/services/background-task-manager.ts
@@ -104,7 +104,12 @@ export class BackgroundTaskManager {
 	getRecentTasks(limit = BackgroundTaskManager.MAX_RECENT): BackgroundTask[] {
 		return [...this.tasks.values()]
 			.filter((t) => t.status === 'complete' || t.status === 'failed' || t.status === 'cancelled')
-			.sort((a, b) => (b.completedAt?.getTime() ?? 0) - (a.completedAt?.getTime() ?? 0))
+			.sort((a, b) => {
+				const byCompleted = (b.completedAt?.getTime() ?? 0) - (a.completedAt?.getTime() ?? 0);
+				if (byCompleted !== 0) return byCompleted;
+				// Tiebreak by startedAt so tasks that began later sort first when they finish in the same millisecond.
+				return b.startedAt.getTime() - a.startedAt.getTime();
+			})
 			.slice(0, limit);
 	}
 

--- a/src/services/image-generation.ts
+++ b/src/services/image-generation.ts
@@ -3,6 +3,7 @@ import { Notice, App, Modal, Setting, TextAreaComponent, normalizePath } from 'o
 import { BaseModelRequest, GeminiClient, GeminiClientFactory } from '../api';
 import { GeminiPrompts } from '../prompts';
 import { getErrorMessage } from '../utils/error-utils';
+import { ensureFolderExists } from '../utils/file-utils';
 
 export class ImageGeneration {
 	private plugin: ObsidianGemini;
@@ -103,9 +104,15 @@ export class ImageGeneration {
 	 * Rejects paths that escape the vault, target protected system folders, or
 	 * land inside the plugin state folder — important because GenerateImageTool
 	 * can be invoked autonomously by the agent (#634).
+	 * Always returns a path ending with ".png" since the code always writes PNG bytes.
 	 */
 	private validateOutputPath(outputPath: string): string {
 		const normalized = normalizePath(outputPath);
+
+		// Reject directory-only paths (empty or trailing slash)
+		if (!normalized || normalized.endsWith('/')) {
+			throw new Error(`Output path must include a filename: "${outputPath}"`);
+		}
 
 		// Reject vault-escaping paths (normalizePath does not resolve ..)
 		if (normalized.startsWith('..') || normalized.split('/').includes('..')) {
@@ -126,7 +133,12 @@ export class ImageGeneration {
 			}
 		}
 
-		return normalized;
+		// Always ensure the file ends with .png — the code always writes PNG bytes.
+		// Replace any existing extension (or append if none) so the vault file is readable.
+		const dotIndex = normalized.lastIndexOf('.');
+		const slashIndex = normalized.lastIndexOf('/');
+		const hasExtension = dotIndex > slashIndex + 1;
+		return hasExtension ? normalized.slice(0, dotIndex) + '.png' : normalized + '.png';
 	}
 
 	/**
@@ -163,6 +175,13 @@ export class ImageGeneration {
 			// Caller specified an explicit path — validate and normalize before use.
 			// Rejects vault-escaping and protected-folder paths (see validateOutputPath).
 			resolvedPath = this.validateOutputPath(outputPath);
+
+			// Ensure the parent folder exists before writing — createBinary will fail
+			// if any intermediate directory in the path is missing.
+			const parentPath = resolvedPath.includes('/') ? resolvedPath.slice(0, resolvedPath.lastIndexOf('/')) : null;
+			if (parentPath) {
+				await ensureFolderExists(this.plugin.app.vault, parentPath, 'image output folder', this.plugin.logger);
+			}
 		} else {
 			// Create a safe filename from the prompt (truncate and sanitize)
 			const sanitizedPrompt = prompt

--- a/src/services/image-generation.ts
+++ b/src/services/image-generation.ts
@@ -56,18 +56,21 @@ export class ImageGeneration {
 	}
 
 	/**
-	 * Generate an image and return the file path
-	 * Used by the agent tool
-	 * @param prompt - Text description of the image to generate
-	 * @param targetNotePath - Optional path to a note to use as reference for attachment folder
+	 * Generate an image and return the file path.
+	 * Used by the agent tool.
+	 *
+	 * @param prompt         - Text description of the image to generate
+	 * @param targetNotePath - Optional: note path used to resolve the attachment folder
+	 * @param outputPath     - Optional: explicit vault path for the output file.
+	 *                         When provided it takes priority over targetNotePath-based resolution.
 	 */
-	async generateImage(prompt: string, targetNotePath?: string): Promise<string> {
+	async generateImage(prompt: string, targetNotePath?: string, outputPath?: string): Promise<string> {
 		try {
 			// Generate the image
 			const base64Data = await this.client.generateImage(prompt, this.plugin.settings.imageModelName);
 
 			// Save the image to vault
-			return await this.saveImageToVault(base64Data, prompt, targetNotePath);
+			return await this.saveImageToVault(base64Data, prompt, targetNotePath, outputPath);
 		} catch (error) {
 			this.plugin.logger.error('Failed to generate image:', error);
 			throw error;
@@ -96,22 +99,19 @@ export class ImageGeneration {
 	}
 
 	/**
-	 * Save base64 image data to the vault
-	 * @param base64Data - Base64 encoded image data
-	 * @param prompt - The prompt used to generate the image
-	 * @param targetNotePath - Optional path to a note to use as reference for attachment folder
+	 * Save base64 image data to the vault.
+	 *
+	 * @param base64Data     - Base64 encoded image data
+	 * @param prompt         - The prompt used to generate the image (used for filename generation)
+	 * @param targetNotePath - Optional note path used to resolve the Obsidian attachment folder
+	 * @param outputPath     - Optional explicit vault path for the file; skips attachment-folder resolution
 	 */
-	private async saveImageToVault(base64Data: string, prompt: string, targetNotePath?: string): Promise<string> {
-		// Create a safe filename from the prompt (truncate and sanitize)
-		const sanitizedPrompt = prompt
-			.substring(0, 50)
-			.replace(/[^a-zA-Z0-9\-_]/g, '-') // More restrictive: only alphanumeric, hyphens, and underscores
-			.replace(/-+/g, '-') // Collapse multiple dashes
-			.replace(/^-|-$/g, ''); // Trim leading/trailing dashes
-
-		const timestamp = Date.now();
-		const filename = `generated-${sanitizedPrompt}-${timestamp}.png`;
-
+	private async saveImageToVault(
+		base64Data: string,
+		prompt: string,
+		targetNotePath?: string,
+		outputPath?: string
+	): Promise<string> {
 		// Convert base64 to binary with validation
 		let binaryData: string;
 		try {
@@ -126,27 +126,41 @@ export class ImageGeneration {
 		// Convert binary string to Uint8Array
 		const bytes = Uint8Array.from(binaryData, (c) => c.charCodeAt(0));
 
-		// Determine reference note path for attachment folder
-		let referenceNotePath: string;
-		if (targetNotePath) {
-			// Use provided target note path
-			referenceNotePath = targetNotePath;
+		let resolvedPath: string;
+
+		if (outputPath) {
+			// Caller specified an explicit path — use it directly (no attachment-folder resolution)
+			resolvedPath = outputPath;
 		} else {
-			// Fall back to active file
-			const activeFile = this.plugin.app.workspace.getActiveFile();
-			if (!activeFile) {
-				throw new Error('No active file and no target note path provided');
+			// Create a safe filename from the prompt (truncate and sanitize)
+			const sanitizedPrompt = prompt
+				.substring(0, 50)
+				.replace(/[^a-zA-Z0-9\-_]/g, '-')
+				.replace(/-+/g, '-')
+				.replace(/^-|-$/g, '');
+
+			const timestamp = Date.now();
+			const filename = `generated-${sanitizedPrompt}-${timestamp}.png`;
+
+			// Determine reference note path for attachment folder resolution
+			let referenceNotePath: string;
+			if (targetNotePath) {
+				referenceNotePath = targetNotePath;
+			} else {
+				const activeFile = this.plugin.app.workspace.getActiveFile();
+				if (!activeFile) {
+					throw new Error('No active file and no target note path provided');
+				}
+				referenceNotePath = activeFile.path;
 			}
-			referenceNotePath = activeFile.path;
+
+			resolvedPath = await this.plugin.app.fileManager.getAvailablePathForAttachment(filename, referenceNotePath);
 		}
 
-		// Use Obsidian's built-in method to get the correct path for attachments
-		const path = await this.plugin.app.fileManager.getAvailablePathForAttachment(filename, referenceNotePath);
-
 		// Save to vault
-		await this.plugin.app.vault.createBinary(path, bytes.buffer);
+		await this.plugin.app.vault.createBinary(resolvedPath, bytes.buffer);
 
-		return path;
+		return resolvedPath;
 	}
 
 	/**

--- a/src/services/image-generation.ts
+++ b/src/services/image-generation.ts
@@ -1,5 +1,5 @@
 import type ObsidianGemini from '../main';
-import { Notice, App, Modal, Setting, TextAreaComponent } from 'obsidian';
+import { Notice, App, Modal, Setting, TextAreaComponent, normalizePath } from 'obsidian';
 import { BaseModelRequest, GeminiClient, GeminiClientFactory } from '../api';
 import { GeminiPrompts } from '../prompts';
 import { getErrorMessage } from '../utils/error-utils';
@@ -99,6 +99,37 @@ export class ImageGeneration {
 	}
 
 	/**
+	 * Validate and normalize an explicit output path supplied by the caller.
+	 * Rejects paths that escape the vault, target protected system folders, or
+	 * land inside the plugin state folder — important because GenerateImageTool
+	 * can be invoked autonomously by the agent (#634).
+	 */
+	private validateOutputPath(outputPath: string): string {
+		const normalized = normalizePath(outputPath);
+
+		// Reject vault-escaping paths (normalizePath does not resolve ..)
+		if (normalized.startsWith('..') || normalized.split('/').includes('..')) {
+			throw new Error(`Output path escapes the vault: "${outputPath}"`);
+		}
+
+		// Reject paths inside .obsidian/
+		if (normalized.split('/').includes('.obsidian')) {
+			throw new Error(`Output path cannot be inside the Obsidian configuration folder: "${outputPath}"`);
+		}
+
+		// Reject paths inside the plugin state folder
+		const historyFolder = this.plugin.settings.historyFolder;
+		if (historyFolder) {
+			const normalizedHistoryFolder = normalizePath(historyFolder);
+			if (normalized === normalizedHistoryFolder || normalized.startsWith(normalizedHistoryFolder + '/')) {
+				throw new Error(`Output path cannot be inside the plugin state folder: "${outputPath}"`);
+			}
+		}
+
+		return normalized;
+	}
+
+	/**
 	 * Save base64 image data to the vault.
 	 *
 	 * @param base64Data     - Base64 encoded image data
@@ -129,8 +160,9 @@ export class ImageGeneration {
 		let resolvedPath: string;
 
 		if (outputPath) {
-			// Caller specified an explicit path — use it directly (no attachment-folder resolution)
-			resolvedPath = outputPath;
+			// Caller specified an explicit path — validate and normalize before use.
+			// Rejects vault-escaping and protected-folder paths (see validateOutputPath).
+			resolvedPath = this.validateOutputPath(outputPath);
 		} else {
 			// Create a safe filename from the prompt (truncate and sanitize)
 			const sanitizedPrompt = prompt

--- a/src/services/lifecycle-service.ts
+++ b/src/services/lifecycle-service.ts
@@ -30,6 +30,8 @@ import { SelectionActionService } from './selection-action-service';
 import { RagIndexingService } from './rag-indexing';
 import { FolderInitializer } from './folder-initializer';
 import { UpdateNotificationModal } from '../ui/update-notification-modal';
+import { BackgroundTaskManager } from './background-task-manager';
+import { BackgroundStatusBar } from './background-status-bar';
 
 // @ts-ignore
 import agentsMemoryTemplateContent from '../../prompts/agentsMemoryTemplate.hbs';
@@ -140,6 +142,10 @@ export class LifecycleService {
 		const plugin = this.plugin;
 
 		plugin.logger.debug('Unloading Gemini Scribe');
+		plugin.backgroundTaskManager?.destroy();
+		plugin.backgroundTaskManager = null;
+		plugin.backgroundStatusBar?.destroy();
+		plugin.backgroundStatusBar = null;
 		plugin.history?.onUnload();
 		plugin.projectManager?.destroy();
 		plugin.toolExecutionLogger?.destroy();
@@ -310,6 +316,14 @@ export class LifecycleService {
 			this.contextTrackingSubscriber = new ContextTrackingSubscriber(plugin);
 			this.accessedFilesSubscriber = new AccessedFilesSubscriber(plugin);
 			this.projectActivationSubscriber = new ProjectActivationSubscriber(plugin);
+		}
+
+		// Background task manager + status bar are created once and persist.
+		// The status bar is the single coordinated surface for both RAG and background tasks.
+		if (!plugin.backgroundTaskManager) {
+			plugin.backgroundTaskManager = new BackgroundTaskManager(plugin, plugin.agentEventBus);
+			plugin.backgroundStatusBar = new BackgroundStatusBar(plugin, plugin.backgroundTaskManager);
+			plugin.backgroundStatusBar.setup();
 		}
 
 		plugin.prompts = new GeminiPrompts(plugin);

--- a/src/services/rag-indexing.ts
+++ b/src/services/rag-indexing.ts
@@ -211,6 +211,9 @@ export class RagIndexingService {
 		this.vaultScanner?.destroy();
 		this.ragCache.destroy();
 
+		// Unregister from the shared status bar so it no longer shows stale RAG state.
+		this.plugin.backgroundStatusBar?.setRagProvider(null);
+
 		this.ai = null;
 		this.fileUploader = null;
 		this.vaultAdapter = null;

--- a/src/services/rag-indexing.ts
+++ b/src/services/rag-indexing.ts
@@ -142,8 +142,9 @@ export class RagIndexingService {
 			// Create or verify File Search Store
 			await this.vaultScanner.ensureFileSearchStore();
 
-			// Setup status bar
-			this.statusBar.setup();
+			// Register RAG state with the shared background status bar (single coordinated surface).
+			// We do not call this.statusBar.setup() — that would create a second item.
+			this.plugin.backgroundStatusBar?.setRagProvider(this.createStatusProvider());
 
 			// Update status
 			this.status = 'idle';
@@ -408,7 +409,9 @@ export class RagIndexingService {
 	// ==================== Private Helpers ====================
 
 	private updateStatusBar(): void {
+		// Update both the legacy RagStatusBar (if it was set up) and the shared background bar.
 		this.statusBar?.update();
+		this.plugin.backgroundStatusBar?.update();
 	}
 
 	/**

--- a/src/tools/image-tools.ts
+++ b/src/tools/image-tools.ts
@@ -26,6 +26,11 @@ export class GenerateImageTool implements Tool {
 				description:
 					'Optional: The path of the note to use for determining the attachment folder location where the image file will be saved. This does NOT insert the image into the note - it only affects where the image file is stored. If not provided, uses the currently active note to determine the attachment folder.',
 			},
+			output_path: {
+				type: 'string' as const,
+				description:
+					'Optional: Explicit vault path where the generated image file should be saved (e.g. "attachments/my-image.png"). When provided, the image is saved at exactly this path regardless of target_note. Useful when the caller needs a predictable location to retrieve the result later.',
+			},
 		},
 		required: ['prompt'],
 	};
@@ -64,8 +69,12 @@ export class GenerateImageTool implements Tool {
 				};
 			}
 
-			// Generate the image
-			const imagePath = await plugin.imageGeneration.generateImage(params.prompt, params.target_note);
+			// Generate the image — explicit output_path takes priority over target_note folder hint
+			const imagePath = await plugin.imageGeneration.generateImage(
+				params.prompt,
+				params.target_note,
+				params.output_path
+			);
 
 			return {
 				success: true,

--- a/src/tools/image-tools.ts
+++ b/src/tools/image-tools.ts
@@ -38,7 +38,13 @@ export class GenerateImageTool implements Tool {
 	requiresConfirmation = true;
 
 	confirmationMessage = (params: any) => {
-		return `Generate an image with prompt: "${params.prompt}"?\n\nThis will create a new image file in your vault.`;
+		let message = `Generate an image with prompt: "${params.prompt}"?\n\nThis will create a new image file in your vault.`;
+		if (params.output_path) {
+			message += `\n\nDestination: ${params.output_path}`;
+		} else if (params.target_note) {
+			message += `\n\nAttachment folder resolved from: ${params.target_note}`;
+		}
+		return message;
 	};
 
 	getProgressDescription(params: { prompt: string }): string {

--- a/src/types/agent-events.ts
+++ b/src/types/agent-events.ts
@@ -66,6 +66,29 @@ export interface AgentEventMap {
 	sessionLoaded: Readonly<{
 		session: ChatSession;
 	}>;
+
+	/** A background task has started running */
+	backgroundTaskStarted: Readonly<{
+		taskId: string;
+		type: string;
+		label: string;
+	}>;
+
+	/** A background task completed successfully */
+	backgroundTaskComplete: Readonly<{
+		taskId: string;
+		type: string;
+		label: string;
+		outputPath: string | undefined;
+	}>;
+
+	/** A background task failed or was cancelled */
+	backgroundTaskFailed: Readonly<{
+		taskId: string;
+		type: string;
+		label: string;
+		error: string;
+	}>;
 }
 
 /** Union of all valid event names */

--- a/src/ui/background-tasks-modal.ts
+++ b/src/ui/background-tasks-modal.ts
@@ -78,10 +78,8 @@ export class BackgroundTasksModal extends Modal {
 
 		// Label + meta
 		const info = li.createDiv({ cls: 'gemini-bg-task-info' });
-		info.createSpan({ text: task.label, cls: 'gemini-bg-task-label' });
-
-		const meta = info.createSpan({ cls: 'gemini-bg-task-meta' });
-		meta.setText(this.formatMeta(task));
+		info.createDiv({ text: task.label, cls: 'gemini-bg-task-label' });
+		info.createDiv({ text: this.formatMeta(task), cls: 'gemini-bg-task-meta' });
 
 		// Output link
 		if (task.outputPath && task.status === 'complete') {
@@ -100,7 +98,7 @@ export class BackgroundTasksModal extends Modal {
 
 		// Cancel button
 		if (canCancel) {
-			const btn = li.createEl('button', { text: 'Cancel', cls: 'gemini-bg-task-cancel' });
+			const btn = li.createEl('button', { text: 'Cancel', cls: 'gemini-bg-task-cancel mod-warning' });
 			btn.addEventListener('click', () => {
 				this.plugin.backgroundTaskManager?.cancel(task.id);
 				this.onOpen(); // re-render

--- a/src/ui/background-tasks-modal.ts
+++ b/src/ui/background-tasks-modal.ts
@@ -1,0 +1,125 @@
+import { App, Modal, setIcon } from 'obsidian';
+import type ObsidianGemini from '../main';
+import type { BackgroundTask } from '../services/background-task-manager';
+
+/**
+ * Modal that lists all running and recently completed background tasks.
+ * Opened by clicking the status bar indicator or via the command palette.
+ */
+export class BackgroundTasksModal extends Modal {
+	private plugin: ObsidianGemini;
+
+	constructor(app: App, plugin: ObsidianGemini) {
+		super(app);
+		this.plugin = plugin;
+	}
+
+	onOpen(): void {
+		const { contentEl } = this;
+		contentEl.empty();
+		contentEl.addClass('gemini-bg-tasks-modal');
+
+		contentEl.createEl('h2', { text: 'Background Tasks' });
+
+		const manager = this.plugin.backgroundTaskManager;
+		if (!manager) {
+			contentEl.createEl('p', { text: 'Background task manager not available.' });
+			return;
+		}
+
+		const active = manager.getActiveTasks();
+		const recent = manager.getRecentTasks();
+
+		if (active.length === 0 && recent.length === 0) {
+			contentEl.createEl('p', {
+				text: 'No background tasks yet. Long-running operations like deep research and image generation will appear here.',
+				cls: 'gemini-bg-tasks-empty',
+			});
+			return;
+		}
+
+		if (active.length > 0) {
+			contentEl.createEl('h3', { text: 'Running' });
+			const list = contentEl.createEl('ul', { cls: 'gemini-bg-tasks-list' });
+			for (const task of active) {
+				this.renderTaskItem(list, task, true);
+			}
+		}
+
+		if (recent.length > 0) {
+			contentEl.createEl('h3', { text: 'Recent' });
+			const list = contentEl.createEl('ul', { cls: 'gemini-bg-tasks-list' });
+			for (const task of recent) {
+				this.renderTaskItem(list, task, false);
+			}
+		}
+	}
+
+	private renderTaskItem(container: HTMLElement, task: BackgroundTask, canCancel: boolean): void {
+		const li = container.createEl('li', { cls: `gemini-bg-task gemini-bg-task--${task.status}` });
+
+		// Status icon
+		const iconEl = li.createSpan({ cls: 'gemini-bg-task-icon' });
+		switch (task.status) {
+			case 'pending':
+			case 'running':
+				setIcon(iconEl, 'loader');
+				break;
+			case 'complete':
+				setIcon(iconEl, 'check-circle');
+				break;
+			case 'failed':
+				setIcon(iconEl, 'alert-circle');
+				break;
+			case 'cancelled':
+				setIcon(iconEl, 'x-circle');
+				break;
+		}
+
+		// Label + meta
+		const info = li.createDiv({ cls: 'gemini-bg-task-info' });
+		info.createSpan({ text: task.label, cls: 'gemini-bg-task-label' });
+
+		const meta = info.createSpan({ cls: 'gemini-bg-task-meta' });
+		meta.setText(this.formatMeta(task));
+
+		// Output link
+		if (task.outputPath && task.status === 'complete') {
+			const link = info.createEl('a', { text: 'Open result', href: '#', cls: 'gemini-bg-task-link' });
+			link.addEventListener('click', (e) => {
+				e.preventDefault();
+				this.plugin.app.workspace.openLinkText(task.outputPath!, '', false);
+				this.close();
+			});
+		}
+
+		// Error message
+		if (task.error && task.status === 'failed') {
+			info.createSpan({ text: task.error, cls: 'gemini-bg-task-error' });
+		}
+
+		// Cancel button
+		if (canCancel) {
+			const btn = li.createEl('button', { text: 'Cancel', cls: 'gemini-bg-task-cancel' });
+			btn.addEventListener('click', () => {
+				this.plugin.backgroundTaskManager?.cancel(task.id);
+				this.onOpen(); // re-render
+			});
+		}
+	}
+
+	private formatMeta(task: BackgroundTask): string {
+		const started = task.startedAt.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+		if (task.completedAt) {
+			const durationMs = task.completedAt.getTime() - task.startedAt.getTime();
+			const durationLabel =
+				durationMs < 60_000 ? `${Math.round(durationMs / 1000)}s` : `${Math.round(durationMs / 60_000)}m`;
+			return `Started ${started} · ${durationLabel}`;
+		}
+		return `Started ${started}`;
+	}
+
+	onClose(): void {
+		this.contentEl.empty();
+	}
+}

--- a/src/ui/background-tasks-modal.ts
+++ b/src/ui/background-tasks-modal.ts
@@ -39,16 +39,26 @@ export class BackgroundTasksModal extends Modal {
 		}
 
 		if (active.length > 0) {
-			contentEl.createEl('h3', { text: 'Running' });
-			const list = contentEl.createEl('ul', { cls: 'gemini-bg-tasks-list' });
-			for (const task of active) {
+			const label = active.length > 10 ? `Running (${active.length})` : 'Running';
+			contentEl.createEl('h3', { text: label });
+			const scrollWrap = contentEl.createDiv({ cls: 'gemini-bg-tasks-scroll' });
+			const list = scrollWrap.createEl('ul', { cls: 'gemini-bg-tasks-list' });
+			// Show at most 10 running tasks — the rest are still tracked, just not rendered
+			for (const task of active.slice(0, 10)) {
 				this.renderTaskItem(list, task, true);
+			}
+			if (active.length > 10) {
+				scrollWrap.createEl('p', {
+					text: `+ ${active.length - 10} more running tasks`,
+					cls: 'gemini-bg-tasks-overflow',
+				});
 			}
 		}
 
 		if (recent.length > 0) {
 			contentEl.createEl('h3', { text: 'Recent' });
-			const list = contentEl.createEl('ul', { cls: 'gemini-bg-tasks-list' });
+			const scrollWrap = contentEl.createDiv({ cls: 'gemini-bg-tasks-scroll' });
+			const list = scrollWrap.createEl('ul', { cls: 'gemini-bg-tasks-list' });
 			for (const task of recent) {
 				this.renderTaskItem(list, task, false);
 			}

--- a/styles.css
+++ b/styles.css
@@ -4434,6 +4434,7 @@ If your plugin does not need CSS, delete this file.
 	color: var(--text-muted);
 }
 
+.gemini-bg-task--pending .gemini-bg-task-icon,
 .gemini-bg-task--running .gemini-bg-task-icon {
 	color: var(--color-accent);
 }

--- a/styles.css
+++ b/styles.css
@@ -4398,6 +4398,18 @@ If your plugin does not need CSS, delete this file.
 	font-size: var(--font-ui-small);
 }
 
+.gemini-bg-tasks-scroll {
+	max-height: min(320px, 50vh);
+	overflow-y: auto;
+}
+
+.gemini-bg-tasks-overflow {
+	font-size: var(--font-ui-smaller);
+	color: var(--text-muted);
+	margin: 4px 0 0;
+	padding-left: 4px;
+}
+
 .gemini-bg-tasks-list {
 	list-style: none;
 	margin: 0;

--- a/styles.css
+++ b/styles.css
@@ -4382,3 +4382,129 @@ If your plugin does not need CSS, delete this file.
 .gemini-diff-editor .cm-editor {
 	height: 100%;
 }
+
+/* ── Background Tasks Modal ────────────────────────────────────────────────── */
+
+.gemini-bg-tasks-modal h3 {
+	margin: 12px 0 6px;
+	font-size: var(--font-ui-small);
+	text-transform: uppercase;
+	letter-spacing: 0.05em;
+	color: var(--text-muted);
+}
+
+.gemini-bg-tasks-empty {
+	color: var(--text-muted);
+	font-size: var(--font-ui-small);
+}
+
+.gemini-bg-tasks-list {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+}
+
+.gemini-bg-task {
+	display: flex;
+	align-items: flex-start;
+	gap: 10px;
+	padding: 8px 10px;
+	border-radius: var(--radius-s);
+	background: var(--background-secondary);
+}
+
+.gemini-bg-task-icon {
+	flex-shrink: 0;
+	margin-top: 2px;
+	color: var(--text-muted);
+}
+
+.gemini-bg-task--running .gemini-bg-task-icon {
+	color: var(--color-accent);
+}
+.gemini-bg-task--complete .gemini-bg-task-icon {
+	color: var(--color-green);
+}
+.gemini-bg-task--failed .gemini-bg-task-icon {
+	color: var(--color-red);
+}
+.gemini-bg-task--cancelled .gemini-bg-task-icon {
+	color: var(--text-faint);
+}
+
+.gemini-bg-task-info {
+	flex: 1;
+	min-width: 0;
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+}
+
+.gemini-bg-task-label {
+	font-size: var(--font-ui-small);
+	font-weight: 500;
+	color: var(--text-normal);
+}
+
+.gemini-bg-task-meta {
+	font-size: var(--font-ui-smaller);
+	color: var(--text-muted);
+}
+
+.gemini-bg-task-error {
+	font-size: var(--font-ui-smaller);
+	color: var(--color-red);
+}
+
+.gemini-bg-task-link {
+	font-size: var(--font-ui-smaller);
+	color: var(--color-accent);
+	text-decoration: none;
+}
+
+.gemini-bg-task-cancel {
+	flex-shrink: 0;
+	align-self: center;
+	font-size: var(--font-ui-smaller);
+	padding: 3px 10px;
+	cursor: pointer;
+}
+
+/* ── Background Status Bar ─────────────────────────────────────────────────── */
+
+.gemini-bg-status-bar {
+	display: flex;
+	align-items: center;
+	gap: 4px;
+	cursor: pointer;
+}
+
+.gemini-bg-status-icon {
+	display: flex;
+	align-items: center;
+}
+
+.gemini-bg-status-icon svg {
+	width: 12px;
+	height: 12px;
+}
+
+.gemini-bg-status-text {
+	font-size: var(--font-ui-smaller);
+}
+
+@keyframes gemini-spin {
+	from {
+		transform: rotate(0deg);
+	}
+	to {
+		transform: rotate(360deg);
+	}
+}
+
+.gemini-bg-active .gemini-bg-status-icon svg {
+	animation: gemini-spin 1s linear infinite;
+}

--- a/test/services/background-task-manager.test.ts
+++ b/test/services/background-task-manager.test.ts
@@ -1,0 +1,291 @@
+import { BackgroundTaskManager } from '../../src/services/background-task-manager';
+import { AgentEventBus } from '../../src/agent/agent-event-bus';
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+function createMockLogger(): any {
+	return {
+		log: jest.fn(),
+		debug: jest.fn(),
+		error: jest.fn(),
+		warn: jest.fn(),
+		child: jest.fn().mockReturnThis(),
+	};
+}
+
+function createMockPlugin(overrides: Record<string, any> = {}): any {
+	return {
+		logger: createMockLogger(),
+		backgroundStatusBar: { update: jest.fn() },
+		app: {
+			workspace: {
+				openLinkText: jest.fn(),
+			},
+		},
+		...overrides,
+	};
+}
+
+// Mock Obsidian's Notice — provide a noticeEl so showCompletionNotice doesn't throw
+jest.mock('obsidian', () => ({
+	Notice: jest.fn().mockImplementation(() => ({
+		noticeEl: {
+			createSpan: jest.fn().mockReturnValue({ setText: jest.fn() }),
+			createEl: jest.fn().mockReturnValue({
+				addEventListener: jest.fn(),
+				setText: jest.fn(),
+			}),
+		},
+		hide: jest.fn(),
+	})),
+}));
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeManager() {
+	const logger = createMockLogger();
+	const bus = new AgentEventBus(logger);
+	const plugin = createMockPlugin();
+	const manager = new BackgroundTaskManager(plugin, bus);
+	return { manager, bus, plugin };
+}
+
+/** Returns a promise that resolves after all pending micro-tasks + one macro-task tick. */
+function flushAsync(): Promise<void> {
+	return new Promise((r) => setTimeout(r, 0));
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('BackgroundTaskManager', () => {
+	describe('submit', () => {
+		it('returns a task ID immediately without blocking', () => {
+			const { manager } = makeManager();
+			let workStarted = false;
+
+			const id = manager.submit('test', 'Test task', async () => {
+				workStarted = true;
+				return undefined;
+			});
+
+			// ID is returned synchronously — work has NOT necessarily started yet
+			expect(typeof id).toBe('string');
+			expect(id.length).toBeGreaterThan(0);
+			// work may or may not have started; the important thing is the ID came back instantly
+			void workStarted; // suppress unused-variable lint
+		});
+
+		it('assigns sequential, unique IDs', () => {
+			const { manager } = makeManager();
+			const id1 = manager.submit('t', 'Task 1', async () => undefined);
+			const id2 = manager.submit('t', 'Task 2', async () => undefined);
+			const id3 = manager.submit('t', 'Task 3', async () => undefined);
+			expect(id1).not.toBe(id2);
+			expect(id2).not.toBe(id3);
+		});
+	});
+
+	describe('task lifecycle — success', () => {
+		it('transitions pending → running → complete', async () => {
+			const { manager } = makeManager();
+			const states: string[] = [];
+
+			const id = manager.submit('research', 'My Research', async () => {
+				states.push(manager.getTask(id)!.status);
+				return 'output/result.md';
+			});
+
+			// Before the async work runs, task exists
+			const taskBefore = manager.getTask(id);
+			expect(taskBefore).toBeDefined();
+
+			await flushAsync();
+
+			const taskAfter = manager.getTask(id)!;
+			expect(taskAfter.status).toBe('complete');
+			expect(taskAfter.outputPath).toBe('output/result.md');
+			expect(taskAfter.completedAt).toBeInstanceOf(Date);
+		});
+
+		it('emits backgroundTaskStarted and backgroundTaskComplete events', async () => {
+			const logger = createMockLogger();
+			const bus = new AgentEventBus(logger);
+			const plugin = createMockPlugin();
+			const manager = new BackgroundTaskManager(plugin, bus);
+
+			const started = jest.fn().mockResolvedValue(undefined);
+			const completed = jest.fn().mockResolvedValue(undefined);
+			bus.on('backgroundTaskStarted', started);
+			bus.on('backgroundTaskComplete', completed);
+
+			manager.submit('img', 'Generate image', async () => 'images/out.png');
+			await flushAsync();
+
+			expect(started).toHaveBeenCalledTimes(1);
+			expect(started).toHaveBeenCalledWith(expect.objectContaining({ type: 'img', label: 'Generate image' }));
+			expect(completed).toHaveBeenCalledTimes(1);
+			expect(completed).toHaveBeenCalledWith(expect.objectContaining({ outputPath: 'images/out.png' }));
+		});
+
+		it('moves to getRecentTasks after completion', async () => {
+			const { manager } = makeManager();
+			manager.submit('t', 'Done task', async () => undefined);
+			await flushAsync();
+
+			expect(manager.getActiveTasks()).toHaveLength(0);
+			const recent = manager.getRecentTasks();
+			expect(recent).toHaveLength(1);
+			expect(recent[0].status).toBe('complete');
+		});
+	});
+
+	describe('task lifecycle — failure', () => {
+		it('transitions running → failed when work throws', async () => {
+			const { manager } = makeManager();
+			const id = manager.submit('t', 'Failing task', async () => {
+				throw new Error('API exploded');
+			});
+			await flushAsync();
+
+			const task = manager.getTask(id)!;
+			expect(task.status).toBe('failed');
+			expect(task.error).toContain('API exploded');
+			expect(task.completedAt).toBeInstanceOf(Date);
+		});
+
+		it('emits backgroundTaskFailed when work throws', async () => {
+			const logger = createMockLogger();
+			const bus = new AgentEventBus(logger);
+			const plugin = createMockPlugin();
+			const manager = new BackgroundTaskManager(plugin, bus);
+
+			const failed = jest.fn().mockResolvedValue(undefined);
+			bus.on('backgroundTaskFailed', failed);
+
+			manager.submit('t', 'Bad task', async () => {
+				throw new Error('boom');
+			});
+			await flushAsync();
+
+			expect(failed).toHaveBeenCalledTimes(1);
+			// getErrorMessage wraps the raw message — just assert it contains the original text
+			expect(failed).toHaveBeenCalledWith(expect.objectContaining({ error: expect.stringContaining('boom') }));
+		});
+	});
+
+	describe('cancellation', () => {
+		it('cancel() marks an in-flight task as cancelled', async () => {
+			const { manager } = makeManager();
+
+			let resolveFn!: () => void;
+			const blocker = new Promise<void>((r) => (resolveFn = r));
+
+			const id = manager.submit('t', 'Long task', async (isCancelled) => {
+				await blocker;
+				if (isCancelled()) return undefined;
+				return 'output.md';
+			});
+
+			// Cancel before the blocker resolves
+			manager.cancel(id);
+
+			// Now let the work finish
+			resolveFn();
+			await flushAsync();
+
+			const task = manager.getTask(id)!;
+			expect(task.status).toBe('cancelled');
+			expect(task.outputPath).toBeUndefined();
+		});
+
+		it('cancel() has no effect on a completed task', async () => {
+			const { manager } = makeManager();
+			const id = manager.submit('t', 'Done', async () => 'result.md');
+			await flushAsync();
+
+			expect(() => manager.cancel(id)).not.toThrow();
+			expect(manager.getTask(id)!.status).toBe('complete');
+		});
+
+		it('emits backgroundTaskFailed when cancelled', async () => {
+			const logger = createMockLogger();
+			const bus = new AgentEventBus(logger);
+			const plugin = createMockPlugin();
+			const manager = new BackgroundTaskManager(plugin, bus);
+
+			const failed = jest.fn().mockResolvedValue(undefined);
+			bus.on('backgroundTaskFailed', failed);
+
+			let resolveFn!: () => void;
+			const blocker = new Promise<void>((r) => (resolveFn = r));
+
+			const id = manager.submit('t', 'Cancel me', async (isCancelled) => {
+				await blocker;
+				if (isCancelled()) return undefined;
+				return 'out.md';
+			});
+
+			manager.cancel(id);
+			resolveFn();
+			await flushAsync();
+
+			expect(failed).toHaveBeenCalledWith(expect.objectContaining({ error: 'Cancelled' }));
+		});
+	});
+
+	describe('getActiveTasks / getRecentTasks / runningCount', () => {
+		it('runningCount reflects active tasks', async () => {
+			const { manager } = makeManager();
+
+			let resolveFn!: () => void;
+			const blocker = new Promise<void>((r) => (resolveFn = r));
+
+			manager.submit('t', 'Slow', async () => {
+				await blocker;
+				return undefined;
+			});
+
+			// After one tick, the task should be running
+			await Promise.resolve();
+			expect(manager.runningCount).toBeGreaterThanOrEqual(0); // may be 0 or 1 depending on micro-task timing
+
+			resolveFn();
+			await flushAsync();
+			expect(manager.runningCount).toBe(0);
+		});
+
+		it('getRecentTasks returns newest first', async () => {
+			const { manager } = makeManager();
+
+			manager.submit('t', 'First', async () => 'a.md');
+			await flushAsync();
+			manager.submit('t', 'Second', async () => 'b.md');
+			await flushAsync();
+
+			const recent = manager.getRecentTasks();
+			expect(recent[0].label).toBe('Second');
+			expect(recent[1].label).toBe('First');
+		});
+	});
+
+	describe('destroy', () => {
+		it('cancels active tasks and clears state', async () => {
+			const { manager } = makeManager();
+
+			let resolveFn!: () => void;
+			const blocker = new Promise<void>((r) => (resolveFn = r));
+			manager.submit('t', 'Slow', async () => {
+				await blocker;
+				return undefined;
+			});
+
+			manager.destroy();
+			resolveFn();
+			await flushAsync();
+
+			// After destroy, tasks are cleared
+			expect(manager.getActiveTasks()).toHaveLength(0);
+			expect(manager.getRecentTasks()).toHaveLength(0);
+		});
+	});
+});

--- a/test/services/background-task-manager.test.ts
+++ b/test/services/background-task-manager.test.ts
@@ -245,9 +245,10 @@ describe('BackgroundTaskManager', () => {
 				return undefined;
 			});
 
-			// After one tick, the task should be running
+			// run() sets task.status = 'running' synchronously before its first await,
+			// so after submit() returns the task is already counted.
 			await Promise.resolve();
-			expect(manager.runningCount).toBeGreaterThanOrEqual(0); // may be 0 or 1 depending on micro-task timing
+			expect(manager.runningCount).toBe(1);
 
 			resolveFn();
 			await flushAsync();

--- a/test/services/lifecycle-service.test.ts
+++ b/test/services/lifecycle-service.test.ts
@@ -138,6 +138,15 @@ function createMockPlugin(overrides: Record<string, any> = {}): any {
 		manifest: { version: '1.0.0' },
 		saveData: jest.fn(),
 		registerEvent: jest.fn(),
+		addStatusBarItem: jest.fn().mockReturnValue({
+			addClass: jest.fn(),
+			removeClass: jest.fn(),
+			createSpan: jest.fn().mockReturnValue({ setText: jest.fn() }),
+			addEventListener: jest.fn(),
+			remove: jest.fn(),
+			style: {},
+			querySelector: jest.fn().mockReturnValue(null),
+		}),
 		...overrides,
 	};
 }

--- a/test/services/lifecycle-service.test.ts
+++ b/test/services/lifecycle-service.test.ts
@@ -109,9 +109,25 @@ jest.mock('../../src/services/project-manager', () => ({
 	})),
 }));
 jest.mock('../../src/ui/update-notification-modal', () => ({ UpdateNotificationModal: jest.fn() }));
+jest.mock('../../src/services/background-task-manager', () => ({
+	BackgroundTaskManager: jest.fn().mockImplementation(() => ({
+		destroy: jest.fn(),
+		runningCount: 0,
+	})),
+}));
+jest.mock('../../src/services/background-status-bar', () => ({
+	BackgroundStatusBar: jest.fn().mockImplementation(() => ({
+		setup: jest.fn(),
+		update: jest.fn(),
+		destroy: jest.fn(),
+		setRagProvider: jest.fn(),
+	})),
+}));
 
 // Must be after all jest.mock calls
 import { LifecycleService } from '../../src/services/lifecycle-service';
+import { BackgroundTaskManager } from '../../src/services/background-task-manager';
+import { BackgroundStatusBar } from '../../src/services/background-status-bar';
 import { ToolRegistrar } from '../../src/services/tool-registrar';
 import { ProjectActivationSubscriber } from '../../src/subscribers/project-activation-subscriber';
 
@@ -243,6 +259,31 @@ describe('LifecycleService', () => {
 			expect(ProjectActivationSubscriber).toHaveBeenCalledTimes(1);
 			expect(ProjectActivationSubscriber).toHaveBeenCalledWith(mockPlugin);
 		});
+
+		it('should create backgroundTaskManager and backgroundStatusBar on first setup', async () => {
+			await lifecycle.setup();
+
+			expect(mockPlugin.backgroundTaskManager).toBeDefined();
+			expect(mockPlugin.backgroundStatusBar).toBeDefined();
+			expect(BackgroundTaskManager).toHaveBeenCalledTimes(1);
+			expect(BackgroundStatusBar).toHaveBeenCalledTimes(1);
+			expect(mockPlugin.backgroundStatusBar.setup).toHaveBeenCalledTimes(1);
+		});
+
+		it('should not recreate backgroundTaskManager or backgroundStatusBar on re-setup', async () => {
+			await lifecycle.setup();
+
+			const firstManager = mockPlugin.backgroundTaskManager;
+			const firstStatusBar = mockPlugin.backgroundStatusBar;
+
+			mockPlugin.isGeminiInitialized = true;
+			await lifecycle.setup();
+
+			expect(mockPlugin.backgroundTaskManager).toBe(firstManager);
+			expect(mockPlugin.backgroundStatusBar).toBe(firstStatusBar);
+			expect(BackgroundTaskManager).toHaveBeenCalledTimes(1);
+			expect(BackgroundStatusBar).toHaveBeenCalledTimes(1);
+		});
 	});
 
 	describe('teardown', () => {
@@ -318,6 +359,23 @@ describe('LifecycleService', () => {
 			mockPlugin.ragIndexing = null;
 
 			await expect(lifecycle.onUnload()).resolves.not.toThrow();
+		});
+
+		it('should destroy backgroundTaskManager and backgroundStatusBar on unload', async () => {
+			await lifecycle.setup();
+
+			const manager = mockPlugin.backgroundTaskManager;
+			const statusBar = mockPlugin.backgroundStatusBar;
+
+			mockPlugin.mcpManager = null;
+			mockPlugin.ragIndexing = null;
+
+			await lifecycle.onUnload();
+
+			expect(manager.destroy).toHaveBeenCalledTimes(1);
+			expect(statusBar.destroy).toHaveBeenCalledTimes(1);
+			expect(mockPlugin.backgroundTaskManager).toBeNull();
+			expect(mockPlugin.backgroundStatusBar).toBeNull();
 		});
 	});
 });

--- a/test/tools/image-tools.test.ts
+++ b/test/tools/image-tools.test.ts
@@ -51,7 +51,7 @@ describe('ImageTools', () => {
 				prompt: 'a loaf of bread',
 				wikilink: `![[${imagePath}]]`,
 			});
-			expect(mockImageGeneration.generateImage).toHaveBeenCalledWith('a loaf of bread', undefined);
+			expect(mockImageGeneration.generateImage).toHaveBeenCalledWith('a loaf of bread', undefined, undefined);
 		});
 
 		it('should pass target_note parameter when provided', async () => {
@@ -67,7 +67,49 @@ describe('ImageTools', () => {
 			);
 
 			expect(result.success).toBe(true);
-			expect(mockImageGeneration.generateImage).toHaveBeenCalledWith('a sunset', 'my-note.md');
+			expect(mockImageGeneration.generateImage).toHaveBeenCalledWith('a sunset', 'my-note.md', undefined);
+		});
+
+		it('should pass output_path parameter when provided', async () => {
+			const imagePath = 'attachments/my-custom-image.png';
+			mockImageGeneration.generateImage.mockResolvedValue(imagePath);
+
+			const result = await tool.execute(
+				{
+					prompt: 'a mountain',
+					output_path: 'attachments/my-custom-image.png',
+				},
+				mockContext
+			);
+
+			expect(result.success).toBe(true);
+			expect(result.data).toEqual({
+				path: imagePath,
+				prompt: 'a mountain',
+				wikilink: `![[${imagePath}]]`,
+			});
+			expect(mockImageGeneration.generateImage).toHaveBeenCalledWith(
+				'a mountain',
+				undefined,
+				'attachments/my-custom-image.png'
+			);
+		});
+
+		it('should prefer output_path over target_note when both are provided', async () => {
+			const imagePath = 'custom/path/image.png';
+			mockImageGeneration.generateImage.mockResolvedValue(imagePath);
+
+			await tool.execute(
+				{
+					prompt: 'test',
+					target_note: 'some-note.md',
+					output_path: 'custom/path/image.png',
+				},
+				mockContext
+			);
+
+			// output_path and target_note are both forwarded; resolution priority is in the service
+			expect(mockImageGeneration.generateImage).toHaveBeenCalledWith('test', 'some-note.md', 'custom/path/image.png');
 		});
 
 		it('should return error when image generation service is not available', async () => {


### PR DESCRIPTION
## Summary

Implements PR 1a of the background/scheduled tasks work discussed in #589.

Adds a `BackgroundTaskManager` service so long-running operations (deep research, image generation) can run without blocking the UI. Includes a single coordinated status bar indicator, a monitoring modal, and completion notices with vault links. Also adds an `output_path` parameter to `GenerateImageTool` so background image submissions have a predictable, addressable output location.

Fixes #589

## Changes

- **`BackgroundTaskManager` service** — `submit(type, label, work)` returns a task ID immediately; caller never blocks. Emits `backgroundTaskStarted`, `backgroundTaskComplete`, and `backgroundTaskFailed` events on the existing `AgentEventBus`
- **`BackgroundStatusBar`** — single coordinated status bar item reflecting both RAG indexing state and background task state (not two icons side by side). Click opens the monitoring modal
- **`BackgroundTasksModal`** — lists running tasks with Cancel button and the 20 most recent completed/failed/cancelled tasks, each with an Open result link when an output file exists
- **`output_path` on `GenerateImageTool`** — optional explicit vault path for the output file so fire-and-forget image submissions are locatable after the fact
- **`styles.css`** — modal task row layout (icon, label, meta on separate lines, status colours), Cancel button styling, status bar spin animation
- **`AgentEventBus` event types** — added `backgroundTaskStarted`, `backgroundTaskComplete`, `backgroundTaskFailed` to `agent-events.ts`
- **`LifecycleService`** — registers `BackgroundTaskManager` and `BackgroundStatusBar` once, alongside the event bus, surviving re-initialisation
- **Command** — "View Background Tasks" added to the command palette
- **Tests** — task lifecycle transitions (pending → running → complete/failed/cancelled), cancellation, event emission, `output_path` forwarding
- **Docs** — `docs/guide/background-tasks.md` describing the status bar, monitoring modal, and result access

## Non-goals (deferred to follow-up issues)

- Agent `background: true` flag — see #634
- Dedupe of identical in-flight submissions
- Shared `BackgroundWork` interface with RAG
- Scheduled task engine — see #633 (next in sequence)

## Screenshots / Screencast

**Background Tasks modal — running task with Cancel:**
Modal shows spinning loader icon, task label, start time, and a red Cancel button. Cancellation works immediately and moves the task to the Recent section.

**Background Tasks modal — completed tasks:**
Completed tasks show a green check icon. Tasks with output files show an Open result link that navigates to the note in Obsidian.

**Status bar indicator:**
Single indicator at the bottom of the screen. Shows spinning icon + task count while tasks are running. Disappears when idle.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards)
- [x] Documentation has been updated (if applicable)
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude (claude-sonnet-4-6 via Claude Code)
- [x] I have reviewed and understand all AI-generated code in this PR

## Next Steps

After this merges, #633 will implement the scheduled task execution engine — `ScheduledTaskManager` with a 60s setInterval loop, markdown-per-task storage in `{historyFolder}/Scheduled-Tasks/`, headless agent session execution, and pure `computeNextRunAt()` for unit-tested scheduling logic.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unified Background Tasks status indicator combining background work and RAG indexing progress
  * Background Tasks panel: view running tasks (with per-task Cancel) and recent history; "Open result" links for completed outputs
  * Optional output_path to control image generation save location

* **Documentation**
  * New guide describing background task behavior, how to open the panel, cancellation semantics, and locating results

* **Behavior**
  * Completion/failure notices include clickable vault links and clear statuses
<!-- end of auto-generated comment: release notes by coderabbit.ai -->