### PR TITLE
feat: unified activity modal with Background Tasks + RAG tabs (#656)

### DIFF
--- a/src/services/background-status-bar.ts
+++ b/src/services/background-status-bar.ts
@@ -41,7 +41,8 @@ export class BackgroundStatusBar {
 
 		this.statusBarItem.addEventListener('click', async () => {
 			const { BackgroundTasksModal } = await import('../ui/background-tasks-modal');
-			new BackgroundTasksModal(this.plugin.app, this.plugin).open();
+			const defaultTab = this.taskManager.runningCount > 0 ? 'tasks' : 'rag';
+			new BackgroundTasksModal(this.plugin.app, this.plugin, defaultTab).open();
 		});
 
 		this.update();

--- a/src/services/obsidian-file-adapter.ts
+++ b/src/services/obsidian-file-adapter.ts
@@ -132,8 +132,8 @@ export class ObsidianVaultAdapter implements FileSystemAdapter {
 				// Read text content
 				const content = await this.vault.read(file);
 
-				// Skip empty or very small text files
-				if (!content || content.trim().length < 10) {
+				// Skip truly empty files — very short content is still worth indexing
+				if (!content) {
 					return null;
 				}
 
@@ -182,10 +182,11 @@ export class ObsidianVaultAdapter implements FileSystemAdapter {
 			const hashArray = Array.from(new Uint8Array(hashBuffer));
 			return hashArray.map((b) => b.toString(16).padStart(2, '0')).join('');
 		} catch (error) {
-			// Throw error for existing files that fail to hash - prevents storing
-			// empty hashes that would break change detection in smartSync
-			const message = error instanceof Error ? error.message : String(error);
-			throw new Error(`Failed to compute hash for ${filePath}: ${message}`);
+			// Fall back to a metadata-based proxy hash so smart sync still tracks the
+			// file without throwing. mtime+size changes whenever the file changes, so
+			// change detection remains reliable even without a content hash.
+			this.logError?.(`Cannot read file content for hashing, using metadata fallback: ${filePath}`, error);
+			return `mtime:${file.stat.mtime}-size:${file.stat.size}`;
 		}
 	}
 

--- a/src/services/rag-vault-scanner.ts
+++ b/src/services/rag-vault-scanner.ts
@@ -391,7 +391,10 @@ export class RagVaultScanner {
 				parallel: { maxConcurrent: 5 },
 				logger: {
 					debug: (msg: string, ...args: any[]) => this.plugin.logger.debug(msg, ...args),
-					error: (msg: string, ...args: any[]) => this.plugin.logger.error(msg, ...args),
+					// Per-file upload failures are already tracked via the file_error progress
+					// event and surfaced in the RAG Failures tab — downgrade to warn to avoid
+					// alarming console noise for routine skips (empty files, inaccessible notes).
+					error: (msg: string, ...args: any[]) => this.plugin.logger.warn(msg, ...args),
 				},
 				onProgress: async (event: any) => {
 					// Check for cancellation

--- a/src/ui/background-tasks-modal.ts
+++ b/src/ui/background-tasks-modal.ts
@@ -3,6 +3,7 @@ import type ObsidianGemini from '../main';
 import type { BackgroundTask } from '../services/background-task-manager';
 import type { RagDetailedStatus } from './rag-status-modal';
 import type { ProgressListener } from '../services/rag-types';
+import type { RagIndexingService } from '../services/rag-indexing';
 import { getErrorMessage } from '../utils/error-utils';
 
 type ModalTab = 'tasks' | 'rag';
@@ -32,6 +33,7 @@ export class BackgroundTasksModal extends Modal {
 	private ragSearchQuery = '';
 	private ragShowAllFiles = false;
 	private ragDebounceTimer: ReturnType<typeof setTimeout> | null = null;
+	private ragFileScrollTop = 0;
 	private readonly RAG_MAX_FILES_INITIAL = 200;
 
 	constructor(app: App, plugin: ObsidianGemini, defaultTab?: ModalTab) {
@@ -334,6 +336,7 @@ export class BackgroundTasksModal extends Modal {
 				this.ragInnerTab = id;
 				this.ragShowAllFiles = false;
 				this.ragSearchQuery = '';
+				this.ragFileScrollTop = 0;
 				this.renderTabContent();
 			};
 			tab.addEventListener('click', activate);
@@ -352,7 +355,7 @@ export class BackgroundTasksModal extends Modal {
 		}
 	}
 
-	private renderRagInnerContent(container: HTMLElement, status: RagDetailedStatus, rag: any): void {
+	private renderRagInnerContent(container: HTMLElement, status: RagDetailedStatus, rag: RagIndexingService): void {
 		switch (this.ragInnerTab) {
 			case 'overview':
 				this.renderRagOverview(container, status, rag);
@@ -366,7 +369,7 @@ export class BackgroundTasksModal extends Modal {
 		}
 	}
 
-	private renderRagOverview(container: HTMLElement, status: RagDetailedStatus, rag: any): void {
+	private renderRagOverview(container: HTMLElement, status: RagDetailedStatus, rag: RagIndexingService): void {
 		const infoEl = container.createDiv({ cls: 'rag-status-info' });
 
 		// Status row
@@ -476,10 +479,17 @@ export class BackgroundTasksModal extends Modal {
 		const listContainer = container.createDiv({ cls: 'rag-status-file-list' });
 		this.renderRagFileList(listContainer, status);
 
+		// Restore scroll position (lost on progress-tick re-render)
+		listContainer.scrollTop = this.ragFileScrollTop;
+		listContainer.addEventListener('scroll', () => {
+			this.ragFileScrollTop = listContainer.scrollTop;
+		});
+
 		searchInput.addEventListener('input', (e) => {
 			if (this.ragDebounceTimer) clearTimeout(this.ragDebounceTimer);
 			this.ragDebounceTimer = setTimeout(() => {
 				this.ragSearchQuery = (e.target as HTMLInputElement).value;
+				this.ragFileScrollTop = 0;
 				this.renderRagFileList(listContainer, status);
 			}, 150);
 		});
@@ -508,24 +518,17 @@ export class BackgroundTasksModal extends Modal {
 		const display = this.ragShowAllFiles ? filtered : filtered.slice(0, this.RAG_MAX_FILES_INITIAL);
 
 		for (const file of display) {
-			const item = container.createDiv({
+			const item = container.createEl('button', {
 				cls: 'rag-status-file-item rag-status-file-item--clickable',
-				attr: { role: 'button', tabindex: '0', 'aria-label': `Open ${file.path}` },
+				attr: { 'aria-label': `Open ${file.path}` },
 			});
 			const pathEl = item.createSpan({ cls: 'rag-status-file-path' });
 			pathEl.setText(file.path);
 			pathEl.setAttribute('title', file.path);
 			item.createSpan({ cls: 'rag-status-file-time', text: this.formatRagDate(file.lastIndexed) });
-			const open = () => {
+			item.addEventListener('click', () => {
 				this.close();
 				this.plugin.app.workspace.openLinkText(file.path, '', false);
-			};
-			item.addEventListener('click', open);
-			item.addEventListener('keydown', (e) => {
-				if (e.key === 'Enter' || e.key === ' ') {
-					e.preventDefault();
-					open();
-				}
 			});
 		}
 

--- a/src/ui/background-tasks-modal.ts
+++ b/src/ui/background-tasks-modal.ts
@@ -1,44 +1,167 @@
-import { App, Modal, setIcon } from 'obsidian';
+import { App, Modal, Notice, Setting, setIcon } from 'obsidian';
 import type ObsidianGemini from '../main';
 import type { BackgroundTask } from '../services/background-task-manager';
+import type { RagDetailedStatus } from './rag-status-modal';
+import type { ProgressListener } from '../services/rag-types';
+import { getErrorMessage } from '../utils/error-utils';
+
+type ModalTab = 'tasks' | 'rag';
+type RagInnerTab = 'overview' | 'files' | 'failures';
 
 /**
- * Modal that lists all running and recently completed background tasks.
- * Opened by clicking the status bar indicator or via the command palette.
- * Subscribes to AgentEventBus so it live-updates while open.
+ * Unified "Gemini Activity" modal with two top-level tabs:
+ *   - Background Tasks — running + recent tasks (live-updates via AgentEventBus)
+ *   - RAG             — indexing status, progress, and controls (live-updates via ProgressListener)
+ *
+ * Default tab: Background Tasks when any task is running, otherwise RAG (if enabled).
+ * When RAG is disabled and no tasks are running the status bar is hidden, so this
+ * modal is never opened in that state.
+ *
+ * Command-palette entry for the standalone RagStatusModal is unchanged.
  */
 export class BackgroundTasksModal extends Modal {
 	private plugin: ObsidianGemini;
-	private unsubscribers: Array<() => void> = [];
+	private activeTab: ModalTab;
 
-	constructor(app: App, plugin: ObsidianGemini) {
+	// Background Tasks tab state
+	private taskUnsubscribers: Array<() => void> = [];
+
+	// RAG tab state
+	private ragProgressListener: ProgressListener | null = null;
+	private ragInnerTab: RagInnerTab = 'overview';
+	private ragSearchQuery = '';
+	private ragShowAllFiles = false;
+	private ragDebounceTimer: ReturnType<typeof setTimeout> | null = null;
+	private readonly RAG_MAX_FILES_INITIAL = 200;
+
+	constructor(app: App, plugin: ObsidianGemini, defaultTab?: ModalTab) {
 		super(app);
 		this.plugin = plugin;
+
+		if (defaultTab) {
+			this.activeTab = defaultTab;
+		} else {
+			const hasRunningTasks = (plugin.backgroundTaskManager?.runningCount ?? 0) > 0;
+			const ragEnabled = plugin.ragIndexing !== null;
+			this.activeTab = hasRunningTasks || !ragEnabled ? 'tasks' : 'rag';
+		}
 	}
 
 	onOpen(): void {
-		this.render();
+		this.renderShell();
 
-		// Subscribe to task lifecycle events so the modal stays current while open.
+		// --- Background Tasks live-updates ---
 		const bus = this.plugin.agentEventBus;
-		const refresh = async () => this.render();
-		this.unsubscribers.push(
-			bus.on('backgroundTaskStarted', refresh),
-			bus.on('backgroundTaskComplete', refresh),
-			bus.on('backgroundTaskFailed', refresh)
-		);
+		if (bus) {
+			const refreshTasks = async () => {
+				if (this.activeTab === 'tasks') this.renderTabContent();
+			};
+			this.taskUnsubscribers.push(
+				bus.on('backgroundTaskStarted', refreshTasks),
+				bus.on('backgroundTaskComplete', refreshTasks),
+				bus.on('backgroundTaskFailed', refreshTasks)
+			);
+		}
+
+		// --- RAG live-updates ---
+		if (this.plugin.ragIndexing) {
+			this.ragProgressListener = () => {
+				if (this.activeTab === 'rag') this.renderTabContent();
+			};
+			this.plugin.ragIndexing.addProgressListener(this.ragProgressListener);
+		}
 	}
 
-	private render(): void {
+	onClose(): void {
+		this.taskUnsubscribers.forEach((unsub) => unsub());
+		this.taskUnsubscribers = [];
+
+		if (this.ragProgressListener && this.plugin.ragIndexing) {
+			this.plugin.ragIndexing.removeProgressListener(this.ragProgressListener);
+			this.ragProgressListener = null;
+		}
+
+		if (this.ragDebounceTimer) {
+			clearTimeout(this.ragDebounceTimer);
+			this.ragDebounceTimer = null;
+		}
+
+		this.contentEl.empty();
+	}
+
+	// ---------------------------------------------------------------------------
+	// Shell (tab bar + content slot)
+	// ---------------------------------------------------------------------------
+
+	private renderShell(): void {
 		const { contentEl } = this;
 		contentEl.empty();
-		contentEl.addClass('gemini-bg-tasks-modal');
+		contentEl.addClass('gemini-activity-modal');
 
-		contentEl.createEl('h2', { text: 'Background Tasks' });
+		// Outer tab bar
+		const tabBar = contentEl.createDiv({ cls: 'gemini-activity-tab-bar' });
+		this.renderTabBar(tabBar);
 
+		// Content slot — re-populated by renderTabContent()
+		contentEl.createDiv({ cls: 'gemini-activity-content' });
+		this.renderTabContent();
+	}
+
+	private renderTabBar(tabBar: HTMLElement): void {
+		tabBar.empty();
+
+		const tabs: Array<{ id: ModalTab; label: string; icon: string }> = [
+			{ id: 'tasks', label: 'Background Tasks', icon: 'loader' },
+			{ id: 'rag', label: 'RAG', icon: 'database' },
+		];
+
+		for (const { id, label, icon } of tabs) {
+			const tab = tabBar.createDiv({
+				cls: `gemini-activity-tab${this.activeTab === id ? ' gemini-activity-tab--active' : ''}`,
+			});
+			const iconEl = tab.createSpan({ cls: 'gemini-activity-tab-icon' });
+			setIcon(iconEl, icon);
+			tab.createSpan({ cls: 'gemini-activity-tab-label', text: label });
+
+			tab.addEventListener('click', () => {
+				if (this.activeTab === id) return;
+				this.activeTab = id;
+				// Reset RAG inner state when switching to the RAG tab
+				if (id === 'rag') {
+					this.ragInnerTab = 'overview';
+					this.ragSearchQuery = '';
+					this.ragShowAllFiles = false;
+				}
+				// Update tab bar active styles without full shell re-render
+				tabBar.querySelectorAll('.gemini-activity-tab').forEach((el) => {
+					el.removeClass('gemini-activity-tab--active');
+				});
+				tab.addClass('gemini-activity-tab--active');
+				this.renderTabContent();
+			});
+		}
+	}
+
+	private renderTabContent(): void {
+		const slot = this.contentEl.querySelector<HTMLElement>('.gemini-activity-content');
+		if (!slot) return;
+		slot.empty();
+
+		if (this.activeTab === 'tasks') {
+			this.renderTasksTab(slot);
+		} else {
+			this.renderRagTab(slot);
+		}
+	}
+
+	// ---------------------------------------------------------------------------
+	// Background Tasks tab
+	// ---------------------------------------------------------------------------
+
+	private renderTasksTab(container: HTMLElement): void {
 		const manager = this.plugin.backgroundTaskManager;
 		if (!manager) {
-			contentEl.createEl('p', { text: 'Background task manager not available.' });
+			container.createEl('p', { text: 'Background task manager not available.' });
 			return;
 		}
 
@@ -46,7 +169,7 @@ export class BackgroundTasksModal extends Modal {
 		const recent = manager.getRecentTasks();
 
 		if (active.length === 0 && recent.length === 0) {
-			contentEl.createEl('p', {
+			container.createEl('p', {
 				text: 'No background tasks yet. Long-running operations like deep research and image generation will appear here.',
 				cls: 'gemini-bg-tasks-empty',
 			});
@@ -55,10 +178,9 @@ export class BackgroundTasksModal extends Modal {
 
 		if (active.length > 0) {
 			const label = active.length > 10 ? `Running (${active.length})` : 'Running';
-			contentEl.createEl('h3', { text: label });
-			const scrollWrap = contentEl.createDiv({ cls: 'gemini-bg-tasks-scroll' });
+			container.createEl('h3', { text: label });
+			const scrollWrap = container.createDiv({ cls: 'gemini-bg-tasks-scroll' });
 			const list = scrollWrap.createEl('ul', { cls: 'gemini-bg-tasks-list' });
-			// Show at most 10 running tasks — the rest are still tracked, just not rendered
 			for (const task of active.slice(0, 10)) {
 				this.renderTaskItem(list, task, true);
 			}
@@ -71,15 +193,15 @@ export class BackgroundTasksModal extends Modal {
 		}
 
 		if (recent.length > 0) {
-			const recentHeader = contentEl.createDiv({ cls: 'gemini-bg-tasks-recent-header' });
+			const recentHeader = container.createDiv({ cls: 'gemini-bg-tasks-recent-header' });
 			recentHeader.createEl('h3', { text: 'Recent' });
 			const clearBtn = recentHeader.createEl('button', { text: 'Clear', cls: 'gemini-bg-tasks-clear' });
 			clearBtn.addEventListener('click', () => {
 				this.plugin.backgroundTaskManager?.clearFinished();
-				this.render();
+				this.renderTabContent();
 			});
 
-			const scrollWrap = contentEl.createDiv({ cls: 'gemini-bg-tasks-scroll' });
+			const scrollWrap = container.createDiv({ cls: 'gemini-bg-tasks-scroll' });
 			const list = scrollWrap.createEl('ul', { cls: 'gemini-bg-tasks-list' });
 			for (const task of recent) {
 				this.renderTaskItem(list, task, false);
@@ -90,7 +212,6 @@ export class BackgroundTasksModal extends Modal {
 	private renderTaskItem(container: HTMLElement, task: BackgroundTask, canCancel: boolean): void {
 		const li = container.createEl('li', { cls: `gemini-bg-task gemini-bg-task--${task.status}` });
 
-		// Status icon
 		const iconEl = li.createSpan({ cls: 'gemini-bg-task-icon' });
 		switch (task.status) {
 			case 'pending':
@@ -108,12 +229,10 @@ export class BackgroundTasksModal extends Modal {
 				break;
 		}
 
-		// Label + meta
 		const info = li.createDiv({ cls: 'gemini-bg-task-info' });
 		info.createDiv({ text: task.label, cls: 'gemini-bg-task-label' });
-		info.createDiv({ text: this.formatMeta(task), cls: 'gemini-bg-task-meta' });
+		info.createDiv({ text: this.formatTaskMeta(task), cls: 'gemini-bg-task-meta' });
 
-		// Output link
 		if (task.outputPath && task.status === 'complete') {
 			const link = info.createEl('a', { text: 'Open result', href: '#', cls: 'gemini-bg-task-link' });
 			link.addEventListener('click', (e) => {
@@ -123,23 +242,21 @@ export class BackgroundTasksModal extends Modal {
 			});
 		}
 
-		// Error message — first sentence only, full text on hover
 		if (task.error && task.status === 'failed') {
 			const short = this.truncateError(task.error);
 			info.createSpan({ text: short, cls: 'gemini-bg-task-error', title: task.error } as any);
 		}
 
-		// Cancel button
 		if (canCancel) {
 			const btn = li.createEl('button', { text: 'Cancel', cls: 'gemini-bg-task-cancel mod-warning' });
 			btn.addEventListener('click', () => {
 				this.plugin.backgroundTaskManager?.cancel(task.id);
-				this.render();
+				this.renderTabContent();
 			});
 		}
 	}
 
-	private formatMeta(task: BackgroundTask): string {
+	private formatTaskMeta(task: BackgroundTask): string {
 		const started = task.startedAt.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
 		if (task.completedAt) {
 			const durationMs = task.completedAt.getTime() - task.startedAt.getTime();
@@ -161,10 +278,291 @@ export class BackgroundTasksModal extends Modal {
 		const firstLine = stripped.split(/[\n.]/)[0].trim();
 		return firstLine.length > 120 ? firstLine.slice(0, 117) + '…' : firstLine;
 	}
+	// ---------------------------------------------------------------------------
+	// RAG tab
+	// ---------------------------------------------------------------------------
 
-	onClose(): void {
-		this.unsubscribers.forEach((unsub) => unsub());
-		this.unsubscribers = [];
-		this.contentEl.empty();
+	private renderRagTab(container: HTMLElement): void {
+		const rag = this.plugin.ragIndexing;
+		if (!rag) {
+			container.createEl('p', {
+				text: 'RAG indexing is not enabled. Enable it in Settings → Gemini Scribe.',
+				cls: 'gemini-bg-tasks-empty',
+			});
+			return;
+		}
+
+		const status: RagDetailedStatus = rag.getDetailedStatus();
+
+		// Inner tab bar (Overview / Files / Failures)
+		const innerTabBar = container.createDiv({ cls: 'rag-status-tabs' });
+		this.renderRagInnerTabBar(innerTabBar, status);
+
+		// Inner tab content
+		const innerContent = container.createDiv({ cls: 'rag-status-content' });
+		this.renderRagInnerContent(innerContent, status, rag);
+	}
+
+	private renderRagInnerTabBar(tabBar: HTMLElement, status: RagDetailedStatus): void {
+		tabBar.empty();
+
+		const createTab = (id: RagInnerTab, label: string) => {
+			const tab = tabBar.createDiv({
+				cls: `rag-status-tab${this.ragInnerTab === id ? ' rag-status-tab-active' : ''}`,
+				text: label,
+			});
+			tab.addEventListener('click', () => {
+				if (this.ragInnerTab === id) return;
+				this.ragInnerTab = id;
+				this.ragShowAllFiles = false;
+				this.ragSearchQuery = '';
+				this.renderTabContent();
+			});
+		};
+
+		createTab('overview', 'Overview');
+		createTab('files', `Files (${status.indexedCount.toLocaleString()})`);
+		if (status.failedCount > 0) {
+			createTab('failures', `Failures (${status.failedCount})`);
+		}
+	}
+
+	private renderRagInnerContent(container: HTMLElement, status: RagDetailedStatus, rag: any): void {
+		switch (this.ragInnerTab) {
+			case 'overview':
+				this.renderRagOverview(container, status, rag);
+				break;
+			case 'files':
+				this.renderRagFiles(container, status);
+				break;
+			case 'failures':
+				this.renderRagFailures(container, status);
+				break;
+		}
+	}
+
+	private renderRagOverview(container: HTMLElement, status: RagDetailedStatus, rag: any): void {
+		const infoEl = container.createDiv({ cls: 'rag-status-info' });
+
+		// Status row
+		const statusRow = infoEl.createDiv({ cls: 'rag-status-row' });
+		statusRow.createSpan({ cls: 'rag-status-label', text: 'Status' });
+		const statusValue = statusRow.createSpan({ cls: `rag-status-value ${this.ragStatusClass(status.status)}` });
+		statusValue.setText(this.ragStatusText(status.status));
+
+		// Files indexed
+		const filesRow = infoEl.createDiv({ cls: 'rag-status-row' });
+		filesRow.createSpan({ cls: 'rag-status-label', text: 'Files indexed' });
+		filesRow.createSpan({ cls: 'rag-status-value', text: status.indexedCount.toLocaleString() });
+
+		// Pending changes
+		const pendingRow = infoEl.createDiv({ cls: 'rag-status-row' });
+		pendingRow.createSpan({ cls: 'rag-status-label', text: 'Pending' });
+		pendingRow.createSpan({
+			cls: 'rag-status-value',
+			text: `${status.pendingCount} change${status.pendingCount !== 1 ? 's' : ''}`,
+		});
+
+		// Failures (if any)
+		if (status.failedCount > 0) {
+			const failedRow = infoEl.createDiv({ cls: 'rag-status-row' });
+			failedRow.createSpan({ cls: 'rag-status-label', text: 'Failed' });
+			failedRow.createSpan({
+				cls: 'rag-status-value rag-status-error',
+				text: `${status.failedCount} file${status.failedCount !== 1 ? 's' : ''}`,
+			});
+		}
+
+		// Last sync
+		if (status.lastSync) {
+			const syncRow = infoEl.createDiv({ cls: 'rag-status-row' });
+			syncRow.createSpan({ cls: 'rag-status-label', text: 'Last sync' });
+			syncRow.createSpan({ cls: 'rag-status-value', text: this.formatRagDate(status.lastSync) });
+		}
+
+		// Store name
+		if (status.storeName) {
+			const storeRow = infoEl.createDiv({ cls: 'rag-status-row' });
+			storeRow.createSpan({ cls: 'rag-status-label', text: 'Store' });
+			storeRow.createSpan({ cls: 'rag-status-value rag-status-store', text: status.storeName });
+		}
+
+		// Action buttons
+		const isIndexing = status.status === 'indexing';
+		const hasPending = status.pendingCount > 0;
+
+		new Setting(container)
+			.addButton((btn) =>
+				btn
+					.setButtonText('Sync Now')
+					.setDisabled(isIndexing || !hasPending)
+					.setTooltip(hasPending ? 'Process pending changes now' : 'No pending changes')
+					.onClick(async () => {
+						btn.setDisabled(true);
+						btn.setButtonText('Syncing...');
+						try {
+							await rag.syncPendingChanges();
+							btn.setButtonText('Sync Now');
+							this.renderTabContent();
+						} catch (error) {
+							new Notice(`Sync failed: ${getErrorMessage(error)}`);
+							btn.setButtonText('Sync Now');
+							btn.setDisabled(false);
+						}
+					})
+			)
+			.addButton((btn) =>
+				btn
+					.setButtonText('Reindex All')
+					.setDisabled(isIndexing)
+					.onClick(async () => {
+						this.close();
+						const { RagProgressModal } = await import('./rag-progress-modal');
+						const progressModal = new RagProgressModal(this.plugin.app, rag, (result) => {
+							new Notice(`RAG Indexing complete: ${result.indexed} indexed, ${result.skipped} unchanged`);
+						});
+						progressModal.open();
+						rag.indexVault().catch((error: unknown) => {
+							new Notice(`RAG Indexing failed: ${getErrorMessage(error)}`);
+						});
+					})
+			)
+			.addButton((btn) =>
+				btn
+					.setButtonText('Settings')
+					.setCta()
+					.onClick(() => {
+						this.close();
+						// @ts-expect-error — Obsidian internal API
+						this.plugin.app.setting.open();
+						// @ts-expect-error — Obsidian internal API
+						this.plugin.app.setting.openTabById('gemini-scribe');
+					})
+			);
+	}
+
+	private renderRagFiles(container: HTMLElement, status: RagDetailedStatus): void {
+		const searchContainer = container.createDiv({ cls: 'rag-status-search-container' });
+		const searchInput = searchContainer.createEl('input', {
+			cls: 'rag-status-search',
+			attr: { type: 'text', placeholder: 'Search files...', value: this.ragSearchQuery },
+		});
+
+		const listContainer = container.createDiv({ cls: 'rag-status-file-list' });
+		this.renderRagFileList(listContainer, status);
+
+		searchInput.addEventListener('input', (e) => {
+			if (this.ragDebounceTimer) clearTimeout(this.ragDebounceTimer);
+			this.ragDebounceTimer = setTimeout(() => {
+				this.ragSearchQuery = (e.target as HTMLInputElement).value;
+				this.renderRagFileList(listContainer, status);
+			}, 150);
+		});
+	}
+
+	private renderRagFileList(container: HTMLElement, status: RagDetailedStatus): void {
+		container.empty();
+
+		if (status.indexedFiles.length === 0) {
+			container.createDiv({ cls: 'rag-status-empty', text: 'No files indexed yet' });
+			return;
+		}
+
+		let filtered = status.indexedFiles;
+		if (this.ragSearchQuery) {
+			const q = this.ragSearchQuery.toLowerCase();
+			filtered = filtered.filter((f) => f.path.toLowerCase().includes(q));
+		}
+
+		if (filtered.length === 0) {
+			container.createDiv({ cls: 'rag-status-empty', text: 'No files match your search' });
+			return;
+		}
+
+		const total = filtered.length;
+		const display = this.ragShowAllFiles ? filtered : filtered.slice(0, this.RAG_MAX_FILES_INITIAL);
+
+		for (const file of display) {
+			const item = container.createDiv({ cls: 'rag-status-file-item rag-status-file-item--clickable' });
+			const pathEl = item.createSpan({ cls: 'rag-status-file-path' });
+			pathEl.setText(file.path);
+			pathEl.setAttribute('title', file.path);
+			item.createSpan({ cls: 'rag-status-file-time', text: this.formatRagDate(file.lastIndexed) });
+			item.addEventListener('click', () => {
+				this.plugin.app.workspace.openLinkText(file.path, '', false);
+				this.close();
+			});
+		}
+
+		if (!this.ragShowAllFiles && total > this.RAG_MAX_FILES_INITIAL) {
+			const more = container.createDiv({ cls: 'rag-status-show-more' });
+			more.setText(`Show all ${total.toLocaleString()} files`);
+			more.addEventListener('click', () => {
+				this.ragShowAllFiles = true;
+				this.renderRagFileList(container, status);
+			});
+		}
+	}
+
+	private renderRagFailures(container: HTMLElement, status: RagDetailedStatus): void {
+		if (status.failedFiles.length === 0) {
+			container.createDiv({ cls: 'rag-status-empty', text: 'No failures recorded' });
+			return;
+		}
+
+		const listContainer = container.createDiv({ cls: 'rag-status-failure-list' });
+		for (const failure of status.failedFiles) {
+			const item = listContainer.createDiv({ cls: 'rag-status-failure-item' });
+			const headerRow = item.createDiv({ cls: 'rag-status-failure-header' });
+			const iconEl = headerRow.createSpan({ cls: 'rag-status-failure-icon' });
+			setIcon(iconEl, 'x-circle');
+			const pathEl = headerRow.createSpan({ cls: 'rag-status-failure-path' });
+			pathEl.setText(failure.path);
+			pathEl.setAttribute('title', failure.path);
+			headerRow.createSpan({ cls: 'rag-status-failure-time', text: this.formatRagDate(failure.timestamp) });
+			item.createDiv({ cls: 'rag-status-failure-error', text: failure.error });
+		}
+	}
+
+	// ---------------------------------------------------------------------------
+	// RAG display helpers
+	// ---------------------------------------------------------------------------
+
+	private ragStatusText(status: string): string {
+		const map: Record<string, string> = {
+			idle: 'Ready',
+			indexing: 'Indexing...',
+			error: 'Error',
+			paused: 'Paused',
+			disabled: 'Disabled',
+			rate_limited: 'Rate Limited',
+		};
+		return map[status] ?? 'Unknown';
+	}
+
+	private ragStatusClass(status: string): string {
+		const map: Record<string, string> = {
+			idle: 'rag-status-ready',
+			indexing: 'rag-status-indexing',
+			error: 'rag-status-error',
+			paused: 'rag-status-paused',
+			rate_limited: 'rag-status-rate-limited',
+		};
+		return map[status] ?? '';
+	}
+
+	private formatRagDate(timestamp: number): string {
+		const date = new Date(timestamp);
+		const now = new Date();
+		const diffMs = now.getTime() - date.getTime();
+		const diffMins = Math.floor(diffMs / 60000);
+		const diffHours = Math.floor(diffMs / 3600000);
+		const diffDays = Math.floor(diffMs / 86400000);
+
+		if (diffMins < 1) return 'Just now';
+		if (diffMins < 60) return `${diffMins} minute${diffMins === 1 ? '' : 's'} ago`;
+		if (diffHours < 24) return `${diffHours} hour${diffHours === 1 ? '' : 's'} ago`;
+		if (diffDays < 7) return `${diffDays} day${diffDays === 1 ? '' : 's'} ago`;
+		return date.toLocaleDateString();
 	}
 }

--- a/src/ui/background-tasks-modal.ts
+++ b/src/ui/background-tasks-modal.ts
@@ -66,7 +66,13 @@ export class BackgroundTasksModal extends Modal {
 		// --- RAG live-updates ---
 		if (this.plugin.ragIndexing) {
 			this.ragProgressListener = () => {
-				if (this.activeTab === 'rag') this.renderTabContent();
+				if (this.activeTab !== 'rag') return;
+				// Don't wipe the Files tab while the search box has focus — the
+				// debounce timer may still hold a reference to the old list container.
+				const active = document.activeElement;
+				if (this.ragInnerTab === 'files' && active instanceof HTMLElement && active.hasClass('rag-status-search'))
+					return;
+				this.renderTabContent();
 			};
 			this.plugin.ragIndexing.addProgressListener(this.ragProgressListener);
 		}
@@ -118,12 +124,13 @@ export class BackgroundTasksModal extends Modal {
 		for (const { id, label, icon } of tabs) {
 			const tab = tabBar.createDiv({
 				cls: `gemini-activity-tab${this.activeTab === id ? ' gemini-activity-tab--active' : ''}`,
+				attr: { role: 'tab', tabindex: '0', 'aria-selected': String(this.activeTab === id) },
 			});
 			const iconEl = tab.createSpan({ cls: 'gemini-activity-tab-icon' });
 			setIcon(iconEl, icon);
 			tab.createSpan({ cls: 'gemini-activity-tab-label', text: label });
 
-			tab.addEventListener('click', () => {
+			const activate = () => {
 				if (this.activeTab === id) return;
 				this.activeTab = id;
 				// Reset RAG inner state when switching to the RAG tab
@@ -135,9 +142,19 @@ export class BackgroundTasksModal extends Modal {
 				// Update tab bar active styles without full shell re-render
 				tabBar.querySelectorAll('.gemini-activity-tab').forEach((el) => {
 					el.removeClass('gemini-activity-tab--active');
+					el.setAttribute('aria-selected', 'false');
 				});
 				tab.addClass('gemini-activity-tab--active');
+				tab.setAttribute('aria-selected', 'true');
 				this.renderTabContent();
+			};
+
+			tab.addEventListener('click', activate);
+			tab.addEventListener('keydown', (e) => {
+				if (e.key === 'Enter' || e.key === ' ') {
+					e.preventDefault();
+					activate();
+				}
 			});
 		}
 	}
@@ -310,13 +327,21 @@ export class BackgroundTasksModal extends Modal {
 			const tab = tabBar.createDiv({
 				cls: `rag-status-tab${this.ragInnerTab === id ? ' rag-status-tab-active' : ''}`,
 				text: label,
+				attr: { role: 'tab', tabindex: '0', 'aria-selected': String(this.ragInnerTab === id) },
 			});
-			tab.addEventListener('click', () => {
+			const activate = () => {
 				if (this.ragInnerTab === id) return;
 				this.ragInnerTab = id;
 				this.ragShowAllFiles = false;
 				this.ragSearchQuery = '';
 				this.renderTabContent();
+			};
+			tab.addEventListener('click', activate);
+			tab.addEventListener('keydown', (e) => {
+				if (e.key === 'Enter' || e.key === ' ') {
+					e.preventDefault();
+					activate();
+				}
 			});
 		};
 
@@ -483,14 +508,24 @@ export class BackgroundTasksModal extends Modal {
 		const display = this.ragShowAllFiles ? filtered : filtered.slice(0, this.RAG_MAX_FILES_INITIAL);
 
 		for (const file of display) {
-			const item = container.createDiv({ cls: 'rag-status-file-item rag-status-file-item--clickable' });
+			const item = container.createDiv({
+				cls: 'rag-status-file-item rag-status-file-item--clickable',
+				attr: { role: 'button', tabindex: '0', 'aria-label': `Open ${file.path}` },
+			});
 			const pathEl = item.createSpan({ cls: 'rag-status-file-path' });
 			pathEl.setText(file.path);
 			pathEl.setAttribute('title', file.path);
 			item.createSpan({ cls: 'rag-status-file-time', text: this.formatRagDate(file.lastIndexed) });
-			item.addEventListener('click', () => {
-				this.plugin.app.workspace.openLinkText(file.path, '', false);
+			const open = () => {
 				this.close();
+				this.plugin.app.workspace.openLinkText(file.path, '', false);
+			};
+			item.addEventListener('click', open);
+			item.addEventListener('keydown', (e) => {
+				if (e.key === 'Enter' || e.key === ' ') {
+					e.preventDefault();
+					open();
+				}
 			});
 		}
 

--- a/styles.css
+++ b/styles.css
@@ -3691,6 +3691,17 @@ If your plugin does not need CSS, delete this file.
 	padding: 8px 12px;
 	border-bottom: 1px solid var(--background-modifier-border);
 	transition: background 0.15s ease;
+	/* reset <button> browser defaults */
+	width: 100%;
+	background: none;
+	border-left: none;
+	border-right: none;
+	border-top: none;
+	border-radius: 0;
+	text-align: left;
+	font: inherit;
+	color: inherit;
+	box-shadow: none;
 }
 
 .rag-status-file-item:last-child {

--- a/styles.css
+++ b/styles.css
@@ -3701,6 +3701,10 @@ If your plugin does not need CSS, delete this file.
 	background: var(--background-modifier-hover);
 }
 
+.rag-status-file-item--clickable {
+	cursor: pointer;
+}
+
 .rag-status-file-path {
 	flex: 1;
 	min-width: 0;
@@ -4394,13 +4398,74 @@ If your plugin does not need CSS, delete this file.
 	height: 100%;
 }
 
+/* ── Unified Activity Modal (Background Tasks + RAG) ──────────────────────── */
+
+.modal.modal-container:has(.gemini-activity-modal) {
+	width: 600px;
+	max-width: 90vw;
+}
+
+.gemini-activity-tab-bar {
+	display: flex;
+	gap: 4px;
+	margin-bottom: 16px;
+	border-bottom: 1px solid var(--background-modifier-border);
+	padding-bottom: 8px;
+}
+
+.gemini-activity-tab {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	padding: 8px 16px;
+	border-radius: var(--radius-s);
+	cursor: pointer;
+	font-size: var(--font-ui-small);
+	color: var(--text-muted);
+	transition:
+		background 0.15s ease,
+		color 0.15s ease;
+}
+
+.gemini-activity-tab:hover {
+	background: var(--background-modifier-hover);
+	color: var(--text-normal);
+}
+
+.gemini-activity-tab--active {
+	background: var(--interactive-accent);
+	color: var(--text-on-accent);
+}
+
+.gemini-activity-tab--active:hover {
+	background: var(--interactive-accent-hover);
+	color: var(--text-on-accent);
+}
+
+.gemini-activity-tab-icon {
+	display: flex;
+	align-items: center;
+	width: 16px;
+	height: 16px;
+}
+
+.gemini-activity-tab-icon svg {
+	width: 16px;
+	height: 16px;
+}
+
+.gemini-activity-content {
+	min-height: 200px;
+}
+
 /* ── Background Tasks Modal ────────────────────────────────────────────────── */
 
 .gemini-bg-tasks-modal .modal-content {
 	padding-right: 16px;
 }
 
-.gemini-bg-tasks-modal h3 {
+.gemini-bg-tasks-modal h3,
+.gemini-activity-modal h3 {
 	margin: 12px 0 6px;
 	font-size: var(--font-ui-small);
 	text-transform: uppercase;


### PR DESCRIPTION
## Summary

Converts `BackgroundTasksModal` into a unified tabbed modal that surfaces both background task state and RAG indexing state behind the shared status bar icon — restoring the RAG stats affordance that was lost when #632 replaced the separate RAG status bar.

Fixes #656

Also fixes a related bug where `vault.readBinary()` throws on virtual Obsidian files (e.g. built-in tutorial notes), causing noisy upload errors during RAG indexing. Falls back to an `mtime+size` hash so smart sync continues tracking those files without crashing.

## Changes

- **`src/ui/background-tasks-modal.ts`** — Complete rewrite as `BackgroundTasksModal` with two top-level tabs:
  - **Background Tasks** — existing running/recent task list with live-updates via `AgentEventBus` (`backgroundTaskStarted/Complete/Failed`)
  - **RAG** — inner Overview / Files / Failures sub-tabs; searchable file list (click to open note); controls: Sync Now (disabled when no pending changes), Reindex All, Settings; live-updates via `ProgressListener`
- **`src/services/background-status-bar.ts`** — Status bar click now defaults to Background Tasks tab when any task is running, otherwise RAG tab
- **`styles.css`** — New CSS for `.gemini-activity-modal`, `.gemini-activity-tab-bar`, `.gemini-activity-tab`, `.gemini-activity-tab--active`, `.gemini-activity-tab-icon`, `.gemini-activity-content`; modal width 600px; clickable file row cursor
- **`src/services/obsidian-file-adapter.ts`** — `computeHash()` no longer throws when `vault.readBinary()` fails; falls back to `mtime:X-size:Y` proxy hash; removes overly aggressive `< 10 char` skip threshold
- **`src/services/rag-vault-scanner.ts`** — Downgrade external uploader's per-file error logs from `error` to `warn` (failures are already surfaced in the RAG Failures tab)

## Screenshots / Screencast

<!-- See attached screenshots showing the unified modal with both tabs, the RAG overview with live status, the searchable Files tab, and the Failures tab -->

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards)
- [ ] Documentation has been updated (n/a — no new settings or user-facing commands; existing modal UI only)
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude (claude-sonnet-4-6 via Claude Code)
- [x] I have reviewed and understand all AI-generated code in this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unified "Gemini Activity" modal combining Background Tasks and RAG tabs, with tab routing and per-tab views
  * RAG tab: Overview, Files (debounced search, capped initial list, show-all), Failures, and action buttons (Sync Now, Reindex All, Settings)
  * Modal now opens defaulting to the appropriate tab based on running tasks

* **Bug Fixes**
  * More resilient file indexing/upload behavior and improved short-file handling

* **Style**
  * Updated unified modal and file-item styling for consistent appearance and clickable states
<!-- end of auto-generated comment: release notes by coderabbit.ai -->