### PR TITLE
fix: mobile agent view layout on iOS (#668)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { Plugin, WorkspaceLeaf, Editor, MarkdownView, MarkdownFileInfo } from 'obsidian';
+import { Plugin, WorkspaceLeaf, Editor, MarkdownView, MarkdownFileInfo, Platform } from 'obsidian';
 import ObsidianGeminiSettingTab from './ui/settings';
 import { AgentView, VIEW_TYPE_AGENT } from './ui/agent-view/agent-view';
 import { GeminiDiffView } from './ui/agent-view/gemini-diff-view';
@@ -651,13 +651,34 @@ export default class ObsidianGemini extends Plugin {
 		let leaf: WorkspaceLeaf | null = null;
 		const leaves = workspace.getLeavesOfType(VIEW_TYPE_AGENT);
 
+		// On mobile, prefer a main-area tab so the agent view gets the full screen
+		// instead of a cramped slide-out drawer. If an existing leaf lives in a
+		// sidebar (leftover from a prior install), detach it so we can create a
+		// fresh main-area leaf.
+		if (Platform.isMobile) {
+			const rootSplit = workspace.rootSplit;
+			const mainLeaf = leaves.find((l) => l.getRoot() === rootSplit) ?? null;
+			if (mainLeaf) {
+				leaf = mainLeaf;
+				await workspace.revealLeaf(leaf);
+			} else {
+				for (const sidebarLeaf of leaves) sidebarLeaf.detach();
+				leaf = workspace.getLeaf('tab');
+				if (leaf) {
+					await leaf.setViewState({ type: VIEW_TYPE_AGENT, active: true });
+					await workspace.revealLeaf(leaf);
+				} else {
+					this.logger.error('Could not find a leaf to open the agent view');
+				}
+			}
+			return;
+		}
+
 		if (leaves.length > 0) {
 			// A leaf with our view already exists, use that
 			leaf = leaves[0];
 			await workspace.revealLeaf(leaf);
 		} else {
-			// Our view could not be found in the workspace, create a new leaf
-			// in the right sidebar for it
 			leaf = workspace.getRightLeaf(false);
 			if (leaf) {
 				await leaf.setViewState({ type: VIEW_TYPE_AGENT, active: true });

--- a/src/ui/agent-view/agent-view.ts
+++ b/src/ui/agent-view/agent-view.ts
@@ -1,4 +1,4 @@
-import { ItemView, MarkdownView, WorkspaceLeaf, TFile, Notice } from 'obsidian';
+import { ItemView, MarkdownView, Platform, WorkspaceLeaf, TFile, Notice } from 'obsidian';
 import { ChatSession, SessionModelConfig } from '../../types/agent';
 import { GeminiConversationEntry } from '../../types/conversation';
 import type ObsidianGemini from '../../main';
@@ -90,8 +90,90 @@ export class AgentView extends ItemView {
 		// Register link click handler for internal links
 		this.registerLinkClickHandler();
 
+		if (Platform.isMobile) {
+			this.applyMobileLayoutFix(container as HTMLElement);
+		}
+
 		// Create default agent session
 		await this.createNewSession();
+	}
+
+	// Obsidian mobile's bottom nav/toolbar floats over view-content on iOS.
+	// Locating it lets us dock the input above it rather than behind it.
+	private findMobileNavbar(): HTMLElement | null {
+		const selectors = [
+			'.app-container .mobile-navbar',
+			'.app-container .mobile-toolbar',
+			'.mobile-navbar',
+			'.mobile-toolbar',
+			'.mod-mobile-toolbar',
+		];
+		for (const sel of selectors) {
+			const el = document.querySelector<HTMLElement>(sel);
+			if (el && el.offsetHeight > 0) return el;
+		}
+		return null;
+	}
+
+	/**
+	 * iOS WebKit inside Obsidian mobile has two bugs that break the agent
+	 * view layout:
+	 *   1. Flex-grow fails to expand the chat area when the container
+	 *      resizes for the keyboard, so the chat collapses to ~24px.
+	 *   2. Focusing the input scrolls an ancestor to "reveal" it, which
+	 *      pushes our children off-screen.
+	 * We compute chat's height directly (targeting the smaller of container
+	 * bottom or mobile-navbar top) and lock overflow on the container and
+	 * its parent so nothing can scroll behind our back. setProperty with
+	 * 'important' is defensive — themes or other plugins sometimes add
+	 * `!important` to flex rules that would otherwise beat inline styles.
+	 */
+	private applyMobileLayoutFix(container: HTMLElement) {
+		const apply = () => {
+			const chat = container.querySelector<HTMLElement>('.gemini-agent-chat');
+			const iarea = container.querySelector<HTMLElement>('.gemini-agent-input-area');
+			if (!chat || !iarea) return;
+			const ctrBottom = container.getBoundingClientRect().bottom;
+			const navbarTop = this.findMobileNavbar()?.getBoundingClientRect().top ?? Infinity;
+			const targetBottom = Math.min(ctrBottom, navbarTop);
+			chat.style.setProperty('flex-grow', '0', 'important');
+			chat.style.setProperty('flex-shrink', '0', 'important');
+			chat.style.setProperty('flex-basis', 'auto', 'important');
+			for (let i = 0; i < 3; i++) {
+				const delta = targetBottom - iarea.getBoundingClientRect().bottom;
+				if (Math.abs(delta) < 1) break;
+				const newH = Math.max(0, chat.offsetHeight + delta);
+				chat.style.setProperty('height', `${newH}px`, 'important');
+				void chat.offsetHeight;
+			}
+		};
+		apply();
+
+		const ro = new ResizeObserver(() => apply());
+		ro.observe(container);
+		const iarea = container.querySelector<HTMLElement>('.gemini-agent-input-area');
+		if (iarea) ro.observe(iarea);
+
+		const vv = window.visualViewport;
+		vv?.addEventListener('resize', apply);
+
+		container.style.setProperty('overflow', 'hidden', 'important');
+		const parent = container.parentElement;
+		parent?.style.setProperty('overflow', 'hidden', 'important');
+		const onScroll = () => {
+			if (container.scrollTop !== 0) container.scrollTop = 0;
+			if (parent && parent.scrollTop !== 0) parent.scrollTop = 0;
+			apply();
+		};
+		container.addEventListener('scroll', onScroll, { passive: true });
+		parent?.addEventListener('scroll', onScroll, { passive: true });
+
+		this.register(() => {
+			ro.disconnect();
+			vv?.removeEventListener('resize', apply);
+			container.removeEventListener('scroll', onScroll);
+			parent?.removeEventListener('scroll', onScroll);
+		});
 	}
 
 	private async createAgentInterface(container: HTMLElement) {

--- a/src/ui/agent-view/agent-view.ts
+++ b/src/ui/agent-view/agent-view.ts
@@ -157,8 +157,21 @@ export class AgentView extends ItemView {
 		const vv = window.visualViewport;
 		vv?.addEventListener('resize', apply);
 
-		container.style.setProperty('overflow', 'hidden', 'important');
+		// Capture overflow before overriding so we can restore it on teardown.
+		// Obsidian reuses host elements across views; leaving `overflow: hidden`
+		// behind would make subsequent views non-scrollable.
 		const parent = container.parentElement;
+		const prevContainerOverflow = {
+			value: container.style.getPropertyValue('overflow'),
+			priority: container.style.getPropertyPriority('overflow'),
+		};
+		const prevParentOverflow = parent
+			? {
+					value: parent.style.getPropertyValue('overflow'),
+					priority: parent.style.getPropertyPriority('overflow'),
+				}
+			: null;
+		container.style.setProperty('overflow', 'hidden', 'important');
 		parent?.style.setProperty('overflow', 'hidden', 'important');
 		const onScroll = () => {
 			if (container.scrollTop !== 0) container.scrollTop = 0;
@@ -173,6 +186,18 @@ export class AgentView extends ItemView {
 			vv?.removeEventListener('resize', apply);
 			container.removeEventListener('scroll', onScroll);
 			parent?.removeEventListener('scroll', onScroll);
+			if (prevContainerOverflow.value) {
+				container.style.setProperty('overflow', prevContainerOverflow.value, prevContainerOverflow.priority);
+			} else {
+				container.style.removeProperty('overflow');
+			}
+			if (parent && prevParentOverflow) {
+				if (prevParentOverflow.value) {
+					parent.style.setProperty('overflow', prevParentOverflow.value, prevParentOverflow.priority);
+				} else {
+					parent.style.removeProperty('overflow');
+				}
+			}
 		});
 	}
 

--- a/styles.css
+++ b/styles.css
@@ -1146,6 +1146,7 @@ If your plugin does not need CSS, delete this file.
 /* Chat Container */
 .gemini-agent-chat {
 	flex: 1;
+	min-height: 0;
 	overflow-y: auto;
 	padding: var(--size-4-3);
 	background-color: var(--background-primary);
@@ -1362,6 +1363,16 @@ If your plugin does not need CSS, delete this file.
 	background-color: var(--background-secondary);
 	border-top: 1px solid var(--background-modifier-border);
 	flex-shrink: 0;
+}
+
+/* On mobile, Obsidian draws a navbar/toolbar at the bottom of the view. A
+   small bottom padding ensures the input row clears the home-indicator area.
+   Avoid env(safe-area-inset-bottom) here: on iOS Obsidian's WKWebView it
+   reports the virtual keyboard height while the keyboard is open, which
+   inflates this element by hundreds of pixels and shoves the input off
+   screen when typing. A fixed pad is safer than a misreported env(). */
+.is-mobile .gemini-agent-input-area {
+	padding-bottom: var(--size-4-3);
 }
 
 /* Wrapper for input + send button */


### PR DESCRIPTION
## Summary

Fixes #668. The agent view's input was unusable on iOS Obsidian — focusing it triggered a "double jump" where the layout shifted twice, the chat area collapsed to ~24px, and the input ended up behind the virtual keyboard or Obsidian's mobile nav bar. Reporters hit this on iOS 18 and Android.

Root causes (iOS WebKit inside Obsidian):
1. **Flex-grow fails** when the container resizes for the keyboard, so the chat collapses.
2. **iOS auto-scrolls ancestors** to reveal the focused input, pushing children off-screen.
3. **Mobile nav bar floats over view-content**, so a full-height container drops the input behind it.

## Changes

- On mobile, open the agent view as a main-area tab (full screen) instead of the right sidebar drawer. Existing sidebar leaves from prior installs are auto-detached.
- New `applyMobileLayoutFix()` computes chat height explicitly, targeting `min(container.bottom, mobile-navbar.top)`, so the input docks above the keyboard when open and above the nav bar when closed. Uses `getBoundingClientRect()` (viewport coords) throughout to avoid `offsetParent` ambiguity.
- Lock `overflow: hidden` on the container and its parent; reset `scrollTop = 0` on any scroll — blocks iOS's keyboard-reveal scroll from shifting our children.
- Re-applies on `ResizeObserver` (container + input area) and `visualViewport.resize` so the layout tracks keyboard toggles and multi-line input growth.
- Minor: `min-height: 0` on `.gemini-agent-chat` (flex-shrink trick) and mobile padding-bottom on the input area.

All new logic is gated behind `Platform.isMobile`, so desktop is untouched.

## Screenshots

Keyboard closed — input docks above Obsidian's mobile nav bar:

![Closed](https://github.com/user-attachments/assets/closed) <!-- replace with uploaded image if needed -->

Keyboard open — input docks above the keyboard, chat fills remaining space:

![Open](https://github.com/user-attachments/assets/open) <!-- replace with uploaded image if needed -->

## Test plan

- [x] Verified on iPhone (iOS) via iCloud-synced test vault — both keyboard states
- [x] Verified the full-screen tab behavior replaces the right-sidebar drawer on mobile
- [x] Desktop behavior unchanged (right sidebar still used) — all 1382 unit tests pass
- [ ] Android verification — requesting the #668 reporter (@JayadityaGit) confirm

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — verified on iOS; Android still needs reporter confirmation but all changes are guarded by `Platform.isMobile`
- [x] Documentation has been updated (if applicable) — N/A: fix only, no user-facing surface change
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved agent view behavior on mobile: reuses or relocates the main view when appropriate and avoids duplicate side views.
  * Enhanced chat layout and scrolling so messages stay visible above mobile UI and input area.

* **Style**
  * Adjusted chat container and input-area spacing for correct flex sizing and mobile clearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->