### PR TITLE
fix(evals): switch session correctly and bypass tool confirmations

### DIFF
--- a/evals/lib/obsidian-driver.mjs
+++ b/evals/lib/obsidian-driver.mjs
@@ -46,9 +46,22 @@ export async function createSession(title) {
 	const result = await obsidianEval(
 		`(async () => {
     const p = app.plugins.plugins['gemini-scribe'];
-    const session = await p.sessionManager.createAgentSession(${titleLiteral});
-    // Load the session in the agent view
-    await p.agentView?.session?.loadSession(session);
+    // Empty requireConfirmation so the session metadata doesn't ask for
+    // confirmation. (The real gate is settings.toolPermissions, which we
+    // bypass via allowedWithoutConfirmation below.)
+    const session = await p.sessionManager.createAgentSession(${titleLiteral}, { requireConfirmation: [] });
+    // Use AgentView.loadSession (the public method) — it updates both the
+    // session controller AND AgentView's own currentSession field. Calling
+    // the controller's loadSession directly leaves AgentView.currentSession
+    // pointing at the previously-loaded session, so messages get persisted
+    // to the wrong session and the harness reads back stale history.
+    await p.agentView.loadSession(session);
+    // Pre-approve every registered tool for this session so write_file /
+    // delete_file / fetch_url etc. don't pop a UI confirmation mid-eval.
+    // loadSession() clears this set, so it must run AFTER the load.
+    for (const tool of p.toolRegistry?.getAllTools?.() || []) {
+      p.agentView.allowToolWithoutConfirmation(tool.name);
+    }
     return JSON.stringify({ sessionId: session.id, historyPath: session.historyPath });
   })()`,
 		{ timeoutMs: 15_000 }

--- a/evals/tasks/create-note-from-search.json
+++ b/evals/tasks/create-note-from-search.json
@@ -3,7 +3,7 @@
 	"description": "Search vault for information and create a new summary note",
 	"userMessage": "Search the eval-scratch folder for notes about AI topics. Create a new note called 'eval-scratch/AI Summary.md' that lists the key AI concepts found across those notes. Keep it concise.",
 	"fixture": "find-tagged-notes",
-	"expectedTools": ["find_files_by_content", "create_file"],
+	"expectedTools": ["write_file"],
 	"forbiddenTools": ["delete_file"],
 	"outputMatchers": [{ "type": "contains", "value": "AI Summary" }],
 	"maxTurns": 20,

--- a/evals/tasks/find-tagged-notes.json
+++ b/evals/tasks/find-tagged-notes.json
@@ -3,8 +3,8 @@
 	"description": "Find notes tagged with #research and list their titles",
 	"userMessage": "Search the eval-scratch folder for all notes tagged with #research. List each note's title. Do not modify any files.",
 	"fixture": "find-tagged-notes",
-	"expectedTools": ["find_files_by_content"],
-	"forbiddenTools": ["delete_file", "modify_file", "create_file"],
+	"expectedTools": [],
+	"forbiddenTools": ["delete_file", "write_file", "update_frontmatter", "append_content"],
 	"outputMatchers": [
 		{ "type": "contains", "value": "Neural Networks" },
 		{ "type": "contains", "value": "Transformer Architecture" },

--- a/evals/tasks/multi-file-summary.json
+++ b/evals/tasks/multi-file-summary.json
@@ -3,8 +3,8 @@
 	"description": "Read multiple files and produce a synthesized summary",
 	"userMessage": "Read all the notes in the eval-scratch folder and write a brief summary of what topics they cover. Don't create any new files — just tell me.",
 	"fixture": "multi-file-summary",
-	"expectedTools": ["find_files_by_name", "read_file"],
-	"forbiddenTools": ["delete_file", "modify_file", "create_file"],
+	"expectedTools": ["read_file"],
+	"forbiddenTools": ["delete_file", "write_file", "update_frontmatter", "append_content"],
 	"outputMatchers": [
 		{ "type": "contains", "value": "machine learning" },
 		{ "type": "contains", "value": "productivity" }

--- a/evals/tasks/smoke-list-files.json
+++ b/evals/tasks/smoke-list-files.json
@@ -4,7 +4,7 @@
 	"userMessage": "Use the find_files_by_name tool to list all markdown files in the eval-scratch folder. Report their names.",
 	"fixture": "smoke-list-files",
 	"expectedTools": ["find_files_by_name"],
-	"forbiddenTools": ["delete_file", "modify_file", "create_file"],
+	"forbiddenTools": ["delete_file", "write_file", "update_frontmatter", "append_content"],
 	"outputMatchers": [{ "type": "contains", "value": "hello-world" }],
 	"maxTurns": 10,
 	"timeoutMs": 60000


### PR DESCRIPTION
## Summary

Three bugs found while running the eval harness from #676 end-to-end on a real vault. Net effect: solve rate went from 40% to 80% on the same 5-task suite. The remaining failure is a CLI-output flakiness issue, not a rubric problem.

## Changes

### 1. Session loading was a no-op for the message pipeline

`evals/lib/obsidian-driver.mjs:createSession` called `agentView.session.loadSession(session)` — the inner controller's method. That updates `agentView.session.currentSession` but **not** `agentView.currentSession`, which is the field the send pipeline (`agentView.send.sendMessage()`) actually reads. Result: every eval message was persisted to whatever session the agent view had loaded before the harness ran, while the harness then queried the (empty) eval session for the response.

Switched to the public `agentView.loadSession(session)` which updates both fields.

### 2. Tool confirmations blocked headless runs

`requireConfirmation: []` on the session metadata doesn't actually gate the confirmation prompt — `settings.toolPermissions` does. So the harness was triggering UI dialogs for `write_file`, `update_frontmatter`, etc. mid-run.

Fixed by iterating `p.toolRegistry.getAllTools()` after `loadSession` and adding each tool name to `agentView.allowedWithoutConfirmation`. Has to run after the load because `loadSession()` clears that set.

### 3. Stale / over-specified rubrics

Several task definitions referenced tool names that don't exist in the codebase (`create_file`, `modify_file`) and over-specified `expectedTools` to a single approach when multiple tool paths are reasonable.

- `create-note-from-search.json` — `expectedTools: ["find_files_by_content", "create_file"]` → `["write_file"]`
- `multi-file-summary.json` — `expectedTools: ["find_files_by_name", "read_file"]` → `["read_file"]`
- `find-tagged-notes.json` — `expectedTools: ["find_files_by_content"]` → `[]` (the matchers already verify correctness)
- All five tasks — `forbiddenTools` updated to use real tool names (`write_file`, `update_frontmatter`, `append_content`)

## Verification

```
Task                          Pass  Solve  Turns  Cache%  Cost($)  Loops
--------------------------------------------------------------------------------
create-note-from-search         OK    OK       3     62%   0.0012      0
find-tagged-notes               OK    OK       3     61%   0.0011      0
multi-file-summary             FAIL  FAIL      0      0%   0.0000      0
read-and-answer                 OK    OK       2     66%   0.0009      0
smoke-list-files                OK    OK       2     67%   0.0009      0
```

`multi-file-summary` failed due to a log line (`[Gemini Scribe] ...`) leaking into `obsidianEval` stdout, causing `JSON.parse` to fail. The new error message — courtesy of the try/catch added during PR #676 review — surfaces this cleanly: `Unexpected token 'G', "[Gemini Scr"... is not valid JSON`. Worth a follow-up to make `obsidianEval` drop log-prefixed lines before parsing.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A, follow-up bug fixes for the eval harness merged in #676
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop — ran the harness end-to-end against a live Test Vault
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — desktop-only tooling
- [x] Documentation has been updated (if applicable) — N/A, no user-visible behavior change
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced agent session management to resolve stale session references that could impact message persistence and history tracking accuracy.
  * Eliminated confirmation prompts interrupting automated evaluation workflows.
  * Pre-configured tool permissions to enable seamless tool execution during evaluations without manual intervention.

* **Chores**
  * Refined evaluation task configurations with updated tool usage expectations and adjusted file write-operation constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->