### PR TITLE
fix: preserve editor selection for get_workspace_state (#542)

### DIFF
--- a/__mocks__/obsidian.js
+++ b/__mocks__/obsidian.js
@@ -36,6 +36,15 @@ class Modal {
 
 class WorkspaceLeaf {}
 
+class MarkdownView {
+	constructor() {
+		this.file = null;
+		this.editor = {
+			getSelection: jest.fn().mockReturnValue(''),
+		};
+	}
+}
+
 class TFile {
 	constructor(path = 'test.md') {
 		this.path = path;
@@ -283,6 +292,7 @@ class Plugin {
 
 module.exports = {
 	ItemView,
+	MarkdownView,
 	Modal,
 	WorkspaceLeaf,
 	TFile,

--- a/src/main.ts
+++ b/src/main.ts
@@ -187,6 +187,12 @@ export default class ObsidianGemini extends Plugin {
 	public backgroundTaskManager: BackgroundTaskManager | null = null;
 	public backgroundStatusBar: BackgroundStatusBar | null = null;
 
+	// Snapshot of the last non-empty editor selection at the moment the user
+	// engaged the agent input. Used as a fallback in GetWorkspaceStateTool,
+	// whose live read of view.editor.getSelection() returns empty once focus
+	// has moved to the agent chat input.
+	public lastEditorSelection: { path: string; text: string } | null = null;
+
 	// Private members
 	private ribbonIcon!: HTMLElement;
 	public isGeminiInitialized: boolean = false;

--- a/src/tools/vault/get-workspace-state-tool.ts
+++ b/src/tools/vault/get-workspace-state-tool.ts
@@ -67,6 +67,14 @@ export class GetWorkspaceStateTool implements Tool {
 					// Editor may not be available
 				}
 
+				// Fallback: when focus has moved to the agent input the live
+				// selection reads empty. AgentView snapshots the selection on
+				// input focus; use it when this leaf matches the cached path.
+				if (!selection && plugin.lastEditorSelection?.path === path) {
+					const cached = plugin.lastEditorSelection.text;
+					selection = cached.length > MAX_SELECTION_LENGTH ? cached.slice(0, MAX_SELECTION_LENGTH) + '...' : cached;
+				}
+
 				const existing = fileMap.get(path);
 				if (existing) {
 					// Merge: visible/active if ANY leaf qualifies

--- a/src/ui/agent-view/agent-view.ts
+++ b/src/ui/agent-view/agent-view.ts
@@ -1,4 +1,4 @@
-import { ItemView, WorkspaceLeaf, TFile, Notice } from 'obsidian';
+import { ItemView, MarkdownView, WorkspaceLeaf, TFile, Notice } from 'obsidian';
 import { ChatSession, SessionModelConfig } from '../../types/agent';
 import { GeminiConversationEntry } from '../../types/conversation';
 import type ObsidianGemini from '../../main';
@@ -108,6 +108,13 @@ export class AgentView extends ItemView {
 		this.userInput = elements.userInput;
 		this.sendButton = elements.sendButton;
 		this.tokenUsageContainer = elements.tokenUsageContainer;
+
+		// Snapshot the editor selection before/after focus transfers to the agent
+		// input. Clicking into the input blurs the editor and leaves
+		// view.editor.getSelection() returning empty by the time tools run.
+		// pointerdown fires pre-transfer (mouse); focus catches keyboard tab.
+		this.registerDomEvent(this.userInput, 'pointerdown', this.captureEditorSelection);
+		this.registerDomEvent(this.userInput, 'focus', this.captureEditorSelection);
 
 		// Initialize the unified file shelf above the input row
 		const shelfParent = elements.imagePreviewContainer.parentElement!;
@@ -267,6 +274,48 @@ export class AgentView extends ItemView {
 	private updateSessionHeader() {
 		this.ui.createCompactHeader(this.sessionHeader, this.currentSession, this.getUICallbacks());
 	}
+
+	/**
+	 * Capture the user's current editor selection and stash it on the plugin.
+	 * GetWorkspaceStateTool falls back to this when its live read returns empty
+	 * (which happens once focus has moved to the agent input).
+	 *
+	 * Iterates leaves rather than only checking the active view because at
+	 * focus-time the agent view is the active view — the markdown editor with
+	 * the selection is no longer returned by getActiveViewOfType.
+	 *
+	 * Always writes (including null) so a focus with no selection clears stale
+	 * cache from an earlier turn.
+	 */
+	private captureEditorSelection = (): void => {
+		let captured: { path: string; text: string } | null = null;
+
+		const activeView = this.app.workspace.getActiveViewOfType(MarkdownView);
+		if (activeView?.file) {
+			try {
+				const sel = activeView.editor.getSelection();
+				if (sel) captured = { path: activeView.file.path, text: sel };
+			} catch {
+				// Editor may not be ready
+			}
+		}
+
+		if (!captured) {
+			this.app.workspace.iterateAllLeaves((leaf) => {
+				if (captured) return;
+				const v = leaf.view;
+				if (!(v instanceof MarkdownView) || !v.file) return;
+				try {
+					const sel = v.editor.getSelection();
+					if (sel) captured = { path: v.file.path, text: sel };
+				} catch {
+					// Editor may not be ready
+				}
+			});
+		}
+
+		this.plugin.lastEditorSelection = captured;
+	};
 
 	/**
 	 * Remove a file from context

--- a/src/ui/agent-view/agent-view.ts
+++ b/src/ui/agent-view/agent-view.ts
@@ -56,6 +56,7 @@ export class AgentView extends ItemView {
 	private allowedWithoutConfirmation: Set<string> = new Set(); // Session-level allowed tools
 	private shelf!: AgentViewShelf;
 	private tokenUsageContainer!: HTMLElement;
+	private skipNextFocusSelectionCapture = false;
 
 	constructor(leaf: WorkspaceLeaf, plugin: ObsidianGemini) {
 		super(leaf);
@@ -113,8 +114,19 @@ export class AgentView extends ItemView {
 		// input. Clicking into the input blurs the editor and leaves
 		// view.editor.getSelection() returning empty by the time tools run.
 		// pointerdown fires pre-transfer (mouse); focus catches keyboard tab.
-		this.registerDomEvent(this.userInput, 'pointerdown', this.captureEditorSelection);
-		this.registerDomEvent(this.userInput, 'focus', this.captureEditorSelection);
+		// On mouse, pointerdown is authoritative — skip the focus that follows
+		// so it can't clobber the snapshot with null if CM6 clears state on blur.
+		this.registerDomEvent(this.userInput, 'pointerdown', () => {
+			this.captureEditorSelection();
+			this.skipNextFocusSelectionCapture = true;
+		});
+		this.registerDomEvent(this.userInput, 'focus', () => {
+			if (this.skipNextFocusSelectionCapture) {
+				this.skipNextFocusSelectionCapture = false;
+				return;
+			}
+			this.captureEditorSelection();
+		});
 
 		// Initialize the unified file shelf above the input row
 		const shelfParent = elements.imagePreviewContainer.parentElement!;

--- a/test/tools/vault-tools.test.ts
+++ b/test/tools/vault-tools.test.ts
@@ -1184,7 +1184,9 @@ describe('VaultTools', () => {
 				(file as any).path = filePath;
 				(file as any).name = 'test.md';
 
-				const view = new MarkdownView();
+				// Cast through unknown: the runtime MarkdownView mock is a
+				// zero-arg class, but the d.ts signature requires a leaf.
+				const view = new (MarkdownView as unknown as new () => MarkdownView)();
 				(view as any).file = file;
 				(view as any).editor.getSelection.mockReturnValue(opts.liveSelection);
 

--- a/test/tools/vault-tools.test.ts
+++ b/test/tools/vault-tools.test.ts
@@ -49,7 +49,7 @@ jest.mock('obsidian', () => ({
 }));
 
 // Import the mocked classes
-import { TFile, TFolder } from 'obsidian';
+import { TFile, TFolder, MarkdownView } from 'obsidian';
 
 // Mock Obsidian objects
 const mockFile = new TFile();
@@ -1168,6 +1168,112 @@ describe('VaultTools', () => {
 			expect(result.success).toBe(true);
 			expect(result.data.openFiles).toEqual([]);
 			expect(result.data.project).toBeNull();
+		});
+
+		describe('cached selection fallback', () => {
+			// Builds the minimum plumbing to exercise the fallback: a single
+			// markdown leaf whose editor.getSelection() returns `liveSelection`,
+			// with the plugin's cached selection set to `cached`.
+			function buildContext(opts: {
+				liveSelection: string;
+				cached: { path: string; text: string } | null;
+				filePath?: string;
+			}) {
+				const filePath = opts.filePath ?? 'notes/test.md';
+				const file = new TFile();
+				(file as any).path = filePath;
+				(file as any).name = 'test.md';
+
+				const view = new MarkdownView();
+				(view as any).file = file;
+				(view as any).editor.getSelection.mockReturnValue(opts.liveSelection);
+
+				const leaf = { view, containerEl: { isShown: () => true } };
+
+				const mockWorkspace = {
+					getActiveFile: jest.fn().mockReturnValue(file),
+					getActiveViewOfType: jest.fn().mockReturnValue(view),
+					iterateAllLeaves: jest.fn((cb: (l: any) => void) => cb(leaf)),
+				};
+
+				const metadataCache = {
+					...mockMetadataCache,
+					fileToLinktext: jest.fn((f: any) => f.path.replace(/\.md$/, '')),
+				};
+
+				return {
+					...mockContext,
+					plugin: {
+						...mockPlugin,
+						app: {
+							...mockPlugin.app,
+							workspace: mockWorkspace,
+							metadataCache,
+						},
+						lastEditorSelection: opts.cached,
+					},
+				};
+			}
+
+			it('uses cached selection when live read is empty and path matches', async () => {
+				const context = buildContext({
+					liveSelection: '',
+					cached: { path: 'notes/test.md', text: 'remembered foo' },
+				});
+
+				const result = await tool.execute({}, context);
+
+				expect(result.success).toBe(true);
+				expect(result.data.openFiles).toHaveLength(1);
+				expect(result.data.openFiles[0].selection).toBe('remembered foo');
+			});
+
+			it('ignores cached selection when path does not match', async () => {
+				const context = buildContext({
+					liveSelection: '',
+					cached: { path: 'other/file.md', text: 'unrelated' },
+				});
+
+				const result = await tool.execute({}, context);
+
+				expect(result.data.openFiles[0].selection).toBeNull();
+			});
+
+			it('prefers live selection over cached', async () => {
+				const context = buildContext({
+					liveSelection: 'live text',
+					cached: { path: 'notes/test.md', text: 'stale cache' },
+				});
+
+				const result = await tool.execute({}, context);
+
+				expect(result.data.openFiles[0].selection).toBe('live text');
+			});
+
+			it('truncates long cached selections', async () => {
+				const longText = 'x'.repeat(1500);
+				const context = buildContext({
+					liveSelection: '',
+					cached: { path: 'notes/test.md', text: longText },
+				});
+
+				const result = await tool.execute({}, context);
+
+				const selection: string = result.data.openFiles[0].selection;
+				expect(selection.endsWith('...')).toBe(true);
+				expect(selection.length).toBe(1003); // 1000 chars + '...'
+			});
+
+			it('returns null selection when no cache and live is empty', async () => {
+				const context = buildContext({
+					liveSelection: '',
+					cached: null,
+				});
+
+				const result = await tool.execute({}, context);
+
+				expect(result.data.openFiles[0].selection).toBeNull();
+			});
 		});
 	});
 


### PR DESCRIPTION
## Summary

Fixes #542. `get_workspace_state` now reports the user's text selection even after they've clicked into the agent chat input.

The agent input is a contenteditable div; clicking into it steals the native selection from the markdown editor, so by the time the model calls the tool, `view.editor.getSelection()` reads empty. The fix snapshots the selection on `pointerdown`/`focus` of the agent input and the tool falls back to the cache when the live read is empty for a leaf whose path matches.

## Changes

- `src/main.ts` — new `lastEditorSelection` cache on the plugin instance
- `src/ui/agent-view/agent-view.ts` — `captureEditorSelection` snapshots the active markdown editor's selection on agent-input `pointerdown` (pre-focus-transfer, covers mouse) and `focus` (covers keyboard tab), writing to the plugin cache (including `null` to clear stale state)
- `src/tools/vault/get-workspace-state-tool.ts` — falls back to the cached selection when the live read is empty and the cached path matches the leaf's path; truncation honored
- `__mocks__/obsidian.js` — added `MarkdownView` mock so tools can be tested with real `instanceof` checks
- `test/tools/vault-tools.test.ts` — 5 new tests covering path match, path mismatch, live-precedence, truncation of long cached selections, and null-cache behavior

## Screenshots / Screencast

Internal fix — no UI changes. Verified by reloading the plugin, selecting text in a note, clicking into the agent input, and asking the agent to report the selection. The tool now returns the selected text.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop
- [ ] I have verified this change does not break Mobile (no mobile-specific code paths; `pointerdown`/`focus` are supported on touch browsers)
- [x] Documentation has been updated (if applicable) — the existing agent-mode guide already documents the intended behavior; this PR makes it work reliably
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Editor selection is now preserved when switching focus to the agent input.
  * Implements a fallback mechanism to restore previously selected text when live selection data becomes unavailable.

* **Tests**
  * Added test coverage for editor selection fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->