### PR TITLE
feat(evals): --model= flag to override chatModelName for a run

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -21,6 +21,9 @@ npm run eval -- --task=smoke
 # Override how many times each task runs
 npm run eval -- --repeat=5
 
+# Sweep models against a fixed task suite (see Model overrides below)
+npm run eval -- --model=gemini-2.5-flash-lite
+
 # Keep scratch files and session history for debugging
 npm run eval -- --keep-artifacts
 ```
@@ -37,6 +40,27 @@ Each task runs **N** times (default `N=3`, override with `--repeat=N`). Two sets
 Tasks that land between 0 and N solves are flagged as **flaky** (e.g. `2/3 ⚠` in the summary). One flaky task isn't necessarily a regression, but the trend matters — if a change takes a previously-stable task into flaky territory, that's visible in the compare output.
 
 Rule of thumb: `N=3` for day-to-day development, `N=5` or more if you're publishing numbers or making a merge-blocking decision.
+
+## Model overrides
+
+By default the harness uses whatever `chatModelName` is currently set in the plugin's settings. Pass `--model=<id>` to override that for the duration of the run:
+
+```bash
+npm run eval -- --model=gemini-2.5-flash-lite
+npm run eval -- --model=gemini-2.5-pro --repeat=5
+```
+
+The override is **transient**: it's applied to `plugin.settings.chatModelName` in memory at the start of the run and restored on exit (including on Ctrl-C / SIGTERM). The setting is **not** persisted to disk, so the user's configured model is unaffected.
+
+The override stamps into the result file's `model` field, so a multi-model sweep produces one result file per invocation that compare and trend independently:
+
+```bash
+for m in gemini-2.5-flash gemini-2.5-flash-lite gemini-2.5-pro; do
+  npm run eval -- --model=$m --repeat=5
+done
+```
+
+Caveat: while the harness is running, the live agent view is using the override too. That's the same disruption already implied by the harness driving the agent — just don't try to use the agent view in another window mid-run.
 
 ## Comparing against a baseline
 

--- a/evals/lib/obsidian-driver.mjs
+++ b/evals/lib/obsidian-driver.mjs
@@ -36,6 +36,40 @@ export async function obsidianEval(code, { timeoutMs = EVAL_TIMEOUT_MS } = {}) {
 }
 
 /**
+ * Read a single key from the plugin's in-memory settings.
+ *
+ * Returns whatever is currently on `plugin.settings[key]` (including null
+ * or undefined for unset keys). Does not touch disk — pairs with `setSetting`
+ * to apply transient overrides for an eval run.
+ */
+export async function getSetting(key) {
+	const keyLiteral = JSON.stringify(key);
+	const result = await obsidianEval(
+		`JSON.stringify(app.plugins.plugins['gemini-scribe'].settings[${keyLiteral}] ?? null)`
+	);
+	return JSON.parse(result);
+}
+
+/**
+ * Mutate a single key on the plugin's in-memory settings without persisting.
+ *
+ * Used for transient eval-run overrides (e.g. `--model=` flag). Does NOT
+ * call `saveSettings()` — that would trigger a full plugin reinit, which
+ * is overkill for keys like `chatModelName` that are read fresh from
+ * `plugin.settings` per-request.
+ */
+export async function setSetting(key, value) {
+	const keyLiteral = JSON.stringify(key);
+	const valueLiteral = JSON.stringify(value);
+	await obsidianEval(
+		`(() => {
+    app.plugins.plugins['gemini-scribe'].settings[${keyLiteral}] = ${valueLiteral};
+    return '"set"';
+  })()`
+	);
+}
+
+/**
  * Verify the plugin is loaded and the agent view is available.
  */
 export async function verifyPlugin() {

--- a/evals/run.mjs
+++ b/evals/run.mjs
@@ -28,6 +28,8 @@ import {
 	cleanup,
 	getLastModelResponse,
 	obsidianEval,
+	getSetting,
+	setSetting,
 } from './lib/obsidian-driver.mjs';
 import { installCollector, readAndClearCollector, removeCollector } from './lib/collector.mjs';
 import { scoreTask } from './lib/scorer.mjs';
@@ -44,12 +46,48 @@ function parseArgs() {
 	if (!Number.isInteger(repeat) || repeat < 1) {
 		throw new Error(`--repeat must be a positive integer, got "${repeatArg}"`);
 	}
+	// Use slice(1).join('=') so model ids containing '=' (none today, but
+	// future-proof for things like cross-region prefixes) survive the split.
+	const modelArg = args.find((a) => a.startsWith('--model='));
+	const model = modelArg ? modelArg.slice('--model='.length) : null;
+	if (model !== null && model.length === 0) {
+		throw new Error('--model requires a non-empty value');
+	}
 	return {
 		taskFilter: args.find((a) => a.startsWith('--task='))?.split('=')[1] || null,
 		keepArtifacts: args.includes('--keep-artifacts'),
 		repeat,
+		model,
 	};
 }
+
+// Module-scoped state for the chat-model override so signal handlers can
+// reach it. `originalChatModel` may be null/string; the boolean tracks
+// whether we successfully captured a prior value to restore.
+let originalChatModel = null;
+let modelWasOverridden = false;
+
+async function restoreChatModel() {
+	if (!modelWasOverridden) return;
+	try {
+		await setSetting('chatModelName', originalChatModel);
+	} catch (err) {
+		console.error(`Failed to restore chatModelName: ${err.message}`);
+	}
+	modelWasOverridden = false;
+}
+
+// Restore the override on Ctrl-C / kill so the user's plugin doesn't keep
+// running with the eval's model long after the harness exits.
+process.on('SIGINT', async () => {
+	console.log('\n[interrupted] restoring chatModelName...');
+	await restoreChatModel();
+	process.exit(130);
+});
+process.on('SIGTERM', async () => {
+	await restoreChatModel();
+	process.exit(143);
+});
 
 async function loadTasks(filter) {
 	const tasksDir = join(EVALS_DIR, 'tasks');
@@ -178,7 +216,7 @@ async function runTask(task, keepArtifacts) {
 }
 
 async function main() {
-	const { taskFilter, keepArtifacts, repeat } = parseArgs();
+	const { taskFilter, keepArtifacts, repeat, model } = parseArgs();
 	console.log('=== Gemini Scribe Eval Harness ===');
 
 	// Verify prerequisites
@@ -191,34 +229,47 @@ async function main() {
 	}
 	console.log(`Plugin v${pluginStatus.version} ready.`);
 
-	// Load tasks
-	const tasks = await loadTasks(taskFilter);
-	if (tasks.length === 0) {
-		console.error('No tasks found' + (taskFilter ? ` matching "${taskFilter}"` : '') + '.');
-		process.exit(1);
+	// Apply the chat-model override BEFORE loading tasks so the result-file's
+	// `model` field (read via getModelName at the end) reflects the override.
+	if (model) {
+		originalChatModel = await getSetting('chatModelName');
+		await setSetting('chatModelName', model);
+		modelWasOverridden = true;
+		console.log(`Overriding chatModelName: ${originalChatModel ?? '(unset)'} → ${model}`);
 	}
-	console.log(`Running ${tasks.length} task(s) × ${repeat} run${repeat === 1 ? '' : 's'}...`);
 
-	// Run tasks sequentially. Each task runs `repeat` times so we can report
-	// pass^k reliability on top of per-run pass/solve rates.
-	const taskResults = [];
-	for (const task of tasks) {
-		const runs = [];
-		for (let i = 0; i < repeat; i++) {
-			const runLabel = repeat > 1 ? ` [run ${i + 1}/${repeat}]` : '';
-			console.log(`\n--- Running: ${task.id}${runLabel} ---`);
-			runs.push(await runTask(task, keepArtifacts));
+	try {
+		// Load tasks
+		const tasks = await loadTasks(taskFilter);
+		if (tasks.length === 0) {
+			console.error('No tasks found' + (taskFilter ? ` matching "${taskFilter}"` : '') + '.');
+			process.exit(1);
 		}
-		taskResults.push(aggregateTaskRuns(task.id, runs));
-	}
+		console.log(`Running ${tasks.length} task(s) × ${repeat} run${repeat === 1 ? '' : 's'}...`);
 
-	// Build result, write, print
-	const gitSha = getGitSha();
-	const modelName = await getModelName();
-	const result = buildResult(taskResults, gitSha, modelName);
-	const outPath = await writeResults(result, EVALS_DIR);
-	printSummary(result);
-	console.log(`Results written to: ${outPath}`);
+		// Run tasks sequentially. Each task runs `repeat` times so we can report
+		// pass^k reliability on top of per-run pass/solve rates.
+		const taskResults = [];
+		for (const task of tasks) {
+			const runs = [];
+			for (let i = 0; i < repeat; i++) {
+				const runLabel = repeat > 1 ? ` [run ${i + 1}/${repeat}]` : '';
+				console.log(`\n--- Running: ${task.id}${runLabel} ---`);
+				runs.push(await runTask(task, keepArtifacts));
+			}
+			taskResults.push(aggregateTaskRuns(task.id, runs));
+		}
+
+		// Build result, write, print
+		const gitSha = getGitSha();
+		const modelName = await getModelName();
+		const result = buildResult(taskResults, gitSha, modelName);
+		const outPath = await writeResults(result, EVALS_DIR);
+		printSummary(result);
+		console.log(`Results written to: ${outPath}`);
+	} finally {
+		await restoreChatModel();
+	}
 }
 
 main().catch((err) => {


### PR DESCRIPTION
## Summary

Closes #689. Part of #687.

Pairs naturally with #688's pass^k: the canonical "did this change help?" experiment is *hold the suite fixed × hold N fixed × sweep the model*. Without this you had to toggle the plugin setting by hand and reload between models, which made any meaningful sweep painful.

```bash
for m in gemini-2.5-flash gemini-2.5-flash-lite gemini-2.5-pro; do
  npm run eval -- --model=$m --repeat=5
done
```

## Changes

- **`lib/obsidian-driver.mjs`** — new `getSetting(key)` and `setSetting(key, value)` helpers. `setSetting` mutates `plugin.settings` in memory and intentionally does **not** call `saveSettings()` because that triggers a full plugin reinit (`setupGeminiScribe`), which would tear down the agent view session the harness is driving. Verified by grep that every `chatModelName` consumer reads `plugin.settings` fresh at request time (e.g. `agent-view-send.ts:301`, `agent-view-tool-followup.ts:42,63`, `tools/google-search-tool.ts:55`), so direct mutation takes effect on the next API call without any reload.
- **`run.mjs`** — parse `--model=<id>` (rejects empty value), capture the prior `chatModelName`, apply override **before** loading tasks (so `getModelName()` at the end of the run picks up the override for the result file's `model` field), restore in `finally`. Module-scoped state is reachable from SIGINT/SIGTERM handlers that restore and exit with the conventional 128+signal status code (130 / 143).
- **`README.md`** — new "Model overrides" section explaining the transient-only semantics, the not-persisted-to-disk guarantee, the signal-safe restore, and a copy-pasteable sweep loop.

## Verification

Tested all four paths against a live vault. Captured original `chatModelName = gemini-3.1-pro-preview-customtools`:

| Path | Result |
| --- | --- |
| Override applied at start | Result file shows `Model: gemini-2.5-flash-lite`, cost reflects flash-lite pricing ✓ |
| Restore after clean exit | `obsidian eval` post-run shows original model back ✓ |
| Setting visible to live plugin during run | `obsidian eval` mid-run shows the override is the live value ✓ |
| Restore after SIGINT mid-run | log prints `[interrupted] restoring chatModelName...`, `obsidian eval` post-kill shows original restored, process exits 130 ✓ |

Pre-flight: `npm run format-check` clean, `npm test` 1427 passed (5 pre-existing skips), `npm run build` clean.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer — closes #689, part of #687
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop — end-to-end with override + restore + SIGINT against the live Test Vault
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — desktop-only tooling
- [x] Documentation has been updated (if applicable) — README's new "Model overrides" section
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Override model selection during evaluation runs with the `--model=<id>` parameter.
  * Model overrides are temporary and automatically restored after execution, including when interrupted.
  * Selected model is recorded in results for comparing performance across different models.
  * Added documentation with examples for testing single and multiple models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->