### PR TITLE
fix: pre-resolve generate_image background output_path

### DIFF
--- a/prompts/agentRulesPrompt.hbs
+++ b/prompts/agentRulesPrompt.hbs
@@ -26,8 +26,8 @@ Both tools accept an optional `background: true` parameter. Use it when:
 - You have other tool calls to make that don't depend on the result
 
 When using `background: true`:
-- Always provide `output_file` (deep_research) or `output_path` (generate_image) so you know exactly where to find the result
-- The tool returns `{ taskId, output_file }` or `{ taskId, output_path }` immediately
+- The tool returns `{ taskId, output_file }` or `{ taskId, output_path }` immediately — the path is always populated, you don't have to provide one
+- You may optionally pass `output_file` / `output_path` to override the default location (research defaults to `Background Research/<date> <topic>.md`; images default to the vault's configured attachment folder)
 - Retrieve the result later using `read_file` on the returned path — no new tool call to the original tool is needed
 - Do NOT use `background: true` if subsequent steps immediately depend on the output — use foreground mode instead so the result is available inline
 

--- a/src/services/image-generation.ts
+++ b/src/services/image-generation.ts
@@ -143,8 +143,17 @@ export class ImageGeneration {
 	}
 
 	/**
-	 * Build the timestamped filename used when no explicit outputPath is given.
+	 * Build the default filename used when no explicit outputPath is given.
 	 * Centralised so resolveDefaultOutputPath and saveImageToVault can't drift.
+	 *
+	 * Includes a timestamp AND a short random suffix so two concurrent
+	 * background tasks can't propose the same path. `getAvailablePathForAttachment`
+	 * is a non-atomic availability check — if it returned the same "free" path
+	 * to two callers, the second write would throw when `vault.createBinary`
+	 * encountered the file the first task wrote. The random suffix drops
+	 * collision probability to ~1-in-2-billion per same-millisecond submission
+	 * with the same prompt slice, from the ~100% it would be otherwise in
+	 * that (rare) case.
 	 */
 	private buildDefaultFilename(prompt: string): string {
 		const sanitizedPrompt = prompt
@@ -152,7 +161,8 @@ export class ImageGeneration {
 			.replace(/[^a-zA-Z0-9\-_]/g, '-')
 			.replace(/-+/g, '-')
 			.replace(/^-|-$/g, '');
-		return `generated-${sanitizedPrompt}-${Date.now()}.png`;
+		const randomSuffix = Math.random().toString(36).substring(2, 8);
+		return `generated-${sanitizedPrompt}-${Date.now()}-${randomSuffix}.png`;
 	}
 
 	/**

--- a/src/services/image-generation.ts
+++ b/src/services/image-generation.ts
@@ -100,17 +100,41 @@ export class ImageGeneration {
 	}
 
 	/**
+	 * Resolve the exact vault path an image will be saved at, for either an
+	 * explicit caller-supplied path or the default attachment-folder flow.
+	 *
+	 * When `outputPath` is provided, validates it and rewrites the extension
+	 * to `.png` (saveImageToVault writes PNG bytes unconditionally). When it
+	 * isn't, falls back to the default attachment-folder resolution.
+	 *
+	 * Used by background mode of GenerateImageTool to pre-compute the path at
+	 * submit time and return it synchronously — the agent relies on this path
+	 * being the exact location it can later `read_file`. Must stay in sync
+	 * with saveImageToVault so the promise-at-submit matches the
+	 * actual-write.
+	 *
+	 * Throws synchronously on an invalid explicit path (vault escape,
+	 * protected folder, etc.) or when the default branch has no active file
+	 * and no `targetNotePath` to anchor the attachment folder.
+	 */
+	async resolveOutputPath(prompt: string, targetNotePath?: string, outputPath?: string): Promise<string> {
+		if (outputPath) {
+			// Runs the same validation/normalisation saveImageToVault uses,
+			// including rewriting any non-.png extension to .png.
+			return this.validateOutputPath(outputPath);
+		}
+		return this.resolveDefaultOutputPath(prompt, targetNotePath);
+	}
+
+	/**
 	 * Resolve the path the image WOULD be saved at when no explicit `outputPath`
 	 * is given. Mirrors the no-`outputPath` branch of saveImageToVault.
 	 *
-	 * Used by background mode of GenerateImageTool to pre-compute the path at
-	 * submit time and surface it to the agent — without this, background
-	 * callers see `output_path: null` and have no programmatic way to find the
-	 * file once the task completes.
+	 * Prefer `resolveOutputPath` for callers that may or may not have an
+	 * explicit path — it handles both branches consistently. This method is
+	 * kept public for callers that specifically want the default flow.
 	 *
-	 * Throws if no active file exists and no `targetNotePath` is provided
-	 * (callers in background contexts must provide one or check for active
-	 * file existence themselves).
+	 * Throws if no active file exists and no `targetNotePath` is provided.
 	 */
 	async resolveDefaultOutputPath(prompt: string, targetNotePath?: string): Promise<string> {
 		const filename = this.buildDefaultFilename(prompt);

--- a/src/services/image-generation.ts
+++ b/src/services/image-generation.ts
@@ -100,6 +100,52 @@ export class ImageGeneration {
 	}
 
 	/**
+	 * Resolve the path the image WOULD be saved at when no explicit `outputPath`
+	 * is given. Mirrors the no-`outputPath` branch of saveImageToVault.
+	 *
+	 * Used by background mode of GenerateImageTool to pre-compute the path at
+	 * submit time and surface it to the agent — without this, background
+	 * callers see `output_path: null` and have no programmatic way to find the
+	 * file once the task completes.
+	 *
+	 * Throws if no active file exists and no `targetNotePath` is provided
+	 * (callers in background contexts must provide one or check for active
+	 * file existence themselves).
+	 */
+	async resolveDefaultOutputPath(prompt: string, targetNotePath?: string): Promise<string> {
+		const filename = this.buildDefaultFilename(prompt);
+		const referenceNotePath = this.resolveReferenceNotePath(targetNotePath);
+		return this.plugin.app.fileManager.getAvailablePathForAttachment(filename, referenceNotePath);
+	}
+
+	/**
+	 * Build the timestamped filename used when no explicit outputPath is given.
+	 * Centralised so resolveDefaultOutputPath and saveImageToVault can't drift.
+	 */
+	private buildDefaultFilename(prompt: string): string {
+		const sanitizedPrompt = prompt
+			.substring(0, 50)
+			.replace(/[^a-zA-Z0-9\-_]/g, '-')
+			.replace(/-+/g, '-')
+			.replace(/^-|-$/g, '');
+		return `generated-${sanitizedPrompt}-${Date.now()}.png`;
+	}
+
+	/**
+	 * Resolve the note path used as the attachment-folder reference. Falls back
+	 * to the active file when no explicit target is given. Throws when neither
+	 * is available — Obsidian's getAvailablePathForAttachment requires a context.
+	 */
+	private resolveReferenceNotePath(targetNotePath?: string): string {
+		if (targetNotePath) return targetNotePath;
+		const activeFile = this.plugin.app.workspace.getActiveFile();
+		if (!activeFile) {
+			throw new Error('No active file and no target note path provided');
+		}
+		return activeFile.path;
+	}
+
+	/**
 	 * Validate and normalize an explicit output path supplied by the caller.
 	 * Rejects paths that escape the vault, target protected system folders, or
 	 * land inside the plugin state folder — important because GenerateImageTool
@@ -183,29 +229,7 @@ export class ImageGeneration {
 				await ensureFolderExists(this.plugin.app.vault, parentPath, 'image output folder', this.plugin.logger);
 			}
 		} else {
-			// Create a safe filename from the prompt (truncate and sanitize)
-			const sanitizedPrompt = prompt
-				.substring(0, 50)
-				.replace(/[^a-zA-Z0-9\-_]/g, '-')
-				.replace(/-+/g, '-')
-				.replace(/^-|-$/g, '');
-
-			const timestamp = Date.now();
-			const filename = `generated-${sanitizedPrompt}-${timestamp}.png`;
-
-			// Determine reference note path for attachment folder resolution
-			let referenceNotePath: string;
-			if (targetNotePath) {
-				referenceNotePath = targetNotePath;
-			} else {
-				const activeFile = this.plugin.app.workspace.getActiveFile();
-				if (!activeFile) {
-					throw new Error('No active file and no target note path provided');
-				}
-				referenceNotePath = activeFile.path;
-			}
-
-			resolvedPath = await this.plugin.app.fileManager.getAvailablePathForAttachment(filename, referenceNotePath);
+			resolvedPath = await this.resolveDefaultOutputPath(prompt, targetNotePath);
 		}
 
 		// Save to vault

--- a/src/tools/image-tools.ts
+++ b/src/tools/image-tools.ts
@@ -13,7 +13,7 @@ export class GenerateImageTool implements Tool {
 	classification = ToolClassification.WRITE;
 	description =
 		'Generate an image from a text prompt and save it to the vault. Returns the wikilink that can be used to embed the image in a note. IMPORTANT: This tool only generates and saves the image file - it does NOT insert the image into any note. To add the generated image to a note, you must use write_file to insert the returned wikilink into the note content. ' +
-		'Set background=true to submit as a background task and return immediately with { taskId, output_path } — provide output_path so you know the exact location to retrieve the result with read_file.';
+		'Set background=true to submit as a background task and return immediately with { taskId, output_path }. The returned output_path is the exact vault location where the image will land — read it later with read_file.';
 
 	parameters = {
 		type: 'object' as const,
@@ -36,7 +36,7 @@ export class GenerateImageTool implements Tool {
 				type: 'boolean' as const,
 				description:
 					'When true, submit as a background task and return immediately with { taskId, output_path }. ' +
-					'Provide output_path alongside background=true so you know the exact path to read the result with read_file once the task completes.',
+					'The output_path in the response is the exact vault location where the image will be saved — pass it to read_file once the task completes.',
 			},
 		},
 		required: ['prompt'],
@@ -90,24 +90,36 @@ export class GenerateImageTool implements Tool {
 
 				// Capture the active file now — it may change while the task is in flight.
 				// Used as the attachment-folder reference when no explicit output_path is given.
-				const activeFilePath = plugin.app.workspace.getActiveFile()?.path ?? null;
+				const activeFilePath = plugin.app.workspace.getActiveFile()?.path ?? undefined;
+				const referenceNotePath = params.target_note ?? activeFilePath;
+
+				// Pre-resolve the output path at submit time so the agent has a concrete
+				// vault path to read_file later. Without this we'd return null and the
+				// agent would have to guess the timestamped attachment-folder path.
+				let resolvedOutputPath: string;
+				try {
+					resolvedOutputPath = params.output_path
+						? params.output_path
+						: await plugin.imageGeneration.resolveDefaultOutputPath(params.prompt, referenceNotePath);
+				} catch (error) {
+					return {
+						success: false,
+						error: `Failed to resolve image output path: ${error instanceof Error ? error.message : String(error)}`,
+					};
+				}
 
 				const imageGeneration = plugin.imageGeneration;
 				const label = params.prompt.length > 40 ? params.prompt.slice(0, 37) + '…' : params.prompt;
 				const taskId = plugin.backgroundTaskManager.submit('image-generation', label, async (isCancelled) => {
 					if (isCancelled()) return undefined;
-					return imageGeneration.generateImage(
-						params.prompt,
-						params.target_note ?? activeFilePath ?? undefined,
-						params.output_path
-					);
+					// Always pass the pre-resolved path as the explicit outputPath so the
+					// task writes exactly where we told the agent it would land.
+					return imageGeneration.generateImage(params.prompt, referenceNotePath, resolvedOutputPath);
 				});
 
 				return {
 					success: true,
-					// output_path is null when not provided — the image lands in the vault's
-					// configured attachment folder; the agent should use find_files_by_name to locate it.
-					data: { taskId, output_path: params.output_path ?? null },
+					data: { taskId, output_path: resolvedOutputPath },
 				};
 			}
 

--- a/src/tools/image-tools.ts
+++ b/src/tools/image-tools.ts
@@ -94,13 +94,17 @@ export class GenerateImageTool implements Tool {
 				const referenceNotePath = params.target_note ?? activeFilePath;
 
 				// Pre-resolve the output path at submit time so the agent has a concrete
-				// vault path to read_file later. Without this we'd return null and the
-				// agent would have to guess the timestamped attachment-folder path.
+				// vault path to read_file later. resolveOutputPath handles both the
+				// explicit-path case (validation + .png extension rewrite) and the
+				// default attachment-folder case — so the path we return here always
+				// matches where the task will actually write.
 				let resolvedOutputPath: string;
 				try {
-					resolvedOutputPath = params.output_path
-						? params.output_path
-						: await plugin.imageGeneration.resolveDefaultOutputPath(params.prompt, referenceNotePath);
+					resolvedOutputPath = await plugin.imageGeneration.resolveOutputPath(
+						params.prompt,
+						referenceNotePath,
+						params.output_path
+					);
 				} catch (error) {
 					return {
 						success: false,

--- a/test/tools/image-tools.test.ts
+++ b/test/tools/image-tools.test.ts
@@ -4,6 +4,7 @@ import { ToolExecutionContext } from '../../src/tools/types';
 // Mock the image generation service
 const mockImageGeneration = {
 	generateImage: jest.fn(),
+	resolveDefaultOutputPath: jest.fn(),
 };
 
 const mockBackgroundTaskManager = {
@@ -217,11 +218,39 @@ describe('ImageTools', () => {
 			expect(label.endsWith('…')).toBe(true);
 		});
 
-		it('returns null output_path when none provided (image lands in attachment folder)', async () => {
+		it('pre-resolves output_path via attachment folder when none provided', async () => {
+			mockImageGeneration.resolveDefaultOutputPath.mockResolvedValue('attachments/generated-a-dog-12345.png');
+
 			const result = await tool.execute({ prompt: 'a dog', background: true }, mockContext);
 
 			expect(result.success).toBe(true);
-			expect(result.data.output_path).toBeNull();
+			expect(result.data.output_path).toBe('attachments/generated-a-dog-12345.png');
+			// Resolution uses the prompt and the active file as the attachment-folder reference
+			expect(mockImageGeneration.resolveDefaultOutputPath).toHaveBeenCalledWith('a dog', 'active-note.md');
+		});
+
+		it('uses explicit output_path without consulting resolveDefaultOutputPath', async () => {
+			const result = await tool.execute(
+				{ prompt: 'a dog', background: true, output_path: 'pictures/dog.png' },
+				mockContext
+			);
+
+			expect(result.success).toBe(true);
+			expect(result.data.output_path).toBe('pictures/dog.png');
+			expect(mockImageGeneration.resolveDefaultOutputPath).not.toHaveBeenCalled();
+		});
+
+		it('returns a tool error when path resolution fails (no active file, no target_note)', async () => {
+			mockImageGeneration.resolveDefaultOutputPath.mockRejectedValue(
+				new Error('No active file and no target note path provided')
+			);
+
+			const result = await tool.execute({ prompt: 'a cat', background: true }, mockContext);
+
+			expect(result.success).toBe(false);
+			expect(result.error).toContain('Failed to resolve image output path');
+			expect(result.error).toContain('No active file');
+			expect(mockBackgroundTaskManager.submit).not.toHaveBeenCalled();
 		});
 
 		it('returns error when BackgroundTaskManager is unavailable', async () => {
@@ -236,27 +265,36 @@ describe('ImageTools', () => {
 			expect(result.error).toContain('Background task manager not available');
 		});
 
-		it('callback invokes generateImage with prompt, active file as target_note, and no output_path', async () => {
+		it('callback invokes generateImage with the pre-resolved output_path', async () => {
+			mockImageGeneration.resolveDefaultOutputPath.mockResolvedValue('attachments/result.png');
 			mockImageGeneration.generateImage.mockResolvedValue('attachments/result.png');
 
 			await tool.execute({ prompt: 'a sunset', background: true }, mockContext);
 
 			const callback = mockBackgroundTaskManager.submit.mock.calls[0][2];
-			const outputPath = await callback(() => false);
+			const returnedPath = await callback(() => false);
 
-			expect(mockImageGeneration.generateImage).toHaveBeenCalledWith('a sunset', 'active-note.md', undefined);
-			expect(outputPath).toBe('attachments/result.png');
+			// The resolved path is passed through as the explicit outputPath so the
+			// task writes exactly where we told the agent it would land.
+			expect(mockImageGeneration.generateImage).toHaveBeenCalledWith(
+				'a sunset',
+				'active-note.md',
+				'attachments/result.png'
+			);
+			expect(returnedPath).toBe('attachments/result.png');
 		});
 
 		it('callback uses explicit target_note over captured active file', async () => {
-			mockImageGeneration.generateImage.mockResolvedValue('attachments/result.png');
+			mockImageGeneration.resolveDefaultOutputPath.mockResolvedValue('my-folder/result.png');
+			mockImageGeneration.generateImage.mockResolvedValue('my-folder/result.png');
 
 			await tool.execute({ prompt: 'a fox', background: true, target_note: 'my-note.md' }, mockContext);
 
 			const callback = mockBackgroundTaskManager.submit.mock.calls[0][2];
 			await callback(() => false);
 
-			expect(mockImageGeneration.generateImage).toHaveBeenCalledWith('a fox', 'my-note.md', undefined);
+			expect(mockImageGeneration.resolveDefaultOutputPath).toHaveBeenCalledWith('a fox', 'my-note.md');
+			expect(mockImageGeneration.generateImage).toHaveBeenCalledWith('a fox', 'my-note.md', 'my-folder/result.png');
 		});
 
 		it('callback returns undefined when cancelled', async () => {

--- a/test/tools/image-tools.test.ts
+++ b/test/tools/image-tools.test.ts
@@ -4,7 +4,7 @@ import { ToolExecutionContext } from '../../src/tools/types';
 // Mock the image generation service
 const mockImageGeneration = {
 	generateImage: jest.fn(),
-	resolveDefaultOutputPath: jest.fn(),
+	resolveOutputPath: jest.fn(),
 };
 
 const mockBackgroundTaskManager = {
@@ -185,6 +185,11 @@ describe('ImageTools', () => {
 		beforeEach(() => {
 			tool = new GenerateImageTool();
 			jest.clearAllMocks();
+			// Default: the resolver echoes back the explicit output_path (or a generic
+			// default if not provided). Individual tests override as needed.
+			mockImageGeneration.resolveOutputPath.mockImplementation(
+				async (_prompt: string, _target: string | undefined, explicit?: string) => explicit ?? 'attachments/default.png'
+			);
 		});
 
 		it('returns taskId and output_path immediately without calling generateImage', async () => {
@@ -219,37 +224,44 @@ describe('ImageTools', () => {
 		});
 
 		it('pre-resolves output_path via attachment folder when none provided', async () => {
-			mockImageGeneration.resolveDefaultOutputPath.mockResolvedValue('attachments/generated-a-dog-12345.png');
+			mockImageGeneration.resolveOutputPath.mockResolvedValue('attachments/generated-a-dog-12345.png');
 
 			const result = await tool.execute({ prompt: 'a dog', background: true }, mockContext);
 
 			expect(result.success).toBe(true);
 			expect(result.data.output_path).toBe('attachments/generated-a-dog-12345.png');
-			// Resolution uses the prompt and the active file as the attachment-folder reference
-			expect(mockImageGeneration.resolveDefaultOutputPath).toHaveBeenCalledWith('a dog', 'active-note.md');
+			// Resolver is called with the prompt, active file as reference, and no explicit path
+			expect(mockImageGeneration.resolveOutputPath).toHaveBeenCalledWith('a dog', 'active-note.md', undefined);
 		});
 
-		it('uses explicit output_path without consulting resolveDefaultOutputPath', async () => {
+		it('routes explicit output_path through the service resolver so validation applies', async () => {
+			// The service normalises .jpg → .png when validating — caller and resolver see
+			// the same final path so the agent isn't lied to.
+			mockImageGeneration.resolveOutputPath.mockResolvedValue('pictures/dog.png');
+
 			const result = await tool.execute(
-				{ prompt: 'a dog', background: true, output_path: 'pictures/dog.png' },
+				{ prompt: 'a dog', background: true, output_path: 'pictures/dog.jpg' },
 				mockContext
 			);
 
 			expect(result.success).toBe(true);
 			expect(result.data.output_path).toBe('pictures/dog.png');
-			expect(mockImageGeneration.resolveDefaultOutputPath).not.toHaveBeenCalled();
+			expect(mockImageGeneration.resolveOutputPath).toHaveBeenCalledWith('a dog', 'active-note.md', 'pictures/dog.jpg');
 		});
 
-		it('returns a tool error when path resolution fails (no active file, no target_note)', async () => {
-			mockImageGeneration.resolveDefaultOutputPath.mockRejectedValue(
-				new Error('No active file and no target note path provided')
+		it('returns a tool error synchronously when the resolver throws (invalid path or no reference)', async () => {
+			mockImageGeneration.resolveOutputPath.mockRejectedValue(
+				new Error('Output path cannot be inside the plugin state folder')
 			);
 
-			const result = await tool.execute({ prompt: 'a cat', background: true }, mockContext);
+			const result = await tool.execute(
+				{ prompt: 'a cat', background: true, output_path: 'gemini-scribe/bad.png' },
+				mockContext
+			);
 
 			expect(result.success).toBe(false);
 			expect(result.error).toContain('Failed to resolve image output path');
-			expect(result.error).toContain('No active file');
+			expect(result.error).toContain('plugin state folder');
 			expect(mockBackgroundTaskManager.submit).not.toHaveBeenCalled();
 		});
 
@@ -266,7 +278,7 @@ describe('ImageTools', () => {
 		});
 
 		it('callback invokes generateImage with the pre-resolved output_path', async () => {
-			mockImageGeneration.resolveDefaultOutputPath.mockResolvedValue('attachments/result.png');
+			mockImageGeneration.resolveOutputPath.mockResolvedValue('attachments/result.png');
 			mockImageGeneration.generateImage.mockResolvedValue('attachments/result.png');
 
 			await tool.execute({ prompt: 'a sunset', background: true }, mockContext);
@@ -285,7 +297,7 @@ describe('ImageTools', () => {
 		});
 
 		it('callback uses explicit target_note over captured active file', async () => {
-			mockImageGeneration.resolveDefaultOutputPath.mockResolvedValue('my-folder/result.png');
+			mockImageGeneration.resolveOutputPath.mockResolvedValue('my-folder/result.png');
 			mockImageGeneration.generateImage.mockResolvedValue('my-folder/result.png');
 
 			await tool.execute({ prompt: 'a fox', background: true, target_note: 'my-note.md' }, mockContext);
@@ -293,7 +305,7 @@ describe('ImageTools', () => {
 			const callback = mockBackgroundTaskManager.submit.mock.calls[0][2];
 			await callback(() => false);
 
-			expect(mockImageGeneration.resolveDefaultOutputPath).toHaveBeenCalledWith('a fox', 'my-note.md');
+			expect(mockImageGeneration.resolveOutputPath).toHaveBeenCalledWith('a fox', 'my-note.md', undefined);
 			expect(mockImageGeneration.generateImage).toHaveBeenCalledWith('a fox', 'my-note.md', 'my-folder/result.png');
 		});
 


### PR DESCRIPTION
## Summary

Closes #659.

When the agent calls \`generate_image\` with \`background: true\` and no explicit \`output_path\`, the tool used to return \`{ taskId, output_path: null }\` and the actual save location was only known internally inside \`ImageGeneration\` after the task ran. The agent had no programmatic way to retrieve the result — the agent rules said "always provide output_path" but if the agent forgot, the file was effectively unreachable.

This PR pre-resolves the path at submit time using the same attachment-folder logic the foreground path already uses (\`getAvailablePathForAttachment\` with the active file or \`target_note\` as the reference), then passes that resolved path through to \`generateImage\` as the explicit \`outputPath\`. The agent always gets back a real path it can \`read_file\` once the task completes. Mirrors how \`deep_research\` already handles its background output path.

## Changes

- **\`src/services/image-generation.ts\`** — extract \`resolveDefaultOutputPath\` as a public helper (along with private \`buildDefaultFilename\` / \`resolveReferenceNotePath\` to avoid drift). Refactor \`saveImageToVault\`'s no-\`outputPath\` branch to use the same helper. No behavior change for the foreground path.
- **\`src/tools/image-tools.ts\`** — in background mode, call \`resolveDefaultOutputPath\` when no \`output_path\` is provided. Surface resolution failures (e.g. no active file and no \`target_note\`) as a tool error returned synchronously, instead of letting them blow up inside the background task callback minutes later.
- **\`prompts/agentRulesPrompt.hbs\`** — update background-tasks guidance: the returned \`output_path\` is always populated, so the agent doesn't need to supply one. It may still pass an explicit value to override the default location.
- **Tool description and parameter doc** updated to match the new contract.
- **3 new tests** in \`test/tools/image-tools.test.ts\`:
  - Pre-resolution succeeds and the resolved path is returned + passed through to \`generateImage\`.
  - Explicit \`output_path\` bypasses the resolver.
  - Resolution failure (no active file, no \`target_note\`) returns a tool error and does NOT submit a doomed background task.

## Behavior change

Background \`generate_image\` calls without \`output_path\` previously returned \`null\`; they now return the actual destination path. Calls *with* an explicit \`output_path\` are unaffected. Foreground mode is untouched.

## Test plan

- [x] \`npm test\` — all 1,380 tests pass
- [x] \`npm run build\` — clean
- [x] \`npm run format-check\` — clean
- [ ] Manual: agent generates an image with \`background: true\` and no \`output_path\` → the immediate response contains a real \`output_path\`; the file actually lands at that path; \`read_file\` on it succeeds (in progress)
- [ ] Manual: agent provides explicit \`output_path\` → image still lands at the requested location

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer (#659)
- [x] All CI checks pass (\`npm test\`, \`npm run build\`, \`npm run format-check\`)
- [x] I have tested this change on Desktop
- [ ] I have verified this change does not break Mobile — no platform-specific APIs touched; \`getAvailablePathForAttachment\` is mobile-safe
- [x] Documentation has been updated (if applicable) — agent rules prompt and tool descriptions updated to reflect new contract
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Background image generation now always returns a concrete vault output path alongside the task ID; the path is ready to use for reading the file.
  * Defaults are computed and returned when no output path is provided; explicit paths are validated/normalized and may override defaults.
  * Filenames are made unique by including timestamp and random suffixes.

* **Bug Fixes**
  * Failures to resolve output paths are surfaced immediately, preventing submission of unwritable background tasks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->