### PR TITLE
fix: point ModelListProvider remote URL at master branch

### DIFF
--- a/src/services/model-list-provider.ts
+++ b/src/services/model-list-provider.ts
@@ -11,7 +11,7 @@ interface ModelListJson {
 	models: GeminiModel[];
 }
 
-const REMOTE_URL = 'https://raw.githubusercontent.com/allenhutchison/obsidian-gemini/main/src/data/models.json';
+const REMOTE_URL = 'https://raw.githubusercontent.com/allenhutchison/obsidian-gemini/master/src/data/models.json';
 const CACHE_DURATION = 24 * 60 * 60 * 1000; // 24 hours
 
 export class ModelListProvider {


### PR DESCRIPTION
## Summary

`ModelListProvider` fetches the latest `models.json` from GitHub so users get new Gemini model entries without a plugin release. The URL was hardcoded to the `main` branch, but this repository's default branch is `master`. Every fetch returned 404, the fetch was logged as a warning, and users were stuck on bundled models.

Fixes #645

## Changes

- `src/services/model-list-provider.ts` — change `REMOTE_URL` from `.../main/src/data/models.json` to `.../master/src/data/models.json`

## Verification

```
$ curl -sI https://raw.githubusercontent.com/allenhutchison/obsidian-gemini/master/src/data/models.json | head -1
HTTP/2 200
```

Also verified on plugin reload — the `[ModelListProvider] Remote fetch failed: status 404` warning no longer appears.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — one-line URL string change, platform-agnostic
- [x] Documentation has been updated (if applicable) — N/A, no user-facing behavior change
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (claude-opus-4-7)
- [x] I have reviewed and understand all AI-generated code in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal configuration to improve data retrieval reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->