### PR TITLE
feat(evals): pass^k reliability — repeat each task N times

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -12,17 +12,31 @@ Measures agent-loop behavior across repeatable tasks. Produces scored results wi
 ## Running
 
 ```bash
-# Run all tasks
+# Run all tasks (each task runs 3 times by default — see Reliability below)
 npm run eval
 
 # Run a single task (prefix match on task ID)
 npm run eval -- --task=smoke
+
+# Override how many times each task runs
+npm run eval -- --repeat=5
 
 # Keep scratch files and session history for debugging
 npm run eval -- --keep-artifacts
 ```
 
 Results are written to `evals/results/<timestamp>.json` and a summary prints to stdout.
+
+## Reliability: pass^k
+
+Each task runs **N** times (default `N=3`, override with `--repeat=N`). Two sets of metrics come out of that:
+
+- **`pass^k` / `solve^k`** — a task "passes at k" only when **all N runs** pass. This is the τ-bench reliability signal ([arXiv 2406.12045](https://arxiv.org/abs/2406.12045)); it's the number to watch when judging whether a code change helped or hurt, because it's noise-free in the sense that LLM nondeterminism on a single run can't inflate it.
+- **`mean_pass_rate` / `mean_solve_rate`** — proportion of all task × run cells that passed/solved. Useful signal but noisier.
+
+Tasks that land between 0 and N solves are flagged as **flaky** (e.g. `2/3 ⚠` in the summary). One flaky task isn't necessarily a regression, but the trend matters — if a change takes a previously-stable task into flaky territory, that's visible in the compare output.
+
+Rule of thumb: `N=3` for day-to-day development, `N=5` or more if you're publishing numbers or making a merge-blocking decision.
 
 ## Comparing against a baseline
 
@@ -104,14 +118,19 @@ A task is **solved** if it passes AND:
 
 ## Aggregate metrics
 
-| Metric                             | Description                          |
-| ---------------------------------- | ------------------------------------ |
-| `pass_rate`                        | % of tasks passed                    |
-| `solve_rate`                       | % of tasks solved                    |
-| `mean_turns` / `p95_turns`         | Turn distribution                    |
-| `mean_cache_ratio`                 | Average implicit-cache effectiveness |
-| `mean_cost_usd` / `total_cost_usd` | Cost estimates                       |
-| `total_loop_fires`                 | Total loop-detection events          |
+| Metric                             | Description                                                             |
+| ---------------------------------- | ----------------------------------------------------------------------- |
+| `pass_k_rate`                      | % of tasks where **every** run passed (τ-bench `pass^k`)                |
+| `solve_k_rate`                     | % of tasks where **every** run solved — primary signal for code changes |
+| `mean_pass_rate`                   | Proportion of task × run cells that passed                              |
+| `mean_solve_rate`                  | Proportion of task × run cells that solved                              |
+| `flaky_task_count`                 | Tasks where some (but not all) runs solved                              |
+| `n_runs`                           | Number of repeats per task                                              |
+| `total_runs`                       | Total task × run cells (`tasks × n_runs`)                               |
+| `mean_turns` / `p95_turns`         | Turn distribution across all runs                                       |
+| `mean_cache_ratio`                 | Average implicit-cache effectiveness                                    |
+| `mean_cost_usd` / `total_cost_usd` | Per-run mean and total spend (total grows with `--repeat`)              |
+| `total_loop_fires`                 | Total loop-detection events across all runs                             |
 
 ## Architecture
 

--- a/evals/lib/compare.mjs
+++ b/evals/lib/compare.mjs
@@ -14,8 +14,11 @@ import { join, resolve } from 'node:path';
 
 const METRIC_KEYS = ['turns', 'cache_ratio', 'cost_usd', 'loop_fires', 'tool_calls'];
 const AGG_KEYS = [
-	'pass_rate',
-	'solve_rate',
+	'pass_k_rate',
+	'solve_k_rate',
+	'mean_pass_rate',
+	'mean_solve_rate',
+	'flaky_task_count',
 	'mean_turns',
 	'p95_turns',
 	'mean_cache_ratio',
@@ -23,8 +26,21 @@ const AGG_KEYS = [
 	'total_cost_usd',
 	'total_loop_fires',
 ];
-const LOWER_IS_BETTER = new Set(['mean_turns', 'p95_turns', 'mean_cost_usd', 'total_cost_usd', 'total_loop_fires']);
-const HIGHER_IS_BETTER = new Set(['pass_rate', 'solve_rate', 'mean_cache_ratio']);
+const LOWER_IS_BETTER = new Set([
+	'flaky_task_count',
+	'mean_turns',
+	'p95_turns',
+	'mean_cost_usd',
+	'total_cost_usd',
+	'total_loop_fires',
+]);
+const HIGHER_IS_BETTER = new Set([
+	'pass_k_rate',
+	'solve_k_rate',
+	'mean_pass_rate',
+	'mean_solve_rate',
+	'mean_cache_ratio',
+]);
 // Per-task metric directionality. tool_calls is intentionally absent — more
 // or fewer tool calls isn't a regression on its own (it depends on the task).
 const PER_TASK_LOWER_IS_BETTER = new Set(['turns', 'cost_usd', 'loop_fires']);
@@ -80,20 +96,32 @@ async function main() {
 		console.log(`  ${key.padEnd(22)} ${fmtDelta(b, c)}${flag}`);
 	}
 
-	// Per-task comparison
+	// Per-task comparison. Solved/passed are per-task-run counts; treat any
+	// drop in count as a regression (e.g. 3/3 → 2/3 is flakiness appearing,
+	// 2/3 → 0/3 is a harder regression).
 	console.log('\nPer-task changes:');
 	const baseTaskMap = new Map(baseline.tasks.map((t) => [t.id, t]));
 	const currentTaskMap = new Map(current.tasks.map((t) => [t.id, t]));
 	for (const ct of current.tasks) {
 		const bt = baseTaskMap.get(ct.id);
+		const cN = ct.n_runs ?? 1;
+		const cSolved = ct.solved_count ?? (ct.solved ? 1 : 0);
+		const cPassed = ct.passed_count ?? (ct.passed ? 1 : 0);
 		if (!bt) {
-			console.log(`  [NEW] ${ct.id}: solved=${ct.solved}, turns=${ct.metrics.turns}`);
+			console.log(`  [NEW] ${ct.id}: solved ${cSolved}/${cN}, turns ${ct.metrics.turns}`);
 			continue;
 		}
+		const bN = bt.n_runs ?? 1;
+		const bSolved = bt.solved_count ?? (bt.solved ? 1 : 0);
+		const bPassed = bt.passed_count ?? (bt.passed ? 1 : 0);
 		const changes = [];
-		if (bt.solved !== ct.solved) {
-			const marker = bt.solved && !ct.solved ? '⚠ ' : '';
-			changes.push(`${marker}solved: ${bt.solved} → ${ct.solved}`);
+		if (bSolved !== cSolved || bN !== cN) {
+			const marker = cSolved / cN < bSolved / bN ? '⚠ ' : '';
+			changes.push(`${marker}solved: ${bSolved}/${bN} → ${cSolved}/${cN}`);
+		}
+		if (bPassed !== cPassed || bN !== cN) {
+			const marker = cPassed / cN < bPassed / bN ? '⚠ ' : '';
+			changes.push(`${marker}passed: ${bPassed}/${bN} → ${cPassed}/${cN}`);
 		}
 		for (const key of METRIC_KEYS) {
 			const b = bt.metrics[key] ?? 0;

--- a/evals/lib/obsidian-driver.mjs
+++ b/evals/lib/obsidian-driver.mjs
@@ -14,14 +14,25 @@ const EVAL_TIMEOUT_MS = 10_000;
 /**
  * Run a JavaScript expression inside the live Obsidian process via CLI.
  * Returns the stringified result.
+ *
+ * The CLI may interleave log lines (e.g. `[Gemini Scribe] …`) before the
+ * actual reply line, so we locate the line beginning with `=> ` and treat
+ * everything from there to the end of stdout as the reply value. This
+ * preserves multi-line reply support (when the returned value contains
+ * real newlines) while filtering out plugin/console log noise.
  */
 export async function obsidianEval(code, { timeoutMs = EVAL_TIMEOUT_MS } = {}) {
 	const { stdout } = await exec(OBSIDIAN_BIN, ['eval', `code=${code}`], {
 		timeout: timeoutMs,
 	});
-	const raw = stdout.trim();
-	if (raw.startsWith('=>')) return raw.slice(2).trim();
-	return raw;
+	const lines = stdout.split('\n');
+	const replyIdx = lines.findIndex((l) => l.startsWith('=>'));
+	if (replyIdx === -1) {
+		throw new Error(`obsidian eval did not return a "=>" reply. Stdout was:\n${stdout.slice(0, 500)}`);
+	}
+	const replyLines = lines.slice(replyIdx);
+	replyLines[0] = replyLines[0].slice(2); // strip leading "=>"
+	return replyLines.join('\n').trim();
 }
 
 /**

--- a/evals/lib/reporter.mjs
+++ b/evals/lib/reporter.mjs
@@ -3,7 +3,7 @@
  */
 
 import { writeFile, mkdir } from 'node:fs/promises';
-import { join, dirname } from 'node:path';
+import { join } from 'node:path';
 
 function percentile(arr, p) {
 	if (arr.length === 0) return 0;
@@ -12,41 +12,120 @@ function percentile(arr, p) {
 	return sorted[Math.max(0, idx)];
 }
 
+function mean(nums) {
+	if (nums.length === 0) return 0;
+	return nums.reduce((a, b) => a + b, 0) / nums.length;
+}
+
+function round(n, places) {
+	const factor = 10 ** places;
+	return Math.round(n * factor) / factor;
+}
+
+/**
+ * Aggregate N per-run scorer results for a single task into a TaskResult
+ * with run-level detail preserved alongside cross-run aggregates. `pass_k`
+ * / `solve_k` are the τ-bench-style reliability signals (true iff every
+ * one of the N runs passed/solved). `flaky` is the in-between case —
+ * some but not all runs solved.
+ */
+export function aggregateTaskRuns(taskId, runs) {
+	const n = runs.length;
+	const passedCount = runs.filter((r) => r.passed).length;
+	const solvedCount = runs.filter((r) => r.solved).length;
+
+	const metricKeys = [
+		'turns',
+		'tool_calls',
+		'prompt_tokens',
+		'cached_tokens',
+		'cache_ratio',
+		'output_tokens',
+		'cost_usd',
+		'loop_fires',
+		'duration_ms',
+	];
+	const aggMetrics = {};
+	for (const key of metricKeys) {
+		const values = runs.map((r) => r.metrics[key] ?? 0);
+		aggMetrics[key] = key === 'cache_ratio' ? round(mean(values), 3) : round(mean(values), 6);
+	}
+	// tool_list is useful for debugging; keep the first run's so the shape
+	// matches a single-run TaskResult for any downstream consumer.
+	aggMetrics.tool_list = runs[0]?.metrics.tool_list ?? [];
+
+	return {
+		id: taskId,
+		n_runs: n,
+		passed_count: passedCount,
+		solved_count: solvedCount,
+		pass_k: passedCount === n,
+		solve_k: solvedCount === n,
+		flaky: solvedCount > 0 && solvedCount < n,
+		metrics: aggMetrics,
+		runs,
+	};
+}
+
 /**
  * Compute aggregate metrics across all task results.
  */
 export function computeAggregates(taskResults) {
 	const total = taskResults.length;
-	if (total === 0) {
-		return {
-			total_tasks: 0,
-			pass_rate: 0,
-			solve_rate: 0,
-			mean_turns: 0,
-			p95_turns: 0,
-			mean_cache_ratio: 0,
-			mean_cost_usd: 0,
-			total_cost_usd: 0,
-			total_loop_fires: 0,
-		};
-	}
+	const empty = {
+		total_tasks: 0,
+		n_runs: 0,
+		total_runs: 0,
+		pass_k_rate: 0,
+		solve_k_rate: 0,
+		mean_pass_rate: 0,
+		mean_solve_rate: 0,
+		flaky_task_count: 0,
+		mean_turns: 0,
+		p95_turns: 0,
+		mean_cache_ratio: 0,
+		mean_cost_usd: 0,
+		total_cost_usd: 0,
+		total_loop_fires: 0,
+	};
+	if (total === 0) return empty;
 
-	const passed = taskResults.filter((r) => r.passed).length;
-	const solved = taskResults.filter((r) => r.solved).length;
-	const turns = taskResults.map((r) => r.metrics.turns);
-	const costs = taskResults.map((r) => r.metrics.cost_usd);
-	const cacheRatios = taskResults.map((r) => r.metrics.cache_ratio);
+	const nRuns = taskResults[0].n_runs ?? 1;
+	const totalRuns = taskResults.reduce((a, t) => a + (t.n_runs ?? 1), 0);
+
+	const passK = taskResults.filter((t) => t.pass_k).length;
+	const solveK = taskResults.filter((t) => t.solve_k).length;
+	const flakyCount = taskResults.filter((t) => t.flaky).length;
+
+	// Mean rates: proportion of task×run cells that passed/solved.
+	const passedCells = taskResults.reduce((a, t) => a + t.passed_count, 0);
+	const solvedCells = taskResults.reduce((a, t) => a + t.solved_count, 0);
+
+	// Perf metrics flattened across every task×run for p95 / means.
+	const allRuns = taskResults.flatMap((t) => t.runs);
+	const turns = allRuns.map((r) => r.metrics.turns);
+	const costs = allRuns.map((r) => r.metrics.cost_usd);
+	const cacheRatios = allRuns.map((r) => r.metrics.cache_ratio);
+	const loopFires = allRuns.reduce((a, r) => a + r.metrics.loop_fires, 0);
 
 	return {
 		total_tasks: total,
-		pass_rate: Math.round((passed / total) * 100 * 10) / 10,
-		solve_rate: Math.round((solved / total) * 100 * 10) / 10,
-		mean_turns: Math.round((turns.reduce((a, b) => a + b, 0) / total) * 10) / 10,
+		n_runs: nRuns,
+		total_runs: totalRuns,
+		pass_k_rate: round((passK / total) * 100, 1),
+		solve_k_rate: round((solveK / total) * 100, 1),
+		mean_pass_rate: round((passedCells / totalRuns) * 100, 1),
+		mean_solve_rate: round((solvedCells / totalRuns) * 100, 1),
+		flaky_task_count: flakyCount,
+		mean_turns: round(mean(turns), 1),
 		p95_turns: percentile(turns, 95),
-		mean_cache_ratio: Math.round((cacheRatios.reduce((a, b) => a + b, 0) / total) * 1000) / 1000,
-		mean_cost_usd: Math.round((costs.reduce((a, b) => a + b, 0) / total) * 1_000_000) / 1_000_000,
-		total_cost_usd: Math.round(costs.reduce((a, b) => a + b, 0) * 1_000_000) / 1_000_000,
-		total_loop_fires: taskResults.reduce((a, r) => a + r.metrics.loop_fires, 0),
+		mean_cache_ratio: round(mean(cacheRatios), 3),
+		mean_cost_usd: round(mean(costs), 6),
+		total_cost_usd: round(
+			costs.reduce((a, b) => a + b, 0),
+			6
+		),
+		total_loop_fires: loopFires,
 	};
 }
 
@@ -89,30 +168,44 @@ export function printSummary(result) {
 	console.log('\n=== Eval Run Summary ===');
 	console.log(`Git SHA: ${result.git_sha}`);
 	console.log(`Model:   ${result.model}`);
-	console.log(`Tasks:   ${a.total_tasks}`);
+	console.log(`Tasks:   ${a.total_tasks} × ${a.n_runs} run${a.n_runs === 1 ? '' : 's'} = ${a.total_runs} total`);
 	console.log('');
 
 	// Per-task table
-	console.log('Task                          Pass  Solve  Turns  Cache%  Cost($)  Loops');
+	console.log('Task                           Pass  Solve  Turns  Cache%  Cost($)  Loops');
 	console.log('-'.repeat(80));
 	for (const t of result.tasks) {
 		const m = t.metrics;
-		const passStr = t.passed ? ' OK ' : 'FAIL';
-		const solveStr = t.solved ? ' OK ' : 'FAIL';
+		const n = t.n_runs;
+		const passStr = `${t.passed_count}/${n}`.padStart(4);
+		let solveStr = `${t.solved_count}/${n}`;
+		if (t.flaky) solveStr += ' ⚠';
+		else solveStr += '  ';
 		const cacheStr = `${Math.round(m.cache_ratio * 100)}%`;
 		console.log(
-			`${t.id.padEnd(30)} ${passStr}  ${solveStr}  ${String(m.turns).padStart(5)}  ${cacheStr.padStart(6)}  ${m.cost_usd.toFixed(4).padStart(7)}  ${String(m.loop_fires).padStart(5)}`
+			`${t.id.padEnd(30)} ${passStr}  ${solveStr.padStart(5)}  ${m.turns.toFixed(1).padStart(5)}  ${cacheStr.padStart(6)}  ${m.cost_usd.toFixed(4).padStart(7)}  ${String(Math.round(m.loop_fires)).padStart(5)}`
 		);
 	}
 
 	console.log('-'.repeat(80));
 	console.log('');
-	console.log(`Pass rate:      ${a.pass_rate}%`);
-	console.log(`Solve rate:     ${a.solve_rate}%`);
+	const k = a.n_runs;
+	// Reliable headline numbers: "all N runs of this task met the bar."
+	console.log(`pass^${k} rate:     ${a.pass_k_rate}%  (mean ${a.mean_pass_rate}%)`);
+	console.log(`solve^${k} rate:    ${a.solve_k_rate}%  (mean ${a.mean_solve_rate}%)`);
+	if (a.flaky_task_count > 0) {
+		const flakyNames = result.tasks
+			.filter((t) => t.flaky)
+			.map((t) => t.id)
+			.join(', ');
+		console.log(`Flaky tasks:    ${a.flaky_task_count} (${flakyNames})`);
+	} else {
+		console.log(`Flaky tasks:    0`);
+	}
 	console.log(`Mean turns:     ${a.mean_turns} (p95: ${a.p95_turns})`);
 	console.log(`Mean cache:     ${Math.round(a.mean_cache_ratio * 100)}%`);
-	console.log(`Mean cost:      $${a.mean_cost_usd.toFixed(4)}`);
-	console.log(`Total cost:     $${a.total_cost_usd.toFixed(4)}`);
+	console.log(`Mean cost:      $${a.mean_cost_usd.toFixed(4)} per run`);
+	console.log(`Total cost:     $${a.total_cost_usd.toFixed(4)} (${a.total_runs} runs)`);
 	console.log(`Loop fires:     ${a.total_loop_fires}`);
 	console.log('');
 }

--- a/evals/run.mjs
+++ b/evals/run.mjs
@@ -31,15 +31,23 @@ import {
 } from './lib/obsidian-driver.mjs';
 import { installCollector, readAndClearCollector, removeCollector } from './lib/collector.mjs';
 import { scoreTask } from './lib/scorer.mjs';
-import { buildResult, writeResults, printSummary } from './lib/reporter.mjs';
+import { aggregateTaskRuns, buildResult, writeResults, printSummary } from './lib/reporter.mjs';
 
 const EVALS_DIR = resolve(import.meta.dirname);
 
+const DEFAULT_REPEAT = 3;
+
 function parseArgs() {
 	const args = process.argv.slice(2);
+	const repeatArg = args.find((a) => a.startsWith('--repeat='))?.split('=')[1];
+	const repeat = repeatArg ? parseInt(repeatArg, 10) : DEFAULT_REPEAT;
+	if (!Number.isInteger(repeat) || repeat < 1) {
+		throw new Error(`--repeat must be a positive integer, got "${repeatArg}"`);
+	}
 	return {
 		taskFilter: args.find((a) => a.startsWith('--task='))?.split('=')[1] || null,
 		keepArtifacts: args.includes('--keep-artifacts'),
+		repeat,
 	};
 }
 
@@ -95,7 +103,6 @@ async function getModelName() {
 
 async function runTask(task, keepArtifacts) {
 	const title = `[eval] ${task.id}`;
-	console.log(`\n--- Running: ${task.id} ---`);
 	console.log(`  "${task.description}"`);
 
 	let sessionInfo;
@@ -171,7 +178,7 @@ async function runTask(task, keepArtifacts) {
 }
 
 async function main() {
-	const { taskFilter, keepArtifacts } = parseArgs();
+	const { taskFilter, keepArtifacts, repeat } = parseArgs();
 	console.log('=== Gemini Scribe Eval Harness ===');
 
 	// Verify prerequisites
@@ -190,13 +197,19 @@ async function main() {
 		console.error('No tasks found' + (taskFilter ? ` matching "${taskFilter}"` : '') + '.');
 		process.exit(1);
 	}
-	console.log(`Running ${tasks.length} task(s)...`);
+	console.log(`Running ${tasks.length} task(s) × ${repeat} run${repeat === 1 ? '' : 's'}...`);
 
-	// Run tasks sequentially
+	// Run tasks sequentially. Each task runs `repeat` times so we can report
+	// pass^k reliability on top of per-run pass/solve rates.
 	const taskResults = [];
 	for (const task of tasks) {
-		const result = await runTask(task, keepArtifacts);
-		taskResults.push(result);
+		const runs = [];
+		for (let i = 0; i < repeat; i++) {
+			const runLabel = repeat > 1 ? ` [run ${i + 1}/${repeat}]` : '';
+			console.log(`\n--- Running: ${task.id}${runLabel} ---`);
+			runs.push(await runTask(task, keepArtifacts));
+		}
+		taskResults.push(aggregateTaskRuns(task.id, runs));
 	}
 
 	// Build result, write, print


### PR DESCRIPTION
## Summary

Closes #688. Part of the #687 epic.

Each task now runs N times (default 3, `--repeat=N` to override) so we can report the τ-bench `pass^k` / `solve^k` reliability signal alongside per-run means. The motivation: a single-run solve rate of 80% could mean "4/5 tasks reliably solve and 1 is a total failure" or "all 5 tasks pass 80% of the time" — hugely different signals, previously indistinguishable. Now we can tell.

End-to-end run of the existing 5 tasks at N=3:

```
Task                           Pass  Solve  Turns  Cache%  Cost($)  Loops
--------------------------------------------------------------------------------
create-note-from-search         3/3  3/3      4.3     88%   0.0009      0
find-tagged-notes               3/3  3/3      3.3     70%   0.0010      0
multi-file-summary              3/3  2/3 ⚠    3.0     63%   0.0011      0
read-and-answer                 3/3  3/3      2.0     66%   0.0009      0
smoke-list-files                3/3  3/3      2.0     66%   0.0009      0
--------------------------------------------------------------------------------

pass^3 rate:     100%  (mean 100%)
solve^3 rate:    80%  (mean 93.3%)
Flaky tasks:    1 (multi-file-summary)
```

Total spend for this run: $0.0146 across 15 task×runs.

## Changes

- **`run.mjs`** — parse `--repeat=N` (validated as positive integer), wrap the per-task loop N times, pass the runs array to the new aggregator. Per-run log lines include `[run i/N]`.
- **`lib/reporter.mjs`** — new `aggregateTaskRuns(taskId, runs)` produces a TaskResult with run-level detail preserved (`runs[]`) plus cross-run aggregates (`passed_count`, `solved_count`, `pass_k`, `solve_k`, `flaky`, mean metrics). `computeAggregates` adds `pass_k_rate`, `solve_k_rate` (the headline reliability numbers), `mean_pass_rate` / `mean_solve_rate` (the noisier per-cell versions), `flaky_task_count`, `n_runs`, `total_runs`. Summary prints `X/N` per task with a `⚠` on flaky rows; footer shows `pass^k` / `solve^k` with means in parens, lists flaky task ids, and shows total spend as `$X.XXXX (M runs)` so the cost impact is visible.
- **`lib/compare.mjs`** — `AGG_KEYS` updated to the new schema; `pass_k_rate` / `solve_k_rate` / `mean_pass_rate` / `mean_solve_rate` are HIGHER_IS_BETTER, `flaky_task_count` is LOWER_IS_BETTER. Per-task diff compares passed/solved counts as fractions (`3/3 → 2/3 ⚠`) and flags a regression whenever the ratio decreases. Backwards-compatible with old single-run baselines via `?? (t.solved ? 1 : 0)` fallbacks, so an old `baseline.json` still works as input.
- **`README.md`** — new "Reliability: pass^k" section explaining the default, the two metric families, flaky detection, and the rule-of-thumb (N=3 dev, N=5 publish). Aggregate-metrics table updated.

## Verification

- End-to-end at N=3 against the current 5-task suite (stdout above). Exactly caught the `multi-file-summary` flakiness we'd observed ad-hoc during #686.
- Compare script smoke-tested against synthetic baseline / current pairs in both directions (regression and improvement). `3/3 → 2/3 ⚠` renders correctly; aggregate flag fires on `solve_k_rate` / `pass_k_rate` drops and `flaky_task_count` increases; improvements don't fire the marker.
- `npm test` — 1427 passed, 5 pre-existing skips.
- `npm run build` — clean.
- `npm run format-check` — clean.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer — closes #688, part of #687
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop — end-to-end run against the live Test Vault
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — desktop-only tooling
- [x] Documentation has been updated (if applicable) — README's Reliability section plus aggregate-metrics table updated
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--repeat=N` CLI option to run each task multiple times (default 3 times)
  * Introduced reliability metrics (`pass^k`, `solve^k`) tracking all-run success rates
  * Added flaky task detection and reporting when some runs succeed and others fail

* **Bug Fixes**
  * Fixed multi-line result parsing from Obsidian CLI output

* **Documentation**
  * Updated eval-running guide with repeat behavior and reliability metric definitions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->