### PR TITLE
fix: normalize list_files path to handle trailing slashes

### DIFF
--- a/__mocks__/obsidian.js
+++ b/__mocks__/obsidian.js
@@ -115,7 +115,13 @@ const MarkdownRenderer = {
 
 const setIcon = jest.fn();
 const Notice = jest.fn();
-const normalizePath = jest.fn((path) => path);
+// Mirrors Obsidian's normalizePath: collapses duplicate slashes, converts
+// backslashes, strips leading/trailing slashes, and returns '/' for empty input.
+const normalizePath = jest.fn((path) => {
+	if (path == null || /^\s*$/.test(path)) return '/';
+	const collapsed = path.replace(/[\\/]+/g, '/').replace(/(^\/+|\/+$)/g, '');
+	return collapsed || '/';
+});
 // Minimal Obsidian `debounce` mock. Queues the latest args on each call without
 // firing; `run()` drains the queue and invokes the callback; `cancel()` clears
 // it. This matches Obsidian's real debounce semantics (deferred firing) so

--- a/src/tools/vault/list-files-tool.ts
+++ b/src/tools/vault/list-files-tool.ts
@@ -1,7 +1,7 @@
 import { Tool, ToolResult, ToolExecutionContext } from '../types';
 import { ToolCategory } from '../../types/agent';
 import { ToolClassification } from '../../types/tool-policy';
-import { TFile, TFolder } from 'obsidian';
+import { TFile, TFolder, normalizePath } from 'obsidian';
 import type ObsidianGemini from '../../main';
 import { shouldExcludePathForPlugin as shouldExcludePath } from '../../utils/file-utils';
 
@@ -43,9 +43,14 @@ export class ListFilesTool implements Tool {
 		const plugin = context.plugin as ObsidianGemini;
 
 		try {
-			// Default to project root when no path specified and project is active
-			const folderPath = params.path || context.projectRootPath || '';
-			const folder = plugin.app.vault.getAbstractFileByPath(folderPath);
+			// Default to project root when no path specified and project is active.
+			// Normalize to strip trailing slashes and collapse duplicates; empty string stays
+			// empty to preserve "list vault root" semantics. Obsidian's normalizePath("") === "/",
+			// and "/" is also treated as the root shorthand.
+			const rawPath = params.path || context.projectRootPath || '';
+			const normalized = rawPath ? normalizePath(rawPath) : '';
+			const folderPath = normalized === '/' ? '' : normalized;
+			const folder = folderPath ? plugin.app.vault.getAbstractFileByPath(folderPath) : null;
 
 			if (folderPath && !folder) {
 				return {

--- a/src/tools/vault/list-files-tool.ts
+++ b/src/tools/vault/list-files-tool.ts
@@ -52,17 +52,21 @@ export class ListFilesTool implements Tool {
 			const folderPath = normalized === '/' ? '' : normalized;
 			const folder = folderPath ? plugin.app.vault.getAbstractFileByPath(folderPath) : null;
 
+			// Show the resolved path in errors — `params.path` may be empty when
+			// falling back to `context.projectRootPath`, which would render blank.
+			const displayPath = folderPath || params.path || '(vault root)';
+
 			if (folderPath && !folder) {
 				return {
 					success: false,
-					error: `Folder not found: ${params.path}`,
+					error: `Folder not found: ${displayPath}`,
 				};
 			}
 
 			if (folderPath && !(folder instanceof TFolder)) {
 				return {
 					success: false,
-					error: `Path is not a folder: ${params.path}`,
+					error: `Path is not a folder: ${displayPath}`,
 				};
 			}
 

--- a/test/tools/vault-tools.test.ts
+++ b/test/tools/vault-tools.test.ts
@@ -34,7 +34,11 @@ jest.mock('../../src/files', () => ({
 // Use the existing mock by extending it
 jest.mock('obsidian', () => ({
 	...jest.requireActual('../../__mocks__/obsidian.js'),
-	normalizePath: jest.fn((path: string) => path),
+	normalizePath: jest.fn((path: string) => {
+		if (path == null || /^\s*$/.test(path)) return '/';
+		const collapsed = path.replace(/[\\/]+/g, '/').replace(/(^\/+|\/+$)/g, '');
+		return collapsed || '/';
+	}),
 	TFolder: class TFolder {
 		path: string;
 		name: string;
@@ -586,6 +590,31 @@ describe('VaultTools', () => {
 			expect(result.success).toBe(true);
 			expect(result.data?.count).toBe(1);
 			expect(result.data?.files[0].name).toBe('note.md');
+		});
+
+		it('should strip a trailing slash before folder lookup', async () => {
+			// Obsidian stores folder paths without trailing slashes, so
+			// getAbstractFileByPath('Areas/People/') would return null.
+			// The tool must normalize the path before lookup.
+			mockVault.getAbstractFileByPath.mockImplementation((p: string) => (p === 'Areas/People' ? mockFolder : null));
+
+			const result = await tool.execute({ path: 'Areas/People/' }, mockContext);
+
+			expect(result.success).toBe(true);
+			expect(mockVault.getAbstractFileByPath).toHaveBeenCalledWith('Areas/People');
+			expect(result.data?.path).toBe('Areas/People');
+		});
+
+		it('should treat "/" as the vault root', async () => {
+			const rootFolder = new TFolder();
+			rootFolder.children = [mockFile];
+			mockVault.getRoot.mockReturnValue(rootFolder);
+
+			const result = await tool.execute({ path: '/' }, mockContext);
+
+			expect(result.success).toBe(true);
+			expect(result.data?.path).toBe('');
+			expect(result.data?.count).toBe(1);
 		});
 
 		it('should include non-markdown files in recursive listing', async () => {

--- a/test/tools/vault-tools.test.ts
+++ b/test/tools/vault-tools.test.ts
@@ -34,11 +34,6 @@ jest.mock('../../src/files', () => ({
 // Use the existing mock by extending it
 jest.mock('obsidian', () => ({
 	...jest.requireActual('../../__mocks__/obsidian.js'),
-	normalizePath: jest.fn((path: string) => {
-		if (path == null || /^\s*$/.test(path)) return '/';
-		const collapsed = path.replace(/[\\/]+/g, '/').replace(/(^\/+|\/+$)/g, '');
-		return collapsed || '/';
-	}),
 	TFolder: class TFolder {
 		path: string;
 		name: string;


### PR DESCRIPTION
## Summary

`list_files` was the only vault tool that did not normalize its path before calling `vault.getAbstractFileByPath()`. Obsidian stores folder paths without trailing slashes, so `list_files("Areas/People/")` returned "Folder not found" while `list_files("Areas/People")` succeeded. An agent running a multi-tool skill got confused by this inconsistency — it saw the list fail, tried `create_folder("Areas/People")` (which correctly normalizes), was told the folder already existed, then listed successfully with the un-slashed path.

Every other vault tool (`read_file`, `write_file`, `create_folder`, `move_file`, `delete_file`) already calls `normalizePath()`. This PR brings `list_files` in line.

## Changes

- `src/tools/vault/list-files-tool.ts` — import `normalizePath` and apply it to non-empty paths; treat `/` as the vault-root shorthand; preserve the "empty string means root" semantics.
- `test/tools/vault-tools.test.ts` — two regression tests: trailing-slash input resolves to the normalized folder, and `/` is treated as the root.
- `__mocks__/obsidian.js` and the local mock override in `vault-tools.test.ts` — upgrade the `normalizePath` mock from pass-through to a faithful implementation (collapse duplicate/backslashes, strip leading and trailing slashes, return `/` for empty input). Required so the regression tests actually exercise the bug.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — small bug fix authored by the maintainer; no separate issue
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards) — tool runs identically on mobile; no platform-specific code touched
- [ ] Documentation has been updated (if applicable) — N/A; internal bug fix with no user-facing doc surface
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved path normalization used when listing files: handles trailing/duplicate slashes and treats root references consistently so listings and error messages reflect the resolved location.

* **Tests**
  * Added tests covering normalization behavior and explicit root-directory handling to ensure correct lookup and returned metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->