### PR TITLE
fix: add confirmationProvider to ScheduledTaskRunner

### DIFF
--- a/src/services/scheduled-task-runner.ts
+++ b/src/services/scheduled-task-runner.ts
@@ -2,7 +2,8 @@ import { normalizePath } from 'obsidian';
 import type ObsidianGemini from '../main';
 import type { ScheduledTask } from './scheduled-task-manager';
 import { ToolCategory, DestructiveAction } from '../types/agent';
-import { IConfirmationProvider, ToolExecutionContext, ConfirmationResult } from '../tools/types';
+import type { ConfirmationResult, DiffContext, IConfirmationProvider, Tool } from '../tools/types';
+import { ToolExecutionContext } from '../tools/types';
 import { GeminiClientFactory } from '../api';
 import { ExtendedModelRequest } from '../api/interfaces/model-api';
 import { ensureFolderExists } from '../utils/file-utils';
@@ -17,16 +18,24 @@ import { AgentLoop } from '../agent/agent-loop';
  * there's no surface on which to surface a mid-run confirmation dialog.
  */
 class HeadlessConfirmationProvider implements IConfirmationProvider {
-	async showConfirmationInChat(): Promise<ConfirmationResult> {
+	// Full signatures (rather than zero-arg stubs) pin this class to the real
+	// IConfirmationProvider contract — future additions to the interface will
+	// break compilation here instead of silently passing.
+	async showConfirmationInChat(
+		_tool: Tool,
+		_parameters: unknown,
+		_executionId: string,
+		_diffContext?: DiffContext
+	): Promise<ConfirmationResult> {
 		return { confirmed: true, allowWithoutConfirmation: false };
 	}
-	isToolAllowedWithoutConfirmation(): boolean {
+	isToolAllowedWithoutConfirmation(_toolName: string): boolean {
 		return true;
 	}
-	allowToolWithoutConfirmation(): void {
+	allowToolWithoutConfirmation(_toolName: string): void {
 		/* no-op */
 	}
-	updateProgress(): void {
+	updateProgress(_message: string, _status: string): void {
 		/* no-op */
 	}
 }

--- a/src/services/scheduled-task-runner.ts
+++ b/src/services/scheduled-task-runner.ts
@@ -2,13 +2,34 @@ import { normalizePath } from 'obsidian';
 import type ObsidianGemini from '../main';
 import type { ScheduledTask } from './scheduled-task-manager';
 import { ToolCategory, DestructiveAction } from '../types/agent';
-import { ToolExecutionContext } from '../tools/types';
+import { IConfirmationProvider, ToolExecutionContext, ConfirmationResult } from '../tools/types';
 import { GeminiClientFactory } from '../api';
 import { ExtendedModelRequest } from '../api/interfaces/model-api';
 import { ensureFolderExists } from '../utils/file-utils';
 import { formatLocalDate, formatLocalTimestamp } from '../utils/format-utils';
 import { buildTurnPreamble } from '../utils/turn-preamble';
 import { AgentLoop } from '../agent/agent-loop';
+
+/**
+ * Auto-approve all tool confirmations for headless scheduled-task runs.
+ * Scheduled tasks run unattended with an explicit `enabledTools` frontmatter
+ * allowlist — the user has already opted in by authoring the task file, so
+ * there's no surface on which to surface a mid-run confirmation dialog.
+ */
+class HeadlessConfirmationProvider implements IConfirmationProvider {
+	async showConfirmationInChat(): Promise<ConfirmationResult> {
+		return { confirmed: true, allowWithoutConfirmation: false };
+	}
+	isToolAllowedWithoutConfirmation(): boolean {
+		return true;
+	}
+	allowToolWithoutConfirmation(): void {
+		/* no-op */
+	}
+	updateProgress(): void {
+		/* no-op */
+	}
+}
 
 /**
  * Runs a single scheduled task headlessly:
@@ -88,6 +109,7 @@ export class ScheduledTaskRunner {
 					plugin: this.plugin,
 					session,
 					isCancelled,
+					confirmationProvider: new HeadlessConfirmationProvider(),
 					maxIterations: 20,
 				},
 			});

--- a/test/services/scheduled-task-runner.test.ts
+++ b/test/services/scheduled-task-runner.test.ts
@@ -199,6 +199,13 @@ describe('ScheduledTaskRunner', () => {
 					plugin,
 					isCancelled: expect.any(Function),
 					maxIterations: 20,
+					// Regression guard: ScheduledTaskRunner must supply a headless
+					// confirmationProvider so AgentLoop never has to fall back.
+					confirmationProvider: expect.objectContaining({
+						showConfirmationInChat: expect.any(Function),
+						isToolAllowedWithoutConfirmation: expect.any(Function),
+						allowToolWithoutConfirmation: expect.any(Function),
+					}),
 				}),
 			})
 		);

--- a/test/services/scheduled-task-runner.test.ts
+++ b/test/services/scheduled-task-runner.test.ts
@@ -47,7 +47,16 @@ jest.mock('../../src/agent/agent-loop', () => ({
 import { GeminiClientFactory } from '../../src/api';
 
 function successfulLoopResult(markdown = 'Tool result text.'): AgentLoopResult {
-	return { markdown, history: [], cancelled: false, retried: false, fellBack: false, exhausted: false, iterations: 1 };
+	return {
+		markdown,
+		history: [],
+		cancelled: false,
+		retried: false,
+		fellBack: false,
+		exhausted: false,
+		loopAborted: false,
+		iterations: 1,
+	};
 }
 
 function createMockPlugin(vaultFiles: Record<string, string> = {}): any {


### PR DESCRIPTION
## Summary

Fixes a master build regression. #650 merged after #672 but didn't pick up the new required `confirmationProvider` field on `AgentLoopOptions`, so fresh builds on master fail:

```
src/services/scheduled-task-runner.ts(87,5): error TS2741: Property 'confirmationProvider' is missing in type '{ plugin: ObsidianGemini; session: ChatSession; isCancelled: () => boolean; maxIterations: number; }' but required in type 'AgentLoopOptions'.
```

This adds a `HeadlessConfirmationProvider` that auto-approves all tool confirmations. Scheduled tasks already opt into their tool surface via the `enabledTools` frontmatter allowlist, and headless runs have no UI surface on which to display a mid-run prompt — auto-approve is the right semantics here.

Found while rebasing #676 onto master.

## Changes

- `src/services/scheduled-task-runner.ts`: add inline `HeadlessConfirmationProvider` implementing `IConfirmationProvider` (auto-approves, no-op progress), pass an instance to `AgentLoop.run()`.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A, this is a build hotfix for a regression from #650 × #672
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — no platform surface touched
- [x] Documentation has been updated (if applicable) — N/A, internal build fix with no user-visible behavior change
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Scheduled tasks now automatically confirm and approve tool actions so background runs proceed without manual confirmation prompts.
* **Tests**
  * Test helpers and assertions updated to reflect the scheduler’s expanded loop result shape and to guard that confirmation behavior is provided during task execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->