### PR TITLE
fix: Clear shelf when creating or loading agent session (#648)

### DIFF
--- a/src/services/generated-help-references.ts
+++ b/src/services/generated-help-references.ts
@@ -10,6 +10,7 @@
 import refAgentMode from '../../docs/guide/agent-mode.md';
 import refAgentSkills from '../../docs/guide/agent-skills.md';
 import refAiWriting from '../../docs/guide/ai-writing.md';
+import refBackgroundTasks from '../../docs/guide/background-tasks.md';
 import refCompletions from '../../docs/guide/completions.md';
 import refContextSystem from '../../docs/guide/context-system.md';
 import refCustomPrompts from '../../docs/guide/custom-prompts.md';
@@ -29,6 +30,7 @@ export const helpResources = new Map<string, string>([
 	['references/agent-mode.md', refAgentMode],
 	['references/agent-skills.md', refAgentSkills],
 	['references/ai-writing.md', refAiWriting],
+	['references/background-tasks.md', refBackgroundTasks],
 	['references/completions.md', refCompletions],
 	['references/context-system.md', refContextSystem],
 	['references/custom-prompts.md', refCustomPrompts],
@@ -50,6 +52,7 @@ export const helpReferencesTable = `| Reference | Topic |
 | \`references/agent-mode.md\` | Agent Mode Guide |
 | \`references/agent-skills.md\` | Agent Skills |
 | \`references/ai-writing.md\` | Selection-Based AI Features Guide |
+| \`references/background-tasks.md\` | Background Tasks |
 | \`references/completions.md\` | IDE-Style Completions Guide |
 | \`references/context-system.md\` | Context System Guide |
 | \`references/custom-prompts.md\` | Custom Prompts Guide |

--- a/src/ui/agent-view/agent-view.ts
+++ b/src/ui/agent-view/agent-view.ts
@@ -390,10 +390,11 @@ export class AgentView extends ItemView {
 	private async createNewSession() {
 		await this.session.createNewSession();
 		this.currentSession = this.session.getCurrentSession();
-		// Re-render header now that currentSession is updated — the header
-		// rendered inside createNewSession() used the stale reference.
+		// Re-render header and shelf now that currentSession is updated — the
+		// callbacks fired inside createNewSession() used the stale reference,
+		// so the shelf would otherwise still show the previous session's files.
 		this.updateSessionHeader();
-		// Emit after this.currentSession is updated so subscribers see the correct session
+		this.updateContextPanel();
 		if (this.currentSession) {
 			await this.plugin.agentEventBus?.emit('sessionCreated', { session: this.currentSession });
 		}
@@ -406,7 +407,7 @@ export class AgentView extends ItemView {
 		await this.session.loadSession(session);
 		this.currentSession = this.session.getCurrentSession();
 		this.updateSessionHeader();
-		// Emit after this.currentSession is updated so subscribers see the correct session
+		this.updateContextPanel();
 		if (this.currentSession) {
 			await this.plugin.agentEventBus?.emit('sessionLoaded', { session: this.currentSession });
 		}

--- a/test/ui/agent-view.test.ts
+++ b/test/ui/agent-view.test.ts
@@ -1310,4 +1310,74 @@ describe('AgentView UI Tests', () => {
 			expect(send.isCancellationRequested()).toBe(false);
 		});
 	});
+
+	describe('Session Reset Shelf (#648)', () => {
+		// Regression: when starting a new session or loading a different one, the
+		// shelf must reflect the destination session's context files and drop the
+		// previous session's entries.
+		function installStubs(oldSession: any) {
+			const shelf = {
+				loadFromSession: jest.fn(),
+				clear: jest.fn(),
+			};
+			(agentView as any).shelf = shelf;
+			(agentView as any).currentSession = oldSession;
+			// Stub updateSessionHeader to avoid DOM rendering in test harness.
+			(agentView as any).updateSessionHeader = jest.fn();
+			return shelf;
+		}
+
+		it('should clear shelf entries from previous session when creating a new session', async () => {
+			const oldFile = { path: 'old.md', basename: 'old' } as any;
+			const oldSession = { id: 'old', context: { contextFiles: [oldFile] } };
+			const newSession = { id: 'new', context: { contextFiles: [] } };
+
+			const shelf = installStubs(oldSession);
+
+			// Stub the session module: simulate the callback ordering of the real
+			// AgentViewSession, where updateContextPanel fires *before* agent-view
+			// mirrors the new currentSession reference.
+			(agentView as any).session = {
+				createNewSession: jest.fn(async () => {
+					(agentView as any).session.getCurrentSession = () => newSession;
+					// The real module invokes uiCallbacks.updateContextPanel here,
+					// while agent-view.currentSession still points at oldSession.
+					(agentView as any).updateContextPanel();
+				}),
+				getCurrentSession: () => oldSession,
+			};
+
+			const createNewSession = AgentView.prototype['createNewSession'];
+			await createNewSession.call(agentView);
+
+			// Last call must use the new session's context files (empty), not the
+			// stale old session's files.
+			const calls = shelf.loadFromSession.mock.calls;
+			expect(calls.length).toBeGreaterThanOrEqual(1);
+			expect(calls[calls.length - 1][0]).toEqual([]);
+		});
+
+		it('should clear shelf entries when loading a different session', async () => {
+			const oldFile = { path: 'old.md', basename: 'old' } as any;
+			const oldSession = { id: 'old', context: { contextFiles: [oldFile] } };
+			const loadedSession = { id: 'loaded', context: { contextFiles: [] } };
+
+			const shelf = installStubs(oldSession);
+
+			(agentView as any).session = {
+				loadSession: jest.fn(async () => {
+					(agentView as any).session.getCurrentSession = () => loadedSession;
+					(agentView as any).updateContextPanel();
+				}),
+				getCurrentSession: () => oldSession,
+			};
+
+			const realLoadSession = AgentView.prototype.loadSession;
+			await realLoadSession.call(agentView, loadedSession);
+
+			const calls = shelf.loadFromSession.mock.calls;
+			expect(calls.length).toBeGreaterThanOrEqual(1);
+			expect(calls[calls.length - 1][0]).toEqual([]);
+		});
+	});
 });

--- a/test/ui/agent-view.test.ts
+++ b/test/ui/agent-view.test.ts
@@ -1359,8 +1359,12 @@ describe('AgentView UI Tests', () => {
 
 		it('should clear shelf entries when loading a different session', async () => {
 			const oldFile = { path: 'old.md', basename: 'old' } as any;
-			const oldSession = { id: 'old', context: { contextFiles: [oldFile] } };
-			const loadedSession = { id: 'loaded', context: { contextFiles: [] } };
+			const oldSession = await plugin.sessionManager.createAgentSession('old', {
+				contextFiles: [oldFile],
+			});
+			const loadedSession = await plugin.sessionManager.createAgentSession('loaded', {
+				contextFiles: [],
+			});
 
 			const shelf = installStubs(oldSession);
 


### PR DESCRIPTION
## Summary

Fixes #648. When a user created a new agent session or loaded a different one, the file shelf continued to show the previous session's context files instead of clearing.

`AgentView` holds its own `currentSession` mirror that is only updated **after** it delegates to `AgentViewSession`. Inside that delegation, the session module fires the `updateContextPanel` callback — which reads the stale `currentSession` reference and repopulates the shelf from the old session's files. The session header had a defensive re-render for the same timing issue; the shelf did not.

## Changes

- `src/ui/agent-view/agent-view.ts`: Add `this.updateContextPanel()` after `this.currentSession` is refreshed in both `createNewSession` and `loadSession`, mirroring the existing header re-render.
- `test/ui/agent-view.test.ts`: Add two regression tests under "Session Reset Shelf (#648)" that simulate the stale-reference callback ordering and verify `shelf.loadFromSession` is last called with the destination session's (empty) `contextFiles`. Confirmed these fail without the fix.
- `src/services/generated-help-references.ts`: Regenerated — picks up the `background-tasks.md` reference missed in #637.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop
- [ ] I have verified this change does not break Mobile — N/A: no platform-specific code touched; pure UI state logic shared across platforms
- [x] Documentation has been updated (if applicable) — N/A: `docs/guide/context-system.md` already documents "Files are removed when creating a new session" as the intended behavior; this fix makes the implementation match the docs.
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added help documentation for background tasks.

* **Bug Fixes**
  * Ensured the context panel/shelf updates immediately when creating or switching sessions to avoid stale context entries.

* **Tests**
  * Added regression tests covering session transitions to verify the context panel/shelf resets correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->