### PR TITLE
fix(evals): strip log-line noise from obsidian eval stdout

### DIFF
--- a/evals/lib/obsidian-driver.mjs
+++ b/evals/lib/obsidian-driver.mjs
@@ -14,14 +14,25 @@ const EVAL_TIMEOUT_MS = 10_000;
 /**
  * Run a JavaScript expression inside the live Obsidian process via CLI.
  * Returns the stringified result.
+ *
+ * The CLI may interleave log lines (e.g. `[Gemini Scribe] …`) before the
+ * actual reply line, so we locate the line beginning with `=> ` and treat
+ * everything from there to the end of stdout as the reply value. This
+ * preserves multi-line reply support (when the returned value contains
+ * real newlines) while filtering out plugin/console log noise.
  */
 export async function obsidianEval(code, { timeoutMs = EVAL_TIMEOUT_MS } = {}) {
 	const { stdout } = await exec(OBSIDIAN_BIN, ['eval', `code=${code}`], {
 		timeout: timeoutMs,
 	});
-	const raw = stdout.trim();
-	if (raw.startsWith('=>')) return raw.slice(2).trim();
-	return raw;
+	const lines = stdout.split('\n');
+	const replyIdx = lines.findIndex((l) => l.startsWith('=>'));
+	if (replyIdx === -1) {
+		throw new Error(`obsidian eval did not return a "=>" reply. Stdout was:\n${stdout.slice(0, 500)}`);
+	}
+	const replyLines = lines.slice(replyIdx);
+	replyLines[0] = replyLines[0].slice(2); // strip leading "=>"
+	return replyLines.join('\n').trim();
 }
 
 /**


### PR DESCRIPTION
## Summary

Closes #685.

`evals/lib/obsidian-driver.mjs:obsidianEval` was assuming the entire stdout started with `=>`, but plugin log lines (e.g. `[Gemini Scribe] …`) and stray `console.log` output land **before** the reply line. When that happened the previous logic returned the whole blob to the caller, which then crashed in `JSON.parse` downstream — observed during post-#684 verification on the `multi-file-summary` task:

```
errors: ["Failed to parse collector events: Unexpected token 'G', \"[Gemini Scr\"... is not valid JSON"]
```

That looks like a real eval failure but is purely a harness flake.

## Changes

`obsidianEval` now splits stdout by line, locates the first line beginning with `=>`, and returns everything from that line to the end of stdout as the reply. This:

- **Filters log noise** that appears before the reply
- **Preserves multi-line replies** for the rare case where the returned value contains real newlines (e.g. a literal string with embedded `\n` characters)
- **Throws a diagnostic error** if no `=>` line is found at all (the eval threw or the CLI failed in some other way), so the failure mode is legible instead of a confusing downstream `JSON.parse` on error text

## Verification

Manually tested four scenarios via a temporary script:

| Case | Result |
| --- | --- |
| Clean reply: `JSON.stringify({a: 1})` | `{"a":1}` ✓ |
| Log line precedes reply (the bug) | `{"events":[1,2]}` parsed correctly ✓ |
| Multi-line reply: `'line1\nline2\nline3'` | newlines preserved ✓ |
| No `=>` (eval threw) | `Error: obsidian eval did not return a "=>" reply. Stdout was: …` ✓ |

Three consecutive `npm run eval` runs end-to-end:

| Run | Pass rate | Solve rate | Errors |
| --- | --- | --- | --- |
| 1 | 100% | 100% | 0 |
| 2 | 100% | 80% | 0 (matcher miss only) |
| 3 | 100% | 80% | 0 (matcher miss only) |

Zero harness errors across all three. Solve rate variation is LLM nondeterminism on output matchers, not a harness issue.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer — fixes #685
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop — ran the harness 3x against a live Test Vault
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — desktop-only tooling
- [x] Documentation has been updated (if applicable) — N/A, no user-visible behavior change
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced CLI evaluation to more reliably parse command outputs
  * Improved error reporting with diagnostic information when output parsing encounters issues
  * Added support for properly handling multi-line responses from CLI commands

<!-- end of auto-generated comment: release notes by coderabbit.ai -->