### PR TITLE
test: regression test for recall_sessions matching deleted-file refs

### DIFF
--- a/test/tools/session-recall-tool.test.ts
+++ b/test/tools/session-recall-tool.test.ts
@@ -130,6 +130,31 @@ describe('RecallSessionsTool', () => {
 		expect(titles).toEqual(['Has context']);
 	});
 
+	// Regression for #506: recall uses raw refs from frontmatter (no metadata-cache
+	// resolution), so a ref to a since-deleted file survives in accessedFileRefs and
+	// still matches. If someone reintroduces hydration here, this test will fail
+	// because the deleted file's ref would be dropped at the session-manager layer.
+	it('still matches sessions whose accessed_files ref a since-deleted file', async () => {
+		const withDeleted = makeSession({
+			id: 'a',
+			title: 'Touched a note that was later deleted',
+			accessedFileRefs: ['Deleted Note'],
+		});
+		const unrelated = makeSession({
+			id: 'b',
+			title: 'Unrelated',
+			accessedFileRefs: ['Other'],
+		});
+		const ctx = makeContext({
+			sessionManager: { getSessionMetadata: jest.fn().mockResolvedValue([withDeleted, unrelated]) },
+		});
+
+		const result = await getTool().execute({ filePath: 'Deleted Note' }, ctx);
+		expect(result.success).toBe(true);
+		const titles = (result.data as any).sessions.map((s: any) => s.title);
+		expect(titles).toEqual(['Touched a note that was later deleted']);
+	});
+
 	it('matches filePath with full vault path against basename refs (bidirectional)', async () => {
 		const matching = makeSession({
 			id: 'a',

--- a/test/tools/session-recall-tool.test.ts
+++ b/test/tools/session-recall-tool.test.ts
@@ -130,11 +130,15 @@ describe('RecallSessionsTool', () => {
 		expect(titles).toEqual(['Has context']);
 	});
 
-	// Regression for #506: recall uses raw refs from frontmatter (no metadata-cache
-	// resolution), so a ref to a since-deleted file survives in accessedFileRefs and
-	// still matches. If someone reintroduces hydration here, this test will fail
-	// because the deleted file's ref would be dropped at the session-manager layer.
-	it('still matches sessions whose accessed_files ref a since-deleted file', async () => {
+	// Recall-layer half of the #506 regression. SessionManager.getSessionMetadata
+	// is stubbed here, so this test only proves: given a ref string whose
+	// underlying file no longer exists in the vault, the recall filter still
+	// matches it (because matching is pure string-substring on the raw ref and
+	// never consults the metadata cache). The partner invariant — that
+	// getSessionMetadata itself preserves such refs by not resolving wikilinks —
+	// is covered in test/agent/session-manager.test.ts by the
+	// "should not call getFirstLinkpathDest (no TFile resolution)" test.
+	it('filter still matches a ref string even when its underlying file no longer exists', async () => {
 		const withDeleted = makeSession({
 			id: 'a',
 			title: 'Touched a note that was later deleted',


### PR DESCRIPTION
## Summary

Fixes #506. The bug described in #506 was incidentally resolved by #583 (2026-04-08, six days after #506 was filed). That PR switched `recall_sessions` away from the hydrated `accessedFiles: Set<TFile>` to a raw-refs path via `sessionManager.getSessionMetadata()` + `extractRawRefs()`. `extractRawRefs` only strips `[[ ]]` — no metadata-cache resolution — so a wikilink to a since-deleted file survives intact in `accessedFileRefs` and still matches via substring.

This PR is a **regression test only**. It makes the "deleted file still matches" scenario explicit in `session-recall-tool.test.ts` so nobody silently reintroduces hydration on the recall path. (The session-manager layer already has a partner test at `test/agent/session-manager.test.ts:612` asserting `getFirstLinkpathDest` is never called.)

No production code changes.

## Changes

- `test/tools/session-recall-tool.test.ts`: new test "still matches sessions whose accessed_files ref a since-deleted file" with a comment pointing to #506 / #583.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer (#506)
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop — 1383/1383 tests pass
- [x] I have verified this change does not break Mobile — test-only change, no runtime code touched
- [x] Documentation has been updated — N/A (test-only)
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a regression test to ensure the session recall feature reliably finds sessions referenced by a deleted note’s raw reference string, and only returns matching sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->