### PR TITLE
feat: abort runaway tool loops via per-turn detector escalation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,6 +115,8 @@ The plugin uses a simplified factory pattern (`GeminiClientFactory`) to create G
 - Tracks identical tool calls within time windows
 - Configurable thresholds and time windows
 - Session-specific tracking with automatic cleanup
+- Blocked calls are flagged with `loopDetected: true` on `ToolResult` and emit a `toolLoopDetected` event on the agent bus
+- `AgentLoop` counts those fires per turn and aborts the turn after `AGENT_LOOP_ABORT_THRESHOLD` (currently 3) — the result comes back with `loopAborted: true` and a user-visible notice, which the UI displays but does not persist to session history
 
 11. **YAML Frontmatter**: Agent instructions include guidance for respecting YAML frontmatter when modifying files
 

--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -95,9 +95,25 @@ export interface AgentLoopResult {
 	fellBack: boolean;
 	/** True if `maxIterations` was reached without a terminal text response. */
 	exhausted: boolean;
+	/**
+	 * True if the turn was aborted because the tool loop detector fired more
+	 * times than `AGENT_LOOP_ABORT_THRESHOLD` in a single turn. `markdown` is
+	 * a user-visible notice the caller may render but should not persist as a
+	 * model response.
+	 */
+	loopAborted: boolean;
 	/** Number of tool-execution batches that ran. */
 	iterations: number;
 }
+
+/**
+ * Number of tool-loop-detector fires (per turn) before the loop aborts the
+ * turn entirely. Individual identical-call blocking still happens on every
+ * fire via `ToolExecutionEngine`; this threshold exists so a model that
+ * keeps re-attempting the same call after being told "loop detected" still
+ * gets stopped cleanly instead of burning iterations and tokens.
+ */
+export const AGENT_LOOP_ABORT_THRESHOLD = 3;
 
 /**
  * Drives the tool-execution loop after the initial model response. Iterates
@@ -139,6 +155,12 @@ export class AgentLoop {
 		let conversationHistory = initialHistory;
 		let userMessage = initialUserMessage;
 		let iterations = 0;
+		// Turn-scoped count of tool-loop-detector fires. Incremented per blocked
+		// call (each `ToolResult` with `loopDetected: true`). Once it reaches
+		// AGENT_LOOP_ABORT_THRESHOLD the turn aborts cleanly so a model that
+		// refuses to adapt after being told "loop detected" doesn't burn the
+		// rest of the iteration budget.
+		let loopFireCount = 0;
 
 		// Lazily resolve the model API factory once — same instance is reused
 		// for every follow-up and retry request in this loop.
@@ -163,6 +185,7 @@ export class AgentLoop {
 					retried: false,
 					fellBack: false,
 					exhausted: true,
+					loopAborted: false,
 					iterations,
 				};
 			}
@@ -172,6 +195,27 @@ export class AgentLoop {
 			await this.safeHook('onToolBatchStart', plugin, () => hooks?.onToolBatchStart?.(sortedToolCalls, iterations));
 			iterations++;
 			const toolResults = await this.executeToolBatch(sortedToolCalls, toolContext, options);
+
+			// Count any loop-detector fires in this batch against the turn budget.
+			// If the model has triggered the detector too many times in this turn,
+			// stop iterating — the "please try a different approach" hint isn't
+			// working and continuing just burns tokens/time.
+			for (const tr of toolResults) {
+				if (tr.result.loopDetected) loopFireCount++;
+			}
+			if (loopFireCount >= AGENT_LOOP_ABORT_THRESHOLD) {
+				plugin.logger.warn(
+					`[AgentLoop] Aborting turn: tool loop detector fired ${loopFireCount} times ` +
+						`(threshold ${AGENT_LOOP_ABORT_THRESHOLD})`
+				);
+				const updatedHistory = buildToolHistoryTurns({
+					conversationHistory,
+					userMessage,
+					toolCalls: currentToolCalls,
+					toolResults,
+				});
+				return this.loopAbortedResult(updatedHistory, iterations, loopFireCount);
+			}
 
 			// Emit toolChainComplete so subscribers (accessed-files tracker, etc.) see this batch.
 			await this.safeEmit(plugin, 'toolChainComplete', {
@@ -241,6 +285,7 @@ export class AgentLoop {
 					retried: false,
 					fellBack: false,
 					exhausted: false,
+					loopAborted: false,
 					iterations,
 				};
 			}
@@ -277,6 +322,7 @@ export class AgentLoop {
 					retried: true,
 					fellBack: false,
 					exhausted: false,
+					loopAborted: false,
 					iterations,
 				};
 			}
@@ -290,6 +336,7 @@ export class AgentLoop {
 				retried: true,
 				fellBack: true,
 				exhausted: false,
+				loopAborted: false,
 				iterations,
 			};
 		}
@@ -303,6 +350,7 @@ export class AgentLoop {
 			retried: false,
 			fellBack: false,
 			exhausted: false,
+			loopAborted: false,
 			iterations: 0,
 		};
 	}
@@ -346,6 +394,22 @@ export class AgentLoop {
 			retried: false,
 			fellBack: false,
 			exhausted: false,
+			loopAborted: false,
+			iterations,
+		};
+	}
+
+	private loopAbortedResult(history: any[], iterations: number, fireCount: number): AgentLoopResult {
+		return {
+			markdown:
+				`The agent kept retrying the same tool call (loop detector fired ${fireCount} times). ` +
+				'Stopping this turn to prevent a runaway loop. Try rephrasing your request or starting a new session.',
+			history,
+			cancelled: false,
+			retried: false,
+			fellBack: false,
+			exhausted: false,
+			loopAborted: true,
 			iterations,
 		};
 	}

--- a/src/tools/execution-engine.ts
+++ b/src/tools/execution-engine.ts
@@ -73,8 +73,23 @@ export class ToolExecutionEngine {
 			const loopInfo = this.loopDetector.getLoopInfo(context.session.id, toolCall);
 			if (loopInfo.isLoop) {
 				this.plugin.logger.warn(`Loop detected for tool ${toolCall.name}:`, loopInfo);
+
+				// Surface the fire on the event bus so UI (and headless) subscribers can react.
+				// Emit is fire-and-forget; a throwing subscriber must not block the block.
+				try {
+					void this.plugin.agentEventBus?.emit('toolLoopDetected', {
+						toolName: toolCall.name,
+						args: toolCall.arguments || {},
+						identicalCallCount: loopInfo.identicalCallCount,
+						timeWindowMs: loopInfo.timeWindowMs,
+					});
+				} catch (error) {
+					this.plugin.logger.error('Failed to emit toolLoopDetected event:', error);
+				}
+
 				return {
 					success: false,
+					loopDetected: true,
 					error: `Execution loop detected: ${toolCall.name} has been called ${loopInfo.identicalCallCount} times with the same parameters in the last ${loopInfo.timeWindowMs / 1000} seconds. Please try a different approach.`,
 				};
 			}

--- a/src/tools/types.ts
+++ b/src/tools/types.ts
@@ -14,6 +14,12 @@ export interface ToolResult {
 	requiresConfirmation?: boolean;
 	/** Binary attachments to inject as inlineData parts alongside the functionResponse */
 	inlineData?: Array<{ base64: string; mimeType: string }>;
+	/**
+	 * Set when the engine blocked this call because the loop detector fired.
+	 * AgentLoop reads this to track how many times the detector has tripped in
+	 * the current turn; after enough fires, the loop aborts the turn entirely.
+	 */
+	loopDetected?: boolean;
 }
 
 /**

--- a/src/types/agent-events.ts
+++ b/src/types/agent-events.ts
@@ -52,6 +52,18 @@ export interface AgentEventMap {
 		toolCount: number;
 	}>;
 
+	/**
+	 * Tool loop detector fired and blocked a call. Emitted per fire so UI
+	 * subscribers can surface it (chat notice, badge, etc.) beyond the
+	 * logger.warn already emitted by the engine.
+	 */
+	toolLoopDetected: Readonly<{
+		toolName: string;
+		args: Record<string, unknown>;
+		identicalCallCount: number;
+		timeWindowMs: number;
+	}>;
+
 	/** After any API response (initial, follow-up, or retry) with usage metadata */
 	apiResponseReceived: Readonly<{
 		usageMetadata?: UsageMetadata;

--- a/src/ui/agent-view/agent-view-tools.ts
+++ b/src/ui/agent-view/agent-view-tools.ts
@@ -130,9 +130,10 @@ export class AgentViewTools {
 
 			await this.context.displayMessage(aiEntry);
 
-			// The empty-response fallback message is a UI-only courtesy — don't
-			// pollute session history with synthetic content the model didn't say.
-			if (!result.fellBack) {
+			// `fellBack` (empty-response courtesy) and `loopAborted` (loop-detector
+			// escalation) both produce UI-only notices — don't pollute session
+			// history with synthetic content the model didn't actually say.
+			if (!result.fellBack && !result.loopAborted) {
 				await this.plugin.sessionHistory.addEntryToSession(currentSession, aiEntry);
 			}
 

--- a/test/agent/agent-loop.test.ts
+++ b/test/agent/agent-loop.test.ts
@@ -733,4 +733,59 @@ describe('AgentLoop', () => {
 			expect(plugin.toolExecutionEngine.executeTool).not.toHaveBeenCalled();
 		});
 	});
+
+	describe('loop-detector escalation', () => {
+		test('aborts the turn once loopDetected fires accumulate past threshold', async () => {
+			const plugin = buildPlugin();
+			// Every tool call comes back already blocked by the engine — mimics the
+			// model stubbornly re-attempting the same call after being told to stop.
+			plugin.toolExecutionEngine.executeTool = jest
+				.fn()
+				.mockResolvedValue({ success: false, loopDetected: true, error: 'Execution loop detected' });
+
+			const session = buildSession();
+			// Model keeps replying with more tool calls — would loop forever without the abort.
+			const api = {
+				generateModelResponse: jest.fn().mockResolvedValue(toolResponse([tc('read_file', { path: 'a' })])),
+			} as any;
+
+			const loop = new AgentLoop();
+			const result = await loop.run({
+				initialResponse: toolResponse([tc('read_file', { path: 'a' })]),
+				initialUserMessage: 'q',
+				initialHistory: [],
+				options: { plugin, session, confirmationProvider, isCancelled: () => false, createModelApi: () => api },
+			});
+
+			expect(result.loopAborted).toBe(true);
+			expect(result.cancelled).toBe(false);
+			expect(result.exhausted).toBe(false);
+			expect(result.markdown).toMatch(/loop detector fired/i);
+			// Threshold is 3 — one blocked call per batch, so three batches run before abort.
+			expect(result.iterations).toBe(3);
+			expect(plugin.toolExecutionEngine.executeTool).toHaveBeenCalledTimes(3);
+		});
+
+		test('does not abort when only non-loop failures occur', async () => {
+			const plugin = buildPlugin();
+			// Regular failures without the loopDetected flag must not escalate.
+			plugin.toolExecutionEngine.executeTool = jest
+				.fn()
+				.mockResolvedValue({ success: false, error: 'generic failure' });
+
+			const session = buildSession();
+			const api = makeScriptedModelApi([textResponse('recovered')]);
+
+			const loop = new AgentLoop();
+			const result = await loop.run({
+				initialResponse: toolResponse([tc('read_file'), tc('read_file'), tc('read_file'), tc('read_file')]),
+				initialUserMessage: 'q',
+				initialHistory: [],
+				options: { plugin, session, confirmationProvider, isCancelled: () => false, createModelApi: () => api },
+			});
+
+			expect(result.loopAborted).toBe(false);
+			expect(result.markdown).toBe('recovered');
+		});
+	});
 });

--- a/test/tools/execution-engine.test.ts
+++ b/test/tools/execution-engine.test.ts
@@ -422,3 +422,110 @@ describe('ToolExecutionEngine - Error Handling', () => {
 		expect(results[1].error).toBe('Tool non_existent not found');
 	});
 });
+
+describe('ToolExecutionEngine - Loop Detection', () => {
+	let plugin: any;
+	let registry: ToolRegistry;
+	let engine: ToolExecutionEngine;
+
+	// A minimal always-succeeds READ tool — avoids hauling in the real
+	// vault-tool dependency surface just to exercise the loop detector.
+	const noopTool = {
+		name: 'noop',
+		description: 'noop',
+		category: ToolCategory.READ_ONLY,
+		classification: ToolClassification.READ,
+		parameters: { type: 'object' as const, properties: {}, required: [] },
+		execute: jest.fn().mockResolvedValue({ success: true, data: {} }),
+	};
+
+	beforeEach(() => {
+		plugin = {
+			settings: {
+				loopDetectionEnabled: true,
+				loopDetectionThreshold: 3,
+				loopDetectionTimeWindowSeconds: 60,
+			},
+			logger: { log: jest.fn(), debug: jest.fn(), warn: jest.fn(), error: jest.fn() },
+			agentEventBus: { emit: jest.fn().mockResolvedValue(undefined) },
+		};
+
+		registry = new ToolRegistry(plugin);
+		engine = new ToolExecutionEngine(plugin, registry);
+		registry.registerTool(noopTool as any);
+	});
+
+	afterEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('blocks further identical calls with loopDetected: true and emits toolLoopDetected', async () => {
+		const context = {
+			plugin,
+			session: {
+				id: 'loop-session',
+				type: 'agent-session',
+				context: {
+					contextFiles: [],
+					contextDepth: 2,
+					enabledTools: [ToolCategory.READ_ONLY],
+					requireConfirmation: [],
+				},
+			},
+		} as any;
+
+		const call = { name: 'noop', arguments: {} };
+
+		// Threshold is 3 — getLoopInfo is consulted *before* recordExecution, so
+		// the first 3 attempts pass (record counts: 0, 1, 2) and the 4th trips
+		// because 3 >= threshold.
+		const results = [];
+		for (let i = 0; i < 4; i++) {
+			results.push(await engine.executeTool(call, context, denyProvider));
+		}
+
+		expect(results.slice(0, 3).every((r) => r.success)).toBe(true);
+		expect(results.slice(0, 3).some((r) => r.loopDetected)).toBe(false);
+
+		const blocked = results[3];
+		expect(blocked.success).toBe(false);
+		expect(blocked.loopDetected).toBe(true);
+		expect(blocked.error).toMatch(/loop detected/i);
+
+		expect(plugin.agentEventBus.emit).toHaveBeenCalledTimes(1);
+		expect(plugin.agentEventBus.emit).toHaveBeenCalledWith(
+			'toolLoopDetected',
+			expect.objectContaining({
+				toolName: 'noop',
+				args: {},
+				identicalCallCount: 3,
+			})
+		);
+	});
+
+	it('does not set loopDetected when detection is disabled', async () => {
+		plugin.settings.loopDetectionEnabled = false;
+
+		const context = {
+			plugin,
+			session: {
+				id: 'no-detection-session',
+				type: 'agent-session',
+				context: {
+					contextFiles: [],
+					contextDepth: 2,
+					enabledTools: [ToolCategory.READ_ONLY],
+					requireConfirmation: [],
+				},
+			},
+		} as any;
+
+		const call = { name: 'noop', arguments: {} };
+		for (let i = 0; i < 5; i++) {
+			const result = await engine.executeTool(call, context, denyProvider);
+			expect(result.success).toBe(true);
+			expect(result.loopDetected).toBeUndefined();
+		}
+		expect(plugin.agentEventBus.emit).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
## Summary

Fixes #620. Three of the four design steps were already wired — the per-tool loop detector blocks identical calls inside `ToolExecutionEngine` and returns a failed `ToolResult` the model can react to. What was missing is the per-turn escalation so a model that refuses to adapt after being told "loop detected" eventually stops the turn instead of burning the iteration budget.

This also adds the `toolLoopDetected` event the original design called for, so UI and headless subscribers get a real surface beyond the existing `logger.warn`.

Out of scope: cyclical-but-not-identical tool sequences (e.g. `read A → write B → read A → write B …`) — that's tracked in #661 and needs real-world data to design well.

## Changes

- `ToolResult` gains an optional `loopDetected: boolean` flag. `ToolExecutionEngine.executeTool` sets it when the detector fires on a blocked call. The existing "Execution loop detected…" error string is preserved so the model still sees the hint.
- `toolLoopDetected` added to `AgentEventMap` with `{ toolName, args, identicalCallCount, timeWindowMs }`. The engine emits it fire-and-forget on every block.
- `AgentLoop.executeToolBatch` tracks a turn-local fire counter. Once it hits `AGENT_LOOP_ABORT_THRESHOLD` (hardcoded at 3; trivially promotable to a setting if needed), the loop returns an `AgentLoopResult` with the new `loopAborted: true` field and a user-visible notice string as `markdown`.
- `AgentViewTools.handleToolCalls` displays the notice in chat but does not persist it to session history — same treatment as the empty-response fallback (`fellBack`).
- `AGENTS.md` — short update documenting the flag, the event, and the threshold.

## Test plan

- New engine tests: the Nth identical call is blocked with `loopDetected: true` and exactly one `toolLoopDetected` event fires; when `loopDetectionEnabled: false` no flag is set and no event fires.
- New `AgentLoop` tests: aborts after 3 blocked fires across successive batches; non-loop failures (generic `success: false`) don't trigger the abort.
- Full suite: 1387 pass (4 new), 5 skipped. Format + build clean.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer (#620 — issue body updated 2026-04-21 to reflect current state)
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop — 1387/1387 tests pass
- [x] I have verified this change does not break Mobile — pure loop-logic change, no mobile-specific code paths touched
- [x] Documentation has been updated — AGENTS.md. No user-facing docs affected (hardcoded threshold, no settings change).
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Tool loop detection now automatically halts agent processing after 3 repeated identical tool calls within a single turn and displays a user-visible notice explaining the interruption.

* **Improvements**
  * Session history no longer persists conversation turns that were halted by tool loop detection.

* **Tests**
  * Added comprehensive tests for tool loop detection behavior and escalation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->