### PR TITLE
chore: Upgrade GitHub Actions to Node.js 24.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '18.x'
+          node-version: '24.x'
 
       - name: Install dependencies
         run: npm install

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: '24.x'
           cache: npm
 
       - name: Install dependencies

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '18'
+          node-version: '24.x'
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/model-update.yml
+++ b/.github/workflows/model-update.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '18.x'
+          node-version: '24.x'
 
       - name: Check for new models
         id: update

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '18.x'
+          node-version: '24.x'
       - name: Install dependencies
         run: npm install
       - name: Run tests
@@ -36,7 +36,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '18.x'
+          node-version: '24.x'
 
       - name: Build plugin
         run: |


### PR DESCRIPTION
Fixes #643

GitHub is [deprecating Node.js 20](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) on actions runners. This PR upgrades all workflows to Node.js 24.x (Active LTS) to ensure CI/CD stability, security, and performance. 

Changes:
- Updated CI, Docs, Lint, Model Update, and Release workflows to use Node.js 24.x.
- Standardized all node-version strings to use the '24.x' format for consistency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build and continuous integration environment to Node.js 24.x across all workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->