### PR TITLE
fix: correct Agent Mode documentation link path

### DIFF
--- a/src/ui/agent-view/agent-view-messages.ts
+++ b/src/ui/agent-view/agent-view-messages.ts
@@ -8,7 +8,7 @@ import { Tool, DiffContext, ConfirmationResult } from '../../tools/types';
 
 // Documentation and help content
 const DOCS_BASE_URL = 'https://github.com/allenhutchison/obsidian-gemini/blob/master/docs';
-const AGENT_MODE_GUIDE_URL = `${DOCS_BASE_URL}/agent-mode-guide.md`;
+const AGENT_MODE_GUIDE_URL = `${DOCS_BASE_URL}/guide/agent-mode.md`;
 
 const AGENT_CAPABILITIES = [
 	{ icon: 'search', text: 'Search and read files in your vault' },


### PR DESCRIPTION
## Summary

Fixes #638

The "Learn more about Agent Mode" link in the Agent View empty state was currently leading to a 404 on GitHub because it was missing the `guide/` subdirectory in the path.

## Changes

- Updated `AGENT_MODE_GUIDE_URL` in `src/ui/agent-view/agent-view-messages.ts` to point to `docs/guide/agent-mode.md`.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards)
- [x] Documentation has been updated (N/A: fixing the link *to* the documentation)

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Gemini CLI
- [x] I have reviewed and understand all AI-generated code in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Agent Mode documentation link to point to the correct resource location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->