### PR TITLE
feat: add Ollama provider for local-model support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,10 @@
 
 Gemini Scribe is an Obsidian plugin that integrates Google's Gemini AI models, providing powerful AI-driven assistance for note-taking, writing, and knowledge management directly within Obsidian. It leverages your notes as context for AI interactions, making it a highly personalized and integrated experience.
 
-> **Note:** This plugin requires a Google Gemini API key. Free tier available at [Google AI Studio](https://aistudio.google.com/apikey).
+> **Note:** Pick one of two setup paths in plugin settings → **Provider**:
+>
+> - **Google Gemini (cloud)** — requires a Gemini API key (free tier available at [Google AI Studio](https://aistudio.google.com/apikey)).
+> - **Ollama (local)** — runs locally with no API key; install [Ollama](https://ollama.com), pull a model, and select it in settings. See [docs/guide/ollama-setup.md](docs/guide/ollama-setup.md) for the feature-parity table.
 
 ## What's New in v4.6.0
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ Gemini Scribe is an Obsidian plugin that integrates Google's Gemini AI models, p
 4. Open Agent Chat with the ribbon icon or command palette
 5. Start using the AI agent to work with your vault!
 
+**Prefer running models locally?** Gemini Scribe also supports [Ollama](https://ollama.com) — install Ollama, pull a model with `ollama pull llama3.2`, and switch the **Provider** in settings to "Ollama (local)". A few Gemini-built-in features (Google Search, URL Context, Deep Research, image generation, RAG) are unavailable on Ollama; see [docs/guide/ollama-setup.md](docs/guide/ollama-setup.md) for details.
+
 ## Installation
 
 1.  **Community Plugins (Recommended):**
@@ -85,7 +87,8 @@ Gemini Scribe is an Obsidian plugin that integrates Google's Gemini AI models, p
 2.  **Configure Plugin Settings:**
     - Open Obsidian Settings.
     - Go to "Gemini Scribe" under "Community plugins".
-    - **API Key:** Paste your Gemini API key here. Your key is stored securely using Obsidian's SecretStorage.
+    - **Provider:** Choose `Google Gemini (cloud)` (default) or `Ollama (local)`. The Ollama option exposes a base-URL field and refreshes the model list from `GET /api/tags`.
+    - **API Key:** (Gemini only) Paste your Gemini API key here. Your key is stored securely using Obsidian's SecretStorage.
     - **Chat Model:** Select the preferred Gemini model for chat interactions (default: `gemini-flash-latest`).
     - **Summary Model:** Select the preferred Gemini model for generating summaries (default: `gemini-flash-latest`).
     - **Completion Model:** Select the preferred model for IDE-style completions (default: `gemini-flash-lite-latest`).

--- a/__mocks__/obsidian.js
+++ b/__mocks__/obsidian.js
@@ -116,6 +116,7 @@ export const MarkdownRenderer = {
 
 export const setIcon = vi.fn();
 export const Notice = vi.fn();
+export const requestUrl = vi.fn();
 // Mirrors Obsidian's normalizePath: collapses duplicate slashes, converts
 // backslashes, strips leading/trailing slashes, and returns '/' for empty input.
 export const normalizePath = vi.fn((path) => {

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -33,6 +33,7 @@ export default defineConfig({
 					text: 'Getting Started',
 					items: [
 						{ text: 'Introduction', link: '/guide/getting-started' },
+						{ text: 'Ollama (Local Models)', link: '/guide/ollama-setup' },
 						{ text: 'FAQ', link: '/guide/faq' },
 					],
 				},

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -28,6 +28,10 @@ Welcome to Gemini Scribe, an Obsidian plugin that integrates Google's Gemini AI 
 3. **Initialize Context** — Click "Initialize Vault Context" to help the agent understand your vault
 4. **Start Chatting** — Open Gemini Chat with the ribbon icon or command palette and start giving the AI tasks!
 
+### Prefer running models locally?
+
+Gemini Scribe also supports [Ollama](https://ollama.com) as a provider so you can use local models such as Llama 3.2, Qwen 2.5, or Gemma 3 without an API key. Some Gemini-built-in features (Google Search, URL Context, Deep Research, image generation, RAG) are unavailable on Ollama. See the [Ollama Setup Guide](/guide/ollama-setup) for details.
+
 ## Feature Overview
 
 ### Agent Mode (Core Feature)

--- a/docs/guide/ollama-setup.md
+++ b/docs/guide/ollama-setup.md
@@ -1,0 +1,46 @@
+# Ollama (Local Models)
+
+Gemini Scribe can route chat, summary, completions, rewrite, and agent tool-calling through a local [Ollama](https://ollama.com) daemon instead of the Google Gemini API. Use this when you want offline operation, full data privacy, or to avoid API quota limits.
+
+## Setup
+
+1. **Install Ollama** — Download the installer from [ollama.com](https://ollama.com/download) and run it. The daemon listens on `http://localhost:11434` by default.
+2. **Pull a model** — In a terminal, fetch any model that supports tool calling:
+   ```bash
+   ollama pull llama3.2
+   ollama pull qwen2.5:7b
+   ollama pull llava:13b      # for vision (image input)
+   ```
+3. **Switch the provider in Gemini Scribe** — Open Settings → Gemini Scribe → Provider and choose **Ollama (local)**.
+4. **Pick a model** — The Chat / Summary / Completion dropdowns now list whatever you have pulled. Click **Refresh** if a new pull doesn't show up.
+
+If the daemon runs on a different host or port, edit the **Ollama Base URL** field (e.g. `http://10.0.0.5:11434`).
+
+## What works
+
+- Agent chat with streaming, tool calling, and conversation memory
+- Drag-and-drop / paste of **image** attachments to vision models (e.g. `llava`, `moondream`, `qwen2.5-vl`)
+- File summarization, IDE-style completions, selection rewriting
+- Custom prompts, projects, agent skills, scheduled tasks, MCP servers
+
+## What does not work in Phase 1
+
+These features depend on Gemini built-in services and are hidden when Ollama is the active provider:
+
+| Feature | Why it's gated | Workaround |
+| --- | --- | --- |
+| Google Search tool | Uses Gemini's `googleSearch` grounding | Switch to Gemini for search-heavy sessions |
+| URL Context (web fetch) | Uses Gemini's URL Context API | Paste content into a note, then `read_file` |
+| Deep Research | Built on Gemini multi-step search | Switch to Gemini |
+| Image generation | Ollama has no image-generation API | Switch to Gemini for image-gen |
+| RAG / Vault Search | Uses Gemini File Search Store | Future phase: Ollama embeddings |
+| PDF / audio / video attachments | Ollama only accepts images | Convert to image or text first |
+
+Switching back to Gemini at any time restores all features — settings persist across switches.
+
+## Tips
+
+- **Tool calling** — Most modern instruct models support function calling; older or very small models may not. If the agent loop stalls, try a different model (Llama 3.2, Qwen 2.5, Mistral 0.3 are good starting points).
+- **Context window** — Local models often have smaller context than Gemini. Compaction triggers at 70% of an estimated 32k-token window by default; long sessions will summarise older turns more aggressively than they do on Gemini.
+- **Token counts** — Ollama does not expose a `countTokens` endpoint, so the plugin estimates tokens from character length (chars ÷ 4). The token-usage indicator is approximate.
+- **Daemon down?** — If the daemon stops, agent calls will surface a "Could not connect to the Ollama daemon" notice. Restart with `ollama serve` and click **Refresh model list**.

--- a/docs/guide/ollama-setup.md
+++ b/docs/guide/ollama-setup.md
@@ -41,6 +41,6 @@ Switching back to Gemini at any time restores all features — settings persist 
 ## Tips
 
 - **Tool calling** — Most modern instruct models support function calling; older or very small models may not. If the agent loop stalls, try a different model (Llama 3.2, Qwen 2.5, Mistral 0.3 are good starting points).
-- **Context window** — Local models often have smaller context than Gemini. Compaction triggers at 70% of an estimated 32k-token window by default; long sessions will summarise older turns more aggressively than they do on Gemini.
+- **Context window** — Local models often have smaller context than Gemini. Compaction triggers at the percentage set by `Context Compaction Threshold` (default `20`%) of an estimated 32k-token window; long sessions will summarise older turns earlier than they do on Gemini.
 - **Token counts** — Ollama does not expose a `countTokens` endpoint, so the plugin estimates tokens from character length (chars ÷ 4). The token-usage indicator is approximate.
 - **Daemon down?** — If the daemon stops, agent calls will surface a "Could not connect to the Ollama daemon" notice. Restart with `ollama serve` and click **Refresh model list**.

--- a/docs/guide/ollama-setup.md
+++ b/docs/guide/ollama-setup.md
@@ -27,14 +27,14 @@ If the daemon runs on a different host or port, edit the **Ollama Base URL** fie
 
 These features depend on Gemini built-in services and are hidden when Ollama is the active provider:
 
-| Feature | Why it's gated | Workaround |
-| --- | --- | --- |
-| Google Search tool | Uses Gemini's `googleSearch` grounding | Switch to Gemini for search-heavy sessions |
-| URL Context (web fetch) | Uses Gemini's URL Context API | Paste content into a note, then `read_file` |
-| Deep Research | Built on Gemini multi-step search | Switch to Gemini |
-| Image generation | Ollama has no image-generation API | Switch to Gemini for image-gen |
-| RAG / Vault Search | Uses Gemini File Search Store | Future phase: Ollama embeddings |
-| PDF / audio / video attachments | Ollama only accepts images | Convert to image or text first |
+| Feature                         | Why it's gated                         | Workaround                                  |
+| ------------------------------- | -------------------------------------- | ------------------------------------------- |
+| Google Search tool              | Uses Gemini's `googleSearch` grounding | Switch to Gemini for search-heavy sessions  |
+| URL Context (web fetch)         | Uses Gemini's URL Context API          | Paste content into a note, then `read_file` |
+| Deep Research                   | Built on Gemini multi-step search      | Switch to Gemini                            |
+| Image generation                | Ollama has no image-generation API     | Switch to Gemini for image-gen              |
+| RAG / Vault Search              | Uses Gemini File Search Store          | Future phase: Ollama embeddings             |
+| PDF / audio / video attachments | Ollama only accepts images             | Convert to image or text first              |
 
 Switching back to Gemini at any time restores all features — settings persist across switches.
 

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -80,7 +80,10 @@ This document provides a comprehensive reference for all Obsidian Gemini Scribe 
 
 ## Model Configuration
 
-All models are selected from available Gemini models. The plugin supports dynamic model discovery to automatically fetch the latest models from Google's API.
+The active model list depends on the [`provider`](#provider) setting:
+
+- **Gemini (default)** — models are selected from the bundled Gemini list, refreshed from Google's API on startup so the latest models appear automatically. `imageModelName` is only available on this provider.
+- **Ollama** — the chat / summary / completion dropdowns are populated from `GET <ollamaBaseUrl>/api/tags`, listing whatever you have pulled. Click "Refresh model list" in settings if a freshly pulled model doesn't appear. Image generation is unavailable in this mode.
 
 ### Chat Model
 

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -14,10 +14,26 @@ This document provides a comprehensive reference for all Obsidian Gemini Scribe 
 
 ## Basic Settings
 
+### Provider
+
+- **Setting**: `provider`
+- **Type**: `'gemini' | 'ollama'`
+- **Default**: `'gemini'`
+- **Description**: Selects the model backend. `gemini` calls the Google Cloud API; `ollama` calls a local Ollama daemon.
+- **Notes**: Switching providers re-initialises the plugin and resets stale model selections to the new provider's defaults. Provider-coupled features (Google Search, URL Context, Deep Research, image generation, RAG indexing) are hidden when `ollama` is active. See the [Ollama Setup Guide](/guide/ollama-setup) for details.
+
+### Ollama Base URL
+
+- **Setting**: `ollamaBaseUrl`
+- **Type**: String
+- **Default**: `http://localhost:11434`
+- **Required when provider is `ollama`**: Yes
+- **Description**: HTTP endpoint of your Ollama daemon. Update if Ollama runs on a different host or port.
+
 ### API Key
 
 - **Type**: String
-- **Required**: Yes
+- **Required**: Yes (when provider is `gemini`; ignored for `ollama`)
 - **Storage**: Stored securely using Obsidian's SecretStorage API (not saved in `data.json`)
 - **Description**: Your Google AI API key for accessing Gemini models
 - **How to obtain**: Visit [Google AI Studio](https://aistudio.google.com/apikey)

--- a/evals/README.md
+++ b/evals/README.md
@@ -136,34 +136,36 @@ A task is **solved** if it passes AND:
 
 ## Metrics captured per task
 
-| Metric          | Source                                                                        |
-| --------------- | ----------------------------------------------------------------------------- |
-| `turns`         | Count of `apiResponseReceived` events                                         |
-| `tool_calls`    | Count of `toolExecutionComplete` events                                       |
-| `prompt_tokens` | High-water `promptTokenCount`                                                 |
-| `cached_tokens` | `cachedContentTokenCount` at high-water                                       |
-| `cache_ratio`   | `cached / prompt`                                                             |
-| `output_tokens` | Sum of `candidatesTokenCount`                                                 |
-| `cost_usd`      | `(uncached × input_price) + (cached × cache_price) + (output × output_price)` |
-| `loop_fires`    | Tool executions returning "loop detected" error                               |
-| `duration_ms`   | Wall clock from turn start to end                                             |
-| `tool_list`     | Ordered list of tools called                                                  |
+| Metric          | Source                                                                                                 |
+| --------------- | ------------------------------------------------------------------------------------------------------ |
+| `turns`         | Count of `apiResponseReceived` events                                                                  |
+| `tool_calls`    | Count of `toolExecutionComplete` events                                                                |
+| `prompt_tokens` | High-water `promptTokenCount`                                                                          |
+| `cached_tokens` | `cachedContentTokenCount` at high-water (`null` for providers without cache)                           |
+| `cache_ratio`   | `cached / prompt` (`null` for providers without cache, e.g. Ollama)                                    |
+| `output_tokens` | Sum of `candidatesTokenCount`                                                                          |
+| `cost_usd`      | `(uncached × input_price) + (cached × cache_price) + (output × output_price)`; `0` for local providers |
+| `loop_fires`    | Tool executions returning "loop detected" error                                                        |
+| `duration_ms`   | Wall clock from turn start to end                                                                      |
+| `tool_list`     | Ordered list of tools called                                                                           |
 
 ## Aggregate metrics
 
-| Metric                             | Description                                                             |
-| ---------------------------------- | ----------------------------------------------------------------------- |
-| `pass_k_rate`                      | % of tasks where **every** run passed (τ-bench `pass^k`)                |
-| `solve_k_rate`                     | % of tasks where **every** run solved — primary signal for code changes |
-| `mean_pass_rate`                   | Proportion of task × run cells that passed                              |
-| `mean_solve_rate`                  | Proportion of task × run cells that solved                              |
-| `flaky_task_count`                 | Tasks where some (but not all) runs solved                              |
-| `n_runs`                           | Number of repeats per task                                              |
-| `total_runs`                       | Total task × run cells (`tasks × n_runs`)                               |
-| `mean_turns` / `p95_turns`         | Turn distribution across all runs                                       |
-| `mean_cache_ratio`                 | Average implicit-cache effectiveness                                    |
-| `mean_cost_usd` / `total_cost_usd` | Per-run mean and total spend (total grows with `--repeat`)              |
-| `total_loop_fires`                 | Total loop-detection events across all runs                             |
+| Metric                             | Description                                                                             |
+| ---------------------------------- | --------------------------------------------------------------------------------------- |
+| `pass_k_rate`                      | % of tasks where **every** run passed (τ-bench `pass^k`)                                |
+| `solve_k_rate`                     | % of tasks where **every** run solved — primary signal for code changes                 |
+| `mean_pass_rate`                   | Proportion of task × run cells that passed                                              |
+| `mean_solve_rate`                  | Proportion of task × run cells that solved                                              |
+| `flaky_task_count`                 | Tasks where some (but not all) runs solved                                              |
+| `n_runs`                           | Number of repeats per task                                                              |
+| `total_runs`                       | Total task × run cells (`tasks × n_runs`)                                               |
+| `mean_turns` / `p95_turns`         | Turn distribution across all runs                                                       |
+| `mean_cache_ratio`                 | Average implicit-cache effectiveness (`null` if the provider has no cache, e.g. Ollama) |
+| `mean_cost_usd` / `total_cost_usd` | Per-run mean and total spend (total grows with `--repeat`); `0` for local providers     |
+| `total_loop_fires`                 | Total loop-detection events across all runs                                             |
+
+The result file also records `provider` (e.g. `gemini`, `ollama`) at the top level so `compare` can flag cross-provider runs and skip metrics that aren't comparable.
 
 ## Architecture
 

--- a/evals/lib/compare.mjs
+++ b/evals/lib/compare.mjs
@@ -47,12 +47,16 @@ const PER_TASK_LOWER_IS_BETTER = new Set(['turns', 'cost_usd', 'loop_fires']);
 const PER_TASK_HIGHER_IS_BETTER = new Set(['cache_ratio']);
 
 function isMetricRegression(key, before, after) {
+	if (before === null || after === null) return false;
 	if (PER_TASK_LOWER_IS_BETTER.has(key) && after > before) return true;
 	if (PER_TASK_HIGHER_IS_BETTER.has(key) && after < before) return true;
 	return false;
 }
 
 function fmtDelta(before, after) {
+	if (before === null && after === null) return 'n/a';
+	if (before === null) return `n/a → ${after}`;
+	if (after === null) return `${before} → n/a`;
 	const diff = after - before;
 	const sign = diff > 0 ? '+' : '';
 	const pct = before !== 0 ? ` (${sign}${Math.round((diff / before) * 100)}%)` : '';
@@ -86,14 +90,26 @@ async function main() {
 	console.log(`Current:  ${current.run_id} (${current.git_sha})\n`);
 
 	// Aggregate comparison
+	const providersDiffer = (baseline.provider || 'gemini') !== (current.provider || 'gemini');
+	if (providersDiffer) {
+		console.log(`Providers differ: ${baseline.provider || 'gemini'} → ${current.provider || 'gemini'}`);
+		console.log('(cost and cache deltas are not directly comparable)\n');
+	}
 	console.log('Aggregates:');
 	for (const key of AGG_KEYS) {
-		const b = baseline.aggregate[key] ?? 0;
-		const c = current.aggregate[key] ?? 0;
+		const b = baseline.aggregate[key];
+		const c = current.aggregate[key];
+		const bothNull = b === null && c === null;
+		const bIsNull = b === null || b === undefined;
+		const cIsNull = c === null || c === undefined;
 		let flag = '';
-		if (LOWER_IS_BETTER.has(key) && c > b) flag = ' ⚠';
-		else if (HIGHER_IS_BETTER.has(key) && c < b) flag = ' ⚠';
-		console.log(`  ${key.padEnd(22)} ${fmtDelta(b, c)}${flag}`);
+		if (!bothNull && !bIsNull && !cIsNull) {
+			if (LOWER_IS_BETTER.has(key) && c > b) flag = ' ⚠';
+			else if (HIGHER_IS_BETTER.has(key) && c < b) flag = ' ⚠';
+		}
+		const bDisplay = bIsNull ? null : b;
+		const cDisplay = cIsNull ? null : c;
+		console.log(`  ${key.padEnd(22)} ${fmtDelta(bDisplay, cDisplay)}${flag}`);
 	}
 
 	// Per-task comparison. Solved/passed are per-task-run counts; treat any
@@ -124,8 +140,15 @@ async function main() {
 			changes.push(`${marker}passed: ${bPassed}/${bN} → ${cPassed}/${cN}`);
 		}
 		for (const key of METRIC_KEYS) {
-			const b = bt.metrics[key] ?? 0;
-			const c = ct.metrics[key] ?? 0;
+			const b = bt.metrics[key];
+			const c = ct.metrics[key];
+			const bIsNull = b === null || b === undefined;
+			const cIsNull = c === null || c === undefined;
+			if (bIsNull && cIsNull) continue;
+			if (bIsNull !== cIsNull) {
+				changes.push(`${key}: ${fmtDelta(bIsNull ? null : b, cIsNull ? null : c)}`);
+				continue;
+			}
 			if (Math.abs(b - c) > 0.001) {
 				const marker = isMetricRegression(key, b, c) ? '⚠ ' : '';
 				changes.push(`${marker}${key}: ${fmtDelta(b, c)}`);

--- a/evals/lib/compare.mjs
+++ b/evals/lib/compare.mjs
@@ -46,6 +46,13 @@ const HIGHER_IS_BETTER = new Set([
 const PER_TASK_LOWER_IS_BETTER = new Set(['turns', 'cost_usd', 'loop_fires']);
 const PER_TASK_HIGHER_IS_BETTER = new Set(['cache_ratio']);
 
+// Metrics whose meaning depends on the active provider. Pricing tables and
+// cache semantics are not portable across providers (Ollama is free + has no
+// implicit cache; Gemini bills per token + caches), so cross-provider
+// comparison reports omit these rather than report misleading deltas.
+const CROSS_PROVIDER_AGG_KEYS = new Set(['mean_cache_ratio', 'mean_cost_usd', 'total_cost_usd']);
+const CROSS_PROVIDER_TASK_KEYS = new Set(['cache_ratio', 'cost_usd']);
+
 function isMetricRegression(key, before, after) {
 	if (before === null || after === null) return false;
 	if (PER_TASK_LOWER_IS_BETTER.has(key) && after > before) return true;
@@ -97,6 +104,10 @@ async function main() {
 	}
 	console.log('Aggregates:');
 	for (const key of AGG_KEYS) {
+		if (providersDiffer && CROSS_PROVIDER_AGG_KEYS.has(key)) {
+			console.log(`  ${key.padEnd(22)} n/a (cross-provider)`);
+			continue;
+		}
 		const b = baseline.aggregate[key];
 		const c = current.aggregate[key];
 		const bothNull = b === null && c === null;
@@ -140,6 +151,7 @@ async function main() {
 			changes.push(`${marker}passed: ${bPassed}/${bN} → ${cPassed}/${cN}`);
 		}
 		for (const key of METRIC_KEYS) {
+			if (providersDiffer && CROSS_PROVIDER_TASK_KEYS.has(key)) continue;
 			const b = bt.metrics[key];
 			const c = ct.metrics[key];
 			const bIsNull = b === null || b === undefined;

--- a/evals/lib/pricing.mjs
+++ b/evals/lib/pricing.mjs
@@ -17,13 +17,16 @@ const PRICING = {
 };
 
 const FALLBACK = PRICING['gemini-2.5-flash'];
+const FREE = { inputPer1M: 0, cachedPer1M: 0, outputPer1M: 0 };
 
 /**
- * Look up pricing for a model name. Falls back to flash pricing for unknowns.
- * Matches by longest prefix first so "gemini-2.5-flash-lite-001" resolves to
- * "gemini-2.5-flash-lite" instead of "gemini-2.5-flash".
+ * Look up pricing for a model name. Local providers (e.g. Ollama) bill $0;
+ * unknown Gemini models fall back to flash pricing. Matches by longest prefix
+ * first so "gemini-2.5-flash-lite-001" resolves to "gemini-2.5-flash-lite"
+ * instead of "gemini-2.5-flash".
  */
-export function getModelPricing(modelName) {
+export function getModelPricing(modelName, provider) {
+	if (provider === 'ollama') return FREE;
 	if (!modelName) return FALLBACK;
 	const exact = PRICING[modelName];
 	if (exact) return exact;
@@ -41,14 +44,23 @@ export function getModelPricing(modelName) {
  * @param {number} cachedTokens - Portion of prompt served from cache
  * @param {number} outputTokens - Output/candidate tokens
  * @param {string} modelName - Model identifier from settings
+ * @param {string} [provider] - Provider id ("gemini" or "ollama"); local providers bill $0
  * @returns {number} Estimated cost in USD
  */
-export function calculateCost(promptTokens, cachedTokens, outputTokens, modelName) {
-	const pricing = getModelPricing(modelName);
+export function calculateCost(promptTokens, cachedTokens, outputTokens, modelName, provider) {
+	const pricing = getModelPricing(modelName, provider);
 	const uncachedInput = promptTokens - cachedTokens;
 	return (
 		(uncachedInput / 1_000_000) * pricing.inputPer1M +
 		(cachedTokens / 1_000_000) * pricing.cachedPer1M +
 		(outputTokens / 1_000_000) * pricing.outputPer1M
 	);
+}
+
+/**
+ * Whether this provider exposes a meaningful cache-hit metric. Ollama has no
+ * implicit cache, so cache% should be rendered "n/a" rather than "0%".
+ */
+export function providerSupportsCache(provider) {
+	return provider !== 'ollama';
 }

--- a/evals/lib/reporter.mjs
+++ b/evals/lib/reporter.mjs
@@ -105,7 +105,11 @@ export function computeAggregates(taskResults) {
 	const allRuns = taskResults.flatMap((t) => t.runs);
 	const turns = allRuns.map((r) => r.metrics.turns);
 	const costs = allRuns.map((r) => r.metrics.cost_usd);
-	const cacheRatios = allRuns.map((r) => r.metrics.cache_ratio);
+	// Cache ratio is null on providers without a cache (e.g. Ollama). Drop those
+	// from the mean so we don't average "no cache" with real cache hit rates,
+	// and report null when no run had cache data at all.
+	const cacheRatios = allRuns.map((r) => r.metrics.cache_ratio).filter((v) => typeof v === 'number');
+	const meanCache = cacheRatios.length === 0 ? null : round(mean(cacheRatios), 3);
 	const loopFires = allRuns.reduce((a, r) => a + r.metrics.loop_fires, 0);
 
 	return {
@@ -119,7 +123,7 @@ export function computeAggregates(taskResults) {
 		flaky_task_count: flakyCount,
 		mean_turns: round(mean(turns), 1),
 		p95_turns: percentile(turns, 95),
-		mean_cache_ratio: round(mean(cacheRatios), 3),
+		mean_cache_ratio: meanCache,
 		mean_cost_usd: round(mean(costs), 6),
 		total_cost_usd: round(
 			costs.reduce((a, b) => a + b, 0),
@@ -132,11 +136,12 @@ export function computeAggregates(taskResults) {
 /**
  * Build the full result object.
  */
-export function buildResult(taskResults, gitSha, modelName) {
+export function buildResult(taskResults, gitSha, modelName, provider) {
 	return {
 		run_id: new Date().toISOString(),
 		git_sha: gitSha,
 		model: modelName,
+		provider: provider || 'gemini',
 		tasks: taskResults,
 		aggregate: computeAggregates(taskResults),
 	};
@@ -166,9 +171,10 @@ export async function writeResults(result, evalsDir) {
 export function printSummary(result) {
 	const a = result.aggregate;
 	console.log('\n=== Eval Run Summary ===');
-	console.log(`Git SHA: ${result.git_sha}`);
-	console.log(`Model:   ${result.model}`);
-	console.log(`Tasks:   ${a.total_tasks} × ${a.n_runs} run${a.n_runs === 1 ? '' : 's'} = ${a.total_runs} total`);
+	console.log(`Git SHA:  ${result.git_sha}`);
+	console.log(`Provider: ${result.provider || 'gemini'}`);
+	console.log(`Model:    ${result.model}`);
+	console.log(`Tasks:    ${a.total_tasks} × ${a.n_runs} run${a.n_runs === 1 ? '' : 's'} = ${a.total_runs} total`);
 	console.log('');
 
 	// Per-task table
@@ -181,7 +187,7 @@ export function printSummary(result) {
 		let solveStr = `${t.solved_count}/${n}`;
 		if (t.flaky) solveStr += ' ⚠';
 		else solveStr += '  ';
-		const cacheStr = `${Math.round(m.cache_ratio * 100)}%`;
+		const cacheStr = m.cache_ratio === null ? '  -  ' : `${Math.round(m.cache_ratio * 100)}%`;
 		console.log(
 			`${t.id.padEnd(30)} ${passStr}  ${solveStr.padStart(5)}  ${m.turns.toFixed(1).padStart(5)}  ${cacheStr.padStart(6)}  ${m.cost_usd.toFixed(4).padStart(7)}  ${String(Math.round(m.loop_fires)).padStart(5)}`
 		);
@@ -203,7 +209,8 @@ export function printSummary(result) {
 		console.log(`Flaky tasks:    0`);
 	}
 	console.log(`Mean turns:     ${a.mean_turns} (p95: ${a.p95_turns})`);
-	console.log(`Mean cache:     ${Math.round(a.mean_cache_ratio * 100)}%`);
+	const meanCacheStr = a.mean_cache_ratio === null ? 'n/a' : `${Math.round(a.mean_cache_ratio * 100)}%`;
+	console.log(`Mean cache:     ${meanCacheStr}`);
 	console.log(`Mean cost:      $${a.mean_cost_usd.toFixed(4)} per run`);
 	console.log(`Total cost:     $${a.total_cost_usd.toFixed(4)} (${a.total_runs} runs)`);
 	console.log(`Loop fires:     ${a.total_loop_fires}`);

--- a/evals/lib/reporter.mjs
+++ b/evals/lib/reporter.mjs
@@ -47,8 +47,16 @@ export function aggregateTaskRuns(taskId, runs) {
 	];
 	const aggMetrics = {};
 	for (const key of metricKeys) {
+		// cache_ratio is null on providers without a cache (e.g. Ollama). Coercing
+		// missing values to 0 here would make per-task rows show 0% instead of "-"
+		// and let zero-cache providers pollute the per-task aggregate average.
+		if (key === 'cache_ratio') {
+			const values = runs.map((r) => r.metrics.cache_ratio).filter((v) => typeof v === 'number');
+			aggMetrics.cache_ratio = values.length === 0 ? null : round(mean(values), 3);
+			continue;
+		}
 		const values = runs.map((r) => r.metrics[key] ?? 0);
-		aggMetrics[key] = key === 'cache_ratio' ? round(mean(values), 3) : round(mean(values), 6);
+		aggMetrics[key] = round(mean(values), 6);
 	}
 	// tool_list is useful for debugging; keep the first run's so the shape
 	// matches a single-run TaskResult for any downstream consumer.

--- a/evals/lib/scorer.mjs
+++ b/evals/lib/scorer.mjs
@@ -3,7 +3,7 @@
  * Takes raw collector events and produces a structured TaskResult.
  */
 
-import { calculateCost } from './pricing.mjs';
+import { calculateCost, providerSupportsCache } from './pricing.mjs';
 
 /**
  * Score a single task run.
@@ -13,9 +13,10 @@ import { calculateCost } from './pricing.mjs';
  * @param {string} modelResponse - Final model response text
  * @param {string} modelName - Model used for this run
  * @param {number} durationMs - Wall-clock duration
+ * @param {string} [provider] - Provider id ("gemini" or "ollama"); affects pricing and cache reporting
  * @returns {object} TaskResult
  */
-export function scoreTask(task, events, modelResponse, modelName, durationMs) {
+export function scoreTask(task, events, modelResponse, modelName, durationMs, provider) {
 	const apiEvents = events.filter((e) => e.event === 'apiResponseReceived');
 	const toolEvents = events.filter((e) => e.event === 'toolExecutionComplete');
 	const errorEvents = events.filter((e) => e.event === 'turnError');
@@ -43,8 +44,12 @@ export function scoreTask(task, events, modelResponse, modelName, durationMs) {
 		totalOutput += output;
 	}
 
-	const cacheRatio = maxPrompt > 0 ? maxCached / maxPrompt : 0;
-	const costUsd = calculateCost(maxPrompt, maxCached, totalOutput, modelName);
+	// Cache is provider-specific. Ollama has no implicit cache, so we emit null
+	// to mark "not applicable" — distinct from a Gemini run that genuinely served
+	// 0% from cache.
+	const cacheRatio = !providerSupportsCache(provider) ? null : maxPrompt > 0 ? maxCached / maxPrompt : 0;
+	const cachedTokens = !providerSupportsCache(provider) ? null : maxCached;
+	const costUsd = calculateCost(maxPrompt, maxCached, totalOutput, modelName, provider);
 
 	// Loop fires
 	const loopFires = toolEvents.filter(
@@ -83,8 +88,8 @@ export function scoreTask(task, events, modelResponse, modelName, durationMs) {
 			turns,
 			tool_calls: toolCalls,
 			prompt_tokens: maxPrompt,
-			cached_tokens: maxCached,
-			cache_ratio: Math.round(cacheRatio * 1000) / 1000,
+			cached_tokens: cachedTokens,
+			cache_ratio: cacheRatio === null ? null : Math.round(cacheRatio * 1000) / 1000,
 			output_tokens: totalOutput,
 			cost_usd: Math.round(costUsd * 1_000_000) / 1_000_000,
 			loop_fires: loopFires,

--- a/evals/run.mjs
+++ b/evals/run.mjs
@@ -139,7 +139,12 @@ async function getModelName() {
 	return result.replace(/^["']|["']$/g, '');
 }
 
-async function runTask(task, keepArtifacts) {
+async function getProvider() {
+	const result = await obsidianEval("app.plugins.plugins['gemini-scribe'].settings.provider || 'gemini'");
+	return result.replace(/^["']|["']$/g, '');
+}
+
+async function runTask(task, keepArtifacts, provider) {
 	const title = `[eval] ${task.id}`;
 	console.log(`  "${task.description}"`);
 
@@ -173,9 +178,10 @@ async function runTask(task, keepArtifacts) {
 
 		// 6. Score
 		const modelName = await getModelName();
-		const result = scoreTask(task, events, modelResponse, modelName, durationMs);
+		const result = scoreTask(task, events, modelResponse, modelName, durationMs, provider);
+		const costStr = provider === 'ollama' ? 'free' : `$${result.metrics.cost_usd.toFixed(4)}`;
 		console.log(
-			`  ${result.solved ? 'SOLVED' : result.passed ? 'PASSED (not solved)' : 'FAILED'} — ${result.metrics.turns} turns, ${result.metrics.tool_calls} tool calls, $${result.metrics.cost_usd.toFixed(4)}`
+			`  ${result.solved ? 'SOLVED' : result.passed ? 'PASSED (not solved)' : 'FAILED'} — ${result.metrics.turns} turns, ${result.metrics.tool_calls} tool calls, ${costStr}`
 		);
 
 		return result;
@@ -190,8 +196,8 @@ async function runTask(task, keepArtifacts) {
 				turns: 0,
 				tool_calls: 0,
 				prompt_tokens: 0,
-				cached_tokens: 0,
-				cache_ratio: 0,
+				cached_tokens: provider === 'ollama' ? null : 0,
+				cache_ratio: provider === 'ollama' ? null : 0,
 				output_tokens: 0,
 				cost_usd: 0,
 				loop_fires: 0,
@@ -247,6 +253,9 @@ async function main() {
 		}
 		console.log(`Running ${tasks.length} task(s) × ${repeat} run${repeat === 1 ? '' : 's'}...`);
 
+		// Resolve provider once up front so per-run scoring stays consistent.
+		const provider = await getProvider();
+
 		// Run tasks sequentially. Each task runs `repeat` times so we can report
 		// pass^k reliability on top of per-run pass/solve rates.
 		const taskResults = [];
@@ -255,7 +264,7 @@ async function main() {
 			for (let i = 0; i < repeat; i++) {
 				const runLabel = repeat > 1 ? ` [run ${i + 1}/${repeat}]` : '';
 				console.log(`\n--- Running: ${task.id}${runLabel} ---`);
-				runs.push(await runTask(task, keepArtifacts));
+				runs.push(await runTask(task, keepArtifacts, provider));
 			}
 			taskResults.push(aggregateTaskRuns(task.id, runs));
 		}
@@ -263,7 +272,7 @@ async function main() {
 		// Build result, write, print
 		const gitSha = getGitSha();
 		const modelName = await getModelName();
-		const result = buildResult(taskResults, gitSha, modelName);
+		const result = buildResult(taskResults, gitSha, modelName, provider);
 		const outPath = await writeResults(result, EVALS_DIR);
 		printSummary(result);
 		console.log(`Results written to: ${outPath}`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,28 +12,29 @@
 				"@allenhutchison/gemini-utils": "^0.5.0",
 				"@codemirror/merge": "^6.12.1",
 				"@types/turndown": "^5.0.6",
+				"ollama": "^0.6.3",
 				"turndown": "^7.2.4"
 			},
 			"devDependencies": {
 				"@google/genai": "^1.50.1",
 				"@modelcontextprotocol/sdk": "^1.29.0",
+				"@types/jest": "^30.0.0",
 				"@types/node": "^25.6.0",
-				"@vitest/coverage-v8": "^4.1.5",
-				"@vitest/ui": "^4.1.5",
 				"builtin-modules": "5.1.0",
 				"codemirror-companion-extension": "^0.0.11",
 				"esbuild": "0.28.0",
 				"esbuild-plugin-alias": "^0.2.1",
 				"handlebars": "^4.7.9",
 				"husky": "^9.1.7",
-				"jsdom": "^29.0.2",
+				"jest": "^30.3.0",
+				"jest-environment-jsdom": "^30.3.0",
 				"lint-staged": "^16.4.0",
 				"obsidian": "latest",
 				"prettier": "^3.8.3",
+				"ts-jest": "^29.4.6",
 				"tslib": "2.8.1",
 				"typescript": "^6.0.3",
-				"vitepress": "^1.6.4",
-				"vitest": "^4.1.5"
+				"vitepress": "^1.6.4"
 			}
 		},
 		"node_modules/@algolia/abtesting": {
@@ -323,55 +324,167 @@
 			}
 		},
 		"node_modules/@asamuzakjp/css-color": {
-			"version": "5.1.11",
-			"resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
-			"integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+			"integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@asamuzakjp/generational-cache": "^1.0.1",
-				"@csstools/css-calc": "^3.2.0",
-				"@csstools/css-color-parser": "^4.1.0",
-				"@csstools/css-parser-algorithms": "^4.0.0",
-				"@csstools/css-tokenizer": "^4.0.0"
-			},
-			"engines": {
-				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+				"@csstools/css-calc": "^2.1.3",
+				"@csstools/css-color-parser": "^3.0.9",
+				"@csstools/css-parser-algorithms": "^3.0.4",
+				"@csstools/css-tokenizer": "^3.0.3",
+				"lru-cache": "^10.4.3"
 			}
 		},
-		"node_modules/@asamuzakjp/dom-selector": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
-			"integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+		"node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+			"version": "10.4.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/@babel/code-frame": {
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
+			"integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@asamuzakjp/generational-cache": "^1.0.1",
-				"@asamuzakjp/nwsapi": "^2.3.9",
-				"bidi-js": "^1.0.3",
-				"css-tree": "^3.2.1",
-				"is-potential-custom-element-name": "^1.0.1"
+				"@babel/helper-validator-identifier": "^7.27.1",
+				"js-tokens": "^4.0.0",
+				"picocolors": "^1.1.1"
 			},
 			"engines": {
-				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+				"node": ">=6.9.0"
 			}
 		},
-		"node_modules/@asamuzakjp/generational-cache": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
-			"integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+		"node_modules/@babel/compat-data": {
+			"version": "7.28.5",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.5.tgz",
+			"integrity": "sha512-6uFXyCayocRbqhZOB+6XcuZbkMNimwfVGFji8CTZnCzOHVGvDqzvitu1re2AU5LROliz7eQPhB8CpAMvnx9EjA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+				"node": ">=6.9.0"
 			}
 		},
-		"node_modules/@asamuzakjp/nwsapi": {
-			"version": "2.3.9",
-			"resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
-			"integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+		"node_modules/@babel/core": {
+			"version": "7.28.5",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
+			"integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^7.27.1",
+				"@babel/generator": "^7.28.5",
+				"@babel/helper-compilation-targets": "^7.27.2",
+				"@babel/helper-module-transforms": "^7.28.3",
+				"@babel/helpers": "^7.28.4",
+				"@babel/parser": "^7.28.5",
+				"@babel/template": "^7.27.2",
+				"@babel/traverse": "^7.28.5",
+				"@babel/types": "^7.28.5",
+				"@jridgewell/remapping": "^2.3.5",
+				"convert-source-map": "^2.0.0",
+				"debug": "^4.1.0",
+				"gensync": "^1.0.0-beta.2",
+				"json5": "^2.2.3",
+				"semver": "^6.3.1"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/babel"
+			}
+		},
+		"node_modules/@babel/generator": {
+			"version": "7.28.5",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.5.tgz",
+			"integrity": "sha512-3EwLFhZ38J4VyIP6WNtt2kUdW9dokXA9Cr4IVIFHuCpZ3H8/YFOl5JjZHisrn1fATPBmKKqXzDFvh9fUwHz6CQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/parser": "^7.28.5",
+				"@babel/types": "^7.28.5",
+				"@jridgewell/gen-mapping": "^0.3.12",
+				"@jridgewell/trace-mapping": "^0.3.28",
+				"jsesc": "^3.0.2"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-compilation-targets": {
+			"version": "7.27.2",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
+			"integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/compat-data": "^7.27.2",
+				"@babel/helper-validator-option": "^7.27.1",
+				"browserslist": "^4.24.0",
+				"lru-cache": "^5.1.1",
+				"semver": "^6.3.1"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-globals": {
+			"version": "7.28.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+			"integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-module-imports": {
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
+			"integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/traverse": "^7.27.1",
+				"@babel/types": "^7.27.1"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-module-transforms": {
+			"version": "7.28.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.3.tgz",
+			"integrity": "sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-module-imports": "^7.27.1",
+				"@babel/helper-validator-identifier": "^7.27.1",
+				"@babel/traverse": "^7.28.3"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0"
+			}
+		},
+		"node_modules/@babel/helper-plugin-utils": {
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+			"integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.9.0"
+			}
 		},
 		"node_modules/@babel/helper-string-parser": {
 			"version": "7.27.1",
@@ -393,14 +506,38 @@
 				"node": ">=6.9.0"
 			}
 		},
-		"node_modules/@babel/parser": {
-			"version": "7.29.2",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
-			"integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+		"node_modules/@babel/helper-validator-option": {
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+			"integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helpers": {
+			"version": "7.28.4",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.4.tgz",
+			"integrity": "sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/types": "^7.29.0"
+				"@babel/template": "^7.27.2",
+				"@babel/types": "^7.28.4"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/parser": {
+			"version": "7.28.5",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.5.tgz",
+			"integrity": "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/types": "^7.28.5"
 			},
 			"bin": {
 				"parser": "bin/babel-parser.js"
@@ -409,10 +546,283 @@
 				"node": ">=6.0.0"
 			}
 		},
+		"node_modules/@babel/plugin-syntax-async-generators": {
+			"version": "7.8.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
+			"integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-syntax-bigint": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
+			"integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-syntax-class-properties": {
+			"version": "7.12.13",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
+			"integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.12.13"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-syntax-class-static-block": {
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz",
+			"integrity": "sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.14.5"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-syntax-import-attributes": {
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.27.1.tgz",
+			"integrity": "sha512-oFT0FrKHgF53f4vOsZGi2Hh3I35PfSmVs4IBFLFj4dnafP+hIWDLg3VyKmUHfLoLHlyxY4C7DGtmHuJgn+IGww==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.27.1"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-syntax-import-meta": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
+			"integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-syntax-json-strings": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
+			"integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-syntax-jsx": {
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.28.6.tgz",
+			"integrity": "sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.28.6"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-syntax-logical-assignment-operators": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
+			"integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-syntax-nullish-coalescing-operator": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
+			"integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-syntax-numeric-separator": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
+			"integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-syntax-object-rest-spread": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
+			"integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-syntax-optional-catch-binding": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
+			"integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-syntax-optional-chaining": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
+			"integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-syntax-private-property-in-object": {
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz",
+			"integrity": "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.14.5"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-syntax-top-level-await": {
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
+			"integrity": "sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.14.5"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-syntax-typescript": {
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.28.6.tgz",
+			"integrity": "sha512-+nDNmQye7nlnuuHDboPbGm00Vqg3oO8niRRL27/4LYHUsHYh0zJ1xWOz0uRwNFmM1Avzk8wZbc6rdiYhomzv/A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.28.6"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/template": {
+			"version": "7.27.2",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
+			"integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^7.27.1",
+				"@babel/parser": "^7.27.2",
+				"@babel/types": "^7.27.1"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/traverse": {
+			"version": "7.28.5",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.5.tgz",
+			"integrity": "sha512-TCCj4t55U90khlYkVV/0TfkJkAkUg3jZFA3Neb7unZT8CPok7iiRfaX0F+WnqWqt7OxhOn0uBKXCw4lbL8W0aQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^7.27.1",
+				"@babel/generator": "^7.28.5",
+				"@babel/helper-globals": "^7.28.0",
+				"@babel/parser": "^7.28.5",
+				"@babel/template": "^7.27.2",
+				"@babel/types": "^7.28.5",
+				"debug": "^4.3.1"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
 		"node_modules/@babel/types": {
-			"version": "7.29.0",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-			"integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+			"version": "7.28.5",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.5.tgz",
+			"integrity": "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -424,27 +834,11 @@
 			}
 		},
 		"node_modules/@bcoe/v8-coverage": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
-			"integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+			"integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
 			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@bramus/specificity": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
-			"integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"css-tree": "^3.0.0"
-			},
-			"bin": {
-				"specificity": "bin/cli.js"
-			}
+			"license": "MIT"
 		},
 		"node_modules/@codemirror/autocomplete": {
 			"version": "6.20.0",
@@ -545,9 +939,9 @@
 			}
 		},
 		"node_modules/@csstools/color-helpers": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
-			"integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+			"integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
 			"dev": true,
 			"funding": [
 				{
@@ -561,13 +955,13 @@
 			],
 			"license": "MIT-0",
 			"engines": {
-				"node": ">=20.19.0"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@csstools/css-calc": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
-			"integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+			"integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -581,17 +975,17 @@
 			],
 			"license": "MIT",
 			"engines": {
-				"node": ">=20.19.0"
+				"node": ">=18"
 			},
 			"peerDependencies": {
-				"@csstools/css-parser-algorithms": "^4.0.0",
-				"@csstools/css-tokenizer": "^4.0.0"
+				"@csstools/css-parser-algorithms": "^3.0.5",
+				"@csstools/css-tokenizer": "^3.0.4"
 			}
 		},
 		"node_modules/@csstools/css-color-parser": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz",
-			"integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+			"integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
 			"dev": true,
 			"funding": [
 				{
@@ -605,21 +999,21 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"@csstools/color-helpers": "^6.0.2",
-				"@csstools/css-calc": "^3.2.0"
+				"@csstools/color-helpers": "^5.1.0",
+				"@csstools/css-calc": "^2.1.4"
 			},
 			"engines": {
-				"node": ">=20.19.0"
+				"node": ">=18"
 			},
 			"peerDependencies": {
-				"@csstools/css-parser-algorithms": "^4.0.0",
-				"@csstools/css-tokenizer": "^4.0.0"
+				"@csstools/css-parser-algorithms": "^3.0.5",
+				"@csstools/css-tokenizer": "^3.0.4"
 			}
 		},
 		"node_modules/@csstools/css-parser-algorithms": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
-			"integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+			"integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -633,41 +1027,16 @@
 			],
 			"license": "MIT",
 			"engines": {
-				"node": ">=20.19.0"
+				"node": ">=18"
 			},
 			"peerDependencies": {
-				"@csstools/css-tokenizer": "^4.0.0"
-			}
-		},
-		"node_modules/@csstools/css-syntax-patches-for-csstree": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
-			"integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/csstools"
-				},
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/csstools"
-				}
-			],
-			"license": "MIT-0",
-			"peerDependencies": {
-				"css-tree": "^3.2.1"
-			},
-			"peerDependenciesMeta": {
-				"css-tree": {
-					"optional": true
-				}
+				"@csstools/css-tokenizer": "^3.0.4"
 			}
 		},
 		"node_modules/@csstools/css-tokenizer": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
-			"integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+			"integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
 			"dev": true,
 			"funding": [
 				{
@@ -681,7 +1050,7 @@
 			],
 			"license": "MIT",
 			"engines": {
-				"node": ">=20.19.0"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@docsearch/css": {
@@ -736,21 +1105,21 @@
 			}
 		},
 		"node_modules/@emnapi/core": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-			"integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.0.tgz",
+			"integrity": "sha512-0DQ98G9ZQZOxfUcQn1waV2yS8aWdZ6kJMbYCJB3oUBecjWYO1fqJ+a1DRfPF3O5JEkwqwP1A9QEN/9mYm2Yd0w==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
-				"@emnapi/wasi-threads": "1.2.1",
+				"@emnapi/wasi-threads": "1.2.0",
 				"tslib": "^2.4.0"
 			}
 		},
 		"node_modules/@emnapi/runtime": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-			"integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.0.tgz",
+			"integrity": "sha512-QN75eB0IH2ywSpRpNddCRfQIhmJYBCJ1x5Lb3IscKAL8bMnVAKnRg8dCoXbHzVLLH7P38N2Z3mtulB7W0J0FKw==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
@@ -759,9 +1128,9 @@
 			}
 		},
 		"node_modules/@emnapi/wasi-threads": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-			"integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
+			"integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
@@ -1211,24 +1580,6 @@
 				"node": ">=18"
 			}
 		},
-		"node_modules/@exodus/bytes": {
-			"version": "1.15.0",
-			"resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
-			"integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-			},
-			"peerDependencies": {
-				"@noble/hashes": "^1.8.0 || ^2.0.0"
-			},
-			"peerDependenciesMeta": {
-				"@noble/hashes": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/@google/genai": {
 			"version": "1.50.1",
 			"resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.50.1.tgz",
@@ -1378,6 +1729,423 @@
 				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
 			}
 		},
+		"node_modules/@istanbuljs/load-nyc-config": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
+			"integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"camelcase": "^5.3.1",
+				"find-up": "^4.1.0",
+				"get-package-type": "^0.1.0",
+				"js-yaml": "^3.13.1",
+				"resolve-from": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@istanbuljs/schema": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+			"integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@jest/console": {
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/console/-/console-30.3.0.tgz",
+			"integrity": "sha512-PAwCvFJ4696XP2qZj+LAn1BWjZaJ6RjG6c7/lkMaUJnkyMS34ucuIsfqYvfskVNvUI27R/u4P1HMYFnlVXG/Ww==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "30.3.0",
+				"@types/node": "*",
+				"chalk": "^4.1.2",
+				"jest-message-util": "30.3.0",
+				"jest-util": "30.3.0",
+				"slash": "^3.0.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/core": {
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/core/-/core-30.3.0.tgz",
+			"integrity": "sha512-U5mVPsBxLSO6xYbf+tgkymLx+iAhvZX43/xI1+ej2ZOPnPdkdO1CzDmFKh2mZBn2s4XZixszHeQnzp1gm/DIxw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/console": "30.3.0",
+				"@jest/pattern": "30.0.1",
+				"@jest/reporters": "30.3.0",
+				"@jest/test-result": "30.3.0",
+				"@jest/transform": "30.3.0",
+				"@jest/types": "30.3.0",
+				"@types/node": "*",
+				"ansi-escapes": "^4.3.2",
+				"chalk": "^4.1.2",
+				"ci-info": "^4.2.0",
+				"exit-x": "^0.2.2",
+				"graceful-fs": "^4.2.11",
+				"jest-changed-files": "30.3.0",
+				"jest-config": "30.3.0",
+				"jest-haste-map": "30.3.0",
+				"jest-message-util": "30.3.0",
+				"jest-regex-util": "30.0.1",
+				"jest-resolve": "30.3.0",
+				"jest-resolve-dependencies": "30.3.0",
+				"jest-runner": "30.3.0",
+				"jest-runtime": "30.3.0",
+				"jest-snapshot": "30.3.0",
+				"jest-util": "30.3.0",
+				"jest-validate": "30.3.0",
+				"jest-watcher": "30.3.0",
+				"pretty-format": "30.3.0",
+				"slash": "^3.0.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			},
+			"peerDependencies": {
+				"node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+			},
+			"peerDependenciesMeta": {
+				"node-notifier": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@jest/diff-sequences": {
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.3.0.tgz",
+			"integrity": "sha512-cG51MVnLq1ecVUaQ3fr6YuuAOitHK1S4WUJHnsPFE/quQr33ADUx1FfrTCpMCRxvy0Yr9BThKpDjSlcTi91tMA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/environment": {
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.3.0.tgz",
+			"integrity": "sha512-SlLSF4Be735yQXyh2+mctBOzNDx5s5uLv88/j8Qn1wH679PDcwy67+YdADn8NJnGjzlXtN62asGH/T4vWOkfaw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/fake-timers": "30.3.0",
+				"@jest/types": "30.3.0",
+				"@types/node": "*",
+				"jest-mock": "30.3.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/environment-jsdom-abstract": {
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/environment-jsdom-abstract/-/environment-jsdom-abstract-30.3.0.tgz",
+			"integrity": "sha512-0hNFs5N6We3DMCwobzI0ydhkY10sT1tZSC0AAiy+0g2Dt/qEWgrcV5BrMxPczhe41cxW4qm6X+jqZaUdpZIajA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/environment": "30.3.0",
+				"@jest/fake-timers": "30.3.0",
+				"@jest/types": "30.3.0",
+				"@types/jsdom": "^21.1.7",
+				"@types/node": "*",
+				"jest-mock": "30.3.0",
+				"jest-util": "30.3.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			},
+			"peerDependencies": {
+				"canvas": "^3.0.0",
+				"jsdom": "*"
+			},
+			"peerDependenciesMeta": {
+				"canvas": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@jest/expect": {
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/expect/-/expect-30.3.0.tgz",
+			"integrity": "sha512-76Nlh4xJxk2D/9URCn3wFi98d2hb19uWE1idLsTt2ywhvdOldbw3S570hBgn25P4ICUZ/cBjybrBex2g17IDbg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"expect": "30.3.0",
+				"jest-snapshot": "30.3.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/expect-utils": {
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.3.0.tgz",
+			"integrity": "sha512-j0+W5iQQ8hBh7tHZkTQv3q2Fh/M7Je72cIsYqC4OaktgtO7v1So9UTjp6uPBHIaB6beoF/RRsCgMJKvti0wADA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/get-type": "30.1.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/fake-timers": {
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.3.0.tgz",
+			"integrity": "sha512-WUQDs8SOP9URStX1DzhD425CqbN/HxUYCTwVrT8sTVBfMvFqYt/s61EK5T05qnHu0po6RitXIvP9otZxYDzTGQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "30.3.0",
+				"@sinonjs/fake-timers": "^15.0.0",
+				"@types/node": "*",
+				"jest-message-util": "30.3.0",
+				"jest-mock": "30.3.0",
+				"jest-util": "30.3.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/get-type": {
+			"version": "30.1.0",
+			"resolved": "https://registry.npmjs.org/@jest/get-type/-/get-type-30.1.0.tgz",
+			"integrity": "sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/globals": {
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/globals/-/globals-30.3.0.tgz",
+			"integrity": "sha512-+owLCBBdfpgL3HU+BD5etr1SvbXpSitJK0is1kiYjJxAAJggYMRQz5hSdd5pq1sSggfxPbw2ld71pt4x5wwViA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/environment": "30.3.0",
+				"@jest/expect": "30.3.0",
+				"@jest/types": "30.3.0",
+				"jest-mock": "30.3.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/pattern": {
+			"version": "30.0.1",
+			"resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.0.1.tgz",
+			"integrity": "sha512-gWp7NfQW27LaBQz3TITS8L7ZCQ0TLvtmI//4OwlQRx4rnWxcPNIYjxZpDcN4+UlGxgm3jS5QPz8IPTCkb59wZA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*",
+				"jest-regex-util": "30.0.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/reporters": {
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-30.3.0.tgz",
+			"integrity": "sha512-a09z89S+PkQnL055bVj8+pe2Caed2PBOaczHcXCykW5ngxX9EWx/1uAwncxc/HiU0oZqfwseMjyhxgRjS49qPw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@bcoe/v8-coverage": "^0.2.3",
+				"@jest/console": "30.3.0",
+				"@jest/test-result": "30.3.0",
+				"@jest/transform": "30.3.0",
+				"@jest/types": "30.3.0",
+				"@jridgewell/trace-mapping": "^0.3.25",
+				"@types/node": "*",
+				"chalk": "^4.1.2",
+				"collect-v8-coverage": "^1.0.2",
+				"exit-x": "^0.2.2",
+				"glob": "^10.5.0",
+				"graceful-fs": "^4.2.11",
+				"istanbul-lib-coverage": "^3.0.0",
+				"istanbul-lib-instrument": "^6.0.0",
+				"istanbul-lib-report": "^3.0.0",
+				"istanbul-lib-source-maps": "^5.0.0",
+				"istanbul-reports": "^3.1.3",
+				"jest-message-util": "30.3.0",
+				"jest-util": "30.3.0",
+				"jest-worker": "30.3.0",
+				"slash": "^3.0.0",
+				"string-length": "^4.0.2",
+				"v8-to-istanbul": "^9.0.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			},
+			"peerDependencies": {
+				"node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+			},
+			"peerDependenciesMeta": {
+				"node-notifier": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@jest/schemas": {
+			"version": "30.0.5",
+			"resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.5.tgz",
+			"integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@sinclair/typebox": "^0.34.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/snapshot-utils": {
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/snapshot-utils/-/snapshot-utils-30.3.0.tgz",
+			"integrity": "sha512-ORbRN9sf5PP82v3FXNSwmO1OTDR2vzR2YTaR+E3VkSBZ8zadQE6IqYdYEeFH1NIkeB2HIGdF02dapb6K0Mj05g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "30.3.0",
+				"chalk": "^4.1.2",
+				"graceful-fs": "^4.2.11",
+				"natural-compare": "^1.4.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/source-map": {
+			"version": "30.0.1",
+			"resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-30.0.1.tgz",
+			"integrity": "sha512-MIRWMUUR3sdbP36oyNyhbThLHyJ2eEDClPCiHVbrYAe5g3CHRArIVpBw7cdSB5fr+ofSfIb2Tnsw8iEHL0PYQg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/trace-mapping": "^0.3.25",
+				"callsites": "^3.1.0",
+				"graceful-fs": "^4.2.11"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/test-result": {
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-30.3.0.tgz",
+			"integrity": "sha512-e/52nJGuD74AKTSe0P4y5wFRlaXP0qmrS17rqOMHeSwm278VyNyXE3gFO/4DTGF9w+65ra3lo3VKj0LBrzmgdQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/console": "30.3.0",
+				"@jest/types": "30.3.0",
+				"@types/istanbul-lib-coverage": "^2.0.6",
+				"collect-v8-coverage": "^1.0.2"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/test-sequencer": {
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-30.3.0.tgz",
+			"integrity": "sha512-dgbWy9b8QDlQeRZcv7LNF+/jFiiYHTKho1xirauZ7kVwY7avjFF6uTT0RqlgudB5OuIPagFdVtfFMosjVbk1eA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/test-result": "30.3.0",
+				"graceful-fs": "^4.2.11",
+				"jest-haste-map": "30.3.0",
+				"slash": "^3.0.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/transform": {
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/transform/-/transform-30.3.0.tgz",
+			"integrity": "sha512-TLKY33fSLVd/lKB2YI1pH69ijyUblO/BQvCj566YvnwuzoTNr648iE0j22vRvVNk2HsPwByPxATg3MleS3gf5A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/core": "^7.27.4",
+				"@jest/types": "30.3.0",
+				"@jridgewell/trace-mapping": "^0.3.25",
+				"babel-plugin-istanbul": "^7.0.1",
+				"chalk": "^4.1.2",
+				"convert-source-map": "^2.0.0",
+				"fast-json-stable-stringify": "^2.1.0",
+				"graceful-fs": "^4.2.11",
+				"jest-haste-map": "30.3.0",
+				"jest-regex-util": "30.0.1",
+				"jest-util": "30.3.0",
+				"pirates": "^4.0.7",
+				"slash": "^3.0.0",
+				"write-file-atomic": "^5.0.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/types": {
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz",
+			"integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/pattern": "30.0.1",
+				"@jest/schemas": "30.0.5",
+				"@types/istanbul-lib-coverage": "^2.0.6",
+				"@types/istanbul-reports": "^3.0.4",
+				"@types/node": "*",
+				"@types/yargs": "^17.0.33",
+				"chalk": "^4.1.2"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jridgewell/gen-mapping": {
+			"version": "0.3.13",
+			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+			"integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/sourcemap-codec": "^1.5.0",
+				"@jridgewell/trace-mapping": "^0.3.24"
+			}
+		},
+		"node_modules/@jridgewell/remapping": {
+			"version": "2.3.5",
+			"resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+			"integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/gen-mapping": "^0.3.5",
+				"@jridgewell/trace-mapping": "^0.3.24"
+			}
+		},
 		"node_modules/@jridgewell/resolve-uri": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
@@ -1502,32 +2270,16 @@
 			}
 		},
 		"node_modules/@napi-rs/wasm-runtime": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
-			"integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+			"version": "0.2.12",
+			"resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
+			"integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
-				"@tybys/wasm-util": "^0.10.1"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/Brooooooklyn"
-			},
-			"peerDependencies": {
-				"@emnapi/core": "^1.7.1",
-				"@emnapi/runtime": "^1.7.1"
-			}
-		},
-		"node_modules/@oxc-project/types": {
-			"version": "0.127.0",
-			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
-			"integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
-			"dev": true,
-			"license": "MIT",
-			"funding": {
-				"url": "https://github.com/sponsors/Boshen"
+				"@emnapi/core": "^1.4.3",
+				"@emnapi/runtime": "^1.4.3",
+				"@tybys/wasm-util": "^0.10.0"
 			}
 		},
 		"node_modules/@pkgjs/parseargs": {
@@ -1540,12 +2292,18 @@
 				"node": ">=14"
 			}
 		},
-		"node_modules/@polka/url": {
-			"version": "1.0.0-next.29",
-			"resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
-			"integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
+		"node_modules/@pkgr/core": {
+			"version": "0.2.9",
+			"resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz",
+			"integrity": "sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"engines": {
+				"node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/pkgr"
+			}
 		},
 		"node_modules/@protobufjs/aspromise": {
 			"version": "1.1.2",
@@ -1610,270 +2368,6 @@
 			"resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
 			"integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
 			"license": "BSD-3-Clause"
-		},
-		"node_modules/@rolldown/binding-android-arm64": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
-			"integrity": "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"engines": {
-				"node": "^20.19.0 || >=22.12.0"
-			}
-		},
-		"node_modules/@rolldown/binding-darwin-arm64": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.17.tgz",
-			"integrity": "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": "^20.19.0 || >=22.12.0"
-			}
-		},
-		"node_modules/@rolldown/binding-darwin-x64": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.17.tgz",
-			"integrity": "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": "^20.19.0 || >=22.12.0"
-			}
-		},
-		"node_modules/@rolldown/binding-freebsd-x64": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.17.tgz",
-			"integrity": "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"freebsd"
-			],
-			"engines": {
-				"node": "^20.19.0 || >=22.12.0"
-			}
-		},
-		"node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.17.tgz",
-			"integrity": "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": "^20.19.0 || >=22.12.0"
-			}
-		},
-		"node_modules/@rolldown/binding-linux-arm64-gnu": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.17.tgz",
-			"integrity": "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": "^20.19.0 || >=22.12.0"
-			}
-		},
-		"node_modules/@rolldown/binding-linux-arm64-musl": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.17.tgz",
-			"integrity": "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": "^20.19.0 || >=22.12.0"
-			}
-		},
-		"node_modules/@rolldown/binding-linux-ppc64-gnu": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.17.tgz",
-			"integrity": "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==",
-			"cpu": [
-				"ppc64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": "^20.19.0 || >=22.12.0"
-			}
-		},
-		"node_modules/@rolldown/binding-linux-s390x-gnu": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.17.tgz",
-			"integrity": "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==",
-			"cpu": [
-				"s390x"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": "^20.19.0 || >=22.12.0"
-			}
-		},
-		"node_modules/@rolldown/binding-linux-x64-gnu": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.17.tgz",
-			"integrity": "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": "^20.19.0 || >=22.12.0"
-			}
-		},
-		"node_modules/@rolldown/binding-linux-x64-musl": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.17.tgz",
-			"integrity": "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": "^20.19.0 || >=22.12.0"
-			}
-		},
-		"node_modules/@rolldown/binding-openharmony-arm64": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.17.tgz",
-			"integrity": "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"openharmony"
-			],
-			"engines": {
-				"node": "^20.19.0 || >=22.12.0"
-			}
-		},
-		"node_modules/@rolldown/binding-wasm32-wasi": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.17.tgz",
-			"integrity": "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==",
-			"cpu": [
-				"wasm32"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"@emnapi/core": "1.10.0",
-				"@emnapi/runtime": "1.10.0",
-				"@napi-rs/wasm-runtime": "^1.1.4"
-			},
-			"engines": {
-				"node": "^20.19.0 || >=22.12.0"
-			}
-		},
-		"node_modules/@rolldown/binding-win32-arm64-msvc": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.17.tgz",
-			"integrity": "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": "^20.19.0 || >=22.12.0"
-			}
-		},
-		"node_modules/@rolldown/binding-win32-x64-msvc": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.17.tgz",
-			"integrity": "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": "^20.19.0 || >=22.12.0"
-			}
-		},
-		"node_modules/@rolldown/pluginutils": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
-			"integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/@rollup/rollup-android-arm-eabi": {
 			"version": "4.59.0",
@@ -2312,12 +2806,32 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/@standard-schema/spec": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
-			"integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+		"node_modules/@sinclair/typebox": {
+			"version": "0.34.47",
+			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.47.tgz",
+			"integrity": "sha512-ZGIBQ+XDvO5JQku9wmwtabcVTHJsgSWAHYtVuM9pBNNR5E88v6Jcj/llpmsjivig5X8A8HHOb4/mbEKPS5EvAw==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/@sinonjs/commons": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+			"integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"type-detect": "4.0.8"
+			}
+		},
+		"node_modules/@sinonjs/fake-timers": {
+			"version": "15.1.1",
+			"resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.1.1.tgz",
+			"integrity": "sha512-cO5W33JgAPbOh07tvZjUOJ7oWhtaqGHiZw+11DPbyqh2kHTBc3eF/CjJDeQ4205RLQsX6rxCuYOroFQwl7JDRw==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@sinonjs/commons": "^3.0.1"
+			}
 		},
 		"node_modules/@tybys/wasm-util": {
 			"version": "0.10.1",
@@ -2330,15 +2844,49 @@
 				"tslib": "^2.4.0"
 			}
 		},
-		"node_modules/@types/chai": {
-			"version": "5.2.3",
-			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
-			"integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+		"node_modules/@types/babel__core": {
+			"version": "7.20.5",
+			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+			"integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@types/deep-eql": "*",
-				"assertion-error": "^2.0.1"
+				"@babel/parser": "^7.20.7",
+				"@babel/types": "^7.20.7",
+				"@types/babel__generator": "*",
+				"@types/babel__template": "*",
+				"@types/babel__traverse": "*"
+			}
+		},
+		"node_modules/@types/babel__generator": {
+			"version": "7.27.0",
+			"resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+			"integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"node_modules/@types/babel__template": {
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+			"integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/parser": "^7.1.0",
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"node_modules/@types/babel__traverse": {
+			"version": "7.28.0",
+			"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+			"integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/types": "^7.28.2"
 			}
 		},
 		"node_modules/@types/codemirror": {
@@ -2350,13 +2898,6 @@
 			"dependencies": {
 				"@types/tern": "*"
 			}
-		},
-		"node_modules/@types/deep-eql": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
-			"integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/@types/estree": {
 			"version": "1.0.8",
@@ -2373,6 +2914,56 @@
 			"license": "MIT",
 			"dependencies": {
 				"@types/unist": "*"
+			}
+		},
+		"node_modules/@types/istanbul-lib-coverage": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+			"integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/istanbul-lib-report": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
+			"integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/istanbul-lib-coverage": "*"
+			}
+		},
+		"node_modules/@types/istanbul-reports": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
+			"integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/istanbul-lib-report": "*"
+			}
+		},
+		"node_modules/@types/jest": {
+			"version": "30.0.0",
+			"resolved": "https://registry.npmjs.org/@types/jest/-/jest-30.0.0.tgz",
+			"integrity": "sha512-XTYugzhuwqWjws0CVz8QpM36+T+Dz5mTEBKhNs/esGLnCIlGdRy+Dq78NRjd7ls7r8BC8ZRMOrKlkO1hU0JOwA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"expect": "^30.0.0",
+				"pretty-format": "^30.0.0"
+			}
+		},
+		"node_modules/@types/jsdom": {
+			"version": "21.1.7",
+			"resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-21.1.7.tgz",
+			"integrity": "sha512-yOriVnggzrnQ3a9OKOCxaVuSug3w3/SbOj5i7VwXWZEyUNl3bLF9V3MfxGbZKuwqJOQyRfqXyROBB1CoZLFWzA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*",
+				"@types/tough-cookie": "*",
+				"parse5": "^7.0.0"
 			}
 		},
 		"node_modules/@types/linkify-it": {
@@ -2425,6 +3016,13 @@
 			"integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
 			"license": "MIT"
 		},
+		"node_modules/@types/stack-utils": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
+			"integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@types/tern": {
 			"version": "0.23.9",
 			"resolved": "https://registry.npmjs.org/@types/tern/-/tern-0.23.9.tgz",
@@ -2434,6 +3032,13 @@
 			"dependencies": {
 				"@types/estree": "*"
 			}
+		},
+		"node_modules/@types/tough-cookie": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+			"integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@types/turndown": {
 			"version": "5.0.6",
@@ -2455,12 +3060,298 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@types/yargs": {
+			"version": "17.0.35",
+			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
+			"integrity": "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/yargs-parser": "*"
+			}
+		},
+		"node_modules/@types/yargs-parser": {
+			"version": "21.0.3",
+			"resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
+			"integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@ungap/structured-clone": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
 			"integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
 			"dev": true,
 			"license": "ISC"
+		},
+		"node_modules/@unrs/resolver-binding-android-arm-eabi": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.11.1.tgz",
+			"integrity": "sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-android-arm64": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.11.1.tgz",
+			"integrity": "sha512-lCxkVtb4wp1v+EoN+HjIG9cIIzPkX5OtM03pQYkG+U5O/wL53LC4QbIeazgiKqluGeVEeBlZahHalCaBvU1a2g==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-darwin-arm64": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.11.1.tgz",
+			"integrity": "sha512-gPVA1UjRu1Y/IsB/dQEsp2V1pm44Of6+LWvbLc9SDk1c2KhhDRDBUkQCYVWe6f26uJb3fOK8saWMgtX8IrMk3g==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-darwin-x64": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.11.1.tgz",
+			"integrity": "sha512-cFzP7rWKd3lZaCsDze07QX1SC24lO8mPty9vdP+YVa3MGdVgPmFc59317b2ioXtgCMKGiCLxJ4HQs62oz6GfRQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-freebsd-x64": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.11.1.tgz",
+			"integrity": "sha512-fqtGgak3zX4DCB6PFpsH5+Kmt/8CIi4Bry4rb1ho6Av2QHTREM+47y282Uqiu3ZRF5IQioJQ5qWRV6jduA+iGw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.11.1.tgz",
+			"integrity": "sha512-u92mvlcYtp9MRKmP+ZvMmtPN34+/3lMHlyMj7wXJDeXxuM0Vgzz0+PPJNsro1m3IZPYChIkn944wW8TYgGKFHw==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.11.1.tgz",
+			"integrity": "sha512-cINaoY2z7LVCrfHkIcmvj7osTOtm6VVT16b5oQdS4beibX2SYBwgYLmqhBjA1t51CarSaBuX5YNsWLjsqfW5Cw==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.11.1.tgz",
+			"integrity": "sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-linux-arm64-musl": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.11.1.tgz",
+			"integrity": "sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.11.1.tgz",
+			"integrity": "sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.11.1.tgz",
+			"integrity": "sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.11.1.tgz",
+			"integrity": "sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.11.1.tgz",
+			"integrity": "sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-linux-x64-gnu": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz",
+			"integrity": "sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-linux-x64-musl": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.11.1.tgz",
+			"integrity": "sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-wasm32-wasi": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.11.1.tgz",
+			"integrity": "sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==",
+			"cpu": [
+				"wasm32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@napi-rs/wasm-runtime": "^0.2.11"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.11.1.tgz",
+			"integrity": "sha512-nRcz5Il4ln0kMhfL8S3hLkxI85BXs3o8EYoattsJNdsX4YUU89iOkVn7g0VHSRxFuVMdM4Q1jEpIId1Ihim/Uw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.11.1.tgz",
+			"integrity": "sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-win32-x64-msvc": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz",
+			"integrity": "sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
 		},
 		"node_modules/@vitejs/plugin-vue": {
 			"version": "5.2.4",
@@ -2474,145 +3365,6 @@
 			"peerDependencies": {
 				"vite": "^5.0.0 || ^6.0.0",
 				"vue": "^3.2.25"
-			}
-		},
-		"node_modules/@vitest/coverage-v8": {
-			"version": "4.1.5",
-			"resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.5.tgz",
-			"integrity": "sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@bcoe/v8-coverage": "^1.0.2",
-				"@vitest/utils": "4.1.5",
-				"ast-v8-to-istanbul": "^1.0.0",
-				"istanbul-lib-coverage": "^3.2.2",
-				"istanbul-lib-report": "^3.0.1",
-				"istanbul-reports": "^3.2.0",
-				"magicast": "^0.5.2",
-				"obug": "^2.1.1",
-				"std-env": "^4.0.0-rc.1",
-				"tinyrainbow": "^3.1.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/vitest"
-			},
-			"peerDependencies": {
-				"@vitest/browser": "4.1.5",
-				"vitest": "4.1.5"
-			},
-			"peerDependenciesMeta": {
-				"@vitest/browser": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@vitest/expect": {
-			"version": "4.1.5",
-			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
-			"integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@standard-schema/spec": "^1.1.0",
-				"@types/chai": "^5.2.2",
-				"@vitest/spy": "4.1.5",
-				"@vitest/utils": "4.1.5",
-				"chai": "^6.2.2",
-				"tinyrainbow": "^3.1.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/vitest"
-			}
-		},
-		"node_modules/@vitest/pretty-format": {
-			"version": "4.1.5",
-			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
-			"integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"tinyrainbow": "^3.1.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/vitest"
-			}
-		},
-		"node_modules/@vitest/runner": {
-			"version": "4.1.5",
-			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
-			"integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@vitest/utils": "4.1.5",
-				"pathe": "^2.0.3"
-			},
-			"funding": {
-				"url": "https://opencollective.com/vitest"
-			}
-		},
-		"node_modules/@vitest/snapshot": {
-			"version": "4.1.5",
-			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
-			"integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@vitest/pretty-format": "4.1.5",
-				"@vitest/utils": "4.1.5",
-				"magic-string": "^0.30.21",
-				"pathe": "^2.0.3"
-			},
-			"funding": {
-				"url": "https://opencollective.com/vitest"
-			}
-		},
-		"node_modules/@vitest/spy": {
-			"version": "4.1.5",
-			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
-			"integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
-			"dev": true,
-			"license": "MIT",
-			"funding": {
-				"url": "https://opencollective.com/vitest"
-			}
-		},
-		"node_modules/@vitest/ui": {
-			"version": "4.1.5",
-			"resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-4.1.5.tgz",
-			"integrity": "sha512-3Z9HNFiV0IF1fk0JPiK+7kE1GcaIPefQQIBYur6PM5yFIq6agys3uqP/0t966e1wXfmjbRCHDe7qW236Xjwnag==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@vitest/utils": "4.1.5",
-				"fflate": "^0.8.2",
-				"flatted": "^3.4.2",
-				"pathe": "^2.0.3",
-				"sirv": "^3.0.2",
-				"tinyglobby": "^0.2.15",
-				"tinyrainbow": "^3.1.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/vitest"
-			},
-			"peerDependencies": {
-				"vitest": "4.1.5"
-			}
-		},
-		"node_modules/@vitest/utils": {
-			"version": "4.1.5",
-			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
-			"integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@vitest/pretty-format": "4.1.5",
-				"convert-source-map": "^2.0.0",
-				"tinyrainbow": "^3.1.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/vitest"
 			}
 		},
 		"node_modules/@vue/compiler-core": {
@@ -2972,6 +3724,22 @@
 				"node": ">= 14.0.0"
 			}
 		},
+		"node_modules/ansi-escapes": {
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+			"integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"type-fest": "^0.21.3"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/ansi-regex": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -2996,37 +3764,135 @@
 				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
 		},
-		"node_modules/assertion-error": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
-			"integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+		"node_modules/anymatch": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+			"integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"normalize-path": "^3.0.0",
+				"picomatch": "^2.0.4"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/argparse": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
 			"dev": true,
 			"license": "MIT",
+			"dependencies": {
+				"sprintf-js": "~1.0.2"
+			}
+		},
+		"node_modules/babel-jest": {
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.3.0.tgz",
+			"integrity": "sha512-gRpauEU2KRrCox5Z296aeVHR4jQ98BCnu0IO332D/xpHNOsIH/bgSRk9k6GbKIbBw8vFeN6ctuu6tV8WOyVfYQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/transform": "30.3.0",
+				"@types/babel__core": "^7.20.5",
+				"babel-plugin-istanbul": "^7.0.1",
+				"babel-preset-jest": "30.3.0",
+				"chalk": "^4.1.2",
+				"graceful-fs": "^4.2.11",
+				"slash": "^3.0.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.11.0 || ^8.0.0-0"
+			}
+		},
+		"node_modules/babel-plugin-istanbul": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-7.0.1.tgz",
+			"integrity": "sha512-D8Z6Qm8jCvVXtIRkBnqNHX0zJ37rQcFJ9u8WOS6tkYOsRdHBzypCstaxWiu5ZIlqQtviRYbgnRLSoCEvjqcqbA==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"workspaces": [
+				"test/babel-8"
+			],
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@istanbuljs/load-nyc-config": "^1.0.0",
+				"@istanbuljs/schema": "^0.1.3",
+				"istanbul-lib-instrument": "^6.0.2",
+				"test-exclude": "^6.0.0"
+			},
 			"engines": {
 				"node": ">=12"
 			}
 		},
-		"node_modules/ast-v8-to-istanbul": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.0.tgz",
-			"integrity": "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==",
+		"node_modules/babel-plugin-jest-hoist": {
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-30.3.0.tgz",
+			"integrity": "sha512-+TRkByhsws6sfPjVaitzadk1I0F5sPvOVUH5tyTSzhePpsGIVrdeunHSw/C36QeocS95OOk8lunc4rlu5Anwsg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jridgewell/trace-mapping": "^0.3.31",
-				"estree-walker": "^3.0.3",
-				"js-tokens": "^10.0.0"
+				"@types/babel__core": "^7.20.5"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
-		"node_modules/ast-v8-to-istanbul/node_modules/estree-walker": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-			"integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+		"node_modules/babel-preset-current-node-syntax": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.2.0.tgz",
+			"integrity": "sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@types/estree": "^1.0.0"
+				"@babel/plugin-syntax-async-generators": "^7.8.4",
+				"@babel/plugin-syntax-bigint": "^7.8.3",
+				"@babel/plugin-syntax-class-properties": "^7.12.13",
+				"@babel/plugin-syntax-class-static-block": "^7.14.5",
+				"@babel/plugin-syntax-import-attributes": "^7.24.7",
+				"@babel/plugin-syntax-import-meta": "^7.10.4",
+				"@babel/plugin-syntax-json-strings": "^7.8.3",
+				"@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
+				"@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+				"@babel/plugin-syntax-numeric-separator": "^7.10.4",
+				"@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+				"@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+				"@babel/plugin-syntax-optional-chaining": "^7.8.3",
+				"@babel/plugin-syntax-private-property-in-object": "^7.14.5",
+				"@babel/plugin-syntax-top-level-await": "^7.14.5"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0 || ^8.0.0-0"
 			}
+		},
+		"node_modules/babel-preset-jest": {
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-30.3.0.tgz",
+			"integrity": "sha512-6ZcUbWHC+dMz2vfzdNwi87Z1gQsLNK2uLuK1Q89R11xdvejcivlYYwDlEv0FHX3VwEXpbBQ9uufB/MUNpZGfhQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"babel-plugin-jest-hoist": "30.3.0",
+				"babel-preset-current-node-syntax": "^1.2.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.11.0 || ^8.0.0-beta.1"
+			}
+		},
+		"node_modules/balanced-match": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/base64-js": {
 			"version": "1.5.1",
@@ -3048,14 +3914,14 @@
 			],
 			"license": "MIT"
 		},
-		"node_modules/bidi-js": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
-			"integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+		"node_modules/baseline-browser-mapping": {
+			"version": "2.9.11",
+			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.11.tgz",
+			"integrity": "sha512-Sg0xJUNDU1sJNGdfGWhVHX0kkZ+HWcvmVymJbj6NSgZZmW/8S9Y2HQ5euytnIgakgxN6papOAWiwDo1ctFDcoQ==",
 			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"require-from-string": "^2.0.2"
+			"license": "Apache-2.0",
+			"bin": {
+				"baseline-browser-mapping": "dist/cli.js"
 			}
 		},
 		"node_modules/bignumber.js": {
@@ -3140,11 +4006,75 @@
 				"node": "18 || 20 || >=22"
 			}
 		},
+		"node_modules/browserslist": {
+			"version": "4.28.1",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
+			"integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/browserslist"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/browserslist"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"baseline-browser-mapping": "^2.9.0",
+				"caniuse-lite": "^1.0.30001759",
+				"electron-to-chromium": "^1.5.263",
+				"node-releases": "^2.0.27",
+				"update-browserslist-db": "^1.2.0"
+			},
+			"bin": {
+				"browserslist": "cli.js"
+			},
+			"engines": {
+				"node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+			}
+		},
+		"node_modules/bs-logger": {
+			"version": "0.2.6",
+			"resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
+			"integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fast-json-stable-stringify": "2.x"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/bser": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
+			"integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"node-int64": "^0.4.0"
+			}
+		},
 		"node_modules/buffer-equal-constant-time": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
 			"integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
 			"license": "BSD-3-Clause"
+		},
+		"node_modules/buffer-from": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+			"integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/builtin-modules": {
 			"version": "5.1.0",
@@ -3200,6 +4130,47 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/callsites": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+			"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/camelcase": {
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+			"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/caniuse-lite": {
+			"version": "1.0.30001761",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001761.tgz",
+			"integrity": "sha512-JF9ptu1vP2coz98+5051jZ4PwQgd2ni8A+gYSN7EA7dPKIMf0pDlSUxhdmVOaV3/fYK5uWBkgSXJaRLr4+3A6g==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/browserslist"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "CC-BY-4.0"
+		},
 		"node_modules/ccount": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
@@ -3211,14 +4182,31 @@
 				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
-		"node_modules/chai": {
-			"version": "6.2.2",
-			"resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
-			"integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+		"node_modules/chalk": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/char-regex": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
+			"integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">=18"
+				"node": ">=10"
 			}
 		},
 		"node_modules/character-entities-html4": {
@@ -3242,6 +4230,29 @@
 				"type": "github",
 				"url": "https://github.com/sponsors/wooorm"
 			}
+		},
+		"node_modules/ci-info": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.3.1.tgz",
+			"integrity": "sha512-Wdy2Igu8OcBpI2pZePZ5oWjPC38tmDVx5WKUXKwlLYkA0ozo85sLsLvkBbBn/sZaSCMFOGZJ14fvW9t5/d7kdA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/sibiraj-s"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/cjs-module-lexer": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
+			"integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/cli-cursor": {
 			"version": "5.0.0",
@@ -3322,6 +4333,32 @@
 				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
 			}
 		},
+		"node_modules/cliui": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+			"integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"string-width": "^4.2.0",
+				"strip-ansi": "^6.0.1",
+				"wrap-ansi": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/co": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+			"integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"iojs": ">= 1.0.0",
+				"node": ">= 0.12.0"
+			}
+		},
 		"node_modules/codemirror": {
 			"version": "6.0.2",
 			"resolved": "https://registry.npmjs.org/codemirror/-/codemirror-6.0.2.tgz",
@@ -3351,6 +4388,13 @@
 				"@codemirror/state": "^6.2.0",
 				"@codemirror/view": "^6.7.2"
 			}
+		},
+		"node_modules/collect-v8-coverage": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.3.tgz",
+			"integrity": "sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/color-convert": {
 			"version": "2.0.1",
@@ -3387,6 +4431,13 @@
 				"type": "github",
 				"url": "https://github.com/sponsors/wooorm"
 			}
+		},
+		"node_modules/concat-map": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/content-disposition": {
 			"version": "1.0.1",
@@ -3493,18 +4544,18 @@
 				"node": ">= 8"
 			}
 		},
-		"node_modules/css-tree": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
-			"integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+		"node_modules/cssstyle": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+			"integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"mdn-data": "2.27.1",
-				"source-map-js": "^1.2.1"
+				"@asamuzakjp/css-color": "^3.2.0",
+				"rrweb-cssom": "^0.8.0"
 			},
 			"engines": {
-				"node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+				"node": ">=18"
 			}
 		},
 		"node_modules/csstype": {
@@ -3524,17 +4575,17 @@
 			}
 		},
 		"node_modules/data-urls": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
-			"integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+			"integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"whatwg-mimetype": "^5.0.0",
-				"whatwg-url": "^16.0.0"
+				"whatwg-mimetype": "^4.0.0",
+				"whatwg-url": "^14.0.0"
 			},
 			"engines": {
-				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+				"node": ">=18"
 			}
 		},
 		"node_modules/debug": {
@@ -3561,6 +4612,31 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/dedent": {
+			"version": "1.7.2",
+			"resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
+			"integrity": "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"babel-plugin-macros": "^3.1.0"
+			},
+			"peerDependenciesMeta": {
+				"babel-plugin-macros": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/deepmerge": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+			"integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/depd": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -3581,12 +4657,12 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/detect-libc": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
-			"integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+		"node_modules/detect-newline": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
+			"integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
 			"dev": true,
-			"license": "Apache-2.0",
+			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			}
@@ -3642,6 +4718,26 @@
 			"devOptional": true,
 			"license": "MIT"
 		},
+		"node_modules/electron-to-chromium": {
+			"version": "1.5.267",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.267.tgz",
+			"integrity": "sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/emittery": {
+			"version": "0.13.1",
+			"resolved": "https://registry.npmjs.org/emittery/-/emittery-0.13.1.tgz",
+			"integrity": "sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/emittery?sponsor=1"
+			}
+		},
 		"node_modules/emoji-regex": {
 			"version": "10.6.0",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
@@ -3667,13 +4763,13 @@
 			}
 		},
 		"node_modules/entities": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
-			"integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+			"integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
 			"dev": true,
 			"license": "BSD-2-Clause",
 			"engines": {
-				"node": ">=20.19.0"
+				"node": ">=0.12"
 			},
 			"funding": {
 				"url": "https://github.com/fb55/entities?sponsor=1"
@@ -3690,6 +4786,16 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/error-ex": {
+			"version": "1.3.4",
+			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+			"integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-arrayish": "^0.2.1"
 			}
 		},
 		"node_modules/es-define-property": {
@@ -3711,13 +4817,6 @@
 			"engines": {
 				"node": ">= 0.4"
 			}
-		},
-		"node_modules/es-module-lexer": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
-			"integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/es-object-atoms": {
 			"version": "1.1.1",
@@ -3781,12 +4880,46 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/escalade": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+			"integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/escape-html": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
 			"integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
 			"devOptional": true,
 			"license": "MIT"
+		},
+		"node_modules/escape-string-regexp": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+			"integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/esprima": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"bin": {
+				"esparse": "bin/esparse.js",
+				"esvalidate": "bin/esvalidate.js"
+			},
+			"engines": {
+				"node": ">=4"
+			}
 		},
 		"node_modules/estree-walker": {
 			"version": "2.0.2",
@@ -3835,14 +4968,56 @@
 				"node": ">=18.0.0"
 			}
 		},
-		"node_modules/expect-type": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
-			"integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+		"node_modules/execa": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+			"integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
 			"dev": true,
-			"license": "Apache-2.0",
+			"license": "MIT",
+			"dependencies": {
+				"cross-spawn": "^7.0.3",
+				"get-stream": "^6.0.0",
+				"human-signals": "^2.1.0",
+				"is-stream": "^2.0.0",
+				"merge-stream": "^2.0.0",
+				"npm-run-path": "^4.0.1",
+				"onetime": "^5.1.2",
+				"signal-exit": "^3.0.3",
+				"strip-final-newline": "^2.0.0"
+			},
 			"engines": {
-				"node": ">=12.0.0"
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/execa?sponsor=1"
+			}
+		},
+		"node_modules/exit-x": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/exit-x/-/exit-x-0.2.2.tgz",
+			"integrity": "sha512-+I6B/IkJc1o/2tiURyz/ivu/O0nKNEArIUB5O7zBrlDVJr22SCLH3xTeEry428LvFhRzIA1g8izguxJ/gbNcVQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/expect": {
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/expect/-/expect-30.3.0.tgz",
+			"integrity": "sha512-1zQrciTiQfRdo7qJM1uG4navm8DayFa2TgCSRlzUyNkhcJ6XUZF3hjnpkyr3VhAqPH7i/9GkG7Tv5abz6fqz0Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/expect-utils": "30.3.0",
+				"@jest/get-type": "30.1.0",
+				"jest-matcher-utils": "30.3.0",
+				"jest-message-util": "30.3.0",
+				"jest-mock": "30.3.0",
+				"jest-util": "30.3.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/express": {
@@ -3948,6 +5123,13 @@
 			"devOptional": true,
 			"license": "MIT"
 		},
+		"node_modules/fast-json-stable-stringify": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/fast-uri": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
@@ -3965,22 +5147,14 @@
 			],
 			"license": "BSD-3-Clause"
 		},
-		"node_modules/fdir": {
-			"version": "6.5.0",
-			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-			"integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+		"node_modules/fb-watchman": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
+			"integrity": "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==",
 			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12.0.0"
-			},
-			"peerDependencies": {
-				"picomatch": "^3 || ^4"
-			},
-			"peerDependenciesMeta": {
-				"picomatch": {
-					"optional": true
-				}
+			"license": "Apache-2.0",
+			"dependencies": {
+				"bser": "2.1.1"
 			}
 		},
 		"node_modules/fetch-blob": {
@@ -4006,13 +5180,6 @@
 				"node": "^12.20 || >= 14.13"
 			}
 		},
-		"node_modules/fflate": {
-			"version": "0.8.2",
-			"resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
-			"integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/finalhandler": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
@@ -4035,12 +5202,19 @@
 				"url": "https://opencollective.com/express"
 			}
 		},
-		"node_modules/flatted": {
-			"version": "3.4.2",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
-			"integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+		"node_modules/find-up": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+			"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
 			"dev": true,
-			"license": "ISC"
+			"license": "MIT",
+			"dependencies": {
+				"locate-path": "^5.0.0",
+				"path-exists": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
 		},
 		"node_modules/focus-trap": {
 			"version": "7.8.0",
@@ -4112,6 +5286,13 @@
 				"node": ">= 0.8"
 			}
 		},
+		"node_modules/fs.realpath": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+			"dev": true,
+			"license": "ISC"
+		},
 		"node_modules/fsevents": {
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -4166,6 +5347,26 @@
 				"node": ">=18"
 			}
 		},
+		"node_modules/gensync": {
+			"version": "1.0.0-beta.2",
+			"resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+			"integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/get-caller-file": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "6.* || 8.* || >= 10.*"
+			}
+		},
 		"node_modules/get-east-asian-width": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.4.0.tgz",
@@ -4204,6 +5405,16 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/get-package-type": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
+			"integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8.0.0"
+			}
+		},
 		"node_modules/get-proto": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
@@ -4216,6 +5427,19 @@
 			},
 			"engines": {
 				"node": ">= 0.4"
+			}
+		},
+		"node_modules/get-stream": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+			"integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/glob": {
@@ -4277,6 +5501,13 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
+		},
+		"node_modules/graceful-fs": {
+			"version": "4.2.11",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/gtoken": {
 			"version": "8.0.0",
@@ -4405,16 +5636,16 @@
 			"license": "MIT"
 		},
 		"node_modules/html-encoding-sniffer": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
-			"integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+			"integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@exodus/bytes": "^1.6.0"
+				"whatwg-encoding": "^3.1.1"
 			},
 			"engines": {
-				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+				"node": ">=18"
 			}
 		},
 		"node_modules/html-escaper": {
@@ -4456,6 +5687,20 @@
 				"url": "https://opencollective.com/express"
 			}
 		},
+		"node_modules/http-proxy-agent": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+			"integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "^7.1.0",
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
 		"node_modules/https-proxy-agent": {
 			"version": "7.0.6",
 			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
@@ -4467,6 +5712,16 @@
 			},
 			"engines": {
 				"node": ">= 14"
+			}
+		},
+		"node_modules/human-signals": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+			"integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=10.17.0"
 			}
 		},
 		"node_modules/husky": {
@@ -4485,6 +5740,19 @@
 				"url": "https://github.com/sponsors/typicode"
 			}
 		},
+		"node_modules/iconv-lite": {
+			"version": "0.6.3",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+			"integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"safer-buffer": ">= 2.1.2 < 3.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/ignore": {
 			"version": "7.0.5",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
@@ -4492,6 +5760,48 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 4"
+			}
+		},
+		"node_modules/import-local": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
+			"integrity": "sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"pkg-dir": "^4.2.0",
+				"resolve-cwd": "^3.0.0"
+			},
+			"bin": {
+				"import-local-fixture": "fixtures/cli.js"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/imurmurhash": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+			"integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.8.19"
+			}
+		},
+		"node_modules/inflight": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+			"integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+			"deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"once": "^1.3.0",
+				"wrappy": "1"
 			}
 		},
 		"node_modules/inherits": {
@@ -4521,6 +5831,13 @@
 				"node": ">= 0.10"
 			}
 		},
+		"node_modules/is-arrayish": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+			"integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/is-fullwidth-code-point": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -4528,6 +5845,16 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/is-generator-fn": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
+			"integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/is-potential-custom-element-name": {
@@ -4543,6 +5870,19 @@
 			"integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
 			"devOptional": true,
 			"license": "MIT"
+		},
+		"node_modules/is-stream": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+			"integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
 		},
 		"node_modules/is-what": {
 			"version": "5.5.0",
@@ -4573,6 +5913,36 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/istanbul-lib-instrument": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
+			"integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@babel/core": "^7.23.9",
+				"@babel/parser": "^7.23.9",
+				"@istanbuljs/schema": "^0.1.3",
+				"istanbul-lib-coverage": "^3.2.0",
+				"semver": "^7.5.4"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/istanbul-lib-instrument/node_modules/semver": {
+			"version": "7.7.3",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/istanbul-lib-report": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
@@ -4583,6 +5953,21 @@
 				"istanbul-lib-coverage": "^3.0.0",
 				"make-dir": "^4.0.0",
 				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/istanbul-lib-source-maps": {
+			"version": "5.0.6",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+			"integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@jridgewell/trace-mapping": "^0.3.23",
+				"debug": "^4.1.1",
+				"istanbul-lib-coverage": "^3.0.0"
 			},
 			"engines": {
 				"node": ">=10"
@@ -4617,6 +6002,660 @@
 				"@pkgjs/parseargs": "^0.11.0"
 			}
 		},
+		"node_modules/jest": {
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest/-/jest-30.3.0.tgz",
+			"integrity": "sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/core": "30.3.0",
+				"@jest/types": "30.3.0",
+				"import-local": "^3.2.0",
+				"jest-cli": "30.3.0"
+			},
+			"bin": {
+				"jest": "bin/jest.js"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			},
+			"peerDependencies": {
+				"node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+			},
+			"peerDependenciesMeta": {
+				"node-notifier": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/jest-changed-files": {
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-30.3.0.tgz",
+			"integrity": "sha512-B/7Cny6cV5At6M25EWDgf9S617lHivamL8vl6KEpJqkStauzcG4e+WPfDgMMF+H4FVH4A2PLRyvgDJan4441QA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"execa": "^5.1.1",
+				"jest-util": "30.3.0",
+				"p-limit": "^3.1.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-circus": {
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-30.3.0.tgz",
+			"integrity": "sha512-PyXq5szeSfR/4f1lYqCmmQjh0vqDkURUYi9N6whnHjlRz4IUQfMcXkGLeEoiJtxtyPqgUaUUfyQlApXWBSN1RA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/environment": "30.3.0",
+				"@jest/expect": "30.3.0",
+				"@jest/test-result": "30.3.0",
+				"@jest/types": "30.3.0",
+				"@types/node": "*",
+				"chalk": "^4.1.2",
+				"co": "^4.6.0",
+				"dedent": "^1.6.0",
+				"is-generator-fn": "^2.1.0",
+				"jest-each": "30.3.0",
+				"jest-matcher-utils": "30.3.0",
+				"jest-message-util": "30.3.0",
+				"jest-runtime": "30.3.0",
+				"jest-snapshot": "30.3.0",
+				"jest-util": "30.3.0",
+				"p-limit": "^3.1.0",
+				"pretty-format": "30.3.0",
+				"pure-rand": "^7.0.0",
+				"slash": "^3.0.0",
+				"stack-utils": "^2.0.6"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-cli": {
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-30.3.0.tgz",
+			"integrity": "sha512-l6Tqx+j1fDXJEW5bqYykDQQ7mQg+9mhWXtnj+tQZrTWYHyHoi6Be8HPumDSA+UiX2/2buEgjA58iJzdj146uCw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/core": "30.3.0",
+				"@jest/test-result": "30.3.0",
+				"@jest/types": "30.3.0",
+				"chalk": "^4.1.2",
+				"exit-x": "^0.2.2",
+				"import-local": "^3.2.0",
+				"jest-config": "30.3.0",
+				"jest-util": "30.3.0",
+				"jest-validate": "30.3.0",
+				"yargs": "^17.7.2"
+			},
+			"bin": {
+				"jest": "bin/jest.js"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			},
+			"peerDependencies": {
+				"node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+			},
+			"peerDependenciesMeta": {
+				"node-notifier": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/jest-config": {
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-30.3.0.tgz",
+			"integrity": "sha512-WPMAkMAtNDY9P/oKObtsRG/6KTrhtgPJoBTmk20uDn4Uy6/3EJnnaZJre/FMT1KVRx8cve1r7/FlMIOfRVWL4w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/core": "^7.27.4",
+				"@jest/get-type": "30.1.0",
+				"@jest/pattern": "30.0.1",
+				"@jest/test-sequencer": "30.3.0",
+				"@jest/types": "30.3.0",
+				"babel-jest": "30.3.0",
+				"chalk": "^4.1.2",
+				"ci-info": "^4.2.0",
+				"deepmerge": "^4.3.1",
+				"glob": "^10.5.0",
+				"graceful-fs": "^4.2.11",
+				"jest-circus": "30.3.0",
+				"jest-docblock": "30.2.0",
+				"jest-environment-node": "30.3.0",
+				"jest-regex-util": "30.0.1",
+				"jest-resolve": "30.3.0",
+				"jest-runner": "30.3.0",
+				"jest-util": "30.3.0",
+				"jest-validate": "30.3.0",
+				"parse-json": "^5.2.0",
+				"pretty-format": "30.3.0",
+				"slash": "^3.0.0",
+				"strip-json-comments": "^3.1.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			},
+			"peerDependencies": {
+				"@types/node": "*",
+				"esbuild-register": ">=3.4.0",
+				"ts-node": ">=9.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				},
+				"esbuild-register": {
+					"optional": true
+				},
+				"ts-node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/jest-diff": {
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.3.0.tgz",
+			"integrity": "sha512-n3q4PDQjS4LrKxfWB3Z5KNk1XjXtZTBwQp71OP0Jo03Z6V60x++K5L8k6ZrW8MY8pOFylZvHM0zsjS1RqlHJZQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/diff-sequences": "30.3.0",
+				"@jest/get-type": "30.1.0",
+				"chalk": "^4.1.2",
+				"pretty-format": "30.3.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-docblock": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-30.2.0.tgz",
+			"integrity": "sha512-tR/FFgZKS1CXluOQzZvNH3+0z9jXr3ldGSD8bhyuxvlVUwbeLOGynkunvlTMxchC5urrKndYiwCFC0DLVjpOCA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"detect-newline": "^3.1.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-each": {
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-30.3.0.tgz",
+			"integrity": "sha512-V8eMndg/aZ+3LnCJgSm13IxS5XSBM22QSZc9BtPK8Dek6pm+hfUNfwBdvsB3d342bo1q7wnSkC38zjX259qZNA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/get-type": "30.1.0",
+				"@jest/types": "30.3.0",
+				"chalk": "^4.1.2",
+				"jest-util": "30.3.0",
+				"pretty-format": "30.3.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-environment-jsdom": {
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-30.3.0.tgz",
+			"integrity": "sha512-RLEOJy6ip1lpw0yqJ8tB3i88FC7VBz7i00Zvl2qF71IdxjS98gC9/0SPWYIBVXHm5hgCYK0PAlSlnHGGy9RoMg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/environment": "30.3.0",
+				"@jest/environment-jsdom-abstract": "30.3.0",
+				"jsdom": "^26.1.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			},
+			"peerDependencies": {
+				"canvas": "^3.0.0"
+			},
+			"peerDependenciesMeta": {
+				"canvas": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/jest-environment-node": {
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-30.3.0.tgz",
+			"integrity": "sha512-4i6HItw/JSiJVsC5q0hnKIe/hbYfZLVG9YJ/0pU9Hz2n/9qZe3Rhn5s5CUZA5ORZlcdT/vmAXRMyONXJwPrmYQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/environment": "30.3.0",
+				"@jest/fake-timers": "30.3.0",
+				"@jest/types": "30.3.0",
+				"@types/node": "*",
+				"jest-mock": "30.3.0",
+				"jest-util": "30.3.0",
+				"jest-validate": "30.3.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-haste-map": {
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-30.3.0.tgz",
+			"integrity": "sha512-mMi2oqG4KRU0R9QEtscl87JzMXfUhbKaFqOxmjb2CKcbHcUGFrJCBWHmnTiUqi6JcnzoBlO4rWfpdl2k/RfLCA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "30.3.0",
+				"@types/node": "*",
+				"anymatch": "^3.1.3",
+				"fb-watchman": "^2.0.2",
+				"graceful-fs": "^4.2.11",
+				"jest-regex-util": "30.0.1",
+				"jest-util": "30.3.0",
+				"jest-worker": "30.3.0",
+				"picomatch": "^4.0.3",
+				"walker": "^1.0.8"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			},
+			"optionalDependencies": {
+				"fsevents": "^2.3.3"
+			}
+		},
+		"node_modules/jest-haste-map/node_modules/picomatch": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/jest-leak-detector": {
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-30.3.0.tgz",
+			"integrity": "sha512-cuKmUUGIjfXZAiGJ7TbEMx0bcqNdPPI6P1V+7aF+m/FUJqFDxkFR4JqkTu8ZOiU5AaX/x0hZ20KaaIPXQzbMGQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/get-type": "30.1.0",
+				"pretty-format": "30.3.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-matcher-utils": {
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.3.0.tgz",
+			"integrity": "sha512-HEtc9uFQgaUHkC7nLSlQL3Tph4Pjxt/yiPvkIrrDCt9jhoLIgxaubo1G+CFOnmHYMxHwwdaSN7mkIFs6ZK8OhA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/get-type": "30.1.0",
+				"chalk": "^4.1.2",
+				"jest-diff": "30.3.0",
+				"pretty-format": "30.3.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-message-util": {
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.3.0.tgz",
+			"integrity": "sha512-Z/j4Bo+4ySJ+JPJN3b2Qbl9hDq3VrXmnjjGEWD/x0BCXeOXPTV1iZYYzl2X8c1MaCOL+ewMyNBcm88sboE6YWw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^7.27.1",
+				"@jest/types": "30.3.0",
+				"@types/stack-utils": "^2.0.3",
+				"chalk": "^4.1.2",
+				"graceful-fs": "^4.2.11",
+				"picomatch": "^4.0.3",
+				"pretty-format": "30.3.0",
+				"slash": "^3.0.0",
+				"stack-utils": "^2.0.6"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-message-util/node_modules/picomatch": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/jest-mock": {
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.3.0.tgz",
+			"integrity": "sha512-OTzICK8CpE+t4ndhKrwlIdbM6Pn8j00lvmSmq5ejiO+KxukbLjgOflKWMn3KE34EZdQm5RqTuKj+5RIEniYhog==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "30.3.0",
+				"@types/node": "*",
+				"jest-util": "30.3.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-pnp-resolver": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
+			"integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			},
+			"peerDependencies": {
+				"jest-resolve": "*"
+			},
+			"peerDependenciesMeta": {
+				"jest-resolve": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/jest-regex-util": {
+			"version": "30.0.1",
+			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.0.1.tgz",
+			"integrity": "sha512-jHEQgBXAgc+Gh4g0p3bCevgRCVRkB4VB70zhoAE48gxeSr1hfUOsM/C2WoJgVL7Eyg//hudYENbm3Ne+/dRVVA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-resolve": {
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-30.3.0.tgz",
+			"integrity": "sha512-NRtTAHQlpd15F9rUR36jqwelbrDV/dY4vzNte3S2kxCKUJRYNd5/6nTSbYiak1VX5g8IoFF23Uj5TURkUW8O5g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"chalk": "^4.1.2",
+				"graceful-fs": "^4.2.11",
+				"jest-haste-map": "30.3.0",
+				"jest-pnp-resolver": "^1.2.3",
+				"jest-util": "30.3.0",
+				"jest-validate": "30.3.0",
+				"slash": "^3.0.0",
+				"unrs-resolver": "^1.7.11"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-resolve-dependencies": {
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-30.3.0.tgz",
+			"integrity": "sha512-9ev8s3YN6Hsyz9LV75XUwkCVFlwPbaFn6Wp75qnI0wzAINYWY8Fb3+6y59Rwd3QaS3kKXffHXsZMziMavfz/nw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"jest-regex-util": "30.0.1",
+				"jest-snapshot": "30.3.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-runner": {
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-30.3.0.tgz",
+			"integrity": "sha512-gDv6C9LGKWDPLia9TSzZwf4h3kMQCqyTpq+95PODnTRDO0g9os48XIYYkS6D236vjpBir2fF63YmJFtqkS5Duw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/console": "30.3.0",
+				"@jest/environment": "30.3.0",
+				"@jest/test-result": "30.3.0",
+				"@jest/transform": "30.3.0",
+				"@jest/types": "30.3.0",
+				"@types/node": "*",
+				"chalk": "^4.1.2",
+				"emittery": "^0.13.1",
+				"exit-x": "^0.2.2",
+				"graceful-fs": "^4.2.11",
+				"jest-docblock": "30.2.0",
+				"jest-environment-node": "30.3.0",
+				"jest-haste-map": "30.3.0",
+				"jest-leak-detector": "30.3.0",
+				"jest-message-util": "30.3.0",
+				"jest-resolve": "30.3.0",
+				"jest-runtime": "30.3.0",
+				"jest-util": "30.3.0",
+				"jest-watcher": "30.3.0",
+				"jest-worker": "30.3.0",
+				"p-limit": "^3.1.0",
+				"source-map-support": "0.5.13"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-runtime": {
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-30.3.0.tgz",
+			"integrity": "sha512-CgC+hIBJbuh78HEffkhNKcbXAytQViplcl8xupqeIWyKQF50kCQA8J7GeJCkjisC6hpnC9Muf8jV5RdtdFbGng==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/environment": "30.3.0",
+				"@jest/fake-timers": "30.3.0",
+				"@jest/globals": "30.3.0",
+				"@jest/source-map": "30.0.1",
+				"@jest/test-result": "30.3.0",
+				"@jest/transform": "30.3.0",
+				"@jest/types": "30.3.0",
+				"@types/node": "*",
+				"chalk": "^4.1.2",
+				"cjs-module-lexer": "^2.1.0",
+				"collect-v8-coverage": "^1.0.2",
+				"glob": "^10.5.0",
+				"graceful-fs": "^4.2.11",
+				"jest-haste-map": "30.3.0",
+				"jest-message-util": "30.3.0",
+				"jest-mock": "30.3.0",
+				"jest-regex-util": "30.0.1",
+				"jest-resolve": "30.3.0",
+				"jest-snapshot": "30.3.0",
+				"jest-util": "30.3.0",
+				"slash": "^3.0.0",
+				"strip-bom": "^4.0.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-snapshot": {
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-30.3.0.tgz",
+			"integrity": "sha512-f14c7atpb4O2DeNhwcvS810Y63wEn8O1HqK/luJ4F6M4NjvxmAKQwBUWjbExUtMxWJQ0wVgmCKymeJK6NZMnfQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/core": "^7.27.4",
+				"@babel/generator": "^7.27.5",
+				"@babel/plugin-syntax-jsx": "^7.27.1",
+				"@babel/plugin-syntax-typescript": "^7.27.1",
+				"@babel/types": "^7.27.3",
+				"@jest/expect-utils": "30.3.0",
+				"@jest/get-type": "30.1.0",
+				"@jest/snapshot-utils": "30.3.0",
+				"@jest/transform": "30.3.0",
+				"@jest/types": "30.3.0",
+				"babel-preset-current-node-syntax": "^1.2.0",
+				"chalk": "^4.1.2",
+				"expect": "30.3.0",
+				"graceful-fs": "^4.2.11",
+				"jest-diff": "30.3.0",
+				"jest-matcher-utils": "30.3.0",
+				"jest-message-util": "30.3.0",
+				"jest-util": "30.3.0",
+				"pretty-format": "30.3.0",
+				"semver": "^7.7.2",
+				"synckit": "^0.11.8"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-snapshot/node_modules/semver": {
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/jest-util": {
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz",
+			"integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "30.3.0",
+				"@types/node": "*",
+				"chalk": "^4.1.2",
+				"ci-info": "^4.2.0",
+				"graceful-fs": "^4.2.11",
+				"picomatch": "^4.0.3"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-util/node_modules/picomatch": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/jest-validate": {
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-30.3.0.tgz",
+			"integrity": "sha512-I/xzC8h5G+SHCb2P2gWkJYrNiTbeL47KvKeW5EzplkyxzBRBw1ssSHlI/jXec0ukH2q7x2zAWQm7015iusg62Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/get-type": "30.1.0",
+				"@jest/types": "30.3.0",
+				"camelcase": "^6.3.0",
+				"chalk": "^4.1.2",
+				"leven": "^3.1.0",
+				"pretty-format": "30.3.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-validate/node_modules/camelcase": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+			"integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/jest-watcher": {
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-30.3.0.tgz",
+			"integrity": "sha512-PJ1d9ThtTR8aMiBWUdcownq9mDdLXsQzJayTk4kmaBRHKvwNQn+ANveuhEBUyNI2hR1TVhvQ8D5kHubbzBHR/w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/test-result": "30.3.0",
+				"@jest/types": "30.3.0",
+				"@types/node": "*",
+				"ansi-escapes": "^4.3.2",
+				"chalk": "^4.1.2",
+				"emittery": "^0.13.1",
+				"jest-util": "30.3.0",
+				"string-length": "^4.0.2"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-worker": {
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-30.3.0.tgz",
+			"integrity": "sha512-DrCKkaQwHexjRUFTmPzs7sHQe0TSj9nvDALKGdwmK5mW9v7j90BudWirKAJHt3QQ9Dhrg1F7DogPzhChppkJpQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*",
+				"@ungap/structured-clone": "^1.3.0",
+				"jest-util": "30.3.0",
+				"merge-stream": "^2.0.0",
+				"supports-color": "^8.1.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-worker/node_modules/supports-color": {
+			"version": "8.1.1",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+			"integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/supports-color?sponsor=1"
+			}
+		},
 		"node_modules/jose": {
 			"version": "6.1.3",
 			"resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
@@ -4628,43 +6667,56 @@
 			}
 		},
 		"node_modules/js-tokens": {
-			"version": "10.0.0",
-			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
-			"integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/jsdom": {
-			"version": "29.0.2",
-			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.0.2.tgz",
-			"integrity": "sha512-9VnGEBosc/ZpwyOsJBCQ/3I5p7Q5ngOY14a9bf5btenAORmZfDse1ZEheMiWcJ3h81+Fv7HmJFdS0szo/waF2w==",
+		"node_modules/js-yaml": {
+			"version": "3.14.2",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+			"integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@asamuzakjp/css-color": "^5.1.5",
-				"@asamuzakjp/dom-selector": "^7.0.6",
-				"@bramus/specificity": "^2.4.2",
-				"@csstools/css-syntax-patches-for-csstree": "^1.1.1",
-				"@exodus/bytes": "^1.15.0",
-				"css-tree": "^3.2.1",
-				"data-urls": "^7.0.0",
-				"decimal.js": "^10.6.0",
-				"html-encoding-sniffer": "^6.0.0",
+				"argparse": "^1.0.7",
+				"esprima": "^4.0.0"
+			},
+			"bin": {
+				"js-yaml": "bin/js-yaml.js"
+			}
+		},
+		"node_modules/jsdom": {
+			"version": "26.1.0",
+			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
+			"integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"cssstyle": "^4.2.1",
+				"data-urls": "^5.0.0",
+				"decimal.js": "^10.5.0",
+				"html-encoding-sniffer": "^4.0.0",
+				"http-proxy-agent": "^7.0.2",
+				"https-proxy-agent": "^7.0.6",
 				"is-potential-custom-element-name": "^1.0.1",
-				"lru-cache": "^11.2.7",
-				"parse5": "^8.0.0",
+				"nwsapi": "^2.2.16",
+				"parse5": "^7.2.1",
+				"rrweb-cssom": "^0.8.0",
 				"saxes": "^6.0.0",
 				"symbol-tree": "^3.2.4",
-				"tough-cookie": "^6.0.1",
-				"undici": "^7.24.5",
+				"tough-cookie": "^5.1.1",
 				"w3c-xmlserializer": "^5.0.0",
-				"webidl-conversions": "^8.0.1",
-				"whatwg-mimetype": "^5.0.0",
-				"whatwg-url": "^16.0.1",
+				"webidl-conversions": "^7.0.0",
+				"whatwg-encoding": "^3.1.1",
+				"whatwg-mimetype": "^4.0.0",
+				"whatwg-url": "^14.1.1",
+				"ws": "^8.18.0",
 				"xml-name-validator": "^5.0.0"
 			},
 			"engines": {
-				"node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+				"node": ">=18"
 			},
 			"peerDependencies": {
 				"canvas": "^3.0.0"
@@ -4675,6 +6727,19 @@
 				}
 			}
 		},
+		"node_modules/jsesc": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+			"integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"jsesc": "bin/jsesc"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/json-bigint": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
@@ -4683,6 +6748,13 @@
 			"dependencies": {
 				"bignumber.js": "^9.0.0"
 			}
+		},
+		"node_modules/json-parse-even-better-errors": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+			"integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/json-schema-traverse": {
 			"version": "1.0.0",
@@ -4697,6 +6769,19 @@
 			"integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
 			"devOptional": true,
 			"license": "BSD-2-Clause"
+		},
+		"node_modules/json5": {
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+			"integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"json5": "lib/cli.js"
+			},
+			"engines": {
+				"node": ">=6"
+			}
 		},
 		"node_modules/jwa": {
 			"version": "2.0.1",
@@ -4719,266 +6804,22 @@
 				"safe-buffer": "^5.0.1"
 			}
 		},
-		"node_modules/lightningcss": {
-			"version": "1.32.0",
-			"resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
-			"integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+		"node_modules/leven": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+			"integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
 			"dev": true,
-			"license": "MPL-2.0",
-			"dependencies": {
-				"detect-libc": "^2.0.3"
-			},
+			"license": "MIT",
 			"engines": {
-				"node": ">= 12.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			},
-			"optionalDependencies": {
-				"lightningcss-android-arm64": "1.32.0",
-				"lightningcss-darwin-arm64": "1.32.0",
-				"lightningcss-darwin-x64": "1.32.0",
-				"lightningcss-freebsd-x64": "1.32.0",
-				"lightningcss-linux-arm-gnueabihf": "1.32.0",
-				"lightningcss-linux-arm64-gnu": "1.32.0",
-				"lightningcss-linux-arm64-musl": "1.32.0",
-				"lightningcss-linux-x64-gnu": "1.32.0",
-				"lightningcss-linux-x64-musl": "1.32.0",
-				"lightningcss-win32-arm64-msvc": "1.32.0",
-				"lightningcss-win32-x64-msvc": "1.32.0"
+				"node": ">=6"
 			}
 		},
-		"node_modules/lightningcss-android-arm64": {
-			"version": "1.32.0",
-			"resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
-			"integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
-			"cpu": [
-				"arm64"
-			],
+		"node_modules/lines-and-columns": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+			"integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
 			"dev": true,
-			"license": "MPL-2.0",
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"engines": {
-				"node": ">= 12.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/lightningcss-darwin-arm64": {
-			"version": "1.32.0",
-			"resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
-			"integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MPL-2.0",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">= 12.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/lightningcss-darwin-x64": {
-			"version": "1.32.0",
-			"resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
-			"integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MPL-2.0",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">= 12.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/lightningcss-freebsd-x64": {
-			"version": "1.32.0",
-			"resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
-			"integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MPL-2.0",
-			"optional": true,
-			"os": [
-				"freebsd"
-			],
-			"engines": {
-				"node": ">= 12.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/lightningcss-linux-arm-gnueabihf": {
-			"version": "1.32.0",
-			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
-			"integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"license": "MPL-2.0",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 12.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/lightningcss-linux-arm64-gnu": {
-			"version": "1.32.0",
-			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
-			"integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MPL-2.0",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 12.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/lightningcss-linux-arm64-musl": {
-			"version": "1.32.0",
-			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
-			"integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MPL-2.0",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 12.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/lightningcss-linux-x64-gnu": {
-			"version": "1.32.0",
-			"resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
-			"integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MPL-2.0",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 12.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/lightningcss-linux-x64-musl": {
-			"version": "1.32.0",
-			"resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
-			"integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MPL-2.0",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 12.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/lightningcss-win32-arm64-msvc": {
-			"version": "1.32.0",
-			"resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
-			"integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MPL-2.0",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">= 12.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/lightningcss-win32-x64-msvc": {
-			"version": "1.32.0",
-			"resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
-			"integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MPL-2.0",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">= 12.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
+			"license": "MIT"
 		},
 		"node_modules/lint-staged": {
 			"version": "16.4.0",
@@ -5012,6 +6853,19 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=20"
+			}
+		},
+		"node_modules/lint-staged/node_modules/picomatch": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
 		"node_modules/listr2": {
@@ -5109,6 +6963,26 @@
 			"funding": {
 				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
 			}
+		},
+		"node_modules/locate-path": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+			"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"p-locate": "^4.1.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/lodash.memoize": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+			"integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/log-update": {
 			"version": "6.1.0",
@@ -5231,13 +7105,13 @@
 			"license": "Apache-2.0"
 		},
 		"node_modules/lru-cache": {
-			"version": "11.3.5",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
-			"integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+			"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
 			"dev": true,
-			"license": "BlueOak-1.0.0",
-			"engines": {
-				"node": "20 || >=22"
+			"license": "ISC",
+			"dependencies": {
+				"yallist": "^3.0.2"
 			}
 		},
 		"node_modules/magic-string": {
@@ -5248,18 +7122,6 @@
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.5.5"
-			}
-		},
-		"node_modules/magicast": {
-			"version": "0.5.2",
-			"resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
-			"integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/parser": "^7.29.0",
-				"@babel/types": "^7.29.0",
-				"source-map-js": "^1.2.1"
 			}
 		},
 		"node_modules/make-dir": {
@@ -5276,6 +7138,36 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/make-dir/node_modules/semver": {
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/make-error": {
+			"version": "1.3.6",
+			"resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+			"integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/makeerror": {
+			"version": "1.0.12",
+			"resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
+			"integrity": "sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"tmpl": "1.0.5"
 			}
 		},
 		"node_modules/mark.js": {
@@ -5317,13 +7209,6 @@
 				"url": "https://opencollective.com/unified"
 			}
 		},
-		"node_modules/mdn-data": {
-			"version": "2.27.1",
-			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
-			"integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
-			"dev": true,
-			"license": "CC0-1.0"
-		},
 		"node_modules/media-typer": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
@@ -5346,6 +7231,13 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
+		},
+		"node_modules/merge-stream": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+			"integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/micromark-util-character": {
 			"version": "2.1.1",
@@ -5441,6 +7333,16 @@
 			],
 			"license": "MIT"
 		},
+		"node_modules/mimic-fn": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+			"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/mimic-function": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
@@ -5512,16 +7414,6 @@
 				"node": "*"
 			}
 		},
-		"node_modules/mrmime": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
-			"integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/ms": {
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -5546,6 +7438,29 @@
 			"engines": {
 				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
 			}
+		},
+		"node_modules/napi-postinstall": {
+			"version": "0.3.4",
+			"resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.4.tgz",
+			"integrity": "sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"napi-postinstall": "lib/cli.js"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/napi-postinstall"
+			}
+		},
+		"node_modules/natural-compare": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+			"integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/negotiator": {
 			"version": "1.0.0",
@@ -5602,6 +7517,50 @@
 				"url": "https://opencollective.com/node-fetch"
 			}
 		},
+		"node_modules/node-int64": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+			"integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/node-releases": {
+			"version": "2.0.27",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
+			"integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/normalize-path": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/npm-run-path": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+			"integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"path-key": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/nwsapi": {
+			"version": "2.2.23",
+			"resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
+			"integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/object-assign": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -5640,16 +7599,14 @@
 				"@codemirror/view": "6.38.6"
 			}
 		},
-		"node_modules/obug": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
-			"integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
-			"dev": true,
-			"funding": [
-				"https://github.com/sponsors/sxzz",
-				"https://opencollective.com/debug"
-			],
-			"license": "MIT"
+		"node_modules/ollama": {
+			"version": "0.6.3",
+			"resolved": "https://registry.npmjs.org/ollama/-/ollama-0.6.3.tgz",
+			"integrity": "sha512-KEWEhIqE5wtfzEIZbDCLH51VFZ6Z3ZSa6sIOg/E/tBV8S51flyqBOXi+bRxlOYKDf8i327zG9eSTb8IJxvm3Zg==",
+			"license": "MIT",
+			"dependencies": {
+				"whatwg-fetch": "^3.6.20"
+			}
 		},
 		"node_modules/on-finished": {
 			"version": "2.4.1",
@@ -5674,6 +7631,22 @@
 				"wrappy": "1"
 			}
 		},
+		"node_modules/onetime": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+			"integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"mimic-fn": "^2.1.0"
+			},
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/oniguruma-to-es": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-3.1.1.tgz",
@@ -5684,6 +7657,51 @@
 				"emoji-regex-xs": "^1.0.0",
 				"regex": "^6.0.1",
 				"regex-recursion": "^6.0.2"
+			}
+		},
+		"node_modules/p-limit": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+			"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"yocto-queue": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/p-locate": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+			"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"p-limit": "^2.2.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/p-locate/node_modules/p-limit": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+			"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"p-try": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/p-retry": {
@@ -5699,20 +7717,49 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/p-try": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/package-json-from-dist": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
 			"integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
 			"license": "BlueOak-1.0.0"
 		},
-		"node_modules/parse5": {
-			"version": "8.0.1",
-			"resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
-			"integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+		"node_modules/parse-json": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+			"integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"entities": "^8.0.0"
+				"@babel/code-frame": "^7.0.0",
+				"error-ex": "^1.3.1",
+				"json-parse-even-better-errors": "^2.3.0",
+				"lines-and-columns": "^1.1.6"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/parse5": {
+			"version": "7.3.0",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+			"integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"entities": "^6.0.0"
 			},
 			"funding": {
 				"url": "https://github.com/inikulin/parse5?sponsor=1"
@@ -5726,6 +7773,26 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.8"
+			}
+		},
+		"node_modules/path-exists": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/path-is-absolute": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/path-key": {
@@ -5770,13 +7837,6 @@
 				"url": "https://opencollective.com/express"
 			}
 		},
-		"node_modules/pathe": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/perfect-debounce": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
@@ -5792,16 +7852,26 @@
 			"license": "ISC"
 		},
 		"node_modules/picomatch": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+			"integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">=12"
+				"node": ">=8.6"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/pirates": {
+			"version": "4.0.7",
+			"resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+			"integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 6"
 			}
 		},
 		"node_modules/pkce-challenge": {
@@ -5812,6 +7882,19 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/pkg-dir": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+			"integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"find-up": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/postcss": {
@@ -5868,6 +7951,34 @@
 			},
 			"funding": {
 				"url": "https://github.com/prettier/prettier?sponsor=1"
+			}
+		},
+		"node_modules/pretty-format": {
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.3.0.tgz",
+			"integrity": "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/schemas": "30.0.5",
+				"ansi-styles": "^5.2.0",
+				"react-is": "^18.3.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/pretty-format/node_modules/ansi-styles": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
 		},
 		"node_modules/property-information": {
@@ -5929,6 +8040,23 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/pure-rand": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-7.0.1.tgz",
+			"integrity": "sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://github.com/sponsors/dubzzz"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/fast-check"
+				}
+			],
+			"license": "MIT"
+		},
 		"node_modules/qs": {
 			"version": "6.14.2",
 			"resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
@@ -5988,6 +8116,13 @@
 				"url": "https://opencollective.com/express"
 			}
 		},
+		"node_modules/react-is": {
+			"version": "18.3.1",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+			"integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/regex": {
 			"version": "6.1.0",
 			"resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
@@ -6015,6 +8150,16 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/require-directory": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+			"integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/require-from-string": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -6023,6 +8168,29 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/resolve-cwd": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+			"integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"resolve-from": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/resolve-from": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+			"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/restore-cursor": {
@@ -6102,40 +8270,6 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
-		"node_modules/rolldown": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
-			"integrity": "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@oxc-project/types": "=0.127.0",
-				"@rolldown/pluginutils": "1.0.0-rc.17"
-			},
-			"bin": {
-				"rolldown": "bin/cli.mjs"
-			},
-			"engines": {
-				"node": "^20.19.0 || >=22.12.0"
-			},
-			"optionalDependencies": {
-				"@rolldown/binding-android-arm64": "1.0.0-rc.17",
-				"@rolldown/binding-darwin-arm64": "1.0.0-rc.17",
-				"@rolldown/binding-darwin-x64": "1.0.0-rc.17",
-				"@rolldown/binding-freebsd-x64": "1.0.0-rc.17",
-				"@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17",
-				"@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17",
-				"@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17",
-				"@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17",
-				"@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17",
-				"@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17",
-				"@rolldown/binding-linux-x64-musl": "1.0.0-rc.17",
-				"@rolldown/binding-openharmony-arm64": "1.0.0-rc.17",
-				"@rolldown/binding-wasm32-wasi": "1.0.0-rc.17",
-				"@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17",
-				"@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
-			}
-		},
 		"node_modules/rollup": {
 			"version": "4.59.0",
 			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
@@ -6198,6 +8332,13 @@
 				"node": ">= 18"
 			}
 		},
+		"node_modules/rrweb-cssom": {
+			"version": "0.8.0",
+			"resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+			"integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/safe-buffer": {
 			"version": "5.2.1",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -6247,16 +8388,13 @@
 			"peer": true
 		},
 		"node_modules/semver": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
 				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
 			}
 		},
 		"node_modules/send": {
@@ -6454,26 +8592,21 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/siginfo": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
-			"integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+		"node_modules/signal-exit": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
 			"dev": true,
 			"license": "ISC"
 		},
-		"node_modules/sirv": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.2.tgz",
-			"integrity": "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==",
+		"node_modules/slash": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+			"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
 			"dev": true,
 			"license": "MIT",
-			"dependencies": {
-				"@polka/url": "^1.0.0-next.24",
-				"mrmime": "^2.0.0",
-				"totalist": "^3.0.0"
-			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=8"
 			}
 		},
 		"node_modules/slice-ansi": {
@@ -6542,6 +8675,17 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/source-map-support": {
+			"version": "0.5.13",
+			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+			"integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"buffer-from": "^1.0.0",
+				"source-map": "^0.6.0"
+			}
+		},
 		"node_modules/space-separated-tokens": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
@@ -6563,12 +8707,25 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/stackback": {
-			"version": "0.0.2",
-			"resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
-			"integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+		"node_modules/sprintf-js": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+			"integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
 			"dev": true,
-			"license": "MIT"
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/stack-utils": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+			"integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"escape-string-regexp": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
 		},
 		"node_modules/statuses": {
 			"version": "2.0.2",
@@ -6580,13 +8737,6 @@
 				"node": ">= 0.8"
 			}
 		},
-		"node_modules/std-env": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
-			"integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/string-argv": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
@@ -6595,6 +8745,20 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.6.19"
+			}
+		},
+		"node_modules/string-length": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
+			"integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"char-regex": "^1.0.2",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/string-width": {
@@ -6678,6 +8842,39 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/strip-bom": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+			"integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/strip-final-newline": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+			"integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/strip-json-comments": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+			"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/style-mod": {
 			"version": "4.1.3",
 			"resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
@@ -6717,6 +8914,22 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/synckit": {
+			"version": "0.11.12",
+			"resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.12.tgz",
+			"integrity": "sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@pkgr/core": "^0.2.9"
+			},
+			"engines": {
+				"node": "^14.18.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/synckit"
+			}
+		},
 		"node_modules/tabbable": {
 			"version": "6.4.0",
 			"resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
@@ -6724,12 +8937,66 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/tinybench": {
-			"version": "2.9.0",
-			"resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
-			"integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+		"node_modules/test-exclude": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+			"integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
 			"dev": true,
-			"license": "MIT"
+			"license": "ISC",
+			"dependencies": {
+				"@istanbuljs/schema": "^0.1.2",
+				"glob": "^7.1.4",
+				"minimatch": "^3.0.4"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/test-exclude/node_modules/brace-expansion": {
+			"version": "1.1.13",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+			"integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"node_modules/test-exclude/node_modules/glob": {
+			"version": "7.2.3",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+			"deprecated": "Glob versions prior to v9 are no longer supported",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.1.1",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
+			},
+			"engines": {
+				"node": "*"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/test-exclude/node_modules/minimatch": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
+			}
 		},
 		"node_modules/tinyexec": {
 			"version": "1.0.4",
@@ -6741,52 +9008,32 @@
 				"node": ">=18"
 			}
 		},
-		"node_modules/tinyglobby": {
-			"version": "0.2.16",
-			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-			"integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"fdir": "^6.5.0",
-				"picomatch": "^4.0.4"
-			},
-			"engines": {
-				"node": ">=12.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/SuperchupuDev"
-			}
-		},
-		"node_modules/tinyrainbow": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
-			"integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
 		"node_modules/tldts": {
-			"version": "7.0.28",
-			"resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.28.tgz",
-			"integrity": "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==",
+			"version": "6.1.86",
+			"resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+			"integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"tldts-core": "^7.0.28"
+				"tldts-core": "^6.1.86"
 			},
 			"bin": {
 				"tldts": "bin/cli.js"
 			}
 		},
 		"node_modules/tldts-core": {
-			"version": "7.0.28",
-			"resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.28.tgz",
-			"integrity": "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==",
+			"version": "6.1.86",
+			"resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+			"integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/tmpl": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
+			"integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
+			"dev": true,
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/toidentifier": {
 			"version": "1.0.1",
@@ -6798,40 +9045,30 @@
 				"node": ">=0.6"
 			}
 		},
-		"node_modules/totalist": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
-			"integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=6"
-			}
-		},
 		"node_modules/tough-cookie": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
-			"integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+			"integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
-				"tldts": "^7.0.5"
+				"tldts": "^6.1.32"
 			},
 			"engines": {
 				"node": ">=16"
 			}
 		},
 		"node_modules/tr46": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
-			"integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+			"integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"punycode": "^2.3.1"
 			},
 			"engines": {
-				"node": ">=20"
+				"node": ">=18"
 			}
 		},
 		"node_modules/trim-lines": {
@@ -6843,6 +9080,85 @@
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/ts-jest": {
+			"version": "29.4.9",
+			"resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.9.tgz",
+			"integrity": "sha512-LTb9496gYPMCqjeDLdPrKuXtncudeV1yRZnF4Wo5l3SFi0RYEnYRNgMrFIdg+FHvfzjCyQk1cLncWVqiSX+EvQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"bs-logger": "^0.2.6",
+				"fast-json-stable-stringify": "^2.1.0",
+				"handlebars": "^4.7.9",
+				"json5": "^2.2.3",
+				"lodash.memoize": "^4.1.2",
+				"make-error": "^1.3.6",
+				"semver": "^7.7.4",
+				"type-fest": "^4.41.0",
+				"yargs-parser": "^21.1.1"
+			},
+			"bin": {
+				"ts-jest": "cli.js"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || ^18.0.0 || >=20.0.0"
+			},
+			"peerDependencies": {
+				"@babel/core": ">=7.0.0-beta.0 <8",
+				"@jest/transform": "^29.0.0 || ^30.0.0",
+				"@jest/types": "^29.0.0 || ^30.0.0",
+				"babel-jest": "^29.0.0 || ^30.0.0",
+				"jest": "^29.0.0 || ^30.0.0",
+				"jest-util": "^29.0.0 || ^30.0.0",
+				"typescript": ">=4.3 <7"
+			},
+			"peerDependenciesMeta": {
+				"@babel/core": {
+					"optional": true
+				},
+				"@jest/transform": {
+					"optional": true
+				},
+				"@jest/types": {
+					"optional": true
+				},
+				"babel-jest": {
+					"optional": true
+				},
+				"esbuild": {
+					"optional": true
+				},
+				"jest-util": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/ts-jest/node_modules/semver": {
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/ts-jest/node_modules/type-fest": {
+			"version": "4.41.0",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+			"integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+			"dev": true,
+			"license": "(MIT OR CC0-1.0)",
+			"engines": {
+				"node": ">=16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/tslib": {
@@ -6863,6 +9179,29 @@
 			"engines": {
 				"node": ">=18",
 				"npm": ">=9"
+			}
+		},
+		"node_modules/type-detect": {
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/type-fest": {
+			"version": "0.21.3",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+			"integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+			"dev": true,
+			"license": "(MIT OR CC0-1.0)",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/type-is": {
@@ -6933,16 +9272,6 @@
 			},
 			"engines": {
 				"node": ">=0.8.0"
-			}
-		},
-		"node_modules/undici": {
-			"version": "7.25.0",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
-			"integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=20.18.1"
 			}
 		},
 		"node_modules/undici-types": {
@@ -7032,6 +9361,87 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.8"
+			}
+		},
+		"node_modules/unrs-resolver": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
+			"integrity": "sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"dependencies": {
+				"napi-postinstall": "^0.3.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/unrs-resolver"
+			},
+			"optionalDependencies": {
+				"@unrs/resolver-binding-android-arm-eabi": "1.11.1",
+				"@unrs/resolver-binding-android-arm64": "1.11.1",
+				"@unrs/resolver-binding-darwin-arm64": "1.11.1",
+				"@unrs/resolver-binding-darwin-x64": "1.11.1",
+				"@unrs/resolver-binding-freebsd-x64": "1.11.1",
+				"@unrs/resolver-binding-linux-arm-gnueabihf": "1.11.1",
+				"@unrs/resolver-binding-linux-arm-musleabihf": "1.11.1",
+				"@unrs/resolver-binding-linux-arm64-gnu": "1.11.1",
+				"@unrs/resolver-binding-linux-arm64-musl": "1.11.1",
+				"@unrs/resolver-binding-linux-ppc64-gnu": "1.11.1",
+				"@unrs/resolver-binding-linux-riscv64-gnu": "1.11.1",
+				"@unrs/resolver-binding-linux-riscv64-musl": "1.11.1",
+				"@unrs/resolver-binding-linux-s390x-gnu": "1.11.1",
+				"@unrs/resolver-binding-linux-x64-gnu": "1.11.1",
+				"@unrs/resolver-binding-linux-x64-musl": "1.11.1",
+				"@unrs/resolver-binding-wasm32-wasi": "1.11.1",
+				"@unrs/resolver-binding-win32-arm64-msvc": "1.11.1",
+				"@unrs/resolver-binding-win32-ia32-msvc": "1.11.1",
+				"@unrs/resolver-binding-win32-x64-msvc": "1.11.1"
+			}
+		},
+		"node_modules/update-browserslist-db": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+			"integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/browserslist"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/browserslist"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"escalade": "^3.2.0",
+				"picocolors": "^1.1.1"
+			},
+			"bin": {
+				"update-browserslist-db": "cli.js"
+			},
+			"peerDependencies": {
+				"browserslist": ">= 4.21.0"
+			}
+		},
+		"node_modules/v8-to-istanbul": {
+			"version": "9.3.0",
+			"resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
+			"integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"@jridgewell/trace-mapping": "^0.3.12",
+				"@types/istanbul-lib-coverage": "^2.0.1",
+				"convert-source-map": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10.12.0"
 			}
 		},
 		"node_modules/vary": {
@@ -7176,211 +9586,6 @@
 				}
 			}
 		},
-		"node_modules/vitest": {
-			"version": "4.1.5",
-			"resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
-			"integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@vitest/expect": "4.1.5",
-				"@vitest/mocker": "4.1.5",
-				"@vitest/pretty-format": "4.1.5",
-				"@vitest/runner": "4.1.5",
-				"@vitest/snapshot": "4.1.5",
-				"@vitest/spy": "4.1.5",
-				"@vitest/utils": "4.1.5",
-				"es-module-lexer": "^2.0.0",
-				"expect-type": "^1.3.0",
-				"magic-string": "^0.30.21",
-				"obug": "^2.1.1",
-				"pathe": "^2.0.3",
-				"picomatch": "^4.0.3",
-				"std-env": "^4.0.0-rc.1",
-				"tinybench": "^2.9.0",
-				"tinyexec": "^1.0.2",
-				"tinyglobby": "^0.2.15",
-				"tinyrainbow": "^3.1.0",
-				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
-				"why-is-node-running": "^2.3.0"
-			},
-			"bin": {
-				"vitest": "vitest.mjs"
-			},
-			"engines": {
-				"node": "^20.0.0 || ^22.0.0 || >=24.0.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/vitest"
-			},
-			"peerDependencies": {
-				"@edge-runtime/vm": "*",
-				"@opentelemetry/api": "^1.9.0",
-				"@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-				"@vitest/browser-playwright": "4.1.5",
-				"@vitest/browser-preview": "4.1.5",
-				"@vitest/browser-webdriverio": "4.1.5",
-				"@vitest/coverage-istanbul": "4.1.5",
-				"@vitest/coverage-v8": "4.1.5",
-				"@vitest/ui": "4.1.5",
-				"happy-dom": "*",
-				"jsdom": "*",
-				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
-			},
-			"peerDependenciesMeta": {
-				"@edge-runtime/vm": {
-					"optional": true
-				},
-				"@opentelemetry/api": {
-					"optional": true
-				},
-				"@types/node": {
-					"optional": true
-				},
-				"@vitest/browser-playwright": {
-					"optional": true
-				},
-				"@vitest/browser-preview": {
-					"optional": true
-				},
-				"@vitest/browser-webdriverio": {
-					"optional": true
-				},
-				"@vitest/coverage-istanbul": {
-					"optional": true
-				},
-				"@vitest/coverage-v8": {
-					"optional": true
-				},
-				"@vitest/ui": {
-					"optional": true
-				},
-				"happy-dom": {
-					"optional": true
-				},
-				"jsdom": {
-					"optional": true
-				},
-				"vite": {
-					"optional": false
-				}
-			}
-		},
-		"node_modules/vitest/node_modules/@vitest/mocker": {
-			"version": "4.1.5",
-			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
-			"integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@vitest/spy": "4.1.5",
-				"estree-walker": "^3.0.3",
-				"magic-string": "^0.30.21"
-			},
-			"funding": {
-				"url": "https://opencollective.com/vitest"
-			},
-			"peerDependencies": {
-				"msw": "^2.4.9",
-				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
-			},
-			"peerDependenciesMeta": {
-				"msw": {
-					"optional": true
-				},
-				"vite": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/vitest/node_modules/estree-walker": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-			"integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/estree": "^1.0.0"
-			}
-		},
-		"node_modules/vitest/node_modules/vite": {
-			"version": "8.0.10",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
-			"integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"lightningcss": "^1.32.0",
-				"picomatch": "^4.0.4",
-				"postcss": "^8.5.10",
-				"rolldown": "1.0.0-rc.17",
-				"tinyglobby": "^0.2.16"
-			},
-			"bin": {
-				"vite": "bin/vite.js"
-			},
-			"engines": {
-				"node": "^20.19.0 || >=22.12.0"
-			},
-			"funding": {
-				"url": "https://github.com/vitejs/vite?sponsor=1"
-			},
-			"optionalDependencies": {
-				"fsevents": "~2.3.3"
-			},
-			"peerDependencies": {
-				"@types/node": "^20.19.0 || >=22.12.0",
-				"@vitejs/devtools": "^0.1.0",
-				"esbuild": "^0.27.0 || ^0.28.0",
-				"jiti": ">=1.21.0",
-				"less": "^4.0.0",
-				"sass": "^1.70.0",
-				"sass-embedded": "^1.70.0",
-				"stylus": ">=0.54.8",
-				"sugarss": "^5.0.0",
-				"terser": "^5.16.0",
-				"tsx": "^4.8.1",
-				"yaml": "^2.4.2"
-			},
-			"peerDependenciesMeta": {
-				"@types/node": {
-					"optional": true
-				},
-				"@vitejs/devtools": {
-					"optional": true
-				},
-				"esbuild": {
-					"optional": true
-				},
-				"jiti": {
-					"optional": true
-				},
-				"less": {
-					"optional": true
-				},
-				"sass": {
-					"optional": true
-				},
-				"sass-embedded": {
-					"optional": true
-				},
-				"stylus": {
-					"optional": true
-				},
-				"sugarss": {
-					"optional": true
-				},
-				"terser": {
-					"optional": true
-				},
-				"tsx": {
-					"optional": true
-				},
-				"yaml": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/vue": {
 			"version": "3.5.27",
 			"resolved": "https://registry.npmjs.org/vue/-/vue-3.5.27.tgz",
@@ -7422,6 +9627,16 @@
 				"node": ">=18"
 			}
 		},
+		"node_modules/walker": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
+			"integrity": "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"makeerror": "1.0.12"
+			}
+		},
 		"node_modules/web-streams-polyfill": {
 			"version": "3.3.3",
 			"resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
@@ -7432,38 +9647,57 @@
 			}
 		},
 		"node_modules/webidl-conversions": {
-			"version": "8.0.1",
-			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
-			"integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+			"integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
 			"dev": true,
 			"license": "BSD-2-Clause",
 			"engines": {
-				"node": ">=20"
+				"node": ">=12"
 			}
 		},
-		"node_modules/whatwg-mimetype": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
-			"integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=20"
-			}
-		},
-		"node_modules/whatwg-url": {
-			"version": "16.0.1",
-			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
-			"integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+		"node_modules/whatwg-encoding": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+			"integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+			"deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@exodus/bytes": "^1.11.0",
-				"tr46": "^6.0.0",
-				"webidl-conversions": "^8.0.1"
+				"iconv-lite": "0.6.3"
 			},
 			"engines": {
-				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+				"node": ">=18"
+			}
+		},
+		"node_modules/whatwg-fetch": {
+			"version": "3.6.20",
+			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
+			"integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==",
+			"license": "MIT"
+		},
+		"node_modules/whatwg-mimetype": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+			"integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/whatwg-url": {
+			"version": "14.2.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+			"integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tr46": "^5.1.0",
+				"webidl-conversions": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/which": {
@@ -7481,29 +9715,30 @@
 				"node": ">= 8"
 			}
 		},
-		"node_modules/why-is-node-running": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
-			"integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"siginfo": "^2.0.0",
-				"stackback": "0.0.2"
-			},
-			"bin": {
-				"why-is-node-running": "cli.js"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/wordwrap": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
 			"integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/wrap-ansi": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
 		},
 		"node_modules/wrap-ansi-cjs": {
 			"name": "wrap-ansi",
@@ -7529,6 +9764,33 @@
 			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
 			"devOptional": true,
 			"license": "ISC"
+		},
+		"node_modules/write-file-atomic": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
+			"integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"imurmurhash": "^0.1.4",
+				"signal-exit": "^4.0.1"
+			},
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/write-file-atomic/node_modules/signal-exit": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
 		},
 		"node_modules/ws": {
 			"version": "8.18.3",
@@ -7568,6 +9830,23 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/y18n": {
+			"version": "5.0.8",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+			"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/yallist": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+			"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+			"dev": true,
+			"license": "ISC"
+		},
 		"node_modules/yaml": {
 			"version": "2.8.3",
 			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
@@ -7582,6 +9861,48 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/eemeli"
+			}
+		},
+		"node_modules/yargs": {
+			"version": "17.7.2",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+			"integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"cliui": "^8.0.1",
+				"escalade": "^3.1.1",
+				"get-caller-file": "^2.0.5",
+				"require-directory": "^2.1.1",
+				"string-width": "^4.2.3",
+				"y18n": "^5.0.5",
+				"yargs-parser": "^21.1.1"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/yargs-parser": {
+			"version": "21.1.1",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+			"integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/yocto-queue": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+			"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/zod": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,23 +18,23 @@
 			"devDependencies": {
 				"@google/genai": "^1.50.1",
 				"@modelcontextprotocol/sdk": "^1.29.0",
-				"@types/jest": "^30.0.0",
 				"@types/node": "^25.6.0",
+				"@vitest/coverage-v8": "^4.1.5",
+				"@vitest/ui": "^4.1.5",
 				"builtin-modules": "5.1.0",
 				"codemirror-companion-extension": "^0.0.11",
 				"esbuild": "0.28.0",
 				"esbuild-plugin-alias": "^0.2.1",
 				"handlebars": "^4.7.9",
 				"husky": "^9.1.7",
-				"jest": "^30.3.0",
-				"jest-environment-jsdom": "^30.3.0",
+				"jsdom": "^29.0.2",
 				"lint-staged": "^16.4.0",
 				"obsidian": "latest",
 				"prettier": "^3.8.3",
-				"ts-jest": "^29.4.6",
 				"tslib": "2.8.1",
 				"typescript": "^6.0.3",
-				"vitepress": "^1.6.4"
+				"vitepress": "^1.6.4",
+				"vitest": "^4.1.5"
 			}
 		},
 		"node_modules/@algolia/abtesting": {
@@ -324,167 +324,55 @@
 			}
 		},
 		"node_modules/@asamuzakjp/css-color": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
-			"integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+			"version": "5.1.11",
+			"resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+			"integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@csstools/css-calc": "^2.1.3",
-				"@csstools/css-color-parser": "^3.0.9",
-				"@csstools/css-parser-algorithms": "^3.0.4",
-				"@csstools/css-tokenizer": "^3.0.3",
-				"lru-cache": "^10.4.3"
+				"@asamuzakjp/generational-cache": "^1.0.1",
+				"@csstools/css-calc": "^3.2.0",
+				"@csstools/css-color-parser": "^4.1.0",
+				"@csstools/css-parser-algorithms": "^4.0.0",
+				"@csstools/css-tokenizer": "^4.0.0"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
 			}
 		},
-		"node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
-			"version": "10.4.3",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-			"dev": true,
-			"license": "ISC"
-		},
-		"node_modules/@babel/code-frame": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
-			"integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+		"node_modules/@asamuzakjp/dom-selector": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+			"integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.27.1",
-				"js-tokens": "^4.0.0",
-				"picocolors": "^1.1.1"
+				"@asamuzakjp/generational-cache": "^1.0.1",
+				"@asamuzakjp/nwsapi": "^2.3.9",
+				"bidi-js": "^1.0.3",
+				"css-tree": "^3.2.1",
+				"is-potential-custom-element-name": "^1.0.1"
 			},
 			"engines": {
-				"node": ">=6.9.0"
+				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
 			}
 		},
-		"node_modules/@babel/compat-data": {
-			"version": "7.28.5",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.5.tgz",
-			"integrity": "sha512-6uFXyCayocRbqhZOB+6XcuZbkMNimwfVGFji8CTZnCzOHVGvDqzvitu1re2AU5LROliz7eQPhB8CpAMvnx9EjA==",
+		"node_modules/@asamuzakjp/generational-cache": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+			"integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">=6.9.0"
+				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
 			}
 		},
-		"node_modules/@babel/core": {
-			"version": "7.28.5",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
-			"integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
+		"node_modules/@asamuzakjp/nwsapi": {
+			"version": "2.3.9",
+			"resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+			"integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
 			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/code-frame": "^7.27.1",
-				"@babel/generator": "^7.28.5",
-				"@babel/helper-compilation-targets": "^7.27.2",
-				"@babel/helper-module-transforms": "^7.28.3",
-				"@babel/helpers": "^7.28.4",
-				"@babel/parser": "^7.28.5",
-				"@babel/template": "^7.27.2",
-				"@babel/traverse": "^7.28.5",
-				"@babel/types": "^7.28.5",
-				"@jridgewell/remapping": "^2.3.5",
-				"convert-source-map": "^2.0.0",
-				"debug": "^4.1.0",
-				"gensync": "^1.0.0-beta.2",
-				"json5": "^2.2.3",
-				"semver": "^6.3.1"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/babel"
-			}
-		},
-		"node_modules/@babel/generator": {
-			"version": "7.28.5",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.5.tgz",
-			"integrity": "sha512-3EwLFhZ38J4VyIP6WNtt2kUdW9dokXA9Cr4IVIFHuCpZ3H8/YFOl5JjZHisrn1fATPBmKKqXzDFvh9fUwHz6CQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/parser": "^7.28.5",
-				"@babel/types": "^7.28.5",
-				"@jridgewell/gen-mapping": "^0.3.12",
-				"@jridgewell/trace-mapping": "^0.3.28",
-				"jsesc": "^3.0.2"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/helper-compilation-targets": {
-			"version": "7.27.2",
-			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
-			"integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/compat-data": "^7.27.2",
-				"@babel/helper-validator-option": "^7.27.1",
-				"browserslist": "^4.24.0",
-				"lru-cache": "^5.1.1",
-				"semver": "^6.3.1"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/helper-globals": {
-			"version": "7.28.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-			"integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/helper-module-imports": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
-			"integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/traverse": "^7.27.1",
-				"@babel/types": "^7.27.1"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/helper-module-transforms": {
-			"version": "7.28.3",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.3.tgz",
-			"integrity": "sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-module-imports": "^7.27.1",
-				"@babel/helper-validator-identifier": "^7.27.1",
-				"@babel/traverse": "^7.28.3"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0"
-			}
-		},
-		"node_modules/@babel/helper-plugin-utils": {
-			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
-			"integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=6.9.0"
-			}
+			"license": "MIT"
 		},
 		"node_modules/@babel/helper-string-parser": {
 			"version": "7.27.1",
@@ -506,38 +394,14 @@
 				"node": ">=6.9.0"
 			}
 		},
-		"node_modules/@babel/helper-validator-option": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-			"integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/helpers": {
-			"version": "7.28.4",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.4.tgz",
-			"integrity": "sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/template": "^7.27.2",
-				"@babel/types": "^7.28.4"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
 		"node_modules/@babel/parser": {
-			"version": "7.28.5",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.5.tgz",
-			"integrity": "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==",
+			"version": "7.29.2",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+			"integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/types": "^7.28.5"
+				"@babel/types": "^7.29.0"
 			},
 			"bin": {
 				"parser": "bin/babel-parser.js"
@@ -546,283 +410,10 @@
 				"node": ">=6.0.0"
 			}
 		},
-		"node_modules/@babel/plugin-syntax-async-generators": {
-			"version": "7.8.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
-			"integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.8.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-syntax-bigint": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
-			"integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.8.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-syntax-class-properties": {
-			"version": "7.12.13",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
-			"integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.12.13"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-syntax-class-static-block": {
-			"version": "7.14.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz",
-			"integrity": "sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.14.5"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-syntax-import-attributes": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.27.1.tgz",
-			"integrity": "sha512-oFT0FrKHgF53f4vOsZGi2Hh3I35PfSmVs4IBFLFj4dnafP+hIWDLg3VyKmUHfLoLHlyxY4C7DGtmHuJgn+IGww==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.27.1"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-syntax-import-meta": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
-			"integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.10.4"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-syntax-json-strings": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
-			"integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.8.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-syntax-jsx": {
-			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.28.6.tgz",
-			"integrity": "sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.28.6"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-syntax-logical-assignment-operators": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
-			"integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.10.4"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-syntax-nullish-coalescing-operator": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
-			"integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.8.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-syntax-numeric-separator": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
-			"integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.10.4"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-syntax-object-rest-spread": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
-			"integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.8.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-syntax-optional-catch-binding": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
-			"integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.8.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-syntax-optional-chaining": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
-			"integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.8.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-syntax-private-property-in-object": {
-			"version": "7.14.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz",
-			"integrity": "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.14.5"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-syntax-top-level-await": {
-			"version": "7.14.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
-			"integrity": "sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.14.5"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-syntax-typescript": {
-			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.28.6.tgz",
-			"integrity": "sha512-+nDNmQye7nlnuuHDboPbGm00Vqg3oO8niRRL27/4LYHUsHYh0zJ1xWOz0uRwNFmM1Avzk8wZbc6rdiYhomzv/A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.28.6"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/template": {
-			"version": "7.27.2",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
-			"integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/code-frame": "^7.27.1",
-				"@babel/parser": "^7.27.2",
-				"@babel/types": "^7.27.1"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/traverse": {
-			"version": "7.28.5",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.5.tgz",
-			"integrity": "sha512-TCCj4t55U90khlYkVV/0TfkJkAkUg3jZFA3Neb7unZT8CPok7iiRfaX0F+WnqWqt7OxhOn0uBKXCw4lbL8W0aQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/code-frame": "^7.27.1",
-				"@babel/generator": "^7.28.5",
-				"@babel/helper-globals": "^7.28.0",
-				"@babel/parser": "^7.28.5",
-				"@babel/template": "^7.27.2",
-				"@babel/types": "^7.28.5",
-				"debug": "^4.3.1"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
 		"node_modules/@babel/types": {
-			"version": "7.28.5",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.5.tgz",
-			"integrity": "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==",
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+			"integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -833,12 +424,18 @@
 				"node": ">=6.9.0"
 			}
 		},
-		"node_modules/@bcoe/v8-coverage": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
-			"integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+		"node_modules/@bramus/specificity": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+			"integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"dependencies": {
+				"css-tree": "^3.0.0"
+			},
+			"bin": {
+				"specificity": "bin/cli.js"
+			}
 		},
 		"node_modules/@codemirror/autocomplete": {
 			"version": "6.20.0",
@@ -939,9 +536,9 @@
 			}
 		},
 		"node_modules/@csstools/color-helpers": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
-			"integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+			"integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
 			"dev": true,
 			"funding": [
 				{
@@ -955,13 +552,13 @@
 			],
 			"license": "MIT-0",
 			"engines": {
-				"node": ">=18"
+				"node": ">=20.19.0"
 			}
 		},
 		"node_modules/@csstools/css-calc": {
-			"version": "2.1.4",
-			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
-			"integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
+			"integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
 			"dev": true,
 			"funding": [
 				{
@@ -975,17 +572,17 @@
 			],
 			"license": "MIT",
 			"engines": {
-				"node": ">=18"
+				"node": ">=20.19.0"
 			},
 			"peerDependencies": {
-				"@csstools/css-parser-algorithms": "^3.0.5",
-				"@csstools/css-tokenizer": "^3.0.4"
+				"@csstools/css-parser-algorithms": "^4.0.0",
+				"@csstools/css-tokenizer": "^4.0.0"
 			}
 		},
 		"node_modules/@csstools/css-color-parser": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
-			"integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz",
+			"integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -999,21 +596,21 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"@csstools/color-helpers": "^5.1.0",
-				"@csstools/css-calc": "^2.1.4"
+				"@csstools/color-helpers": "^6.0.2",
+				"@csstools/css-calc": "^3.2.0"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=20.19.0"
 			},
 			"peerDependencies": {
-				"@csstools/css-parser-algorithms": "^3.0.5",
-				"@csstools/css-tokenizer": "^3.0.4"
+				"@csstools/css-parser-algorithms": "^4.0.0",
+				"@csstools/css-tokenizer": "^4.0.0"
 			}
 		},
 		"node_modules/@csstools/css-parser-algorithms": {
-			"version": "3.0.5",
-			"resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
-			"integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+			"integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
 			"dev": true,
 			"funding": [
 				{
@@ -1027,16 +624,41 @@
 			],
 			"license": "MIT",
 			"engines": {
-				"node": ">=18"
+				"node": ">=20.19.0"
 			},
 			"peerDependencies": {
-				"@csstools/css-tokenizer": "^3.0.4"
+				"@csstools/css-tokenizer": "^4.0.0"
+			}
+		},
+		"node_modules/@csstools/css-syntax-patches-for-csstree": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
+			"integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT-0",
+			"peerDependencies": {
+				"css-tree": "^3.2.1"
+			},
+			"peerDependenciesMeta": {
+				"css-tree": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@csstools/css-tokenizer": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
-			"integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+			"integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
 			"dev": true,
 			"funding": [
 				{
@@ -1050,7 +672,7 @@
 			],
 			"license": "MIT",
 			"engines": {
-				"node": ">=18"
+				"node": ">=20.19.0"
 			}
 		},
 		"node_modules/@docsearch/css": {
@@ -1105,21 +727,21 @@
 			}
 		},
 		"node_modules/@emnapi/core": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.0.tgz",
-			"integrity": "sha512-0DQ98G9ZQZOxfUcQn1waV2yS8aWdZ6kJMbYCJB3oUBecjWYO1fqJ+a1DRfPF3O5JEkwqwP1A9QEN/9mYm2Yd0w==",
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+			"integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
-				"@emnapi/wasi-threads": "1.2.0",
+				"@emnapi/wasi-threads": "1.2.1",
 				"tslib": "^2.4.0"
 			}
 		},
 		"node_modules/@emnapi/runtime": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.0.tgz",
-			"integrity": "sha512-QN75eB0IH2ywSpRpNddCRfQIhmJYBCJ1x5Lb3IscKAL8bMnVAKnRg8dCoXbHzVLLH7P38N2Z3mtulB7W0J0FKw==",
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+			"integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
@@ -1128,9 +750,9 @@
 			}
 		},
 		"node_modules/@emnapi/wasi-threads": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
-			"integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+			"integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
@@ -1580,6 +1202,24 @@
 				"node": ">=18"
 			}
 		},
+		"node_modules/@exodus/bytes": {
+			"version": "1.15.0",
+			"resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+			"integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+			},
+			"peerDependencies": {
+				"@noble/hashes": "^1.8.0 || ^2.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@noble/hashes": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/@google/genai": {
 			"version": "1.50.1",
 			"resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.50.1.tgz",
@@ -1729,423 +1369,6 @@
 				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
 			}
 		},
-		"node_modules/@istanbuljs/load-nyc-config": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
-			"integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"camelcase": "^5.3.1",
-				"find-up": "^4.1.0",
-				"get-package-type": "^0.1.0",
-				"js-yaml": "^3.13.1",
-				"resolve-from": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/@istanbuljs/schema": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
-			"integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/@jest/console": {
-			"version": "30.3.0",
-			"resolved": "https://registry.npmjs.org/@jest/console/-/console-30.3.0.tgz",
-			"integrity": "sha512-PAwCvFJ4696XP2qZj+LAn1BWjZaJ6RjG6c7/lkMaUJnkyMS34ucuIsfqYvfskVNvUI27R/u4P1HMYFnlVXG/Ww==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "30.3.0",
-				"@types/node": "*",
-				"chalk": "^4.1.2",
-				"jest-message-util": "30.3.0",
-				"jest-util": "30.3.0",
-				"slash": "^3.0.0"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/@jest/core": {
-			"version": "30.3.0",
-			"resolved": "https://registry.npmjs.org/@jest/core/-/core-30.3.0.tgz",
-			"integrity": "sha512-U5mVPsBxLSO6xYbf+tgkymLx+iAhvZX43/xI1+ej2ZOPnPdkdO1CzDmFKh2mZBn2s4XZixszHeQnzp1gm/DIxw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/console": "30.3.0",
-				"@jest/pattern": "30.0.1",
-				"@jest/reporters": "30.3.0",
-				"@jest/test-result": "30.3.0",
-				"@jest/transform": "30.3.0",
-				"@jest/types": "30.3.0",
-				"@types/node": "*",
-				"ansi-escapes": "^4.3.2",
-				"chalk": "^4.1.2",
-				"ci-info": "^4.2.0",
-				"exit-x": "^0.2.2",
-				"graceful-fs": "^4.2.11",
-				"jest-changed-files": "30.3.0",
-				"jest-config": "30.3.0",
-				"jest-haste-map": "30.3.0",
-				"jest-message-util": "30.3.0",
-				"jest-regex-util": "30.0.1",
-				"jest-resolve": "30.3.0",
-				"jest-resolve-dependencies": "30.3.0",
-				"jest-runner": "30.3.0",
-				"jest-runtime": "30.3.0",
-				"jest-snapshot": "30.3.0",
-				"jest-util": "30.3.0",
-				"jest-validate": "30.3.0",
-				"jest-watcher": "30.3.0",
-				"pretty-format": "30.3.0",
-				"slash": "^3.0.0"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			},
-			"peerDependencies": {
-				"node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
-			},
-			"peerDependenciesMeta": {
-				"node-notifier": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@jest/diff-sequences": {
-			"version": "30.3.0",
-			"resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.3.0.tgz",
-			"integrity": "sha512-cG51MVnLq1ecVUaQ3fr6YuuAOitHK1S4WUJHnsPFE/quQr33ADUx1FfrTCpMCRxvy0Yr9BThKpDjSlcTi91tMA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/@jest/environment": {
-			"version": "30.3.0",
-			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.3.0.tgz",
-			"integrity": "sha512-SlLSF4Be735yQXyh2+mctBOzNDx5s5uLv88/j8Qn1wH679PDcwy67+YdADn8NJnGjzlXtN62asGH/T4vWOkfaw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/fake-timers": "30.3.0",
-				"@jest/types": "30.3.0",
-				"@types/node": "*",
-				"jest-mock": "30.3.0"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/@jest/environment-jsdom-abstract": {
-			"version": "30.3.0",
-			"resolved": "https://registry.npmjs.org/@jest/environment-jsdom-abstract/-/environment-jsdom-abstract-30.3.0.tgz",
-			"integrity": "sha512-0hNFs5N6We3DMCwobzI0ydhkY10sT1tZSC0AAiy+0g2Dt/qEWgrcV5BrMxPczhe41cxW4qm6X+jqZaUdpZIajA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/environment": "30.3.0",
-				"@jest/fake-timers": "30.3.0",
-				"@jest/types": "30.3.0",
-				"@types/jsdom": "^21.1.7",
-				"@types/node": "*",
-				"jest-mock": "30.3.0",
-				"jest-util": "30.3.0"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			},
-			"peerDependencies": {
-				"canvas": "^3.0.0",
-				"jsdom": "*"
-			},
-			"peerDependenciesMeta": {
-				"canvas": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@jest/expect": {
-			"version": "30.3.0",
-			"resolved": "https://registry.npmjs.org/@jest/expect/-/expect-30.3.0.tgz",
-			"integrity": "sha512-76Nlh4xJxk2D/9URCn3wFi98d2hb19uWE1idLsTt2ywhvdOldbw3S570hBgn25P4ICUZ/cBjybrBex2g17IDbg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"expect": "30.3.0",
-				"jest-snapshot": "30.3.0"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/@jest/expect-utils": {
-			"version": "30.3.0",
-			"resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.3.0.tgz",
-			"integrity": "sha512-j0+W5iQQ8hBh7tHZkTQv3q2Fh/M7Je72cIsYqC4OaktgtO7v1So9UTjp6uPBHIaB6beoF/RRsCgMJKvti0wADA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/get-type": "30.1.0"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/@jest/fake-timers": {
-			"version": "30.3.0",
-			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.3.0.tgz",
-			"integrity": "sha512-WUQDs8SOP9URStX1DzhD425CqbN/HxUYCTwVrT8sTVBfMvFqYt/s61EK5T05qnHu0po6RitXIvP9otZxYDzTGQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "30.3.0",
-				"@sinonjs/fake-timers": "^15.0.0",
-				"@types/node": "*",
-				"jest-message-util": "30.3.0",
-				"jest-mock": "30.3.0",
-				"jest-util": "30.3.0"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/@jest/get-type": {
-			"version": "30.1.0",
-			"resolved": "https://registry.npmjs.org/@jest/get-type/-/get-type-30.1.0.tgz",
-			"integrity": "sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/@jest/globals": {
-			"version": "30.3.0",
-			"resolved": "https://registry.npmjs.org/@jest/globals/-/globals-30.3.0.tgz",
-			"integrity": "sha512-+owLCBBdfpgL3HU+BD5etr1SvbXpSitJK0is1kiYjJxAAJggYMRQz5hSdd5pq1sSggfxPbw2ld71pt4x5wwViA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/environment": "30.3.0",
-				"@jest/expect": "30.3.0",
-				"@jest/types": "30.3.0",
-				"jest-mock": "30.3.0"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/@jest/pattern": {
-			"version": "30.0.1",
-			"resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.0.1.tgz",
-			"integrity": "sha512-gWp7NfQW27LaBQz3TITS8L7ZCQ0TLvtmI//4OwlQRx4rnWxcPNIYjxZpDcN4+UlGxgm3jS5QPz8IPTCkb59wZA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/node": "*",
-				"jest-regex-util": "30.0.1"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/@jest/reporters": {
-			"version": "30.3.0",
-			"resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-30.3.0.tgz",
-			"integrity": "sha512-a09z89S+PkQnL055bVj8+pe2Caed2PBOaczHcXCykW5ngxX9EWx/1uAwncxc/HiU0oZqfwseMjyhxgRjS49qPw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@bcoe/v8-coverage": "^0.2.3",
-				"@jest/console": "30.3.0",
-				"@jest/test-result": "30.3.0",
-				"@jest/transform": "30.3.0",
-				"@jest/types": "30.3.0",
-				"@jridgewell/trace-mapping": "^0.3.25",
-				"@types/node": "*",
-				"chalk": "^4.1.2",
-				"collect-v8-coverage": "^1.0.2",
-				"exit-x": "^0.2.2",
-				"glob": "^10.5.0",
-				"graceful-fs": "^4.2.11",
-				"istanbul-lib-coverage": "^3.0.0",
-				"istanbul-lib-instrument": "^6.0.0",
-				"istanbul-lib-report": "^3.0.0",
-				"istanbul-lib-source-maps": "^5.0.0",
-				"istanbul-reports": "^3.1.3",
-				"jest-message-util": "30.3.0",
-				"jest-util": "30.3.0",
-				"jest-worker": "30.3.0",
-				"slash": "^3.0.0",
-				"string-length": "^4.0.2",
-				"v8-to-istanbul": "^9.0.1"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			},
-			"peerDependencies": {
-				"node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
-			},
-			"peerDependenciesMeta": {
-				"node-notifier": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@jest/schemas": {
-			"version": "30.0.5",
-			"resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.5.tgz",
-			"integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@sinclair/typebox": "^0.34.0"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/@jest/snapshot-utils": {
-			"version": "30.3.0",
-			"resolved": "https://registry.npmjs.org/@jest/snapshot-utils/-/snapshot-utils-30.3.0.tgz",
-			"integrity": "sha512-ORbRN9sf5PP82v3FXNSwmO1OTDR2vzR2YTaR+E3VkSBZ8zadQE6IqYdYEeFH1NIkeB2HIGdF02dapb6K0Mj05g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "30.3.0",
-				"chalk": "^4.1.2",
-				"graceful-fs": "^4.2.11",
-				"natural-compare": "^1.4.0"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/@jest/source-map": {
-			"version": "30.0.1",
-			"resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-30.0.1.tgz",
-			"integrity": "sha512-MIRWMUUR3sdbP36oyNyhbThLHyJ2eEDClPCiHVbrYAe5g3CHRArIVpBw7cdSB5fr+ofSfIb2Tnsw8iEHL0PYQg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jridgewell/trace-mapping": "^0.3.25",
-				"callsites": "^3.1.0",
-				"graceful-fs": "^4.2.11"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/@jest/test-result": {
-			"version": "30.3.0",
-			"resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-30.3.0.tgz",
-			"integrity": "sha512-e/52nJGuD74AKTSe0P4y5wFRlaXP0qmrS17rqOMHeSwm278VyNyXE3gFO/4DTGF9w+65ra3lo3VKj0LBrzmgdQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/console": "30.3.0",
-				"@jest/types": "30.3.0",
-				"@types/istanbul-lib-coverage": "^2.0.6",
-				"collect-v8-coverage": "^1.0.2"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/@jest/test-sequencer": {
-			"version": "30.3.0",
-			"resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-30.3.0.tgz",
-			"integrity": "sha512-dgbWy9b8QDlQeRZcv7LNF+/jFiiYHTKho1xirauZ7kVwY7avjFF6uTT0RqlgudB5OuIPagFdVtfFMosjVbk1eA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/test-result": "30.3.0",
-				"graceful-fs": "^4.2.11",
-				"jest-haste-map": "30.3.0",
-				"slash": "^3.0.0"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/@jest/transform": {
-			"version": "30.3.0",
-			"resolved": "https://registry.npmjs.org/@jest/transform/-/transform-30.3.0.tgz",
-			"integrity": "sha512-TLKY33fSLVd/lKB2YI1pH69ijyUblO/BQvCj566YvnwuzoTNr648iE0j22vRvVNk2HsPwByPxATg3MleS3gf5A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/core": "^7.27.4",
-				"@jest/types": "30.3.0",
-				"@jridgewell/trace-mapping": "^0.3.25",
-				"babel-plugin-istanbul": "^7.0.1",
-				"chalk": "^4.1.2",
-				"convert-source-map": "^2.0.0",
-				"fast-json-stable-stringify": "^2.1.0",
-				"graceful-fs": "^4.2.11",
-				"jest-haste-map": "30.3.0",
-				"jest-regex-util": "30.0.1",
-				"jest-util": "30.3.0",
-				"pirates": "^4.0.7",
-				"slash": "^3.0.0",
-				"write-file-atomic": "^5.0.1"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/@jest/types": {
-			"version": "30.3.0",
-			"resolved": "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz",
-			"integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/pattern": "30.0.1",
-				"@jest/schemas": "30.0.5",
-				"@types/istanbul-lib-coverage": "^2.0.6",
-				"@types/istanbul-reports": "^3.0.4",
-				"@types/node": "*",
-				"@types/yargs": "^17.0.33",
-				"chalk": "^4.1.2"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/@jridgewell/gen-mapping": {
-			"version": "0.3.13",
-			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
-			"integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jridgewell/sourcemap-codec": "^1.5.0",
-				"@jridgewell/trace-mapping": "^0.3.24"
-			}
-		},
-		"node_modules/@jridgewell/remapping": {
-			"version": "2.3.5",
-			"resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
-			"integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jridgewell/gen-mapping": "^0.3.5",
-				"@jridgewell/trace-mapping": "^0.3.24"
-			}
-		},
 		"node_modules/@jridgewell/resolve-uri": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
@@ -2269,17 +1492,14 @@
 				}
 			}
 		},
-		"node_modules/@napi-rs/wasm-runtime": {
-			"version": "0.2.12",
-			"resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
-			"integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
+		"node_modules/@oxc-project/types": {
+			"version": "0.127.0",
+			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
+			"integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
 			"dev": true,
 			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"@emnapi/core": "^1.4.3",
-				"@emnapi/runtime": "^1.4.3",
-				"@tybys/wasm-util": "^0.10.0"
+			"funding": {
+				"url": "https://github.com/sponsors/Boshen"
 			}
 		},
 		"node_modules/@pkgjs/parseargs": {
@@ -2292,18 +1512,12 @@
 				"node": ">=14"
 			}
 		},
-		"node_modules/@pkgr/core": {
-			"version": "0.2.9",
-			"resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz",
-			"integrity": "sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==",
+		"node_modules/@polka/url": {
+			"version": "1.0.0-next.29",
+			"resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
+			"integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
 			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "^12.20.0 || ^14.18.0 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/pkgr"
-			}
+			"license": "MIT"
 		},
 		"node_modules/@protobufjs/aspromise": {
 			"version": "1.1.2",
@@ -2368,6 +1582,289 @@
 			"resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
 			"integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
 			"license": "BSD-3-Clause"
+		},
+		"node_modules/@rolldown/binding-android-arm64": {
+			"version": "1.0.0-rc.17",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
+			"integrity": "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-darwin-arm64": {
+			"version": "1.0.0-rc.17",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.17.tgz",
+			"integrity": "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-darwin-x64": {
+			"version": "1.0.0-rc.17",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.17.tgz",
+			"integrity": "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-freebsd-x64": {
+			"version": "1.0.0-rc.17",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.17.tgz",
+			"integrity": "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+			"version": "1.0.0-rc.17",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.17.tgz",
+			"integrity": "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-arm64-gnu": {
+			"version": "1.0.0-rc.17",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.17.tgz",
+			"integrity": "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-arm64-musl": {
+			"version": "1.0.0-rc.17",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.17.tgz",
+			"integrity": "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-ppc64-gnu": {
+			"version": "1.0.0-rc.17",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.17.tgz",
+			"integrity": "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-s390x-gnu": {
+			"version": "1.0.0-rc.17",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.17.tgz",
+			"integrity": "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-x64-gnu": {
+			"version": "1.0.0-rc.17",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.17.tgz",
+			"integrity": "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-x64-musl": {
+			"version": "1.0.0-rc.17",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.17.tgz",
+			"integrity": "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-openharmony-arm64": {
+			"version": "1.0.0-rc.17",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.17.tgz",
+			"integrity": "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-wasm32-wasi": {
+			"version": "1.0.0-rc.17",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.17.tgz",
+			"integrity": "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==",
+			"cpu": [
+				"wasm32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@emnapi/core": "1.10.0",
+				"@emnapi/runtime": "1.10.0",
+				"@napi-rs/wasm-runtime": "^1.1.4"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+			"integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@tybys/wasm-util": "^0.10.1"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Brooooooklyn"
+			},
+			"peerDependencies": {
+				"@emnapi/core": "^1.7.1",
+				"@emnapi/runtime": "^1.7.1"
+			}
+		},
+		"node_modules/@rolldown/binding-win32-arm64-msvc": {
+			"version": "1.0.0-rc.17",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.17.tgz",
+			"integrity": "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-win32-x64-msvc": {
+			"version": "1.0.0-rc.17",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.17.tgz",
+			"integrity": "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/pluginutils": {
+			"version": "1.0.0-rc.17",
+			"resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
+			"integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@rollup/rollup-android-arm-eabi": {
 			"version": "4.59.0",
@@ -2806,32 +2303,12 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/@sinclair/typebox": {
-			"version": "0.34.47",
-			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.47.tgz",
-			"integrity": "sha512-ZGIBQ+XDvO5JQku9wmwtabcVTHJsgSWAHYtVuM9pBNNR5E88v6Jcj/llpmsjivig5X8A8HHOb4/mbEKPS5EvAw==",
+		"node_modules/@standard-schema/spec": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+			"integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/@sinonjs/commons": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
-			"integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
-			"dev": true,
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"type-detect": "4.0.8"
-			}
-		},
-		"node_modules/@sinonjs/fake-timers": {
-			"version": "15.1.1",
-			"resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.1.1.tgz",
-			"integrity": "sha512-cO5W33JgAPbOh07tvZjUOJ7oWhtaqGHiZw+11DPbyqh2kHTBc3eF/CjJDeQ4205RLQsX6rxCuYOroFQwl7JDRw==",
-			"dev": true,
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"@sinonjs/commons": "^3.0.1"
-			}
 		},
 		"node_modules/@tybys/wasm-util": {
 			"version": "0.10.1",
@@ -2844,49 +2321,15 @@
 				"tslib": "^2.4.0"
 			}
 		},
-		"node_modules/@types/babel__core": {
-			"version": "7.20.5",
-			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
-			"integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+		"node_modules/@types/chai": {
+			"version": "5.2.3",
+			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+			"integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/parser": "^7.20.7",
-				"@babel/types": "^7.20.7",
-				"@types/babel__generator": "*",
-				"@types/babel__template": "*",
-				"@types/babel__traverse": "*"
-			}
-		},
-		"node_modules/@types/babel__generator": {
-			"version": "7.27.0",
-			"resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
-			"integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/types": "^7.0.0"
-			}
-		},
-		"node_modules/@types/babel__template": {
-			"version": "7.4.4",
-			"resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
-			"integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/parser": "^7.1.0",
-				"@babel/types": "^7.0.0"
-			}
-		},
-		"node_modules/@types/babel__traverse": {
-			"version": "7.28.0",
-			"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
-			"integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/types": "^7.28.2"
+				"@types/deep-eql": "*",
+				"assertion-error": "^2.0.1"
 			}
 		},
 		"node_modules/@types/codemirror": {
@@ -2898,6 +2341,13 @@
 			"dependencies": {
 				"@types/tern": "*"
 			}
+		},
+		"node_modules/@types/deep-eql": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+			"integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@types/estree": {
 			"version": "1.0.8",
@@ -2914,56 +2364,6 @@
 			"license": "MIT",
 			"dependencies": {
 				"@types/unist": "*"
-			}
-		},
-		"node_modules/@types/istanbul-lib-coverage": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
-			"integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/@types/istanbul-lib-report": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
-			"integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/istanbul-lib-coverage": "*"
-			}
-		},
-		"node_modules/@types/istanbul-reports": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
-			"integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/istanbul-lib-report": "*"
-			}
-		},
-		"node_modules/@types/jest": {
-			"version": "30.0.0",
-			"resolved": "https://registry.npmjs.org/@types/jest/-/jest-30.0.0.tgz",
-			"integrity": "sha512-XTYugzhuwqWjws0CVz8QpM36+T+Dz5mTEBKhNs/esGLnCIlGdRy+Dq78NRjd7ls7r8BC8ZRMOrKlkO1hU0JOwA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"expect": "^30.0.0",
-				"pretty-format": "^30.0.0"
-			}
-		},
-		"node_modules/@types/jsdom": {
-			"version": "21.1.7",
-			"resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-21.1.7.tgz",
-			"integrity": "sha512-yOriVnggzrnQ3a9OKOCxaVuSug3w3/SbOj5i7VwXWZEyUNl3bLF9V3MfxGbZKuwqJOQyRfqXyROBB1CoZLFWzA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/node": "*",
-				"@types/tough-cookie": "*",
-				"parse5": "^7.0.0"
 			}
 		},
 		"node_modules/@types/linkify-it": {
@@ -3016,13 +2416,6 @@
 			"integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
 			"license": "MIT"
 		},
-		"node_modules/@types/stack-utils": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
-			"integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/@types/tern": {
 			"version": "0.23.9",
 			"resolved": "https://registry.npmjs.org/@types/tern/-/tern-0.23.9.tgz",
@@ -3032,13 +2425,6 @@
 			"dependencies": {
 				"@types/estree": "*"
 			}
-		},
-		"node_modules/@types/tough-cookie": {
-			"version": "4.0.5",
-			"resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
-			"integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/@types/turndown": {
 			"version": "5.0.6",
@@ -3060,298 +2446,12 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/@types/yargs": {
-			"version": "17.0.35",
-			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
-			"integrity": "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/yargs-parser": "*"
-			}
-		},
-		"node_modules/@types/yargs-parser": {
-			"version": "21.0.3",
-			"resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
-			"integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/@ungap/structured-clone": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
 			"integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
 			"dev": true,
 			"license": "ISC"
-		},
-		"node_modules/@unrs/resolver-binding-android-arm-eabi": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.11.1.tgz",
-			"integrity": "sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"android"
-			]
-		},
-		"node_modules/@unrs/resolver-binding-android-arm64": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.11.1.tgz",
-			"integrity": "sha512-lCxkVtb4wp1v+EoN+HjIG9cIIzPkX5OtM03pQYkG+U5O/wL53LC4QbIeazgiKqluGeVEeBlZahHalCaBvU1a2g==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"android"
-			]
-		},
-		"node_modules/@unrs/resolver-binding-darwin-arm64": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.11.1.tgz",
-			"integrity": "sha512-gPVA1UjRu1Y/IsB/dQEsp2V1pm44Of6+LWvbLc9SDk1c2KhhDRDBUkQCYVWe6f26uJb3fOK8saWMgtX8IrMk3g==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			]
-		},
-		"node_modules/@unrs/resolver-binding-darwin-x64": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.11.1.tgz",
-			"integrity": "sha512-cFzP7rWKd3lZaCsDze07QX1SC24lO8mPty9vdP+YVa3MGdVgPmFc59317b2ioXtgCMKGiCLxJ4HQs62oz6GfRQ==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			]
-		},
-		"node_modules/@unrs/resolver-binding-freebsd-x64": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.11.1.tgz",
-			"integrity": "sha512-fqtGgak3zX4DCB6PFpsH5+Kmt/8CIi4Bry4rb1ho6Av2QHTREM+47y282Uqiu3ZRF5IQioJQ5qWRV6jduA+iGw==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"freebsd"
-			]
-		},
-		"node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.11.1.tgz",
-			"integrity": "sha512-u92mvlcYtp9MRKmP+ZvMmtPN34+/3lMHlyMj7wXJDeXxuM0Vgzz0+PPJNsro1m3IZPYChIkn944wW8TYgGKFHw==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.11.1.tgz",
-			"integrity": "sha512-cINaoY2z7LVCrfHkIcmvj7osTOtm6VVT16b5oQdS4beibX2SYBwgYLmqhBjA1t51CarSaBuX5YNsWLjsqfW5Cw==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.11.1.tgz",
-			"integrity": "sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@unrs/resolver-binding-linux-arm64-musl": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.11.1.tgz",
-			"integrity": "sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.11.1.tgz",
-			"integrity": "sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==",
-			"cpu": [
-				"ppc64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.11.1.tgz",
-			"integrity": "sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==",
-			"cpu": [
-				"riscv64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.11.1.tgz",
-			"integrity": "sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==",
-			"cpu": [
-				"riscv64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.11.1.tgz",
-			"integrity": "sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==",
-			"cpu": [
-				"s390x"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@unrs/resolver-binding-linux-x64-gnu": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz",
-			"integrity": "sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@unrs/resolver-binding-linux-x64-musl": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.11.1.tgz",
-			"integrity": "sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@unrs/resolver-binding-wasm32-wasi": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.11.1.tgz",
-			"integrity": "sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==",
-			"cpu": [
-				"wasm32"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"@napi-rs/wasm-runtime": "^0.2.11"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.11.1.tgz",
-			"integrity": "sha512-nRcz5Il4ln0kMhfL8S3hLkxI85BXs3o8EYoattsJNdsX4YUU89iOkVn7g0VHSRxFuVMdM4Q1jEpIId1Ihim/Uw==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			]
-		},
-		"node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.11.1.tgz",
-			"integrity": "sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ==",
-			"cpu": [
-				"ia32"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			]
-		},
-		"node_modules/@unrs/resolver-binding-win32-x64-msvc": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz",
-			"integrity": "sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			]
 		},
 		"node_modules/@vitejs/plugin-vue": {
 			"version": "5.2.4",
@@ -3365,6 +2465,155 @@
 			"peerDependencies": {
 				"vite": "^5.0.0 || ^6.0.0",
 				"vue": "^3.2.25"
+			}
+		},
+		"node_modules/@vitest/coverage-v8": {
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.5.tgz",
+			"integrity": "sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@bcoe/v8-coverage": "^1.0.2",
+				"@vitest/utils": "4.1.5",
+				"ast-v8-to-istanbul": "^1.0.0",
+				"istanbul-lib-coverage": "^3.2.2",
+				"istanbul-lib-report": "^3.0.1",
+				"istanbul-reports": "^3.2.0",
+				"magicast": "^0.5.2",
+				"obug": "^2.1.1",
+				"std-env": "^4.0.0-rc.1",
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"@vitest/browser": "4.1.5",
+				"vitest": "4.1.5"
+			},
+			"peerDependenciesMeta": {
+				"@vitest/browser": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@vitest/coverage-v8/node_modules/@bcoe/v8-coverage": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+			"integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@vitest/expect": {
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
+			"integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@standard-schema/spec": "^1.1.0",
+				"@types/chai": "^5.2.2",
+				"@vitest/spy": "4.1.5",
+				"@vitest/utils": "4.1.5",
+				"chai": "^6.2.2",
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/pretty-format": {
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
+			"integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/runner": {
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
+			"integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/utils": "4.1.5",
+				"pathe": "^2.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/snapshot": {
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
+			"integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/pretty-format": "4.1.5",
+				"@vitest/utils": "4.1.5",
+				"magic-string": "^0.30.21",
+				"pathe": "^2.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/spy": {
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
+			"integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/ui": {
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-4.1.5.tgz",
+			"integrity": "sha512-3Z9HNFiV0IF1fk0JPiK+7kE1GcaIPefQQIBYur6PM5yFIq6agys3uqP/0t966e1wXfmjbRCHDe7qW236Xjwnag==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/utils": "4.1.5",
+				"fflate": "^0.8.2",
+				"flatted": "^3.4.2",
+				"pathe": "^2.0.3",
+				"sirv": "^3.0.2",
+				"tinyglobby": "^0.2.15",
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"vitest": "4.1.5"
+			}
+		},
+		"node_modules/@vitest/utils": {
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
+			"integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/pretty-format": "4.1.5",
+				"convert-source-map": "^2.0.0",
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
 			}
 		},
 		"node_modules/@vue/compiler-core": {
@@ -3724,22 +2973,6 @@
 				"node": ">= 14.0.0"
 			}
 		},
-		"node_modules/ansi-escapes": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
-			"integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"type-fest": "^0.21.3"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/ansi-regex": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -3764,133 +2997,42 @@
 				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
 		},
-		"node_modules/anymatch": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
-			"integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"normalize-path": "^3.0.0",
-				"picomatch": "^2.0.4"
-			},
-			"engines": {
-				"node": ">= 8"
-			}
-		},
-		"node_modules/argparse": {
-			"version": "1.0.10",
-			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+		"node_modules/assertion-error": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+			"integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
 			"dev": true,
 			"license": "MIT",
-			"dependencies": {
-				"sprintf-js": "~1.0.2"
-			}
-		},
-		"node_modules/babel-jest": {
-			"version": "30.3.0",
-			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.3.0.tgz",
-			"integrity": "sha512-gRpauEU2KRrCox5Z296aeVHR4jQ98BCnu0IO332D/xpHNOsIH/bgSRk9k6GbKIbBw8vFeN6ctuu6tV8WOyVfYQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/transform": "30.3.0",
-				"@types/babel__core": "^7.20.5",
-				"babel-plugin-istanbul": "^7.0.1",
-				"babel-preset-jest": "30.3.0",
-				"chalk": "^4.1.2",
-				"graceful-fs": "^4.2.11",
-				"slash": "^3.0.0"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.11.0 || ^8.0.0-0"
-			}
-		},
-		"node_modules/babel-plugin-istanbul": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-7.0.1.tgz",
-			"integrity": "sha512-D8Z6Qm8jCvVXtIRkBnqNHX0zJ37rQcFJ9u8WOS6tkYOsRdHBzypCstaxWiu5ZIlqQtviRYbgnRLSoCEvjqcqbA==",
-			"dev": true,
-			"license": "BSD-3-Clause",
-			"workspaces": [
-				"test/babel-8"
-			],
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"@istanbuljs/load-nyc-config": "^1.0.0",
-				"@istanbuljs/schema": "^0.1.3",
-				"istanbul-lib-instrument": "^6.0.2",
-				"test-exclude": "^6.0.0"
-			},
 			"engines": {
 				"node": ">=12"
 			}
 		},
-		"node_modules/babel-plugin-jest-hoist": {
-			"version": "30.3.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-30.3.0.tgz",
-			"integrity": "sha512-+TRkByhsws6sfPjVaitzadk1I0F5sPvOVUH5tyTSzhePpsGIVrdeunHSw/C36QeocS95OOk8lunc4rlu5Anwsg==",
+		"node_modules/ast-v8-to-istanbul": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.0.tgz",
+			"integrity": "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@types/babel__core": "^7.20.5"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+				"@jridgewell/trace-mapping": "^0.3.31",
+				"estree-walker": "^3.0.3",
+				"js-tokens": "^10.0.0"
 			}
 		},
-		"node_modules/babel-preset-current-node-syntax": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.2.0.tgz",
-			"integrity": "sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg==",
+		"node_modules/ast-v8-to-istanbul/node_modules/estree-walker": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+			"integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/plugin-syntax-async-generators": "^7.8.4",
-				"@babel/plugin-syntax-bigint": "^7.8.3",
-				"@babel/plugin-syntax-class-properties": "^7.12.13",
-				"@babel/plugin-syntax-class-static-block": "^7.14.5",
-				"@babel/plugin-syntax-import-attributes": "^7.24.7",
-				"@babel/plugin-syntax-import-meta": "^7.10.4",
-				"@babel/plugin-syntax-json-strings": "^7.8.3",
-				"@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
-				"@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
-				"@babel/plugin-syntax-numeric-separator": "^7.10.4",
-				"@babel/plugin-syntax-object-rest-spread": "^7.8.3",
-				"@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
-				"@babel/plugin-syntax-optional-chaining": "^7.8.3",
-				"@babel/plugin-syntax-private-property-in-object": "^7.14.5",
-				"@babel/plugin-syntax-top-level-await": "^7.14.5"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0 || ^8.0.0-0"
+				"@types/estree": "^1.0.0"
 			}
 		},
-		"node_modules/babel-preset-jest": {
-			"version": "30.3.0",
-			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-30.3.0.tgz",
-			"integrity": "sha512-6ZcUbWHC+dMz2vfzdNwi87Z1gQsLNK2uLuK1Q89R11xdvejcivlYYwDlEv0FHX3VwEXpbBQ9uufB/MUNpZGfhQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"babel-plugin-jest-hoist": "30.3.0",
-				"babel-preset-current-node-syntax": "^1.2.0"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.11.0 || ^8.0.0-beta.1"
-			}
-		},
-		"node_modules/balanced-match": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+		"node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+			"integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -3914,14 +3056,14 @@
 			],
 			"license": "MIT"
 		},
-		"node_modules/baseline-browser-mapping": {
-			"version": "2.9.11",
-			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.11.tgz",
-			"integrity": "sha512-Sg0xJUNDU1sJNGdfGWhVHX0kkZ+HWcvmVymJbj6NSgZZmW/8S9Y2HQ5euytnIgakgxN6papOAWiwDo1ctFDcoQ==",
+		"node_modules/bidi-js": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+			"integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
 			"dev": true,
-			"license": "Apache-2.0",
-			"bin": {
-				"baseline-browser-mapping": "dist/cli.js"
+			"license": "MIT",
+			"dependencies": {
+				"require-from-string": "^2.0.2"
 			}
 		},
 		"node_modules/bignumber.js": {
@@ -4006,75 +3148,11 @@
 				"node": "18 || 20 || >=22"
 			}
 		},
-		"node_modules/browserslist": {
-			"version": "4.28.1",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
-			"integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/browserslist"
-				},
-				{
-					"type": "tidelift",
-					"url": "https://tidelift.com/funding/github/npm/browserslist"
-				},
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/ai"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"baseline-browser-mapping": "^2.9.0",
-				"caniuse-lite": "^1.0.30001759",
-				"electron-to-chromium": "^1.5.263",
-				"node-releases": "^2.0.27",
-				"update-browserslist-db": "^1.2.0"
-			},
-			"bin": {
-				"browserslist": "cli.js"
-			},
-			"engines": {
-				"node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-			}
-		},
-		"node_modules/bs-logger": {
-			"version": "0.2.6",
-			"resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
-			"integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"fast-json-stable-stringify": "2.x"
-			},
-			"engines": {
-				"node": ">= 6"
-			}
-		},
-		"node_modules/bser": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
-			"integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"node-int64": "^0.4.0"
-			}
-		},
 		"node_modules/buffer-equal-constant-time": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
 			"integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
 			"license": "BSD-3-Clause"
-		},
-		"node_modules/buffer-from": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-			"integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/builtin-modules": {
 			"version": "5.1.0",
@@ -4130,47 +3208,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/callsites": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-			"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/camelcase": {
-			"version": "5.3.1",
-			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-			"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/caniuse-lite": {
-			"version": "1.0.30001761",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001761.tgz",
-			"integrity": "sha512-JF9ptu1vP2coz98+5051jZ4PwQgd2ni8A+gYSN7EA7dPKIMf0pDlSUxhdmVOaV3/fYK5uWBkgSXJaRLr4+3A6g==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/browserslist"
-				},
-				{
-					"type": "tidelift",
-					"url": "https://tidelift.com/funding/github/npm/caniuse-lite"
-				},
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/ai"
-				}
-			],
-			"license": "CC-BY-4.0"
-		},
 		"node_modules/ccount": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
@@ -4182,31 +3219,14 @@
 				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
-		"node_modules/chalk": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-styles": "^4.1.0",
-				"supports-color": "^7.1.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/chalk?sponsor=1"
-			}
-		},
-		"node_modules/char-regex": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
-			"integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
+		"node_modules/chai": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+			"integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">=10"
+				"node": ">=18"
 			}
 		},
 		"node_modules/character-entities-html4": {
@@ -4230,29 +3250,6 @@
 				"type": "github",
 				"url": "https://github.com/sponsors/wooorm"
 			}
-		},
-		"node_modules/ci-info": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.3.1.tgz",
-			"integrity": "sha512-Wdy2Igu8OcBpI2pZePZ5oWjPC38tmDVx5WKUXKwlLYkA0ozo85sLsLvkBbBn/sZaSCMFOGZJ14fvW9t5/d7kdA==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/sibiraj-s"
-				}
-			],
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/cjs-module-lexer": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
-			"integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/cli-cursor": {
 			"version": "5.0.0",
@@ -4333,32 +3330,6 @@
 				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
 			}
 		},
-		"node_modules/cliui": {
-			"version": "8.0.1",
-			"resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-			"integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"string-width": "^4.2.0",
-				"strip-ansi": "^6.0.1",
-				"wrap-ansi": "^7.0.0"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/co": {
-			"version": "4.6.0",
-			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-			"integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"iojs": ">= 1.0.0",
-				"node": ">= 0.12.0"
-			}
-		},
 		"node_modules/codemirror": {
 			"version": "6.0.2",
 			"resolved": "https://registry.npmjs.org/codemirror/-/codemirror-6.0.2.tgz",
@@ -4388,13 +3359,6 @@
 				"@codemirror/state": "^6.2.0",
 				"@codemirror/view": "^6.7.2"
 			}
-		},
-		"node_modules/collect-v8-coverage": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.3.tgz",
-			"integrity": "sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/color-convert": {
 			"version": "2.0.1",
@@ -4431,13 +3395,6 @@
 				"type": "github",
 				"url": "https://github.com/sponsors/wooorm"
 			}
-		},
-		"node_modules/concat-map": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/content-disposition": {
 			"version": "1.0.1",
@@ -4544,18 +3501,18 @@
 				"node": ">= 8"
 			}
 		},
-		"node_modules/cssstyle": {
-			"version": "4.6.0",
-			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
-			"integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+		"node_modules/css-tree": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+			"integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@asamuzakjp/css-color": "^3.2.0",
-				"rrweb-cssom": "^0.8.0"
+				"mdn-data": "2.27.1",
+				"source-map-js": "^1.2.1"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
 			}
 		},
 		"node_modules/csstype": {
@@ -4575,17 +3532,17 @@
 			}
 		},
 		"node_modules/data-urls": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
-			"integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+			"integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"whatwg-mimetype": "^4.0.0",
-				"whatwg-url": "^14.0.0"
+				"whatwg-mimetype": "^5.0.0",
+				"whatwg-url": "^16.0.0"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
 			}
 		},
 		"node_modules/debug": {
@@ -4612,31 +3569,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/dedent": {
-			"version": "1.7.2",
-			"resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
-			"integrity": "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==",
-			"dev": true,
-			"license": "MIT",
-			"peerDependencies": {
-				"babel-plugin-macros": "^3.1.0"
-			},
-			"peerDependenciesMeta": {
-				"babel-plugin-macros": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/deepmerge": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
-			"integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/depd": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -4657,12 +3589,12 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/detect-newline": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
-			"integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
+		"node_modules/detect-libc": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+			"integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
 			"dev": true,
-			"license": "MIT",
+			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=8"
 			}
@@ -4718,26 +3650,6 @@
 			"devOptional": true,
 			"license": "MIT"
 		},
-		"node_modules/electron-to-chromium": {
-			"version": "1.5.267",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.267.tgz",
-			"integrity": "sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw==",
-			"dev": true,
-			"license": "ISC"
-		},
-		"node_modules/emittery": {
-			"version": "0.13.1",
-			"resolved": "https://registry.npmjs.org/emittery/-/emittery-0.13.1.tgz",
-			"integrity": "sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sindresorhus/emittery?sponsor=1"
-			}
-		},
 		"node_modules/emoji-regex": {
 			"version": "10.6.0",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
@@ -4762,19 +3674,6 @@
 				"node": ">= 0.8"
 			}
 		},
-		"node_modules/entities": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
-			"integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"engines": {
-				"node": ">=0.12"
-			},
-			"funding": {
-				"url": "https://github.com/fb55/entities?sponsor=1"
-			}
-		},
 		"node_modules/environment": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
@@ -4786,16 +3685,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/error-ex": {
-			"version": "1.3.4",
-			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
-			"integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"is-arrayish": "^0.2.1"
 			}
 		},
 		"node_modules/es-define-property": {
@@ -4817,6 +3706,13 @@
 			"engines": {
 				"node": ">= 0.4"
 			}
+		},
+		"node_modules/es-module-lexer": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+			"integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/es-object-atoms": {
 			"version": "1.1.1",
@@ -4880,46 +3776,12 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/escalade": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
-			"integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=6"
-			}
-		},
 		"node_modules/escape-html": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
 			"integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
 			"devOptional": true,
 			"license": "MIT"
-		},
-		"node_modules/escape-string-regexp": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
-			"integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/esprima": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"bin": {
-				"esparse": "bin/esparse.js",
-				"esvalidate": "bin/esvalidate.js"
-			},
-			"engines": {
-				"node": ">=4"
-			}
 		},
 		"node_modules/estree-walker": {
 			"version": "2.0.2",
@@ -4968,56 +3830,14 @@
 				"node": ">=18.0.0"
 			}
 		},
-		"node_modules/execa": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
-			"integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+		"node_modules/expect-type": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+			"integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
 			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"cross-spawn": "^7.0.3",
-				"get-stream": "^6.0.0",
-				"human-signals": "^2.1.0",
-				"is-stream": "^2.0.0",
-				"merge-stream": "^2.0.0",
-				"npm-run-path": "^4.0.1",
-				"onetime": "^5.1.2",
-				"signal-exit": "^3.0.3",
-				"strip-final-newline": "^2.0.0"
-			},
+			"license": "Apache-2.0",
 			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sindresorhus/execa?sponsor=1"
-			}
-		},
-		"node_modules/exit-x": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/exit-x/-/exit-x-0.2.2.tgz",
-			"integrity": "sha512-+I6B/IkJc1o/2tiURyz/ivu/O0nKNEArIUB5O7zBrlDVJr22SCLH3xTeEry428LvFhRzIA1g8izguxJ/gbNcVQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.8.0"
-			}
-		},
-		"node_modules/expect": {
-			"version": "30.3.0",
-			"resolved": "https://registry.npmjs.org/expect/-/expect-30.3.0.tgz",
-			"integrity": "sha512-1zQrciTiQfRdo7qJM1uG4navm8DayFa2TgCSRlzUyNkhcJ6XUZF3hjnpkyr3VhAqPH7i/9GkG7Tv5abz6fqz0Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/expect-utils": "30.3.0",
-				"@jest/get-type": "30.1.0",
-				"jest-matcher-utils": "30.3.0",
-				"jest-message-util": "30.3.0",
-				"jest-mock": "30.3.0",
-				"jest-util": "30.3.0"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+				"node": ">=12.0.0"
 			}
 		},
 		"node_modules/express": {
@@ -5123,13 +3943,6 @@
 			"devOptional": true,
 			"license": "MIT"
 		},
-		"node_modules/fast-json-stable-stringify": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/fast-uri": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
@@ -5146,16 +3959,6 @@
 				}
 			],
 			"license": "BSD-3-Clause"
-		},
-		"node_modules/fb-watchman": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
-			"integrity": "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"bser": "2.1.1"
-			}
 		},
 		"node_modules/fetch-blob": {
 			"version": "3.2.0",
@@ -5180,6 +3983,13 @@
 				"node": "^12.20 || >= 14.13"
 			}
 		},
+		"node_modules/fflate": {
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+			"integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/finalhandler": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
@@ -5202,19 +4012,12 @@
 				"url": "https://opencollective.com/express"
 			}
 		},
-		"node_modules/find-up": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-			"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+		"node_modules/flatted": {
+			"version": "3.4.2",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+			"integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
 			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"locate-path": "^5.0.0",
-				"path-exists": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
+			"license": "ISC"
 		},
 		"node_modules/focus-trap": {
 			"version": "7.8.0",
@@ -5286,13 +4089,6 @@
 				"node": ">= 0.8"
 			}
 		},
-		"node_modules/fs.realpath": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-			"dev": true,
-			"license": "ISC"
-		},
 		"node_modules/fsevents": {
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -5347,26 +4143,6 @@
 				"node": ">=18"
 			}
 		},
-		"node_modules/gensync": {
-			"version": "1.0.0-beta.2",
-			"resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
-			"integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/get-caller-file": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": "6.* || 8.* || >= 10.*"
-			}
-		},
 		"node_modules/get-east-asian-width": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.4.0.tgz",
@@ -5405,16 +4181,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/get-package-type": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
-			"integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8.0.0"
-			}
-		},
 		"node_modules/get-proto": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
@@ -5427,19 +4193,6 @@
 			},
 			"engines": {
 				"node": ">= 0.4"
-			}
-		},
-		"node_modules/get-stream": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
-			"integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/glob": {
@@ -5501,13 +4254,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
-		},
-		"node_modules/graceful-fs": {
-			"version": "4.2.11",
-			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-			"dev": true,
-			"license": "ISC"
 		},
 		"node_modules/gtoken": {
 			"version": "8.0.0",
@@ -5636,16 +4382,16 @@
 			"license": "MIT"
 		},
 		"node_modules/html-encoding-sniffer": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
-			"integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+			"integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"whatwg-encoding": "^3.1.1"
+				"@exodus/bytes": "^1.6.0"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
 			}
 		},
 		"node_modules/html-escaper": {
@@ -5687,20 +4433,6 @@
 				"url": "https://opencollective.com/express"
 			}
 		},
-		"node_modules/http-proxy-agent": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
-			"integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"agent-base": "^7.1.0",
-				"debug": "^4.3.4"
-			},
-			"engines": {
-				"node": ">= 14"
-			}
-		},
 		"node_modules/https-proxy-agent": {
 			"version": "7.0.6",
 			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
@@ -5712,16 +4444,6 @@
 			},
 			"engines": {
 				"node": ">= 14"
-			}
-		},
-		"node_modules/human-signals": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
-			"integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"engines": {
-				"node": ">=10.17.0"
 			}
 		},
 		"node_modules/husky": {
@@ -5740,19 +4462,6 @@
 				"url": "https://github.com/sponsors/typicode"
 			}
 		},
-		"node_modules/iconv-lite": {
-			"version": "0.6.3",
-			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-			"integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"safer-buffer": ">= 2.1.2 < 3.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/ignore": {
 			"version": "7.0.5",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
@@ -5760,48 +4469,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 4"
-			}
-		},
-		"node_modules/import-local": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
-			"integrity": "sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"pkg-dir": "^4.2.0",
-				"resolve-cwd": "^3.0.0"
-			},
-			"bin": {
-				"import-local-fixture": "fixtures/cli.js"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/imurmurhash": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-			"integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.8.19"
-			}
-		},
-		"node_modules/inflight": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-			"integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-			"deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"once": "^1.3.0",
-				"wrappy": "1"
 			}
 		},
 		"node_modules/inherits": {
@@ -5831,13 +4498,6 @@
 				"node": ">= 0.10"
 			}
 		},
-		"node_modules/is-arrayish": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-			"integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/is-fullwidth-code-point": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -5845,16 +4505,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/is-generator-fn": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
-			"integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=6"
 			}
 		},
 		"node_modules/is-potential-custom-element-name": {
@@ -5870,19 +4520,6 @@
 			"integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
 			"devOptional": true,
 			"license": "MIT"
-		},
-		"node_modules/is-stream": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-			"integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
 		},
 		"node_modules/is-what": {
 			"version": "5.5.0",
@@ -5913,36 +4550,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/istanbul-lib-instrument": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
-			"integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
-			"dev": true,
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"@babel/core": "^7.23.9",
-				"@babel/parser": "^7.23.9",
-				"@istanbuljs/schema": "^0.1.3",
-				"istanbul-lib-coverage": "^3.2.0",
-				"semver": "^7.5.4"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/istanbul-lib-instrument/node_modules/semver": {
-			"version": "7.7.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-			"dev": true,
-			"license": "ISC",
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/istanbul-lib-report": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
@@ -5953,21 +4560,6 @@
 				"istanbul-lib-coverage": "^3.0.0",
 				"make-dir": "^4.0.0",
 				"supports-color": "^7.1.0"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/istanbul-lib-source-maps": {
-			"version": "5.0.6",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
-			"integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
-			"dev": true,
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"@jridgewell/trace-mapping": "^0.3.23",
-				"debug": "^4.1.1",
-				"istanbul-lib-coverage": "^3.0.0"
 			},
 			"engines": {
 				"node": ">=10"
@@ -6002,660 +4594,6 @@
 				"@pkgjs/parseargs": "^0.11.0"
 			}
 		},
-		"node_modules/jest": {
-			"version": "30.3.0",
-			"resolved": "https://registry.npmjs.org/jest/-/jest-30.3.0.tgz",
-			"integrity": "sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/core": "30.3.0",
-				"@jest/types": "30.3.0",
-				"import-local": "^3.2.0",
-				"jest-cli": "30.3.0"
-			},
-			"bin": {
-				"jest": "bin/jest.js"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			},
-			"peerDependencies": {
-				"node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
-			},
-			"peerDependenciesMeta": {
-				"node-notifier": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/jest-changed-files": {
-			"version": "30.3.0",
-			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-30.3.0.tgz",
-			"integrity": "sha512-B/7Cny6cV5At6M25EWDgf9S617lHivamL8vl6KEpJqkStauzcG4e+WPfDgMMF+H4FVH4A2PLRyvgDJan4441QA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"execa": "^5.1.1",
-				"jest-util": "30.3.0",
-				"p-limit": "^3.1.0"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-circus": {
-			"version": "30.3.0",
-			"resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-30.3.0.tgz",
-			"integrity": "sha512-PyXq5szeSfR/4f1lYqCmmQjh0vqDkURUYi9N6whnHjlRz4IUQfMcXkGLeEoiJtxtyPqgUaUUfyQlApXWBSN1RA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/environment": "30.3.0",
-				"@jest/expect": "30.3.0",
-				"@jest/test-result": "30.3.0",
-				"@jest/types": "30.3.0",
-				"@types/node": "*",
-				"chalk": "^4.1.2",
-				"co": "^4.6.0",
-				"dedent": "^1.6.0",
-				"is-generator-fn": "^2.1.0",
-				"jest-each": "30.3.0",
-				"jest-matcher-utils": "30.3.0",
-				"jest-message-util": "30.3.0",
-				"jest-runtime": "30.3.0",
-				"jest-snapshot": "30.3.0",
-				"jest-util": "30.3.0",
-				"p-limit": "^3.1.0",
-				"pretty-format": "30.3.0",
-				"pure-rand": "^7.0.0",
-				"slash": "^3.0.0",
-				"stack-utils": "^2.0.6"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-cli": {
-			"version": "30.3.0",
-			"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-30.3.0.tgz",
-			"integrity": "sha512-l6Tqx+j1fDXJEW5bqYykDQQ7mQg+9mhWXtnj+tQZrTWYHyHoi6Be8HPumDSA+UiX2/2buEgjA58iJzdj146uCw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/core": "30.3.0",
-				"@jest/test-result": "30.3.0",
-				"@jest/types": "30.3.0",
-				"chalk": "^4.1.2",
-				"exit-x": "^0.2.2",
-				"import-local": "^3.2.0",
-				"jest-config": "30.3.0",
-				"jest-util": "30.3.0",
-				"jest-validate": "30.3.0",
-				"yargs": "^17.7.2"
-			},
-			"bin": {
-				"jest": "bin/jest.js"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			},
-			"peerDependencies": {
-				"node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
-			},
-			"peerDependenciesMeta": {
-				"node-notifier": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/jest-config": {
-			"version": "30.3.0",
-			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-30.3.0.tgz",
-			"integrity": "sha512-WPMAkMAtNDY9P/oKObtsRG/6KTrhtgPJoBTmk20uDn4Uy6/3EJnnaZJre/FMT1KVRx8cve1r7/FlMIOfRVWL4w==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/core": "^7.27.4",
-				"@jest/get-type": "30.1.0",
-				"@jest/pattern": "30.0.1",
-				"@jest/test-sequencer": "30.3.0",
-				"@jest/types": "30.3.0",
-				"babel-jest": "30.3.0",
-				"chalk": "^4.1.2",
-				"ci-info": "^4.2.0",
-				"deepmerge": "^4.3.1",
-				"glob": "^10.5.0",
-				"graceful-fs": "^4.2.11",
-				"jest-circus": "30.3.0",
-				"jest-docblock": "30.2.0",
-				"jest-environment-node": "30.3.0",
-				"jest-regex-util": "30.0.1",
-				"jest-resolve": "30.3.0",
-				"jest-runner": "30.3.0",
-				"jest-util": "30.3.0",
-				"jest-validate": "30.3.0",
-				"parse-json": "^5.2.0",
-				"pretty-format": "30.3.0",
-				"slash": "^3.0.0",
-				"strip-json-comments": "^3.1.1"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			},
-			"peerDependencies": {
-				"@types/node": "*",
-				"esbuild-register": ">=3.4.0",
-				"ts-node": ">=9.0.0"
-			},
-			"peerDependenciesMeta": {
-				"@types/node": {
-					"optional": true
-				},
-				"esbuild-register": {
-					"optional": true
-				},
-				"ts-node": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/jest-diff": {
-			"version": "30.3.0",
-			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.3.0.tgz",
-			"integrity": "sha512-n3q4PDQjS4LrKxfWB3Z5KNk1XjXtZTBwQp71OP0Jo03Z6V60x++K5L8k6ZrW8MY8pOFylZvHM0zsjS1RqlHJZQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/diff-sequences": "30.3.0",
-				"@jest/get-type": "30.1.0",
-				"chalk": "^4.1.2",
-				"pretty-format": "30.3.0"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-docblock": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-30.2.0.tgz",
-			"integrity": "sha512-tR/FFgZKS1CXluOQzZvNH3+0z9jXr3ldGSD8bhyuxvlVUwbeLOGynkunvlTMxchC5urrKndYiwCFC0DLVjpOCA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"detect-newline": "^3.1.0"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-each": {
-			"version": "30.3.0",
-			"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-30.3.0.tgz",
-			"integrity": "sha512-V8eMndg/aZ+3LnCJgSm13IxS5XSBM22QSZc9BtPK8Dek6pm+hfUNfwBdvsB3d342bo1q7wnSkC38zjX259qZNA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/get-type": "30.1.0",
-				"@jest/types": "30.3.0",
-				"chalk": "^4.1.2",
-				"jest-util": "30.3.0",
-				"pretty-format": "30.3.0"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-environment-jsdom": {
-			"version": "30.3.0",
-			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-30.3.0.tgz",
-			"integrity": "sha512-RLEOJy6ip1lpw0yqJ8tB3i88FC7VBz7i00Zvl2qF71IdxjS98gC9/0SPWYIBVXHm5hgCYK0PAlSlnHGGy9RoMg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/environment": "30.3.0",
-				"@jest/environment-jsdom-abstract": "30.3.0",
-				"jsdom": "^26.1.0"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			},
-			"peerDependencies": {
-				"canvas": "^3.0.0"
-			},
-			"peerDependenciesMeta": {
-				"canvas": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/jest-environment-node": {
-			"version": "30.3.0",
-			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-30.3.0.tgz",
-			"integrity": "sha512-4i6HItw/JSiJVsC5q0hnKIe/hbYfZLVG9YJ/0pU9Hz2n/9qZe3Rhn5s5CUZA5ORZlcdT/vmAXRMyONXJwPrmYQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/environment": "30.3.0",
-				"@jest/fake-timers": "30.3.0",
-				"@jest/types": "30.3.0",
-				"@types/node": "*",
-				"jest-mock": "30.3.0",
-				"jest-util": "30.3.0",
-				"jest-validate": "30.3.0"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-haste-map": {
-			"version": "30.3.0",
-			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-30.3.0.tgz",
-			"integrity": "sha512-mMi2oqG4KRU0R9QEtscl87JzMXfUhbKaFqOxmjb2CKcbHcUGFrJCBWHmnTiUqi6JcnzoBlO4rWfpdl2k/RfLCA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "30.3.0",
-				"@types/node": "*",
-				"anymatch": "^3.1.3",
-				"fb-watchman": "^2.0.2",
-				"graceful-fs": "^4.2.11",
-				"jest-regex-util": "30.0.1",
-				"jest-util": "30.3.0",
-				"jest-worker": "30.3.0",
-				"picomatch": "^4.0.3",
-				"walker": "^1.0.8"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			},
-			"optionalDependencies": {
-				"fsevents": "^2.3.3"
-			}
-		},
-		"node_modules/jest-haste-map/node_modules/picomatch": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
-		"node_modules/jest-leak-detector": {
-			"version": "30.3.0",
-			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-30.3.0.tgz",
-			"integrity": "sha512-cuKmUUGIjfXZAiGJ7TbEMx0bcqNdPPI6P1V+7aF+m/FUJqFDxkFR4JqkTu8ZOiU5AaX/x0hZ20KaaIPXQzbMGQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/get-type": "30.1.0",
-				"pretty-format": "30.3.0"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-matcher-utils": {
-			"version": "30.3.0",
-			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.3.0.tgz",
-			"integrity": "sha512-HEtc9uFQgaUHkC7nLSlQL3Tph4Pjxt/yiPvkIrrDCt9jhoLIgxaubo1G+CFOnmHYMxHwwdaSN7mkIFs6ZK8OhA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/get-type": "30.1.0",
-				"chalk": "^4.1.2",
-				"jest-diff": "30.3.0",
-				"pretty-format": "30.3.0"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-message-util": {
-			"version": "30.3.0",
-			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.3.0.tgz",
-			"integrity": "sha512-Z/j4Bo+4ySJ+JPJN3b2Qbl9hDq3VrXmnjjGEWD/x0BCXeOXPTV1iZYYzl2X8c1MaCOL+ewMyNBcm88sboE6YWw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/code-frame": "^7.27.1",
-				"@jest/types": "30.3.0",
-				"@types/stack-utils": "^2.0.3",
-				"chalk": "^4.1.2",
-				"graceful-fs": "^4.2.11",
-				"picomatch": "^4.0.3",
-				"pretty-format": "30.3.0",
-				"slash": "^3.0.0",
-				"stack-utils": "^2.0.6"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-message-util/node_modules/picomatch": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
-		"node_modules/jest-mock": {
-			"version": "30.3.0",
-			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.3.0.tgz",
-			"integrity": "sha512-OTzICK8CpE+t4ndhKrwlIdbM6Pn8j00lvmSmq5ejiO+KxukbLjgOflKWMn3KE34EZdQm5RqTuKj+5RIEniYhog==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "30.3.0",
-				"@types/node": "*",
-				"jest-util": "30.3.0"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-pnp-resolver": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
-			"integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=6"
-			},
-			"peerDependencies": {
-				"jest-resolve": "*"
-			},
-			"peerDependenciesMeta": {
-				"jest-resolve": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/jest-regex-util": {
-			"version": "30.0.1",
-			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.0.1.tgz",
-			"integrity": "sha512-jHEQgBXAgc+Gh4g0p3bCevgRCVRkB4VB70zhoAE48gxeSr1hfUOsM/C2WoJgVL7Eyg//hudYENbm3Ne+/dRVVA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-resolve": {
-			"version": "30.3.0",
-			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-30.3.0.tgz",
-			"integrity": "sha512-NRtTAHQlpd15F9rUR36jqwelbrDV/dY4vzNte3S2kxCKUJRYNd5/6nTSbYiak1VX5g8IoFF23Uj5TURkUW8O5g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.1.2",
-				"graceful-fs": "^4.2.11",
-				"jest-haste-map": "30.3.0",
-				"jest-pnp-resolver": "^1.2.3",
-				"jest-util": "30.3.0",
-				"jest-validate": "30.3.0",
-				"slash": "^3.0.0",
-				"unrs-resolver": "^1.7.11"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-resolve-dependencies": {
-			"version": "30.3.0",
-			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-30.3.0.tgz",
-			"integrity": "sha512-9ev8s3YN6Hsyz9LV75XUwkCVFlwPbaFn6Wp75qnI0wzAINYWY8Fb3+6y59Rwd3QaS3kKXffHXsZMziMavfz/nw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"jest-regex-util": "30.0.1",
-				"jest-snapshot": "30.3.0"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-runner": {
-			"version": "30.3.0",
-			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-30.3.0.tgz",
-			"integrity": "sha512-gDv6C9LGKWDPLia9TSzZwf4h3kMQCqyTpq+95PODnTRDO0g9os48XIYYkS6D236vjpBir2fF63YmJFtqkS5Duw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/console": "30.3.0",
-				"@jest/environment": "30.3.0",
-				"@jest/test-result": "30.3.0",
-				"@jest/transform": "30.3.0",
-				"@jest/types": "30.3.0",
-				"@types/node": "*",
-				"chalk": "^4.1.2",
-				"emittery": "^0.13.1",
-				"exit-x": "^0.2.2",
-				"graceful-fs": "^4.2.11",
-				"jest-docblock": "30.2.0",
-				"jest-environment-node": "30.3.0",
-				"jest-haste-map": "30.3.0",
-				"jest-leak-detector": "30.3.0",
-				"jest-message-util": "30.3.0",
-				"jest-resolve": "30.3.0",
-				"jest-runtime": "30.3.0",
-				"jest-util": "30.3.0",
-				"jest-watcher": "30.3.0",
-				"jest-worker": "30.3.0",
-				"p-limit": "^3.1.0",
-				"source-map-support": "0.5.13"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-runtime": {
-			"version": "30.3.0",
-			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-30.3.0.tgz",
-			"integrity": "sha512-CgC+hIBJbuh78HEffkhNKcbXAytQViplcl8xupqeIWyKQF50kCQA8J7GeJCkjisC6hpnC9Muf8jV5RdtdFbGng==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/environment": "30.3.0",
-				"@jest/fake-timers": "30.3.0",
-				"@jest/globals": "30.3.0",
-				"@jest/source-map": "30.0.1",
-				"@jest/test-result": "30.3.0",
-				"@jest/transform": "30.3.0",
-				"@jest/types": "30.3.0",
-				"@types/node": "*",
-				"chalk": "^4.1.2",
-				"cjs-module-lexer": "^2.1.0",
-				"collect-v8-coverage": "^1.0.2",
-				"glob": "^10.5.0",
-				"graceful-fs": "^4.2.11",
-				"jest-haste-map": "30.3.0",
-				"jest-message-util": "30.3.0",
-				"jest-mock": "30.3.0",
-				"jest-regex-util": "30.0.1",
-				"jest-resolve": "30.3.0",
-				"jest-snapshot": "30.3.0",
-				"jest-util": "30.3.0",
-				"slash": "^3.0.0",
-				"strip-bom": "^4.0.0"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-snapshot": {
-			"version": "30.3.0",
-			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-30.3.0.tgz",
-			"integrity": "sha512-f14c7atpb4O2DeNhwcvS810Y63wEn8O1HqK/luJ4F6M4NjvxmAKQwBUWjbExUtMxWJQ0wVgmCKymeJK6NZMnfQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/core": "^7.27.4",
-				"@babel/generator": "^7.27.5",
-				"@babel/plugin-syntax-jsx": "^7.27.1",
-				"@babel/plugin-syntax-typescript": "^7.27.1",
-				"@babel/types": "^7.27.3",
-				"@jest/expect-utils": "30.3.0",
-				"@jest/get-type": "30.1.0",
-				"@jest/snapshot-utils": "30.3.0",
-				"@jest/transform": "30.3.0",
-				"@jest/types": "30.3.0",
-				"babel-preset-current-node-syntax": "^1.2.0",
-				"chalk": "^4.1.2",
-				"expect": "30.3.0",
-				"graceful-fs": "^4.2.11",
-				"jest-diff": "30.3.0",
-				"jest-matcher-utils": "30.3.0",
-				"jest-message-util": "30.3.0",
-				"jest-util": "30.3.0",
-				"pretty-format": "30.3.0",
-				"semver": "^7.7.2",
-				"synckit": "^0.11.8"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-snapshot/node_modules/semver": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-			"dev": true,
-			"license": "ISC",
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/jest-util": {
-			"version": "30.3.0",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz",
-			"integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "30.3.0",
-				"@types/node": "*",
-				"chalk": "^4.1.2",
-				"ci-info": "^4.2.0",
-				"graceful-fs": "^4.2.11",
-				"picomatch": "^4.0.3"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-util/node_modules/picomatch": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
-		"node_modules/jest-validate": {
-			"version": "30.3.0",
-			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-30.3.0.tgz",
-			"integrity": "sha512-I/xzC8h5G+SHCb2P2gWkJYrNiTbeL47KvKeW5EzplkyxzBRBw1ssSHlI/jXec0ukH2q7x2zAWQm7015iusg62Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/get-type": "30.1.0",
-				"@jest/types": "30.3.0",
-				"camelcase": "^6.3.0",
-				"chalk": "^4.1.2",
-				"leven": "^3.1.0",
-				"pretty-format": "30.3.0"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-validate/node_modules/camelcase": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
-			"integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/jest-watcher": {
-			"version": "30.3.0",
-			"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-30.3.0.tgz",
-			"integrity": "sha512-PJ1d9ThtTR8aMiBWUdcownq9mDdLXsQzJayTk4kmaBRHKvwNQn+ANveuhEBUyNI2hR1TVhvQ8D5kHubbzBHR/w==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/test-result": "30.3.0",
-				"@jest/types": "30.3.0",
-				"@types/node": "*",
-				"ansi-escapes": "^4.3.2",
-				"chalk": "^4.1.2",
-				"emittery": "^0.13.1",
-				"jest-util": "30.3.0",
-				"string-length": "^4.0.2"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-worker": {
-			"version": "30.3.0",
-			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-30.3.0.tgz",
-			"integrity": "sha512-DrCKkaQwHexjRUFTmPzs7sHQe0TSj9nvDALKGdwmK5mW9v7j90BudWirKAJHt3QQ9Dhrg1F7DogPzhChppkJpQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/node": "*",
-				"@ungap/structured-clone": "^1.3.0",
-				"jest-util": "30.3.0",
-				"merge-stream": "^2.0.0",
-				"supports-color": "^8.1.1"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-worker/node_modules/supports-color": {
-			"version": "8.1.1",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-			"integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"has-flag": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/supports-color?sponsor=1"
-			}
-		},
 		"node_modules/jose": {
 			"version": "6.1.3",
 			"resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
@@ -6666,57 +4604,37 @@
 				"url": "https://github.com/sponsors/panva"
 			}
 		},
-		"node_modules/js-tokens": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/js-yaml": {
-			"version": "3.14.2",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-			"integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"argparse": "^1.0.7",
-				"esprima": "^4.0.0"
-			},
-			"bin": {
-				"js-yaml": "bin/js-yaml.js"
-			}
-		},
 		"node_modules/jsdom": {
-			"version": "26.1.0",
-			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
-			"integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
+			"version": "29.0.2",
+			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.0.2.tgz",
+			"integrity": "sha512-9VnGEBosc/ZpwyOsJBCQ/3I5p7Q5ngOY14a9bf5btenAORmZfDse1ZEheMiWcJ3h81+Fv7HmJFdS0szo/waF2w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"cssstyle": "^4.2.1",
-				"data-urls": "^5.0.0",
-				"decimal.js": "^10.5.0",
-				"html-encoding-sniffer": "^4.0.0",
-				"http-proxy-agent": "^7.0.2",
-				"https-proxy-agent": "^7.0.6",
+				"@asamuzakjp/css-color": "^5.1.5",
+				"@asamuzakjp/dom-selector": "^7.0.6",
+				"@bramus/specificity": "^2.4.2",
+				"@csstools/css-syntax-patches-for-csstree": "^1.1.1",
+				"@exodus/bytes": "^1.15.0",
+				"css-tree": "^3.2.1",
+				"data-urls": "^7.0.0",
+				"decimal.js": "^10.6.0",
+				"html-encoding-sniffer": "^6.0.0",
 				"is-potential-custom-element-name": "^1.0.1",
-				"nwsapi": "^2.2.16",
-				"parse5": "^7.2.1",
-				"rrweb-cssom": "^0.8.0",
+				"lru-cache": "^11.2.7",
+				"parse5": "^8.0.0",
 				"saxes": "^6.0.0",
 				"symbol-tree": "^3.2.4",
-				"tough-cookie": "^5.1.1",
+				"tough-cookie": "^6.0.1",
+				"undici": "^7.24.5",
 				"w3c-xmlserializer": "^5.0.0",
-				"webidl-conversions": "^7.0.0",
-				"whatwg-encoding": "^3.1.1",
-				"whatwg-mimetype": "^4.0.0",
-				"whatwg-url": "^14.1.1",
-				"ws": "^8.18.0",
+				"webidl-conversions": "^8.0.1",
+				"whatwg-mimetype": "^5.0.0",
+				"whatwg-url": "^16.0.1",
 				"xml-name-validator": "^5.0.0"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": "^20.19.0 || ^22.13.0 || >=24.0.0"
 			},
 			"peerDependencies": {
 				"canvas": "^3.0.0"
@@ -6727,17 +4645,40 @@
 				}
 			}
 		},
-		"node_modules/jsesc": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
-			"integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+		"node_modules/jsdom/node_modules/entities": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+			"integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=20.19.0"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/entities?sponsor=1"
+			}
+		},
+		"node_modules/jsdom/node_modules/lru-cache": {
+			"version": "11.3.5",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+			"integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": "20 || >=22"
+			}
+		},
+		"node_modules/jsdom/node_modules/parse5": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+			"integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
 			"dev": true,
 			"license": "MIT",
-			"bin": {
-				"jsesc": "bin/jsesc"
+			"dependencies": {
+				"entities": "^8.0.0"
 			},
-			"engines": {
-				"node": ">=6"
+			"funding": {
+				"url": "https://github.com/inikulin/parse5?sponsor=1"
 			}
 		},
 		"node_modules/json-bigint": {
@@ -6748,13 +4689,6 @@
 			"dependencies": {
 				"bignumber.js": "^9.0.0"
 			}
-		},
-		"node_modules/json-parse-even-better-errors": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-			"integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/json-schema-traverse": {
 			"version": "1.0.0",
@@ -6769,19 +4703,6 @@
 			"integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
 			"devOptional": true,
 			"license": "BSD-2-Clause"
-		},
-		"node_modules/json5": {
-			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
-			"integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-			"dev": true,
-			"license": "MIT",
-			"bin": {
-				"json5": "lib/cli.js"
-			},
-			"engines": {
-				"node": ">=6"
-			}
 		},
 		"node_modules/jwa": {
 			"version": "2.0.1",
@@ -6804,22 +4725,266 @@
 				"safe-buffer": "^5.0.1"
 			}
 		},
-		"node_modules/leven": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
-			"integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+		"node_modules/lightningcss": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+			"integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
 			"dev": true,
-			"license": "MIT",
+			"license": "MPL-2.0",
+			"dependencies": {
+				"detect-libc": "^2.0.3"
+			},
 			"engines": {
-				"node": ">=6"
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			},
+			"optionalDependencies": {
+				"lightningcss-android-arm64": "1.32.0",
+				"lightningcss-darwin-arm64": "1.32.0",
+				"lightningcss-darwin-x64": "1.32.0",
+				"lightningcss-freebsd-x64": "1.32.0",
+				"lightningcss-linux-arm-gnueabihf": "1.32.0",
+				"lightningcss-linux-arm64-gnu": "1.32.0",
+				"lightningcss-linux-arm64-musl": "1.32.0",
+				"lightningcss-linux-x64-gnu": "1.32.0",
+				"lightningcss-linux-x64-musl": "1.32.0",
+				"lightningcss-win32-arm64-msvc": "1.32.0",
+				"lightningcss-win32-x64-msvc": "1.32.0"
 			}
 		},
-		"node_modules/lines-and-columns": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-			"integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+		"node_modules/lightningcss-android-arm64": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+			"integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+			"cpu": [
+				"arm64"
+			],
 			"dev": true,
-			"license": "MIT"
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-darwin-arm64": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+			"integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-darwin-x64": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+			"integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-freebsd-x64": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+			"integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-linux-arm-gnueabihf": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+			"integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-linux-arm64-gnu": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+			"integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-linux-arm64-musl": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+			"integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-linux-x64-gnu": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+			"integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-linux-x64-musl": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+			"integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-win32-arm64-msvc": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+			"integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-win32-x64-msvc": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+			"integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
 		},
 		"node_modules/lint-staged": {
 			"version": "16.4.0",
@@ -6964,26 +5129,6 @@
 				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
 			}
 		},
-		"node_modules/locate-path": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-			"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"p-locate": "^4.1.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/lodash.memoize": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
-			"integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/log-update": {
 			"version": "6.1.0",
 			"resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
@@ -7104,16 +5249,6 @@
 			"integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
 			"license": "Apache-2.0"
 		},
-		"node_modules/lru-cache": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-			"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"yallist": "^3.0.2"
-			}
-		},
 		"node_modules/magic-string": {
 			"version": "0.30.21",
 			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -7122,6 +5257,18 @@
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.5.5"
+			}
+		},
+		"node_modules/magicast": {
+			"version": "0.5.2",
+			"resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
+			"integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/parser": "^7.29.0",
+				"@babel/types": "^7.29.0",
+				"source-map-js": "^1.2.1"
 			}
 		},
 		"node_modules/make-dir": {
@@ -7151,23 +5298,6 @@
 			},
 			"engines": {
 				"node": ">=10"
-			}
-		},
-		"node_modules/make-error": {
-			"version": "1.3.6",
-			"resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-			"integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-			"dev": true,
-			"license": "ISC"
-		},
-		"node_modules/makeerror": {
-			"version": "1.0.12",
-			"resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
-			"integrity": "sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==",
-			"dev": true,
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"tmpl": "1.0.5"
 			}
 		},
 		"node_modules/mark.js": {
@@ -7209,6 +5339,13 @@
 				"url": "https://opencollective.com/unified"
 			}
 		},
+		"node_modules/mdn-data": {
+			"version": "2.27.1",
+			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+			"integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+			"dev": true,
+			"license": "CC0-1.0"
+		},
 		"node_modules/media-typer": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
@@ -7231,13 +5368,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
-		},
-		"node_modules/merge-stream": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
-			"integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/micromark-util-character": {
 			"version": "2.1.1",
@@ -7333,16 +5463,6 @@
 			],
 			"license": "MIT"
 		},
-		"node_modules/mimic-fn": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-			"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=6"
-			}
-		},
 		"node_modules/mimic-function": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
@@ -7414,6 +5534,16 @@
 				"node": "*"
 			}
 		},
+		"node_modules/mrmime": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
+			"integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/ms": {
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -7438,29 +5568,6 @@
 			"engines": {
 				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
 			}
-		},
-		"node_modules/napi-postinstall": {
-			"version": "0.3.4",
-			"resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.4.tgz",
-			"integrity": "sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==",
-			"dev": true,
-			"license": "MIT",
-			"bin": {
-				"napi-postinstall": "lib/cli.js"
-			},
-			"engines": {
-				"node": "^12.20.0 || ^14.18.0 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/napi-postinstall"
-			}
-		},
-		"node_modules/natural-compare": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-			"integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/negotiator": {
 			"version": "1.0.0",
@@ -7517,50 +5624,6 @@
 				"url": "https://opencollective.com/node-fetch"
 			}
 		},
-		"node_modules/node-int64": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
-			"integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/node-releases": {
-			"version": "2.0.27",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
-			"integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/normalize-path": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/npm-run-path": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
-			"integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"path-key": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/nwsapi": {
-			"version": "2.2.23",
-			"resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
-			"integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/object-assign": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -7599,6 +5662,17 @@
 				"@codemirror/view": "6.38.6"
 			}
 		},
+		"node_modules/obug": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+			"integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+			"dev": true,
+			"funding": [
+				"https://github.com/sponsors/sxzz",
+				"https://opencollective.com/debug"
+			],
+			"license": "MIT"
+		},
 		"node_modules/ollama": {
 			"version": "0.6.3",
 			"resolved": "https://registry.npmjs.org/ollama/-/ollama-0.6.3.tgz",
@@ -7631,22 +5705,6 @@
 				"wrappy": "1"
 			}
 		},
-		"node_modules/onetime": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-			"integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"mimic-fn": "^2.1.0"
-			},
-			"engines": {
-				"node": ">=6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/oniguruma-to-es": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-3.1.1.tgz",
@@ -7657,51 +5715,6 @@
 				"emoji-regex-xs": "^1.0.0",
 				"regex": "^6.0.1",
 				"regex-recursion": "^6.0.2"
-			}
-		},
-		"node_modules/p-limit": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-			"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"yocto-queue": "^0.1.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/p-locate": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-			"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"p-limit": "^2.2.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/p-locate/node_modules/p-limit": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-			"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"p-try": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/p-retry": {
@@ -7717,53 +5730,11 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/p-try": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=6"
-			}
-		},
 		"node_modules/package-json-from-dist": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
 			"integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
 			"license": "BlueOak-1.0.0"
-		},
-		"node_modules/parse-json": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
-			"integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/code-frame": "^7.0.0",
-				"error-ex": "^1.3.1",
-				"json-parse-even-better-errors": "^2.3.0",
-				"lines-and-columns": "^1.1.6"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/parse5": {
-			"version": "7.3.0",
-			"resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
-			"integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"entities": "^6.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/inikulin/parse5?sponsor=1"
-			}
 		},
 		"node_modules/parseurl": {
 			"version": "1.3.3",
@@ -7773,26 +5744,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.8"
-			}
-		},
-		"node_modules/path-exists": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/path-is-absolute": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/path-key": {
@@ -7837,6 +5788,13 @@
 				"url": "https://opencollective.com/express"
 			}
 		},
+		"node_modules/pathe": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/perfect-debounce": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
@@ -7851,29 +5809,6 @@
 			"dev": true,
 			"license": "ISC"
 		},
-		"node_modules/picomatch": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-			"integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8.6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
-		"node_modules/pirates": {
-			"version": "4.0.7",
-			"resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
-			"integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 6"
-			}
-		},
 		"node_modules/pkce-challenge": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
@@ -7882,19 +5817,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=16.20.0"
-			}
-		},
-		"node_modules/pkg-dir": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
-			"integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"find-up": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/postcss": {
@@ -7951,34 +5873,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/prettier/prettier?sponsor=1"
-			}
-		},
-		"node_modules/pretty-format": {
-			"version": "30.3.0",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.3.0.tgz",
-			"integrity": "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/schemas": "30.0.5",
-				"ansi-styles": "^5.2.0",
-				"react-is": "^18.3.1"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/pretty-format/node_modules/ansi-styles": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
 		},
 		"node_modules/property-information": {
@@ -8040,23 +5934,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/pure-rand": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-7.0.1.tgz",
-			"integrity": "sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://github.com/sponsors/dubzzz"
-				},
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/fast-check"
-				}
-			],
-			"license": "MIT"
-		},
 		"node_modules/qs": {
 			"version": "6.14.2",
 			"resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
@@ -8116,13 +5993,6 @@
 				"url": "https://opencollective.com/express"
 			}
 		},
-		"node_modules/react-is": {
-			"version": "18.3.1",
-			"resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-			"integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/regex": {
 			"version": "6.1.0",
 			"resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
@@ -8150,16 +6020,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/require-directory": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-			"integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/require-from-string": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -8168,29 +6028,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/resolve-cwd": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
-			"integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"resolve-from": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/resolve-from": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-			"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/restore-cursor": {
@@ -8270,6 +6107,40 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
+		"node_modules/rolldown": {
+			"version": "1.0.0-rc.17",
+			"resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
+			"integrity": "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@oxc-project/types": "=0.127.0",
+				"@rolldown/pluginutils": "1.0.0-rc.17"
+			},
+			"bin": {
+				"rolldown": "bin/cli.mjs"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			},
+			"optionalDependencies": {
+				"@rolldown/binding-android-arm64": "1.0.0-rc.17",
+				"@rolldown/binding-darwin-arm64": "1.0.0-rc.17",
+				"@rolldown/binding-darwin-x64": "1.0.0-rc.17",
+				"@rolldown/binding-freebsd-x64": "1.0.0-rc.17",
+				"@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17",
+				"@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17",
+				"@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17",
+				"@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17",
+				"@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17",
+				"@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17",
+				"@rolldown/binding-linux-x64-musl": "1.0.0-rc.17",
+				"@rolldown/binding-openharmony-arm64": "1.0.0-rc.17",
+				"@rolldown/binding-wasm32-wasi": "1.0.0-rc.17",
+				"@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17",
+				"@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
+			}
+		},
 		"node_modules/rollup": {
 			"version": "4.59.0",
 			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
@@ -8332,13 +6203,6 @@
 				"node": ">= 18"
 			}
 		},
-		"node_modules/rrweb-cssom": {
-			"version": "0.8.0",
-			"resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
-			"integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/safe-buffer": {
 			"version": "5.2.1",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -8386,16 +6250,6 @@
 			"dev": true,
 			"license": "MIT",
 			"peer": true
-		},
-		"node_modules/semver": {
-			"version": "6.3.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-			"dev": true,
-			"license": "ISC",
-			"bin": {
-				"semver": "bin/semver.js"
-			}
 		},
 		"node_modules/send": {
 			"version": "1.2.1",
@@ -8592,21 +6446,26 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/signal-exit": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+		"node_modules/siginfo": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+			"integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
 			"dev": true,
 			"license": "ISC"
 		},
-		"node_modules/slash": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-			"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+		"node_modules/sirv": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.2.tgz",
+			"integrity": "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==",
 			"dev": true,
 			"license": "MIT",
+			"dependencies": {
+				"@polka/url": "^1.0.0-next.24",
+				"mrmime": "^2.0.0",
+				"totalist": "^3.0.0"
+			},
 			"engines": {
-				"node": ">=8"
+				"node": ">=18"
 			}
 		},
 		"node_modules/slice-ansi": {
@@ -8675,17 +6534,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/source-map-support": {
-			"version": "0.5.13",
-			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
-			"integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"buffer-from": "^1.0.0",
-				"source-map": "^0.6.0"
-			}
-		},
 		"node_modules/space-separated-tokens": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
@@ -8707,25 +6555,12 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/sprintf-js": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-			"integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+		"node_modules/stackback": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+			"integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
 			"dev": true,
-			"license": "BSD-3-Clause"
-		},
-		"node_modules/stack-utils": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
-			"integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"escape-string-regexp": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			}
+			"license": "MIT"
 		},
 		"node_modules/statuses": {
 			"version": "2.0.2",
@@ -8737,6 +6572,13 @@
 				"node": ">= 0.8"
 			}
 		},
+		"node_modules/std-env": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+			"integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/string-argv": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
@@ -8745,20 +6587,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.6.19"
-			}
-		},
-		"node_modules/string-length": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
-			"integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"char-regex": "^1.0.2",
-				"strip-ansi": "^6.0.0"
-			},
-			"engines": {
-				"node": ">=10"
 			}
 		},
 		"node_modules/string-width": {
@@ -8842,39 +6670,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/strip-bom": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
-			"integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/strip-final-newline": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
-			"integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/strip-json-comments": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-			"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/style-mod": {
 			"version": "4.1.3",
 			"resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
@@ -8914,22 +6709,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/synckit": {
-			"version": "0.11.12",
-			"resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.12.tgz",
-			"integrity": "sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@pkgr/core": "^0.2.9"
-			},
-			"engines": {
-				"node": "^14.18.0 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/synckit"
-			}
-		},
 		"node_modules/tabbable": {
 			"version": "6.4.0",
 			"resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
@@ -8937,66 +6716,12 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/test-exclude": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
-			"integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+		"node_modules/tinybench": {
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+			"integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
 			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"@istanbuljs/schema": "^0.1.2",
-				"glob": "^7.1.4",
-				"minimatch": "^3.0.4"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/test-exclude/node_modules/brace-expansion": {
-			"version": "1.1.13",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-			"integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
-		"node_modules/test-exclude/node_modules/glob": {
-			"version": "7.2.3",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-			"deprecated": "Glob versions prior to v9 are no longer supported",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"fs.realpath": "^1.0.0",
-				"inflight": "^1.0.4",
-				"inherits": "2",
-				"minimatch": "^3.1.1",
-				"once": "^1.3.0",
-				"path-is-absolute": "^1.0.0"
-			},
-			"engines": {
-				"node": "*"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/test-exclude/node_modules/minimatch": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^1.1.7"
-			},
-			"engines": {
-				"node": "*"
-			}
+			"license": "MIT"
 		},
 		"node_modules/tinyexec": {
 			"version": "1.0.4",
@@ -9008,32 +6733,83 @@
 				"node": ">=18"
 			}
 		},
-		"node_modules/tldts": {
-			"version": "6.1.86",
-			"resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
-			"integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+		"node_modules/tinyglobby": {
+			"version": "0.2.16",
+			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+			"integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"tldts-core": "^6.1.86"
+				"fdir": "^6.5.0",
+				"picomatch": "^4.0.4"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/SuperchupuDev"
+			}
+		},
+		"node_modules/tinyglobby/node_modules/fdir": {
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+			"integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"peerDependencies": {
+				"picomatch": "^3 || ^4"
+			},
+			"peerDependenciesMeta": {
+				"picomatch": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/tinyglobby/node_modules/picomatch": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/tinyrainbow": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+			"integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/tldts": {
+			"version": "7.0.28",
+			"resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.28.tgz",
+			"integrity": "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tldts-core": "^7.0.28"
 			},
 			"bin": {
 				"tldts": "bin/cli.js"
 			}
 		},
 		"node_modules/tldts-core": {
-			"version": "6.1.86",
-			"resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
-			"integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+			"version": "7.0.28",
+			"resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.28.tgz",
+			"integrity": "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/tmpl": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
-			"integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
-			"dev": true,
-			"license": "BSD-3-Clause"
 		},
 		"node_modules/toidentifier": {
 			"version": "1.0.1",
@@ -9045,30 +6821,40 @@
 				"node": ">=0.6"
 			}
 		},
+		"node_modules/totalist": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
+			"integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/tough-cookie": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
-			"integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+			"integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
-				"tldts": "^6.1.32"
+				"tldts": "^7.0.5"
 			},
 			"engines": {
 				"node": ">=16"
 			}
 		},
 		"node_modules/tr46": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
-			"integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+			"integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"punycode": "^2.3.1"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=20"
 			}
 		},
 		"node_modules/trim-lines": {
@@ -9080,85 +6866,6 @@
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/wooorm"
-			}
-		},
-		"node_modules/ts-jest": {
-			"version": "29.4.9",
-			"resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.9.tgz",
-			"integrity": "sha512-LTb9496gYPMCqjeDLdPrKuXtncudeV1yRZnF4Wo5l3SFi0RYEnYRNgMrFIdg+FHvfzjCyQk1cLncWVqiSX+EvQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"bs-logger": "^0.2.6",
-				"fast-json-stable-stringify": "^2.1.0",
-				"handlebars": "^4.7.9",
-				"json5": "^2.2.3",
-				"lodash.memoize": "^4.1.2",
-				"make-error": "^1.3.6",
-				"semver": "^7.7.4",
-				"type-fest": "^4.41.0",
-				"yargs-parser": "^21.1.1"
-			},
-			"bin": {
-				"ts-jest": "cli.js"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || ^18.0.0 || >=20.0.0"
-			},
-			"peerDependencies": {
-				"@babel/core": ">=7.0.0-beta.0 <8",
-				"@jest/transform": "^29.0.0 || ^30.0.0",
-				"@jest/types": "^29.0.0 || ^30.0.0",
-				"babel-jest": "^29.0.0 || ^30.0.0",
-				"jest": "^29.0.0 || ^30.0.0",
-				"jest-util": "^29.0.0 || ^30.0.0",
-				"typescript": ">=4.3 <7"
-			},
-			"peerDependenciesMeta": {
-				"@babel/core": {
-					"optional": true
-				},
-				"@jest/transform": {
-					"optional": true
-				},
-				"@jest/types": {
-					"optional": true
-				},
-				"babel-jest": {
-					"optional": true
-				},
-				"esbuild": {
-					"optional": true
-				},
-				"jest-util": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/ts-jest/node_modules/semver": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-			"dev": true,
-			"license": "ISC",
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/ts-jest/node_modules/type-fest": {
-			"version": "4.41.0",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
-			"integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
-			"dev": true,
-			"license": "(MIT OR CC0-1.0)",
-			"engines": {
-				"node": ">=16"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/tslib": {
@@ -9179,29 +6886,6 @@
 			"engines": {
 				"node": ">=18",
 				"npm": ">=9"
-			}
-		},
-		"node_modules/type-detect": {
-			"version": "4.0.8",
-			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/type-fest": {
-			"version": "0.21.3",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-			"integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
-			"dev": true,
-			"license": "(MIT OR CC0-1.0)",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/type-is": {
@@ -9272,6 +6956,16 @@
 			},
 			"engines": {
 				"node": ">=0.8.0"
+			}
+		},
+		"node_modules/undici": {
+			"version": "7.25.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+			"integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=20.18.1"
 			}
 		},
 		"node_modules/undici-types": {
@@ -9361,87 +7055,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.8"
-			}
-		},
-		"node_modules/unrs-resolver": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
-			"integrity": "sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==",
-			"dev": true,
-			"hasInstallScript": true,
-			"license": "MIT",
-			"dependencies": {
-				"napi-postinstall": "^0.3.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/unrs-resolver"
-			},
-			"optionalDependencies": {
-				"@unrs/resolver-binding-android-arm-eabi": "1.11.1",
-				"@unrs/resolver-binding-android-arm64": "1.11.1",
-				"@unrs/resolver-binding-darwin-arm64": "1.11.1",
-				"@unrs/resolver-binding-darwin-x64": "1.11.1",
-				"@unrs/resolver-binding-freebsd-x64": "1.11.1",
-				"@unrs/resolver-binding-linux-arm-gnueabihf": "1.11.1",
-				"@unrs/resolver-binding-linux-arm-musleabihf": "1.11.1",
-				"@unrs/resolver-binding-linux-arm64-gnu": "1.11.1",
-				"@unrs/resolver-binding-linux-arm64-musl": "1.11.1",
-				"@unrs/resolver-binding-linux-ppc64-gnu": "1.11.1",
-				"@unrs/resolver-binding-linux-riscv64-gnu": "1.11.1",
-				"@unrs/resolver-binding-linux-riscv64-musl": "1.11.1",
-				"@unrs/resolver-binding-linux-s390x-gnu": "1.11.1",
-				"@unrs/resolver-binding-linux-x64-gnu": "1.11.1",
-				"@unrs/resolver-binding-linux-x64-musl": "1.11.1",
-				"@unrs/resolver-binding-wasm32-wasi": "1.11.1",
-				"@unrs/resolver-binding-win32-arm64-msvc": "1.11.1",
-				"@unrs/resolver-binding-win32-ia32-msvc": "1.11.1",
-				"@unrs/resolver-binding-win32-x64-msvc": "1.11.1"
-			}
-		},
-		"node_modules/update-browserslist-db": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
-			"integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/browserslist"
-				},
-				{
-					"type": "tidelift",
-					"url": "https://tidelift.com/funding/github/npm/browserslist"
-				},
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/ai"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"escalade": "^3.2.0",
-				"picocolors": "^1.1.1"
-			},
-			"bin": {
-				"update-browserslist-db": "cli.js"
-			},
-			"peerDependencies": {
-				"browserslist": ">= 4.21.0"
-			}
-		},
-		"node_modules/v8-to-istanbul": {
-			"version": "9.3.0",
-			"resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
-			"integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"@jridgewell/trace-mapping": "^0.3.12",
-				"@types/istanbul-lib-coverage": "^2.0.1",
-				"convert-source-map": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=10.12.0"
 			}
 		},
 		"node_modules/vary": {
@@ -9586,6 +7199,224 @@
 				}
 			}
 		},
+		"node_modules/vitest": {
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
+			"integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/expect": "4.1.5",
+				"@vitest/mocker": "4.1.5",
+				"@vitest/pretty-format": "4.1.5",
+				"@vitest/runner": "4.1.5",
+				"@vitest/snapshot": "4.1.5",
+				"@vitest/spy": "4.1.5",
+				"@vitest/utils": "4.1.5",
+				"es-module-lexer": "^2.0.0",
+				"expect-type": "^1.3.0",
+				"magic-string": "^0.30.21",
+				"obug": "^2.1.1",
+				"pathe": "^2.0.3",
+				"picomatch": "^4.0.3",
+				"std-env": "^4.0.0-rc.1",
+				"tinybench": "^2.9.0",
+				"tinyexec": "^1.0.2",
+				"tinyglobby": "^0.2.15",
+				"tinyrainbow": "^3.1.0",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+				"why-is-node-running": "^2.3.0"
+			},
+			"bin": {
+				"vitest": "vitest.mjs"
+			},
+			"engines": {
+				"node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"@edge-runtime/vm": "*",
+				"@opentelemetry/api": "^1.9.0",
+				"@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+				"@vitest/browser-playwright": "4.1.5",
+				"@vitest/browser-preview": "4.1.5",
+				"@vitest/browser-webdriverio": "4.1.5",
+				"@vitest/coverage-istanbul": "4.1.5",
+				"@vitest/coverage-v8": "4.1.5",
+				"@vitest/ui": "4.1.5",
+				"happy-dom": "*",
+				"jsdom": "*",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@edge-runtime/vm": {
+					"optional": true
+				},
+				"@opentelemetry/api": {
+					"optional": true
+				},
+				"@types/node": {
+					"optional": true
+				},
+				"@vitest/browser-playwright": {
+					"optional": true
+				},
+				"@vitest/browser-preview": {
+					"optional": true
+				},
+				"@vitest/browser-webdriverio": {
+					"optional": true
+				},
+				"@vitest/coverage-istanbul": {
+					"optional": true
+				},
+				"@vitest/coverage-v8": {
+					"optional": true
+				},
+				"@vitest/ui": {
+					"optional": true
+				},
+				"happy-dom": {
+					"optional": true
+				},
+				"jsdom": {
+					"optional": true
+				},
+				"vite": {
+					"optional": false
+				}
+			}
+		},
+		"node_modules/vitest/node_modules/@vitest/mocker": {
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
+			"integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/spy": "4.1.5",
+				"estree-walker": "^3.0.3",
+				"magic-string": "^0.30.21"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"msw": "^2.4.9",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"msw": {
+					"optional": true
+				},
+				"vite": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/vitest/node_modules/estree-walker": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+			"integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "^1.0.0"
+			}
+		},
+		"node_modules/vitest/node_modules/picomatch": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/vitest/node_modules/vite": {
+			"version": "8.0.10",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
+			"integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"lightningcss": "^1.32.0",
+				"picomatch": "^4.0.4",
+				"postcss": "^8.5.10",
+				"rolldown": "1.0.0-rc.17",
+				"tinyglobby": "^0.2.16"
+			},
+			"bin": {
+				"vite": "bin/vite.js"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			},
+			"funding": {
+				"url": "https://github.com/vitejs/vite?sponsor=1"
+			},
+			"optionalDependencies": {
+				"fsevents": "~2.3.3"
+			},
+			"peerDependencies": {
+				"@types/node": "^20.19.0 || >=22.12.0",
+				"@vitejs/devtools": "^0.1.0",
+				"esbuild": "^0.27.0 || ^0.28.0",
+				"jiti": ">=1.21.0",
+				"less": "^4.0.0",
+				"sass": "^1.70.0",
+				"sass-embedded": "^1.70.0",
+				"stylus": ">=0.54.8",
+				"sugarss": "^5.0.0",
+				"terser": "^5.16.0",
+				"tsx": "^4.8.1",
+				"yaml": "^2.4.2"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				},
+				"@vitejs/devtools": {
+					"optional": true
+				},
+				"esbuild": {
+					"optional": true
+				},
+				"jiti": {
+					"optional": true
+				},
+				"less": {
+					"optional": true
+				},
+				"sass": {
+					"optional": true
+				},
+				"sass-embedded": {
+					"optional": true
+				},
+				"stylus": {
+					"optional": true
+				},
+				"sugarss": {
+					"optional": true
+				},
+				"terser": {
+					"optional": true
+				},
+				"tsx": {
+					"optional": true
+				},
+				"yaml": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/vue": {
 			"version": "3.5.27",
 			"resolved": "https://registry.npmjs.org/vue/-/vue-3.5.27.tgz",
@@ -9627,16 +7458,6 @@
 				"node": ">=18"
 			}
 		},
-		"node_modules/walker": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
-			"integrity": "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"makeerror": "1.0.12"
-			}
-		},
 		"node_modules/web-streams-polyfill": {
 			"version": "3.3.3",
 			"resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
@@ -9647,27 +7468,13 @@
 			}
 		},
 		"node_modules/webidl-conversions": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
-			"integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+			"integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
 			"dev": true,
 			"license": "BSD-2-Clause",
 			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/whatwg-encoding": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
-			"integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
-			"deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"iconv-lite": "0.6.3"
-			},
-			"engines": {
-				"node": ">=18"
+				"node": ">=20"
 			}
 		},
 		"node_modules/whatwg-fetch": {
@@ -9677,27 +7484,28 @@
 			"license": "MIT"
 		},
 		"node_modules/whatwg-mimetype": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
-			"integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+			"integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">=18"
+				"node": ">=20"
 			}
 		},
 		"node_modules/whatwg-url": {
-			"version": "14.2.0",
-			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
-			"integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+			"version": "16.0.1",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+			"integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"tr46": "^5.1.0",
-				"webidl-conversions": "^7.0.0"
+				"@exodus/bytes": "^1.11.0",
+				"tr46": "^6.0.0",
+				"webidl-conversions": "^8.0.1"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
 			}
 		},
 		"node_modules/which": {
@@ -9715,30 +7523,29 @@
 				"node": ">= 8"
 			}
 		},
+		"node_modules/why-is-node-running": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+			"integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"siginfo": "^2.0.0",
+				"stackback": "0.0.2"
+			},
+			"bin": {
+				"why-is-node-running": "cli.js"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/wordwrap": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
 			"integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/wrap-ansi": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-styles": "^4.0.0",
-				"string-width": "^4.1.0",
-				"strip-ansi": "^6.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-			}
 		},
 		"node_modules/wrap-ansi-cjs": {
 			"name": "wrap-ansi",
@@ -9764,33 +7571,6 @@
 			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
 			"devOptional": true,
 			"license": "ISC"
-		},
-		"node_modules/write-file-atomic": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
-			"integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"imurmurhash": "^0.1.4",
-				"signal-exit": "^4.0.1"
-			},
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/write-file-atomic/node_modules/signal-exit": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">=14"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
 		},
 		"node_modules/ws": {
 			"version": "8.18.3",
@@ -9830,23 +7610,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/y18n": {
-			"version": "5.0.8",
-			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-			"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/yallist": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-			"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-			"dev": true,
-			"license": "ISC"
-		},
 		"node_modules/yaml": {
 			"version": "2.8.3",
 			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
@@ -9861,48 +7624,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/eemeli"
-			}
-		},
-		"node_modules/yargs": {
-			"version": "17.7.2",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-			"integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"cliui": "^8.0.1",
-				"escalade": "^3.1.1",
-				"get-caller-file": "^2.0.5",
-				"require-directory": "^2.1.1",
-				"string-width": "^4.2.3",
-				"y18n": "^5.0.5",
-				"yargs-parser": "^21.1.1"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/yargs-parser": {
-			"version": "21.1.1",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-			"integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/yocto-queue": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-			"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/zod": {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
 		"@allenhutchison/gemini-utils": "^0.5.0",
 		"@codemirror/merge": "^6.12.1",
 		"@types/turndown": "^5.0.6",
+		"ollama": "^0.6.3",
 		"turndown": "^7.2.4"
 	},
 	"lint-staged": {

--- a/src/api/ollama-client.ts
+++ b/src/api/ollama-client.ts
@@ -331,6 +331,13 @@ export class OllamaClient implements ModelApi {
 					textChunks.push(part.text);
 				} else if (part?.inlineData?.mimeType?.startsWith('image/') && part.inlineData.data) {
 					images.push(part.inlineData.data);
+				} else if (part?.inlineData?.mimeType) {
+					// Mirror buildChatRequest's current-turn handling so resumed sessions
+					// don't silently drop PDF/audio/video context the model never sees.
+					throw new Error(
+						`Ollama only supports image attachments; conversation history contains ${part.inlineData.mimeType}. ` +
+							`Switch to the Gemini provider for PDF, audio, or video input.`
+					);
 				} else if (part?.functionCall) {
 					toolCallParts.push({
 						name: part.functionCall.name,

--- a/src/api/ollama-client.ts
+++ b/src/api/ollama-client.ts
@@ -1,0 +1,430 @@
+/**
+ * Ollama API implementation of the ModelApi interface.
+ *
+ * Uses ollama-js (via the browser entry point) so it works inside Obsidian's
+ * Electron renderer without Node-specific imports. The Ollama daemon runs
+ * locally with no auth, so configuration is just the base URL plus model.
+ *
+ * Phase 1 scope:
+ *  - chat + tool calling for ExtendedModelRequest
+ *  - generate for BaseModelRequest (summary / completions / rewrite)
+ *  - streaming chat with cancellation
+ *  - image attachments via the `images` array (vision-capable models only)
+ *  - usageMetadata derived from prompt_eval_count / eval_count
+ *
+ * Out of scope (no Ollama equivalent):
+ *  - cachedContentTokenCount (Ollama does not expose cache hits)
+ *  - search grounding / rendered HTML (Gemini-only)
+ *  - thoughtSignature (used by Gemini's thinking mode for tool-call replay)
+ */
+
+import { Ollama, ChatRequest, ChatResponse, Message, Tool } from 'ollama/browser';
+import {
+	ModelApi,
+	BaseModelRequest,
+	ExtendedModelRequest,
+	ModelResponse,
+	ToolCall,
+	ToolDefinition,
+	StreamCallback,
+	StreamingModelResponse,
+	InlineDataPart,
+} from './interfaces/model-api';
+import { GeminiPrompts } from '../prompts';
+import type ObsidianGemini from '../main';
+import { getDefaultModelForRole } from '../models';
+
+export interface OllamaClientConfig {
+	baseUrl: string;
+	model?: string;
+	temperature?: number;
+	topP?: number;
+	maxOutputTokens?: number;
+	streamingEnabled?: boolean;
+}
+
+export class OllamaClient implements ModelApi {
+	private client: Ollama;
+	private config: OllamaClientConfig;
+	private prompts: GeminiPrompts;
+	private plugin?: ObsidianGemini;
+
+	constructor(config: OllamaClientConfig, prompts?: GeminiPrompts, plugin?: ObsidianGemini) {
+		this.config = {
+			temperature: 0.7,
+			topP: 1,
+			streamingEnabled: true,
+			...config,
+		};
+		this.plugin = plugin;
+		this.prompts = prompts || new GeminiPrompts(plugin);
+		this.client = new Ollama({ host: this.config.baseUrl });
+	}
+
+	async generateModelResponse(request: BaseModelRequest | ExtendedModelRequest): Promise<ModelResponse> {
+		const isExtended = 'userMessage' in request;
+		const model = request.model || this.config.model || getDefaultModelForRole('chat', 'ollama');
+		if (!model) {
+			throw new Error('No Ollama model selected. Pull a model with `ollama pull <name>` and choose it in settings.');
+		}
+
+		try {
+			if (!isExtended) {
+				const generateResponse = await this.client.generate({
+					model,
+					prompt: request.prompt,
+					stream: false,
+					options: this.buildOptions(request),
+				});
+				return {
+					markdown: generateResponse.response,
+					rendered: '',
+					usageMetadata: this.toUsageMetadata(
+						generateResponse.prompt_eval_count,
+						generateResponse.eval_count
+					),
+				};
+			}
+
+			const chatRequest = await this.buildChatRequest(request as ExtendedModelRequest, model, false);
+			const response = await this.client.chat(chatRequest as ChatRequest & { stream: false });
+			return this.toModelResponse(response);
+		} catch (error) {
+			this.plugin?.logger.error('[OllamaClient] Error generating content:', error);
+			throw error;
+		}
+	}
+
+	generateStreamingResponse(
+		request: BaseModelRequest | ExtendedModelRequest,
+		onChunk: StreamCallback
+	): StreamingModelResponse {
+		const isExtended = 'userMessage' in request;
+		const model = request.model || this.config.model || getDefaultModelForRole('chat', 'ollama');
+
+		let cancelled = false;
+		let accumulatedText = '';
+		let accumulatedThoughts = '';
+		let toolCalls: ToolCall[] | undefined;
+		let promptEvalCount: number | undefined;
+		let evalCount: number | undefined;
+		let activeStream: { abort: () => void } | null = null;
+
+		const complete = (async (): Promise<ModelResponse> => {
+			if (!model) {
+				throw new Error(
+					'No Ollama model selected. Pull a model with `ollama pull <name>` and choose it in settings.'
+				);
+			}
+
+			try {
+				if (!isExtended) {
+					// generate() supports streaming too; route the same way for consistency
+					const stream = await this.client.generate({
+						model,
+						prompt: request.prompt,
+						stream: true,
+						options: this.buildOptions(request),
+					});
+					activeStream = stream;
+
+					for await (const chunk of stream) {
+						if (cancelled) break;
+						if (chunk.response) {
+							accumulatedText += chunk.response;
+							onChunk({ text: chunk.response });
+						}
+						if (chunk.done) {
+							promptEvalCount = chunk.prompt_eval_count;
+							evalCount = chunk.eval_count;
+						}
+					}
+				} else {
+					const chatRequest = await this.buildChatRequest(request as ExtendedModelRequest, model, true);
+					const stream = await this.client.chat(chatRequest as ChatRequest & { stream: true });
+					activeStream = stream;
+
+					for await (const chunk of stream) {
+						if (cancelled) break;
+						const msg = chunk.message;
+						if (msg?.content) {
+							accumulatedText += msg.content;
+							onChunk({ text: msg.content });
+						}
+						if (msg?.thinking) {
+							accumulatedThoughts += msg.thinking;
+							onChunk({ text: '', thought: msg.thinking });
+						}
+						if (msg?.tool_calls?.length) {
+							toolCalls = toolCalls ?? [];
+							for (const tc of msg.tool_calls) {
+								toolCalls.push({
+									name: tc.function.name,
+									arguments: tc.function.arguments || {},
+								});
+							}
+						}
+						if (chunk.done) {
+							promptEvalCount = chunk.prompt_eval_count;
+							evalCount = chunk.eval_count;
+						}
+					}
+				}
+
+				return {
+					markdown: accumulatedText,
+					rendered: '',
+					...(accumulatedThoughts && { thoughts: accumulatedThoughts }),
+					...(toolCalls && toolCalls.length && { toolCalls }),
+					usageMetadata: this.toUsageMetadata(promptEvalCount, evalCount),
+				};
+			} catch (error) {
+				if (cancelled) {
+					return {
+						markdown: accumulatedText,
+						rendered: '',
+						...(accumulatedThoughts && { thoughts: accumulatedThoughts }),
+						...(toolCalls && toolCalls.length && { toolCalls }),
+						usageMetadata: this.toUsageMetadata(promptEvalCount, evalCount),
+					};
+				}
+				this.plugin?.logger.error('[OllamaClient] Streaming error:', error);
+				throw error;
+			}
+		})();
+
+		return {
+			complete,
+			cancel: () => {
+				cancelled = true;
+				try {
+					activeStream?.abort();
+				} catch (err) {
+					this.plugin?.logger.debug('[OllamaClient] Abort failed:', err);
+				}
+			},
+		};
+	}
+
+	private buildOptions(request: BaseModelRequest): Record<string, unknown> {
+		const options: Record<string, unknown> = {};
+		const temperature = request.temperature ?? this.config.temperature;
+		const topP = request.topP ?? this.config.topP;
+		if (typeof temperature === 'number') options.temperature = temperature;
+		if (typeof topP === 'number') options.top_p = topP;
+		if (typeof this.config.maxOutputTokens === 'number') options.num_predict = this.config.maxOutputTokens;
+		return options;
+	}
+
+	private async buildChatRequest(
+		request: ExtendedModelRequest,
+		model: string,
+		stream: boolean
+	): Promise<ChatRequest & { stream: boolean }> {
+		const systemInstruction = await this.buildSystemInstruction(request);
+		const messages: Message[] = [];
+
+		if (systemInstruction) {
+			messages.push({ role: 'system', content: systemInstruction });
+		}
+
+		// Convert conversation history. Entries may be in Gemini Content shape
+		// (role + parts[]) or our internal {role, message|text} shape. We
+		// flatten function-call / function-response parts into Ollama's
+		// `tool_calls` / tool-role messages.
+		for (const entry of request.conversationHistory ?? []) {
+			const converted = this.convertHistoryEntry(entry);
+			if (converted) messages.push(...converted);
+		}
+
+		// Final user turn
+		const userParts: string[] = [];
+		const userImages: string[] = [];
+		if (request.userMessage && request.userMessage.trim()) {
+			userParts.push(request.userMessage);
+		}
+		const allAttachments: InlineDataPart[] = [
+			...(request.inlineAttachments || []),
+			...(request.imageAttachments || []),
+		];
+		for (const att of allAttachments) {
+			if (att.mimeType.startsWith('image/')) {
+				userImages.push(att.base64);
+			} else {
+				throw new Error(
+					`Ollama only supports image attachments; received ${att.mimeType}. ` +
+						`Switch to the Gemini provider for PDF, audio, or video input.`
+				);
+			}
+		}
+		if (userParts.length || userImages.length) {
+			const message: Message = {
+				role: 'user',
+				content: userParts.join('\n\n'),
+			};
+			if (userImages.length) {
+				message.images = userImages;
+			}
+			messages.push(message);
+		}
+
+		const tools = request.availableTools ? this.toOllamaTools(request.availableTools) : undefined;
+
+		return {
+			model,
+			messages,
+			stream,
+			options: this.buildOptions(request),
+			...(tools && tools.length ? { tools } : {}),
+		};
+	}
+
+	private async buildSystemInstruction(request: ExtendedModelRequest): Promise<string> {
+		let agentsMemory: string | null = null;
+		if (this.plugin?.agentsMemory) {
+			try {
+				agentsMemory = await this.plugin.agentsMemory.read();
+			} catch (error) {
+				this.plugin.logger.warn('Failed to load AGENTS.md:', error);
+			}
+		}
+
+		let availableSkills: { name: string; description: string }[] = [];
+		if (this.plugin?.skillManager) {
+			try {
+				availableSkills = await this.plugin.skillManager.getSkillSummaries();
+			} catch (error) {
+				this.plugin.logger.warn('Failed to load skill summaries:', error);
+			}
+		}
+
+		if (request.projectSkills && request.projectSkills.length > 0) {
+			availableSkills = availableSkills.filter((s) => request.projectSkills!.includes(s.name));
+		}
+
+		return this.prompts.getSystemPromptWithCustom(
+			request.availableTools,
+			request.customPrompt,
+			agentsMemory,
+			availableSkills,
+			request.projectInstructions,
+			request.perTurnContext ?? request.prompt,
+			request.sessionStartedAt
+		);
+	}
+
+	private convertHistoryEntry(entry: any): Message[] | null {
+		if (!entry) return null;
+
+		// Gemini Content shape: { role: 'user'|'model', parts: Part[] }
+		if ('role' in entry && Array.isArray(entry.parts)) {
+			const role = entry.role === 'model' ? 'assistant' : entry.role === 'system' ? 'system' : 'user';
+			const textChunks: string[] = [];
+			const images: string[] = [];
+			const toolCallParts: { name: string; arguments: Record<string, any> }[] = [];
+			const toolResponseParts: { name: string; response: any }[] = [];
+			for (const part of entry.parts) {
+				if (typeof part?.text === 'string') {
+					textChunks.push(part.text);
+				} else if (part?.inlineData?.mimeType?.startsWith('image/') && part.inlineData.data) {
+					images.push(part.inlineData.data);
+				} else if (part?.functionCall) {
+					toolCallParts.push({
+						name: part.functionCall.name,
+						arguments: part.functionCall.args || {},
+					});
+				} else if (part?.functionResponse) {
+					toolResponseParts.push({
+						name: part.functionResponse.name,
+						response: part.functionResponse.response,
+					});
+				}
+			}
+
+			const out: Message[] = [];
+
+			// Tool responses become tool-role messages
+			for (const tr of toolResponseParts) {
+				const responseText =
+					typeof tr.response === 'string' ? tr.response : JSON.stringify(tr.response ?? {});
+				out.push({ role: 'tool', content: responseText, tool_name: tr.name });
+			}
+
+			// Assistant turn (text + tool calls together)
+			if (role === 'assistant' && (textChunks.length || toolCallParts.length)) {
+				const message: Message = {
+					role: 'assistant',
+					content: textChunks.join('\n').trim(),
+				};
+				if (toolCallParts.length) {
+					message.tool_calls = toolCallParts.map((tc) => ({
+						function: { name: tc.name, arguments: tc.arguments },
+					}));
+				}
+				out.push(message);
+			} else if (role !== 'assistant' && (textChunks.length || images.length)) {
+				const message: Message = {
+					role,
+					content: textChunks.join('\n\n').trim(),
+				};
+				if (images.length) message.images = images;
+				out.push(message);
+			}
+
+			return out.length ? out : null;
+		}
+
+		// Internal shape: { role, text } or { role, message }
+		if ('role' in entry) {
+			const text = entry.text ?? entry.message;
+			if (typeof text !== 'string' || !text.trim()) return null;
+			const role = entry.role === 'model' || entry.role === 'assistant' ? 'assistant' : 'user';
+			return [{ role, content: text }];
+		}
+
+		return null;
+	}
+
+	private toOllamaTools(tools: ToolDefinition[]): Tool[] {
+		return tools.map((tool) => ({
+			type: 'function',
+			function: {
+				name: tool.name,
+				description: tool.description,
+				parameters: {
+					type: tool.parameters.type ?? 'object',
+					properties: tool.parameters.properties ?? {},
+					required: tool.parameters.required ?? [],
+				},
+			},
+		}));
+	}
+
+	private toModelResponse(response: ChatResponse): ModelResponse {
+		const message = response.message ?? ({} as Message);
+		const toolCalls: ToolCall[] | undefined = message.tool_calls?.length
+			? message.tool_calls.map((tc) => ({
+					name: tc.function.name,
+					arguments: tc.function.arguments || {},
+				}))
+			: undefined;
+
+		return {
+			markdown: message.content ?? '',
+			rendered: '',
+			...(message.thinking && { thoughts: message.thinking }),
+			...(toolCalls && { toolCalls }),
+			usageMetadata: this.toUsageMetadata(response.prompt_eval_count, response.eval_count),
+		};
+	}
+
+	private toUsageMetadata(promptTokens: number | undefined, candidateTokens: number | undefined) {
+		const prompt = promptTokens ?? 0;
+		const candidates = candidateTokens ?? 0;
+		return {
+			promptTokenCount: prompt,
+			candidatesTokenCount: candidates,
+			totalTokenCount: prompt + candidates,
+		};
+	}
+}

--- a/src/api/ollama-client.ts
+++ b/src/api/ollama-client.ts
@@ -32,7 +32,6 @@ import {
 } from './interfaces/model-api';
 import { GeminiPrompts } from '../prompts';
 import type ObsidianGemini from '../main';
-import { getDefaultModelForRole } from '../models';
 
 export interface OllamaClientConfig {
 	baseUrl: string;
@@ -63,7 +62,12 @@ export class OllamaClient implements ModelApi {
 
 	async generateModelResponse(request: BaseModelRequest | ExtendedModelRequest): Promise<ModelResponse> {
 		const isExtended = 'userMessage' in request;
-		const model = request.model || this.config.model || getDefaultModelForRole('chat', 'ollama');
+		// The factory (`GeminiClientFactory.resolveModelName`) is the single
+		// source of role-aware model resolution and always populates
+		// `config.model` per use case (chat / summary / completions / rewrite).
+		// We don't fall back to a chat default here — that would silently route
+		// e.g. a summary request to the chat model when `config.model` is empty.
+		const model = request.model || this.config.model;
 		if (!model) {
 			throw new Error('No Ollama model selected. Pull a model with `ollama pull <name>` and choose it in settings.');
 		}
@@ -76,10 +80,11 @@ export class OllamaClient implements ModelApi {
 					stream: false,
 					options: this.buildOptions(request),
 				});
+				const usageMetadata = this.toUsageMetadata(generateResponse.prompt_eval_count, generateResponse.eval_count);
 				return {
 					markdown: generateResponse.response,
 					rendered: '',
-					usageMetadata: this.toUsageMetadata(generateResponse.prompt_eval_count, generateResponse.eval_count),
+					...(usageMetadata && { usageMetadata }),
 				};
 			}
 
@@ -97,7 +102,9 @@ export class OllamaClient implements ModelApi {
 		onChunk: StreamCallback
 	): StreamingModelResponse {
 		const isExtended = 'userMessage' in request;
-		const model = request.model || this.config.model || getDefaultModelForRole('chat', 'ollama');
+		// See note in generateModelResponse — the factory provides the
+		// role-correct model; no chat-default fallback here.
+		const model = request.model || this.config.model;
 
 		let cancelled = false;
 		let accumulatedText = '';
@@ -174,21 +181,23 @@ export class OllamaClient implements ModelApi {
 					}
 				}
 
+				const usageMetadata = this.toUsageMetadata(promptEvalCount, evalCount);
 				return {
 					markdown: accumulatedText,
 					rendered: '',
 					...(accumulatedThoughts && { thoughts: accumulatedThoughts }),
 					...(toolCalls && toolCalls.length && { toolCalls }),
-					usageMetadata: this.toUsageMetadata(promptEvalCount, evalCount),
+					...(usageMetadata && { usageMetadata }),
 				};
 			} catch (error) {
 				if (cancelled) {
+					const usageMetadata = this.toUsageMetadata(promptEvalCount, evalCount);
 					return {
 						markdown: accumulatedText,
 						rendered: '',
 						...(accumulatedThoughts && { thoughts: accumulatedThoughts }),
 						...(toolCalls && toolCalls.length && { toolCalls }),
-						usageMetadata: this.toUsageMetadata(promptEvalCount, evalCount),
+						...(usageMetadata && { usageMetadata }),
 					};
 				}
 				this.plugin?.logger.error('[OllamaClient] Streaming error:', error);
@@ -421,22 +430,37 @@ export class OllamaClient implements ModelApi {
 				}))
 			: undefined;
 
+		const usageMetadata = this.toUsageMetadata(response.prompt_eval_count, response.eval_count);
 		return {
 			markdown: message.content ?? '',
 			rendered: '',
 			...(message.thinking && { thoughts: message.thinking }),
 			...(toolCalls && { toolCalls }),
-			usageMetadata: this.toUsageMetadata(response.prompt_eval_count, response.eval_count),
+			...(usageMetadata && { usageMetadata }),
 		};
 	}
 
-	private toUsageMetadata(promptTokens: number | undefined, candidateTokens: number | undefined) {
-		const prompt = promptTokens ?? 0;
-		const candidates = candidateTokens ?? 0;
-		return {
-			promptTokenCount: prompt,
-			candidatesTokenCount: candidates,
-			totalTokenCount: prompt + candidates,
-		};
+	/**
+	 * Build a usageMetadata object from Ollama's `prompt_eval_count` /
+	 * `eval_count` fields, which only arrive on the terminal `done` chunk.
+	 * Returning `undefined` (rather than `{0,0,0}`) when both inputs are
+	 * missing preserves the distinction between "stream cancelled, counts
+	 * unknown" and "stream completed with zero tokens" in the token UI and
+	 * eval reporter.
+	 */
+	private toUsageMetadata(
+		promptTokens: number | undefined,
+		candidateTokens: number | undefined
+	): ModelResponse['usageMetadata'] | undefined {
+		if (promptTokens === undefined && candidateTokens === undefined) {
+			return undefined;
+		}
+		const meta: NonNullable<ModelResponse['usageMetadata']> = {};
+		if (promptTokens !== undefined) meta.promptTokenCount = promptTokens;
+		if (candidateTokens !== undefined) meta.candidatesTokenCount = candidateTokens;
+		if (promptTokens !== undefined && candidateTokens !== undefined) {
+			meta.totalTokenCount = promptTokens + candidateTokens;
+		}
+		return meta;
 	}
 }

--- a/src/api/ollama-client.ts
+++ b/src/api/ollama-client.ts
@@ -79,10 +79,7 @@ export class OllamaClient implements ModelApi {
 				return {
 					markdown: generateResponse.response,
 					rendered: '',
-					usageMetadata: this.toUsageMetadata(
-						generateResponse.prompt_eval_count,
-						generateResponse.eval_count
-					),
+					usageMetadata: this.toUsageMetadata(generateResponse.prompt_eval_count, generateResponse.eval_count),
 				};
 			}
 
@@ -112,9 +109,7 @@ export class OllamaClient implements ModelApi {
 
 		const complete = (async (): Promise<ModelResponse> => {
 			if (!model) {
-				throw new Error(
-					'No Ollama model selected. Pull a model with `ollama pull <name>` and choose it in settings.'
-				);
+				throw new Error('No Ollama model selected. Pull a model with `ollama pull <name>` and choose it in settings.');
 			}
 
 			try {
@@ -345,8 +340,7 @@ export class OllamaClient implements ModelApi {
 
 			// Tool responses become tool-role messages
 			for (const tr of toolResponseParts) {
-				const responseText =
-					typeof tr.response === 'string' ? tr.response : JSON.stringify(tr.response ?? {});
+				const responseText = typeof tr.response === 'string' ? tr.response : JSON.stringify(tr.response ?? {});
 				out.push({ role: 'tool', content: responseText, tool_name: tr.name });
 			}
 

--- a/src/api/ollama-client.ts
+++ b/src/api/ollama-client.ts
@@ -353,9 +353,12 @@ export class OllamaClient implements ModelApi {
 
 			const out: Message[] = [];
 
-			// Tool responses become tool-role messages
+			// Tool responses become tool-role messages. Don't coalesce `null` to
+			// `{}` — an explicit null response carries different meaning ("no
+			// result") than an empty object, and JSON.stringify(null) === "null"
+			// is the correct serialization to preserve that.
 			for (const tr of toolResponseParts) {
-				const responseText = typeof tr.response === 'string' ? tr.response : JSON.stringify(tr.response ?? {});
+				const responseText = typeof tr.response === 'string' ? tr.response : JSON.stringify(tr.response);
 				out.push({ role: 'tool', content: responseText, tool_name: tr.name });
 			}
 

--- a/src/api/ollama-client.ts
+++ b/src/api/ollama-client.ts
@@ -122,6 +122,11 @@ export class OllamaClient implements ModelApi {
 						options: this.buildOptions(request),
 					});
 					activeStream = stream;
+					// cancel() may have fired while the await above was outstanding —
+					// abort immediately so the daemon stops generating.
+					if (cancelled) {
+						stream.abort();
+					}
 
 					for await (const chunk of stream) {
 						if (cancelled) break;
@@ -138,6 +143,9 @@ export class OllamaClient implements ModelApi {
 					const chatRequest = await this.buildChatRequest(request as ExtendedModelRequest, model, true);
 					const stream = await this.client.chat(chatRequest as ChatRequest & { stream: true });
 					activeStream = stream;
+					if (cancelled) {
+						stream.abort();
+					}
 
 					for await (const chunk of stream) {
 						if (cancelled) break;

--- a/src/api/simple-factory.ts
+++ b/src/api/simple-factory.ts
@@ -6,6 +6,7 @@
  */
 
 import { GeminiClient, GeminiClientConfig } from './gemini-client';
+import { OllamaClient, OllamaClientConfig } from './ollama-client';
 import { ModelApi } from './interfaces/model-api';
 import { GeminiPrompts } from '../prompts';
 import { RetryDecorator } from './retry-decorator';
@@ -38,35 +39,33 @@ export class GeminiClientFactory {
 	static createFromPlugin(
 		plugin: ObsidianGemini,
 		useCase: ModelUseCase,
-		overrides?: Partial<GeminiClientConfig>
+		overrides?: Partial<GeminiClientConfig> & Partial<OllamaClientConfig>
 	): ModelApi {
 		const settings = plugin.settings;
+		const provider = settings.provider ?? 'gemini';
 
-		// Determine which model to use based on use case
-		let modelName: string;
-		switch (useCase) {
-			case ModelUseCase.CHAT:
-				modelName = settings.chatModelName || getDefaultModelForRole('chat');
-				break;
-			case ModelUseCase.SUMMARY:
-				modelName = settings.summaryModelName || getDefaultModelForRole('summary');
-				break;
-			case ModelUseCase.COMPLETIONS:
-				modelName = settings.completionsModelName || getDefaultModelForRole('completions');
-				break;
-			case ModelUseCase.REWRITE:
-				// Rewrite uses chat model
-				modelName = settings.chatModelName || getDefaultModelForRole('chat');
-				break;
-			case ModelUseCase.SEARCH:
-				// Search uses chat model
-				modelName = settings.chatModelName || getDefaultModelForRole('chat');
-				break;
-			default:
-				modelName = getDefaultModelForRole('chat');
+		const modelName = this.resolveModelName(plugin, useCase);
+
+		const prompts = new GeminiPrompts(plugin);
+
+		const retryConfig = {
+			maxRetries: settings.maxRetries ?? 3,
+			initialBackoffDelay: settings.initialBackoffDelay ?? 1000,
+		};
+
+		if (provider === 'ollama') {
+			const config: OllamaClientConfig = {
+				baseUrl: settings.ollamaBaseUrl || 'http://localhost:11434',
+				model: modelName,
+				temperature: settings.temperature ?? 0.7,
+				topP: settings.topP ?? 1,
+				streamingEnabled: settings.streamingEnabled ?? true,
+				...overrides,
+			};
+			const client = new OllamaClient(config, prompts, plugin);
+			return new RetryDecorator(client, retryConfig, plugin.logger);
 		}
 
-		// Build config
 		const config: GeminiClientConfig = {
 			apiKey: plugin.apiKey,
 			model: modelName,
@@ -75,20 +74,27 @@ export class GeminiClientFactory {
 			streamingEnabled: settings.streamingEnabled ?? true,
 			...overrides,
 		};
-
-		// Create prompts instance with plugin reference so it can access settings
-		const prompts = new GeminiPrompts(plugin);
-
-		// Create client
 		const client = new GeminiClient(config, prompts, plugin);
-
-		// Wrap with retry decorator
-		const retryConfig = {
-			maxRetries: settings.maxRetries ?? 3,
-			initialBackoffDelay: settings.initialBackoffDelay ?? 1000,
-		};
-
 		return new RetryDecorator(client, retryConfig, plugin.logger);
+	}
+
+	private static resolveModelName(plugin: ObsidianGemini, useCase: ModelUseCase): string {
+		const settings = plugin.settings;
+		const provider = settings.provider ?? 'gemini';
+		switch (useCase) {
+			case ModelUseCase.CHAT:
+				return settings.chatModelName || getDefaultModelForRole('chat', provider);
+			case ModelUseCase.SUMMARY:
+				return settings.summaryModelName || getDefaultModelForRole('summary', provider);
+			case ModelUseCase.COMPLETIONS:
+				return settings.completionsModelName || getDefaultModelForRole('completions', provider);
+			case ModelUseCase.REWRITE:
+				return settings.chatModelName || getDefaultModelForRole('chat', provider);
+			case ModelUseCase.SEARCH:
+				return settings.chatModelName || getDefaultModelForRole('chat', provider);
+			default:
+				return getDefaultModelForRole('chat', provider);
+		}
 	}
 
 	/**

--- a/src/main.ts
+++ b/src/main.ts
@@ -591,11 +591,42 @@ export default class ObsidianGemini extends Plugin {
 			},
 		});
 
-		// RAG indexing commands
+		// Image generation command (Gemini-only). Registered unconditionally so
+		// the palette entry stays stable across runtime provider switches; the
+		// callback gates on provider before touching the (potentially null)
+		// `imageGeneration` service.
+		this.addCommand({
+			id: 'gemini-scribe-generate-image',
+			name: 'Generate Image',
+			callback: async () => {
+				if (!this.checkInitialized()) return;
+				if (this.settings.provider === 'ollama') {
+					new Notice('Image generation is not available with the Ollama provider.');
+					return;
+				}
+				if (!this.imageGeneration) {
+					new Notice('Image generation is not available.');
+					return;
+				}
+				const prompt = await this.imageGeneration.promptForImageDescription();
+				if (prompt) {
+					await this.imageGeneration.generateAndInsertImage(prompt);
+				}
+			},
+		});
+
+		// RAG indexing commands. Same pattern as image generation: register
+		// unconditionally and gate at execution time so the palette stays
+		// consistent and the user gets a clear "not available" notice on the
+		// Ollama path (RAG depends on Gemini's File Search Store in Phase 1).
 		this.addCommand({
 			id: 'gemini-scribe-rag-pause',
 			name: 'Pause RAG Sync',
 			callback: () => {
+				if (this.settings.provider === 'ollama') {
+					new Notice('RAG sync is not available with the Ollama provider in Phase 1.');
+					return;
+				}
 				if (!this.ragIndexing) {
 					new Notice('RAG indexing is not enabled');
 					return;
@@ -617,6 +648,10 @@ export default class ObsidianGemini extends Plugin {
 			id: 'gemini-scribe-rag-resume',
 			name: 'Resume RAG Sync',
 			callback: () => {
+				if (this.settings.provider === 'ollama') {
+					new Notice('RAG sync is not available with the Ollama provider in Phase 1.');
+					return;
+				}
 				if (!this.ragIndexing) {
 					new Notice('RAG indexing is not enabled');
 					return;
@@ -634,6 +669,10 @@ export default class ObsidianGemini extends Plugin {
 			id: 'gemini-scribe-rag-status',
 			name: 'Show RAG Status',
 			callback: async () => {
+				if (this.settings.provider === 'ollama') {
+					new Notice('RAG sync is not available with the Ollama provider in Phase 1.');
+					return;
+				}
 				if (!this.ragIndexing) {
 					new Notice('RAG indexing is not enabled');
 					return;

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,7 +8,7 @@ import { ScribeFile } from './files';
 import { GeminiHistory } from './history/history';
 import { GeminiCompletions } from './completions';
 import { Notice } from 'obsidian';
-import { getDefaultModelForRole, GeminiModel } from './models';
+import { getDefaultModelForRole, GeminiModel, ModelProvider } from './models';
 import { ModelManager } from './services/model-manager';
 import { PromptManager, GeminiPrompts } from './prompts';
 import { SelectionRewriter } from './rewrite-selection';
@@ -50,6 +50,10 @@ export interface RagIndexingSettings {
 }
 
 export interface ObsidianGeminiSettings {
+	/** Active model provider. 'gemini' is the cloud default; 'ollama' targets a local Ollama daemon. */
+	provider: ModelProvider;
+	/** Base URL for the Ollama HTTP API. Only used when provider === 'ollama'. */
+	ollamaBaseUrl: string;
 	apiKeySecretName: string;
 	chatModelName: string;
 	summaryModelName: string;
@@ -95,6 +99,8 @@ export interface ObsidianGeminiSettings {
 }
 
 const DEFAULT_SETTINGS: ObsidianGeminiSettings = {
+	provider: 'gemini',
+	ollamaBaseUrl: 'http://localhost:11434',
 	apiKeySecretName: '',
 	chatModelName: getDefaultModelForRole('chat'),
 	summaryModelName: getDefaultModelForRole('summary'),
@@ -151,6 +157,8 @@ export default class ObsidianGemini extends Plugin {
 	settings!: ObsidianGeminiSettings;
 
 	get apiKey(): string {
+		// Ollama runs locally with no auth, so no key is required.
+		if (this.settings?.provider === 'ollama') return '';
 		const secretName = this.settings?.apiKeySecretName;
 		if (!secretName) return '';
 		return this.app.secretStorage.getSecret(secretName) ?? '';
@@ -170,7 +178,7 @@ export default class ObsidianGemini extends Plugin {
 	public examplePrompts!: ExamplePromptsManager;
 	public vaultAnalyzer!: VaultAnalyzer;
 	public deepResearch!: DeepResearchService;
-	public imageGeneration!: ImageGeneration;
+	public imageGeneration: ImageGeneration | null = null;
 	public logger!: Logger;
 	public fileLogWriter: FileLogWriter | null = null;
 	public ragIndexing: RagIndexingService | null = null;
@@ -200,6 +208,8 @@ export default class ObsidianGemini extends Plugin {
 	public isGeminiInitialized: boolean = false;
 	private previousApiKey: string = '';
 	private previousRagEnabled: boolean = false;
+	private previousProvider: ModelProvider = 'gemini';
+	private previousOllamaBaseUrl: string = '';
 	private lifecycle!: LifecycleService;
 
 	async onload() {
@@ -226,6 +236,8 @@ export default class ObsidianGemini extends Plugin {
 			this.isGeminiInitialized = true;
 			this.previousApiKey = this.apiKey;
 			this.previousRagEnabled = this.settings.ragIndexing.enabled;
+			this.previousProvider = this.settings.provider;
+			this.previousOllamaBaseUrl = this.settings.ollamaBaseUrl;
 		} catch (error) {
 			this.logger.error('Failed to initialize Gemini Scribe:', error);
 			new Notice(this.getInitErrorMessage(error));
@@ -255,6 +267,12 @@ export default class ObsidianGemini extends Plugin {
 	 * Distinguishes between "never configured" and "storage retrieval failure".
 	 */
 	private getApiKeyErrorMessage(): string {
+		if (this.settings.provider === 'ollama') {
+			return (
+				`Could not reach Ollama at ${this.settings.ollamaBaseUrl}. ` +
+				'Make sure the Ollama daemon is running and the base URL is correct in Settings \u2192 Gemini Scribe.'
+			);
+		}
 		if (!this.settings.apiKeySecretName) {
 			return (
 				'No Gemini API key configured. Open Settings \u2192 Gemini Scribe to add one. ' +
@@ -753,19 +771,25 @@ export default class ObsidianGemini extends Plugin {
 
 		// Check if we need to re-initialize
 		const apiKeyChanged = this.previousApiKey !== this.apiKey;
-		const needsInit = !this.isGeminiInitialized && this.apiKey;
+		const providerChanged = this.previousProvider !== this.settings.provider;
+		const ollamaUrlChanged =
+			this.settings.provider === 'ollama' && this.previousOllamaBaseUrl !== this.settings.ollamaBaseUrl;
+		// Ollama needs no API key, so first-time init triggers on provider switch alone.
+		const hasCredentials = this.settings.provider === 'ollama' || !!this.apiKey;
+		const needsInit = !this.isGeminiInitialized && hasCredentials;
 
-		// Only re-initialize if API key changed or if not initialized but now have key
-		if (apiKeyChanged || needsInit) {
+		if (apiKeyChanged || providerChanged || ollamaUrlChanged || needsInit) {
 			try {
 				await this.lifecycle.setup();
 				this.isGeminiInitialized = true;
 				this.previousApiKey = this.apiKey;
 				this.previousRagEnabled = this.settings.ragIndexing.enabled;
+				this.previousProvider = this.settings.provider;
+				this.previousOllamaBaseUrl = this.settings.ollamaBaseUrl;
 
 				// If this is the first successful initialization, we may need to
 				// re-register UI components to make them functional
-				if (needsInit && !apiKeyChanged) {
+				if (needsInit && !apiKeyChanged && !providerChanged) {
 					new Notice('Gemini Scribe is now ready to use!');
 				}
 			} catch (error) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -211,6 +211,10 @@ export default class ObsidianGemini extends Plugin {
 	private previousProvider: ModelProvider = 'gemini';
 	private previousOllamaBaseUrl: string = '';
 	private lifecycle!: LifecycleService;
+	// Captures the last initialization failure so guarded commands can surface
+	// the actual cause (e.g. "model not pulled") instead of the ephemeral Notice
+	// the user may have missed. Cleared on a subsequent successful init.
+	private lastInitError: string | null = null;
 
 	async onload() {
 		// Initialize logger early so it's available during setup
@@ -234,12 +238,14 @@ export default class ObsidianGemini extends Plugin {
 		try {
 			await this.lifecycle.setup();
 			this.isGeminiInitialized = true;
+			this.lastInitError = null;
 			this.previousApiKey = this.apiKey;
 			this.previousRagEnabled = this.settings.ragIndexing.enabled;
 			this.previousProvider = this.settings.provider;
 			this.previousOllamaBaseUrl = this.settings.ollamaBaseUrl;
 		} catch (error) {
 			this.logger.error('Failed to initialize Gemini Scribe:', error);
+			this.lastInitError = error instanceof Error ? error.message : String(error);
 			new Notice(this.getInitErrorMessage(error));
 			this.isGeminiInitialized = false;
 		}
@@ -268,6 +274,15 @@ export default class ObsidianGemini extends Plugin {
 	 */
 	private getApiKeyErrorMessage(): string {
 		if (this.settings.provider === 'ollama') {
+			// Surface the captured init error when we have one \u2014 connectivity is the
+			// most common Ollama failure but far from the only one (no model
+			// selected, model not pulled, base URL points at a non-Ollama HTTP
+			// server). The init-time Notice may have already disappeared by the
+			// time the user invokes a guarded command, so reuse the error here
+			// instead of always defaulting to "make sure the daemon is running".
+			if (this.lastInitError) {
+				return `Gemini Scribe failed to initialize: ${this.lastInitError}. Open Settings \u2192 Gemini Scribe to fix.`;
+			}
 			return (
 				`Could not reach Ollama at ${this.settings.ollamaBaseUrl}. ` +
 				'Make sure the Ollama daemon is running and the base URL is correct in Settings \u2192 Gemini Scribe.'
@@ -821,6 +836,7 @@ export default class ObsidianGemini extends Plugin {
 			try {
 				await this.lifecycle.setup();
 				this.isGeminiInitialized = true;
+				this.lastInitError = null;
 				this.previousApiKey = this.apiKey;
 				this.previousRagEnabled = this.settings.ragIndexing.enabled;
 				this.previousProvider = this.settings.provider;
@@ -833,6 +849,7 @@ export default class ObsidianGemini extends Plugin {
 				}
 			} catch (error) {
 				this.logger.error('Failed to re-initialize after settings change:', error);
+				this.lastInitError = error instanceof Error ? error.message : String(error);
 				this.isGeminiInitialized = false;
 			}
 		}

--- a/src/models.ts
+++ b/src/models.ts
@@ -89,11 +89,14 @@ export function getUpdatedModelSettings(currentSettings: any): ModelUpdateResult
 	const newSettings = { ...currentSettings };
 
 	// Helper function to check if a model needs updating.
-	// For Ollama we tolerate empty (the list may not have loaded yet) — only
-	// reset when the configured value is present but no longer in the list.
+	// For Ollama we tolerate empty *only* while the model list hasn't loaded
+	// yet — once /api/tags has resolved, an empty value should be backfilled
+	// to a real default (otherwise a Gemini → Ollama switch made before the
+	// daemon was reachable would leave chat/summary/completions blank
+	// indefinitely, since the empty value never re-triggers reconciliation).
 	const needsUpdate = (modelName: string) => {
 		if (!modelName) {
-			return provider !== 'ollama';
+			return provider !== 'ollama' || availableModelValues.size > 0;
 		}
 		return !availableModelValues.has(modelName);
 	};

--- a/src/models.ts
+++ b/src/models.ts
@@ -3,12 +3,22 @@ import modelData from './data/models.json';
 
 export type ModelRole = 'chat' | 'summary' | 'completions' | 'rewrite' | 'image';
 
+export type ModelProvider = 'gemini' | 'ollama';
+
 export interface GeminiModel {
 	value: string;
 	label: string;
 	defaultForRoles?: ModelRole[];
 	supportsImageGeneration?: boolean;
 	maxTemperature?: number;
+	/** Provider that serves this model. Omitted entries are treated as 'gemini' for backward compat. */
+	provider?: ModelProvider;
+	/** Whether the model is known to support function/tool calling. Defaults to true for Gemini, varies for Ollama. */
+	supportsTools?: boolean;
+	/** Whether the model supports image input (vision). */
+	supportsVision?: boolean;
+	/** Context window in tokens (used for compaction thresholds). */
+	contextWindow?: number;
 }
 
 export const DEFAULT_GEMINI_MODELS: GeminiModel[] = modelData.models as GeminiModel[];
@@ -23,22 +33,43 @@ export function setGeminiModels(newModels: GeminiModel[]): void {
 	GEMINI_MODELS.push(...newModels);
 }
 
-export function getDefaultModelForRole(role: ModelRole): string {
-	const modelForRole = GEMINI_MODELS.find((m) => m.defaultForRoles?.includes(role));
+/**
+ * Resolve the effective provider for a model entry. Entries without an
+ * explicit provider are treated as Gemini (legacy bundled list).
+ */
+export function getModelProvider(model: GeminiModel): ModelProvider {
+	return model.provider ?? 'gemini';
+}
+
+/**
+ * Returns the default model value for a given role, scoped to a provider.
+ * For Gemini, falls back to the first matching bundled model. For Ollama,
+ * falls back to the first available model since we don't ship a curated list.
+ */
+export function getDefaultModelForRole(role: ModelRole, provider: ModelProvider = 'gemini'): string {
+	const candidates = GEMINI_MODELS.filter((m) => getModelProvider(m) === provider);
+
+	const modelForRole = candidates.find((m) => m.defaultForRoles?.includes(role));
 	if (modelForRole) {
 		return modelForRole.value;
 	}
 
-	// If no specific default is found in GEMINI_MODELS, and assuming GEMINI_MODELS is never empty,
-	// fall back to the first model in the list.
+	if (candidates.length > 0) {
+		return candidates[0].value;
+	}
+
+	// No models for this provider yet (e.g. Ollama before /api/tags returns).
+	// Returning an empty string lets callers handle the unconfigured state
+	// rather than throwing at module load.
+	if (provider === 'ollama') {
+		return '';
+	}
+
+	// Gemini list should never be empty — that indicates a serious config problem.
 	if (GEMINI_MODELS.length > 0) {
-		// Note: No default model specified for role, falling back to first model in GEMINI_MODELS
 		return GEMINI_MODELS[0].value;
 	}
 
-	// This case should ideally be unreachable if GEMINI_MODELS is guaranteed to be non-empty.
-	// Adding a safeguard for an extremely unlikely scenario.
-	// This indicates a serious configuration problem.
 	throw new Error('CRITICAL: GEMINI_MODELS array is empty. Please configure available models.');
 }
 
@@ -49,20 +80,27 @@ export interface ModelUpdateResult {
 }
 
 export function getUpdatedModelSettings(currentSettings: any): ModelUpdateResult {
-	const availableModelValues = new Set(GEMINI_MODELS.map((m) => m.value));
+	const provider: ModelProvider = currentSettings?.provider === 'ollama' ? 'ollama' : 'gemini';
+	const availableModelValues = new Set(
+		GEMINI_MODELS.filter((m) => getModelProvider(m) === provider).map((m) => m.value)
+	);
 	let settingsChanged = false;
 	const changedSettingsInfo: string[] = [];
 	const newSettings = { ...currentSettings };
 
-	// Helper function to check if a model needs updating
+	// Helper function to check if a model needs updating.
+	// For Ollama we tolerate empty (the list may not have loaded yet) — only
+	// reset when the configured value is present but no longer in the list.
 	const needsUpdate = (modelName: string) => {
-		// Update if model is empty/undefined OR if the model is no longer available
-		return !modelName || !availableModelValues.has(modelName);
+		if (!modelName) {
+			return provider !== 'ollama';
+		}
+		return !availableModelValues.has(modelName);
 	};
 
-	// Check chat model - only update if truly needed
+	// Check chat model
 	if (needsUpdate(newSettings.chatModelName)) {
-		const newDefaultChat = getDefaultModelForRole('chat');
+		const newDefaultChat = getDefaultModelForRole('chat', provider);
 		if (newDefaultChat) {
 			changedSettingsInfo.push(
 				`Chat model: '${newSettings.chatModelName}' -> '${newDefaultChat}' (legacy model update)`
@@ -72,9 +110,9 @@ export function getUpdatedModelSettings(currentSettings: any): ModelUpdateResult
 		}
 	}
 
-	// Check summary model - only update if truly needed
+	// Check summary model
 	if (needsUpdate(newSettings.summaryModelName)) {
-		const newDefaultSummary = getDefaultModelForRole('summary');
+		const newDefaultSummary = getDefaultModelForRole('summary', provider);
 		if (newDefaultSummary) {
 			changedSettingsInfo.push(
 				`Summary model: '${newSettings.summaryModelName}' -> '${newDefaultSummary}' (legacy model update)`
@@ -84,9 +122,9 @@ export function getUpdatedModelSettings(currentSettings: any): ModelUpdateResult
 		}
 	}
 
-	// Check completions model - only update if truly needed
+	// Check completions model
 	if (needsUpdate(newSettings.completionsModelName)) {
-		const newDefaultCompletions = getDefaultModelForRole('completions');
+		const newDefaultCompletions = getDefaultModelForRole('completions', provider);
 		if (newDefaultCompletions) {
 			changedSettingsInfo.push(
 				`Completions model: '${newSettings.completionsModelName}' -> '${newDefaultCompletions}' (legacy model update)`
@@ -96,9 +134,9 @@ export function getUpdatedModelSettings(currentSettings: any): ModelUpdateResult
 		}
 	}
 
-	// Check image model - only update if truly needed
-	if (needsUpdate(newSettings.imageModelName)) {
-		const newDefaultImage = getDefaultModelForRole('image');
+	// Image generation is Gemini-only in Phase 1 — only reconcile when on Gemini.
+	if (provider === 'gemini' && needsUpdate(newSettings.imageModelName)) {
+		const newDefaultImage = getDefaultModelForRole('image', 'gemini');
 		if (newDefaultImage) {
 			changedSettingsInfo.push(
 				`Image model: '${newSettings.imageModelName}' -> '${newDefaultImage}' (legacy model update)`

--- a/src/models.ts
+++ b/src/models.ts
@@ -98,41 +98,30 @@ export function getUpdatedModelSettings(currentSettings: any): ModelUpdateResult
 		return !availableModelValues.has(modelName);
 	};
 
-	// Check chat model
-	if (needsUpdate(newSettings.chatModelName)) {
-		const newDefaultChat = getDefaultModelForRole('chat', provider);
-		if (newDefaultChat) {
-			changedSettingsInfo.push(
-				`Chat model: '${newSettings.chatModelName}' -> '${newDefaultChat}' (legacy model update)`
-			);
-			newSettings.chatModelName = newDefaultChat;
-			settingsChanged = true;
-		}
-	}
+	const reconcile = (
+		key: 'chatModelName' | 'summaryModelName' | 'completionsModelName',
+		role: ModelRole,
+		label: string
+	) => {
+		if (!needsUpdate(newSettings[key])) return;
+		const next = getDefaultModelForRole(role, provider);
+		// When the active provider has no default available (e.g. Ollama before
+		// /api/tags has resolved), clear the stale value so the factory falls
+		// through to its "no model selected" path instead of sending a
+		// cross-provider model name (e.g. `gemini-flash-latest` to Ollama).
+		const previous = newSettings[key];
+		newSettings[key] = next;
+		changedSettingsInfo.push(
+			next
+				? `${label}: '${previous}' -> '${next}' (legacy model update)`
+				: `${label}: cleared stale '${previous}' (no default for provider '${provider}')`
+		);
+		settingsChanged = true;
+	};
 
-	// Check summary model
-	if (needsUpdate(newSettings.summaryModelName)) {
-		const newDefaultSummary = getDefaultModelForRole('summary', provider);
-		if (newDefaultSummary) {
-			changedSettingsInfo.push(
-				`Summary model: '${newSettings.summaryModelName}' -> '${newDefaultSummary}' (legacy model update)`
-			);
-			newSettings.summaryModelName = newDefaultSummary;
-			settingsChanged = true;
-		}
-	}
-
-	// Check completions model
-	if (needsUpdate(newSettings.completionsModelName)) {
-		const newDefaultCompletions = getDefaultModelForRole('completions', provider);
-		if (newDefaultCompletions) {
-			changedSettingsInfo.push(
-				`Completions model: '${newSettings.completionsModelName}' -> '${newDefaultCompletions}' (legacy model update)`
-			);
-			newSettings.completionsModelName = newDefaultCompletions;
-			settingsChanged = true;
-		}
-	}
+	reconcile('chatModelName', 'chat', 'Chat model');
+	reconcile('summaryModelName', 'summary', 'Summary model');
+	reconcile('completionsModelName', 'completions', 'Completions model');
 
 	// Image generation is Gemini-only in Phase 1 — only reconcile when on Gemini.
 	if (provider === 'gemini' && needsUpdate(newSettings.imageModelName)) {

--- a/src/models.ts
+++ b/src/models.ts
@@ -65,11 +65,11 @@ export function getDefaultModelForRole(role: ModelRole, provider: ModelProvider 
 		return '';
 	}
 
-	// Gemini list should never be empty — that indicates a serious config problem.
-	if (GEMINI_MODELS.length > 0) {
-		return GEMINI_MODELS[0].value;
-	}
-
+	// Gemini list should never be empty (the bundled JSON is shipped). If it is,
+	// surface the configuration problem rather than falling through to
+	// `GEMINI_MODELS[0]` — when both providers populate that global,
+	// `GEMINI_MODELS[0]` could be an Ollama entry and we'd return a
+	// cross-provider model name as the Gemini default.
 	throw new Error('CRITICAL: GEMINI_MODELS array is empty. Please configure available models.');
 }
 

--- a/src/services/context-manager.ts
+++ b/src/services/context-manager.ts
@@ -98,8 +98,11 @@ export class ContextManager {
 		private logger: Logger
 	) {
 		// Only construct the Gemini SDK when the active provider is Gemini —
-		// Ollama runs locally and has no key, so the SDK is unused.
-		this.ai = plugin.settings.provider === 'gemini' ? new GoogleGenAI({ apiKey: plugin.apiKey }) : null;
+		// Ollama runs locally and has no key, so the SDK is unused. Default
+		// missing `provider` to 'gemini' so legacy/upgraded users don't fall
+		// into the Ollama estimation path with `this.ai` left null.
+		const provider = plugin.settings.provider ?? 'gemini';
+		this.ai = provider === 'gemini' ? new GoogleGenAI({ apiKey: plugin.apiKey }) : null;
 	}
 
 	/**
@@ -449,9 +452,13 @@ export class ContextManager {
 			// Ollama has no SDK instance here; route through the factory so we use
 			// whichever provider the user has configured.
 			if (this.plugin.settings.provider === 'ollama' || !this.ai) {
+				// Pass ModelUseCase.SUMMARY to the factory and let its
+				// resolveModelName populate the request — overriding `model`
+				// here would route compaction through the chat model on Ollama
+				// (where the client honours request.model over config.model)
+				// instead of the user's configured `summaryModelName`.
 				const summaryClient = GeminiClientFactory.createFromPlugin(this.plugin, ModelUseCase.SUMMARY);
 				const response = await summaryClient.generateModelResponse({
-					model: modelName,
 					prompt: fullPrompt,
 					temperature: 0.3,
 				});

--- a/src/services/context-manager.ts
+++ b/src/services/context-manager.ts
@@ -13,6 +13,7 @@
 import { GoogleGenAI } from '@google/genai';
 import { Logger } from '../utils/logger';
 import type ObsidianGemini from '../main';
+import { GeminiClientFactory, ModelUseCase } from '../api/simple-factory';
 
 // @ts-ignore
 import contextSummaryPromptContent from '../../prompts/contextSummaryPrompt.hbs';
@@ -22,6 +23,24 @@ const AGGRESSIVE_COMPACTION_THRESHOLD_PERCENT = 80;
 
 /** Default model input token limit (1M for all current Gemini models) */
 const DEFAULT_INPUT_TOKEN_LIMIT = 1_000_000;
+
+/**
+ * Conservative default input token limit for Ollama models. Local models vary
+ * widely (4k–128k); we pick a safe middle so compaction triggers before
+ * smaller models truncate. Users with larger-context models can let
+ * compaction happen later without harm.
+ */
+const OLLAMA_DEFAULT_INPUT_TOKEN_LIMIT = 32_000;
+
+/**
+ * Rough token-count estimate for providers that don't expose a countTokens
+ * endpoint (Ollama). Char/4 is the standard heuristic; drift vs. real tokens
+ * is acceptable here because we only use it to decide whether to compact.
+ */
+function estimateTokensFromContents(contents: any[]): number {
+	const json = JSON.stringify(contents ?? []);
+	return Math.ceil(json.length / 4);
+}
 
 /** Minimum number of recent turns to preserve during compaction */
 const MIN_RECENT_TURNS_TO_KEEP = 6;
@@ -72,13 +91,15 @@ export interface UsageMetadata {
 export class ContextManager {
 	private lastUsageMetadata: UsageMetadata | null = null;
 	private acceptNextLowerUpdate = false;
-	private ai: GoogleGenAI;
+	private ai: GoogleGenAI | null;
 
 	constructor(
 		private plugin: ObsidianGemini,
 		private logger: Logger
 	) {
-		this.ai = new GoogleGenAI({ apiKey: plugin.apiKey });
+		// Only construct the Gemini SDK when the active provider is Gemini —
+		// Ollama runs locally and has no key, so the SDK is unused.
+		this.ai = plugin.settings.provider === 'gemini' ? new GoogleGenAI({ apiKey: plugin.apiKey }) : null;
 	}
 
 	/**
@@ -140,6 +161,9 @@ export class ContextManager {
 	 * Get the input token limit for a given model.
 	 */
 	private async getInputTokenLimit(_modelName: string): Promise<number> {
+		if (this.plugin.settings.provider === 'ollama') {
+			return OLLAMA_DEFAULT_INPUT_TOKEN_LIMIT;
+		}
 		return DEFAULT_INPUT_TOKEN_LIMIT;
 	}
 
@@ -220,15 +244,24 @@ export class ContextManager {
 	}
 
 	/**
-	 * Count tokens for a given set of contents using the Gemini API.
+	 * Count tokens for a given set of contents.
+	 *
+	 * For Gemini, calls the SDK's countTokens endpoint. For Ollama (which has no
+	 * equivalent API) we fall back to a chars/4 estimate — compaction precision
+	 * is degraded but the trigger logic still works.
 	 */
 	async countTokens(modelName: string, contents: any[]): Promise<number> {
+		// Sanitize contents to only include text-compatible parts
+		const sanitizedContents = this.sanitizeContentsForTokenCount(contents);
+
+		if (this.plugin.settings.provider === 'ollama' || !this.ai) {
+			const estimate = estimateTokensFromContents(sanitizedContents);
+			this.logger.log(`[ContextManager] countTokens (Ollama estimate): ${estimate}`);
+			return estimate;
+		}
+
 		try {
 			const config: any = {};
-
-			// Sanitize contents to only include text-compatible parts
-			const sanitizedContents = this.sanitizeContentsForTokenCount(contents);
-
 			const response = await this.ai.models.countTokens({
 				model: modelName,
 				contents: sanitizedContents,
@@ -410,11 +443,29 @@ export class ContextManager {
 			.join('\n\n');
 
 		const summaryPrompt = contextSummaryPromptContent;
+		const fullPrompt = `${summaryPrompt}\n\n---\n\nConversation to summarize:\n\n${conversationText}`;
 
 		try {
+			// Ollama has no SDK instance here; route through the factory so we use
+			// whichever provider the user has configured.
+			if (this.plugin.settings.provider === 'ollama' || !this.ai) {
+				const summaryClient = GeminiClientFactory.createFromPlugin(this.plugin, ModelUseCase.SUMMARY);
+				const response = await summaryClient.generateModelResponse({
+					model: modelName,
+					prompt: fullPrompt,
+					temperature: 0.3,
+				});
+				const summary = response.markdown?.trim();
+				if (!summary) {
+					this.logger.warn('[ContextManager] Summary generation returned empty result');
+					return 'Previous conversation context could not be summarized. The conversation continues below.';
+				}
+				return summary;
+			}
+
 			const response = await this.ai.models.generateContent({
 				model: modelName,
-				contents: `${summaryPrompt}\n\n---\n\nConversation to summarize:\n\n${conversationText}`,
+				contents: fullPrompt,
 				config: {
 					temperature: 0.3, // Low temperature for factual summarization
 					maxOutputTokens: 4096,

--- a/src/services/generated-help-references.ts
+++ b/src/services/generated-help-references.ts
@@ -18,6 +18,7 @@ import refDeepResearch from '../../docs/guide/deep-research.md';
 import refFaq from '../../docs/guide/faq.md';
 import refGettingStarted from '../../docs/guide/getting-started.md';
 import refMcpServers from '../../docs/guide/mcp-servers.md';
+import refOllamaSetup from '../../docs/guide/ollama-setup.md';
 import refProjects from '../../docs/guide/projects.md';
 import refScheduledTasks from '../../docs/guide/scheduled-tasks.md';
 import refSelectionPrompts from '../../docs/guide/selection-prompts.md';
@@ -39,6 +40,7 @@ export const helpResources = new Map<string, string>([
 	['references/faq.md', refFaq],
 	['references/getting-started.md', refGettingStarted],
 	['references/mcp-servers.md', refMcpServers],
+	['references/ollama-setup.md', refOllamaSetup],
 	['references/projects.md', refProjects],
 	['references/scheduled-tasks.md', refScheduledTasks],
 	['references/selection-prompts.md', refSelectionPrompts],
@@ -62,6 +64,7 @@ export const helpReferencesTable = `| Reference | Topic |
 | \`references/faq.md\` | Frequently Asked Questions |
 | \`references/getting-started.md\` | Getting Started |
 | \`references/mcp-servers.md\` | MCP Servers |
+| \`references/ollama-setup.md\` | Ollama (Local Models) |
 | \`references/projects.md\` | Projects |
 | \`references/scheduled-tasks.md\` | Scheduled Tasks |
 | \`references/selection-prompts.md\` | Selection Prompts |

--- a/src/services/image-generation.ts
+++ b/src/services/image-generation.ts
@@ -273,26 +273,13 @@ export class ImageGeneration {
 	}
 
 	/**
-	 * Setup command palette command for image generation
+	 * Prompt the user to enter an image description.
+	 *
+	 * Public because the command-palette entry for image generation lives in
+	 * `main.ts` (so the provider gate stays consistent with the RAG commands)
+	 * and drives this dialog directly.
 	 */
-	async setupImageGenerationCommand() {
-		this.plugin.addCommand({
-			id: 'gemini-scribe-generate-image',
-			name: 'Generate Image',
-			callback: async () => {
-				// Prompt user for image description
-				const prompt = await this.promptForImageDescription();
-				if (prompt) {
-					await this.generateAndInsertImage(prompt);
-				}
-			},
-		});
-	}
-
-	/**
-	 * Prompt the user to enter an image description
-	 */
-	private async promptForImageDescription(): Promise<string | null> {
+	async promptForImageDescription(): Promise<string | null> {
 		return new Promise((resolve) => {
 			const modal = new ImagePromptModal(this.plugin.app, this.plugin, this, (prompt) => {
 				resolve(prompt);

--- a/src/services/lifecycle-service.ts
+++ b/src/services/lifecycle-service.ts
@@ -469,10 +469,13 @@ export class LifecycleService {
 		// Deep research
 		plugin.deepResearch = new DeepResearchService(plugin);
 
-		// Image generation (Gemini-only — Ollama has no image generation API)
+		// Image generation service is Gemini-only — Ollama has no image-gen API.
+		// The command-palette entry is registered unconditionally in main.ts so
+		// it shows a clear "not available" notice on the Ollama path instead of
+		// silently disappearing or pointing at an orphaned closure after a
+		// runtime provider switch.
 		if (plugin.settings.provider !== 'ollama') {
 			plugin.imageGeneration = new ImageGeneration(plugin);
-			await plugin.imageGeneration.setupImageGenerationCommand();
 		}
 
 		// Selection actions

--- a/src/services/lifecycle-service.ts
+++ b/src/services/lifecycle-service.ts
@@ -117,9 +117,13 @@ export class LifecycleService {
 			plugin.mcpManager = null;
 		}
 
-		// Null out completions and summarizer for garbage collection
+		// Null out completions, summarizer, and image generation for gc.
+		// Nulling imageGeneration here is what allows a Gemini → Ollama provider
+		// switch to drop the old Gemini-only instance; the new setup() phase
+		// then creates one only if the active provider supports it.
 		plugin.completions = null;
 		plugin.summarizer = null;
+		plugin.imageGeneration = null;
 
 		// Note: We don't clean up history, sessionManager, etc. as they
 		// maintain user data that should persist across re-initializations

--- a/src/services/lifecycle-service.ts
+++ b/src/services/lifecycle-service.ts
@@ -235,6 +235,19 @@ export class LifecycleService {
 	async initializeRagIndexing(): Promise<void> {
 		const plugin = this.plugin;
 
+		// RAG uses Gemini's File Search Store cloud API — not available on Ollama in Phase 1.
+		if (plugin.settings.provider === 'ollama') {
+			if (plugin.ragIndexing) {
+				const { getRagTools } = await import('../tools/rag-search-tool');
+				for (const tool of getRagTools()) {
+					plugin.toolRegistry?.unregisterTool(tool.name);
+				}
+				await plugin.ragIndexing.destroy();
+				plugin.ragIndexing = null;
+			}
+			return;
+		}
+
 		if (plugin.settings.ragIndexing.enabled) {
 			// Clean up existing instance if re-initializing
 			if (plugin.ragIndexing) {
@@ -419,7 +432,7 @@ export class LifecycleService {
 		// Tool system
 		plugin.toolRegistry = new ToolRegistry(plugin);
 		plugin.toolExecutionEngine = new ToolExecutionEngine(plugin, plugin.toolRegistry);
-		await this.toolRegistrar.registerAll(plugin.toolRegistry, plugin.logger);
+		await this.toolRegistrar.registerAll(plugin.toolRegistry, plugin.logger, plugin);
 
 		// Folder and skill management
 		plugin.folderInitializer = new FolderInitializer(plugin);
@@ -452,9 +465,11 @@ export class LifecycleService {
 		// Deep research
 		plugin.deepResearch = new DeepResearchService(plugin);
 
-		// Image generation
-		plugin.imageGeneration = new ImageGeneration(plugin);
-		await plugin.imageGeneration.setupImageGenerationCommand();
+		// Image generation (Gemini-only — Ollama has no image generation API)
+		if (plugin.settings.provider !== 'ollama') {
+			plugin.imageGeneration = new ImageGeneration(plugin);
+			await plugin.imageGeneration.setupImageGenerationCommand();
+		}
 
 		// Selection actions
 		plugin.selectionActionService = new SelectionActionService(plugin);

--- a/src/services/model-manager.ts
+++ b/src/services/model-manager.ts
@@ -108,10 +108,22 @@ export class ModelManager {
 	}
 
 	/**
+	 * Returns the active provider's full model list (text + image) for the parameter helpers.
+	 * Provider-aware so e.g. Ollama models are validated against their own metadata
+	 * rather than the bundled Gemini list.
+	 */
+	private async getModelsForActiveProvider(): Promise<GeminiModel[]> {
+		if (this.plugin.settings.provider === 'ollama') {
+			return this.ollamaModelsService.getModels();
+		}
+		return this.listProvider.getModels();
+	}
+
+	/**
 	 * Get parameter ranges based on available models.
 	 */
 	async getParameterRanges(): Promise<ParameterRanges> {
-		return ParameterValidationService.getParameterRanges(this.listProvider.getModels());
+		return ParameterValidationService.getParameterRanges(await this.getModelsForActiveProvider());
 	}
 
 	/**
@@ -124,7 +136,7 @@ export class ModelManager {
 		temperature: { isValid: boolean; adjustedValue?: number; warning?: string };
 		topP: { isValid: boolean; adjustedValue?: number; warning?: string };
 	}> {
-		const models = this.listProvider.getModels();
+		const models = await this.getModelsForActiveProvider();
 		return {
 			temperature: ParameterValidationService.validateTemperature(temperature, undefined, models),
 			topP: ParameterValidationService.validateTopP(topP, undefined, models),
@@ -139,7 +151,7 @@ export class ModelManager {
 		topP: string;
 		hasModelData: boolean;
 	}> {
-		return ParameterValidationService.getParameterDisplayInfo(this.listProvider.getModels());
+		return ParameterValidationService.getParameterDisplayInfo(await this.getModelsForActiveProvider());
 	}
 
 	/**

--- a/src/services/model-manager.ts
+++ b/src/services/model-manager.ts
@@ -2,6 +2,7 @@ import type ObsidianGemini from '../main';
 import * as modelsModule from '../models';
 import { GeminiModel, ModelUpdateResult, getUpdatedModelSettings, DEFAULT_GEMINI_MODELS } from '../models';
 import { ModelListProvider } from './model-list-provider';
+import { OllamaModelsService } from './ollama-models-service';
 import { ParameterValidationService, ParameterRanges } from './parameter-validation';
 
 export interface ModelUpdateOptions {
@@ -12,32 +13,50 @@ export interface ModelUpdateOptions {
 export class ModelManager {
 	private plugin: ObsidianGemini;
 	private listProvider: ModelListProvider;
+	private ollamaModelsService: OllamaModelsService;
 	private static staticModels: GeminiModel[] = [...DEFAULT_GEMINI_MODELS];
 
 	constructor(plugin: ObsidianGemini) {
 		this.plugin = plugin;
 		this.listProvider = new ModelListProvider(plugin);
+		this.ollamaModelsService = new OllamaModelsService(plugin);
 	}
 
 	/**
-	 * Get current text/chat models (excludes image generation models).
+	 * Get current text/chat models (excludes image generation models). Provider-aware:
+	 * returns Ollama tags when provider === 'ollama', Gemini bundled+remote otherwise.
 	 */
-	async getAvailableModels(_options: ModelUpdateOptions = {}): Promise<GeminiModel[]> {
+	async getAvailableModels(options: ModelUpdateOptions = {}): Promise<GeminiModel[]> {
+		if (this.plugin.settings.provider === 'ollama') {
+			return this.ollamaModelsService.getModels(options.forceRefresh);
+		}
 		return this.listProvider.getTextModels();
 	}
 
 	/**
-	 * Get image generation models.
+	 * Get image generation models. Phase-1 Ollama support omits image generation, so
+	 * this always returns the Gemini list — the image-model dropdown is hidden in the
+	 * UI when Ollama is the active provider.
 	 */
 	async getImageGenerationModels(): Promise<GeminiModel[]> {
 		return this.listProvider.getImageModels();
 	}
 
 	/**
-	 * Update the global GEMINI_MODELS list from the provider and fix any stale settings.
+	 * Get the Ollama models service for direct interaction (e.g. cache refresh).
 	 */
-	async updateModels(_options: ModelUpdateOptions = {}): Promise<ModelUpdateResult> {
-		const allModels = this.listProvider.getModels();
+	getOllamaModelsService(): OllamaModelsService {
+		return this.ollamaModelsService;
+	}
+
+	/**
+	 * Update the global GEMINI_MODELS list from the active provider and fix any stale settings.
+	 */
+	async updateModels(options: ModelUpdateOptions = {}): Promise<ModelUpdateResult> {
+		const allModels =
+			this.plugin.settings.provider === 'ollama'
+				? await this.ollamaModelsService.getModels(options.forceRefresh)
+				: this.listProvider.getModels();
 		const previousModels = this.getCurrentGeminiModels();
 
 		const hasChanges = this.detectModelChanges(allModels, previousModels);
@@ -55,17 +74,23 @@ export class ModelManager {
 	}
 
 	/**
-	 * Initialize the model manager: load cached remote data and start background fetch.
+	 * Initialize the model manager: load cached data and start background fetch.
 	 */
 	async initialize(): Promise<void> {
 		this.listProvider.initialize();
 
-		// Sync global GEMINI_MODELS with the provider's list
-		const allModels = this.listProvider.getModels();
-		this.updateGlobalModelsList(allModels);
+		if (this.plugin.settings.provider === 'ollama') {
+			// Populate GEMINI_MODELS with Ollama tags (best-effort; daemon may be down).
+			const ollamaModels = await this.ollamaModelsService.getModels();
+			this.updateGlobalModelsList(ollamaModels);
+		} else {
+			// Sync global GEMINI_MODELS with the bundled/remote Gemini list
+			const allModels = this.listProvider.getModels();
+			this.updateGlobalModelsList(allModels);
 
-		// Start non-blocking remote fetch for updates
-		this.listProvider.startRemoteFetch();
+			// Start non-blocking remote fetch for updates
+			this.listProvider.startRemoteFetch();
+		}
 	}
 
 	/**

--- a/src/services/ollama-models-service.ts
+++ b/src/services/ollama-models-service.ts
@@ -5,15 +5,26 @@ import { GeminiModel } from '../models';
 /**
  * Models that Ollama exposes for completions are tiny by convention. We pre-bias
  * known small models toward the completions role; everything else stays available
- * for chat / summary / rewrite.
+ * for chat / summary / rewrite. Patterns are matched with digit-aware boundaries
+ * so e.g. `1b` does not bleed into `11b` and bias `llava:13b` toward completions.
  */
-const COMPLETION_NAME_HINTS = ['mini', 'tiny', '1b', '3b', '0.5b', '1.5b', 'lite'];
+const COMPLETION_NAME_HINT_PATTERNS = [
+	/(?<!\d)0\.5b(?!\d)/i,
+	/(?<!\d)1\.5b(?!\d)/i,
+	/(?<!\d)1b(?!\d)/i,
+	/(?<!\d)3b(?!\d)/i,
+	/\bmini\b/i,
+	/\btiny\b/i,
+	/\blite\b/i,
+];
 
 /**
  * Models known to support vision (image input). Used as a hint only — Ollama
  * does not expose this in /api/tags, so we pattern-match on the family.
  */
 const VISION_NAME_HINTS = ['llava', 'bakllava', 'vision', 'moondream', 'qwen2-vl', 'qwen2.5-vl', 'minicpm-v'];
+
+const OLLAMA_DEFAULT_BASE_URL = 'http://localhost:11434';
 
 interface OllamaTagsModel {
 	name: string;
@@ -53,7 +64,9 @@ export class OllamaModelsService {
 	 * Cache is invalidated when the base URL changes.
 	 */
 	async getModels(forceRefresh = false): Promise<GeminiModel[]> {
-		const baseUrl = this.plugin.settings.ollamaBaseUrl;
+		// Mirror the runtime client's fallback so model refresh and generation
+		// target the same daemon when the user has cleared the field.
+		const baseUrl = this.plugin.settings.ollamaBaseUrl || OLLAMA_DEFAULT_BASE_URL;
 		if (!forceRefresh && this.cachedModels && this.lastBaseUrl === baseUrl) {
 			return this.cachedModels;
 		}
@@ -96,7 +109,7 @@ export class OllamaModelsService {
 	private toGeminiModel(m: OllamaTagsModel): GeminiModel {
 		const name = m.name;
 		const lower = name.toLowerCase();
-		const isCompletion = COMPLETION_NAME_HINTS.some((h) => lower.includes(h));
+		const isCompletion = COMPLETION_NAME_HINT_PATTERNS.some((re) => re.test(lower));
 		const isVision = VISION_NAME_HINTS.some((h) => lower.includes(h));
 
 		const defaultForRoles = isCompletion ? (['completions'] as const) : undefined;

--- a/src/services/ollama-models-service.ts
+++ b/src/services/ollama-models-service.ts
@@ -67,7 +67,8 @@ export class OllamaModelsService {
 		// Mirror the runtime client's fallback so model refresh and generation
 		// target the same daemon when the user has cleared the field.
 		const baseUrl = this.plugin.settings.ollamaBaseUrl || OLLAMA_DEFAULT_BASE_URL;
-		if (!forceRefresh && this.cachedModels && this.lastBaseUrl === baseUrl) {
+		const cacheMatchesBaseUrl = this.lastBaseUrl === baseUrl;
+		if (!forceRefresh && this.cachedModels && cacheMatchesBaseUrl) {
 			return this.cachedModels;
 		}
 
@@ -99,8 +100,11 @@ export class OllamaModelsService {
 			// Don't poison the cache with an empty array — that would stick until
 			// the user manually clicks "Refresh" even after the daemon comes back.
 			// Returning the previous cache (or an empty list as a non-cached
-			// fallback) lets a subsequent automatic call retry the fetch.
-			return this.cachedModels ?? [];
+			// fallback) lets a subsequent automatic call retry the fetch. But only
+			// reuse the cache when it matches the active base URL — falling back to
+			// another daemon's models would let the dropdown surface entries that
+			// don't exist on the new daemon and let the user save invalid selections.
+			return cacheMatchesBaseUrl ? (this.cachedModels ?? []) : [];
 		}
 	}
 

--- a/src/services/ollama-models-service.ts
+++ b/src/services/ollama-models-service.ts
@@ -1,0 +1,121 @@
+import { requestUrl } from 'obsidian';
+import type ObsidianGemini from '../main';
+import { GeminiModel } from '../models';
+
+/**
+ * Models that Ollama exposes for completions are tiny by convention. We pre-bias
+ * known small models toward the completions role; everything else stays available
+ * for chat / summary / rewrite.
+ */
+const COMPLETION_NAME_HINTS = ['mini', 'tiny', '1b', '3b', '0.5b', '1.5b', 'lite'];
+
+/**
+ * Models known to support vision (image input). Used as a hint only — Ollama
+ * does not expose this in /api/tags, so we pattern-match on the family.
+ */
+const VISION_NAME_HINTS = ['llava', 'bakllava', 'vision', 'moondream', 'qwen2-vl', 'qwen2.5-vl', 'minicpm-v'];
+
+interface OllamaTagsModel {
+	name: string;
+	model?: string;
+	size?: number;
+	modified_at?: string;
+	details?: {
+		parameter_size?: string;
+		family?: string;
+		families?: string[];
+	};
+}
+
+interface OllamaTagsResponse {
+	models: OllamaTagsModel[];
+}
+
+/**
+ * Fetches the list of locally available models from an Ollama server's
+ * `/api/tags` endpoint and returns them as `GeminiModel` entries that can
+ * be merged into the global model list.
+ *
+ * Uses Obsidian's `requestUrl` so the call works on both desktop and mobile
+ * without CORS preflight issues.
+ */
+export class OllamaModelsService {
+	private plugin: ObsidianGemini;
+	private cachedModels: GeminiModel[] | null = null;
+	private lastBaseUrl: string | null = null;
+
+	constructor(plugin: ObsidianGemini) {
+		this.plugin = plugin;
+	}
+
+	/**
+	 * Returns the cached model list if available, otherwise fetches fresh.
+	 * Cache is invalidated when the base URL changes.
+	 */
+	async getModels(forceRefresh = false): Promise<GeminiModel[]> {
+		const baseUrl = this.plugin.settings.ollamaBaseUrl;
+		if (!forceRefresh && this.cachedModels && this.lastBaseUrl === baseUrl) {
+			return this.cachedModels;
+		}
+
+		try {
+			const url = `${baseUrl.replace(/\/$/, '')}/api/tags`;
+			const response = await requestUrl({ url, method: 'GET', throw: false });
+
+			if (response.status !== 200) {
+				throw new Error(`Ollama /api/tags returned HTTP ${response.status}`);
+			}
+
+			const data = response.json as OllamaTagsResponse;
+			if (!data || !Array.isArray(data.models)) {
+				throw new Error('Invalid /api/tags response shape');
+			}
+
+			this.cachedModels = data.models.map((m) => this.toGeminiModel(m));
+			this.lastBaseUrl = baseUrl;
+			this.plugin.logger.log(`[OllamaModelsService] Loaded ${this.cachedModels.length} models from ${baseUrl}`);
+			return this.cachedModels;
+		} catch (error) {
+			this.plugin.logger.warn('[OllamaModelsService] Failed to fetch model list:', error);
+			// Cache an empty list so we don't hammer a down server, but tag with the
+			// base URL so a successful retry later replaces it.
+			this.cachedModels = [];
+			this.lastBaseUrl = baseUrl;
+			return [];
+		}
+	}
+
+	/**
+	 * Drop the cache (e.g. when the base URL changes or the user clicks "Refresh").
+	 */
+	invalidate(): void {
+		this.cachedModels = null;
+		this.lastBaseUrl = null;
+	}
+
+	private toGeminiModel(m: OllamaTagsModel): GeminiModel {
+		const name = m.name;
+		const lower = name.toLowerCase();
+		const isCompletion = COMPLETION_NAME_HINTS.some((h) => lower.includes(h));
+		const isVision = VISION_NAME_HINTS.some((h) => lower.includes(h));
+
+		const defaultForRoles = isCompletion ? (['completions'] as const) : undefined;
+
+		return {
+			value: name,
+			label: this.formatLabel(m),
+			provider: 'ollama',
+			supportsTools: true,
+			supportsVision: isVision,
+			...(defaultForRoles && { defaultForRoles: [...defaultForRoles] }),
+		};
+	}
+
+	private formatLabel(m: OllamaTagsModel): string {
+		const param = m.details?.parameter_size;
+		if (param) {
+			return `${m.name} (${param})`;
+		}
+		return m.name;
+	}
+}

--- a/src/services/ollama-models-service.ts
+++ b/src/services/ollama-models-service.ts
@@ -72,6 +72,12 @@ export class OllamaModelsService {
 		}
 
 		try {
+			// Deliberately no retry/backoff here. The Ollama daemon is local; the
+			// dominant failure mode is `ECONNREFUSED` against `localhost:11434`,
+			// which is permanent until the user runs `ollama serve` — retrying
+			// would just delay the actionable error by 6–14s. Settings → Refresh
+			// model list provides the recovery path. Mirrors ModelListProvider's
+			// best-effort + manual-refresh pattern for the bundled Gemini list.
 			const url = `${baseUrl.replace(/\/$/, '')}/api/tags`;
 			const response = await requestUrl({ url, method: 'GET', throw: false });
 

--- a/src/services/ollama-models-service.ts
+++ b/src/services/ollama-models-service.ts
@@ -90,11 +90,11 @@ export class OllamaModelsService {
 			return this.cachedModels;
 		} catch (error) {
 			this.plugin.logger.warn('[OllamaModelsService] Failed to fetch model list:', error);
-			// Cache an empty list so we don't hammer a down server, but tag with the
-			// base URL so a successful retry later replaces it.
-			this.cachedModels = [];
-			this.lastBaseUrl = baseUrl;
-			return [];
+			// Don't poison the cache with an empty array — that would stick until
+			// the user manually clicks "Refresh" even after the daemon comes back.
+			// Returning the previous cache (or an empty list as a non-cached
+			// fallback) lets a subsequent automatic call retry the fetch.
+			return this.cachedModels ?? [];
 		}
 	}
 

--- a/src/services/tool-registrar.ts
+++ b/src/services/tool-registrar.ts
@@ -2,9 +2,13 @@ import { ToolRegistry } from '../tools/tool-registry';
 import { Tool } from '../tools/types';
 import { Logger } from '../utils/logger';
 import { getVaultTools } from '../tools/vault';
+import type ObsidianGemini from '../main';
+import type { ModelProvider } from '../models';
 
 interface ToolSource {
 	name: string;
+	/** Providers this tool source supports. Defaults to all providers if omitted. */
+	providers?: ModelProvider[];
 	getTools: () => Tool[] | Promise<Tool[]>;
 }
 
@@ -12,6 +16,9 @@ interface ToolSource {
  * Manages the canonical list of tool sources and handles bulk
  * registration/unregistration. Eliminates duplication between
  * setupGeminiScribe() and teardownGeminiScribe().
+ *
+ * Provider-coupled sources (web tools backed by Gemini search/URL-context,
+ * image generation) are skipped when the active provider is Ollama.
  *
  * RAG tools are excluded — they have independent lifecycle
  * (toggled without full re-init).
@@ -23,9 +30,17 @@ export class ToolRegistrar {
 			name: 'vault-extended',
 			getTools: () => import('../tools/vault-tools-extended').then((m) => m.getExtendedVaultTools()),
 		},
-		{ name: 'web', getTools: () => import('../tools/web-tools').then((m) => m.getWebTools()) },
+		{
+			name: 'web',
+			providers: ['gemini'],
+			getTools: () => import('../tools/web-tools').then((m) => m.getWebTools()),
+		},
 		{ name: 'memory', getTools: () => import('../tools/memory-tool').then((m) => m.getMemoryTools()) },
-		{ name: 'image', getTools: () => import('../tools/image-tools').then((m) => m.getImageTools()) },
+		{
+			name: 'image',
+			providers: ['gemini'],
+			getTools: () => import('../tools/image-tools').then((m) => m.getImageTools()),
+		},
 		{ name: 'skill', getTools: () => import('../tools/skill-tools').then((m) => m.getSkillTools()) },
 		{
 			name: 'session-recall',
@@ -33,8 +48,13 @@ export class ToolRegistrar {
 		},
 	];
 
-	async registerAll(registry: ToolRegistry, logger: Logger): Promise<void> {
-		for (const source of ToolRegistrar.CORE_SOURCES) {
+	private static activeSources(plugin: ObsidianGemini): ToolSource[] {
+		const provider = plugin.settings.provider ?? 'gemini';
+		return ToolRegistrar.CORE_SOURCES.filter((s) => !s.providers || s.providers.includes(provider));
+	}
+
+	async registerAll(registry: ToolRegistry, logger: Logger, plugin: ObsidianGemini): Promise<void> {
+		for (const source of ToolRegistrar.activeSources(plugin)) {
 			try {
 				const tools = await source.getTools();
 				for (const tool of tools) {
@@ -47,6 +67,8 @@ export class ToolRegistrar {
 	}
 
 	async unregisterAll(registry: ToolRegistry, logger: Logger): Promise<void> {
+		// Unregister every known source, regardless of provider, so a provider
+		// switch cleanly removes the tools that were registered under the old one.
 		for (const source of ToolRegistrar.CORE_SOURCES) {
 			try {
 				const tools = await source.getTools();

--- a/src/ui/settings-general.ts
+++ b/src/ui/settings-general.ts
@@ -33,28 +33,86 @@ export async function renderGeneralSettings(containerEl: HTMLElement, plugin: Ob
 		);
 
 	new Setting(containerEl)
-		.setName('API Key')
+		.setName('Provider')
 		.setDesc(
-			'Link your Google Gemini API key. Click "Link..." and Obsidian will ask for a Secret Name (this is just a label — use any name like "gemini-api") and a Secret Value (paste your API key here). Get a key free at https://aistudio.google.com/apikey'
+			'Choose the model provider. Gemini uses the Google cloud API. Ollama runs models locally on your machine; install from https://ollama.com and pull a model with `ollama pull <name>`.'
 		)
-		.addComponent((el) =>
-			new SecretComponent(app, el).setValue(plugin.settings.apiKeySecretName).onChange(async (secretName) => {
-				plugin.settings.apiKeySecretName = secretName;
-				await plugin.saveSettings();
-			})
+		.addDropdown((dropdown) =>
+			dropdown
+				.addOption('gemini', 'Google Gemini (cloud)')
+				.addOption('ollama', 'Ollama (local)')
+				.setValue(plugin.settings.provider)
+				.onChange(async (value) => {
+					plugin.settings.provider = value as 'gemini' | 'ollama';
+					await plugin.saveSettings();
+					// Re-render the settings tab so provider-specific fields show/hide.
+					containerEl.empty();
+					await renderGeneralSettings(containerEl, plugin, app);
+				})
 		);
 
-	// Add note about model version filtering
-	new Setting(containerEl)
-		.setName('Model Versions')
-		.setDesc(
-			'ℹ️ Only Gemini 2.5+ models are shown. Older model versions have been deprecated by Google and are no longer supported.'
-		)
-		.addButton((button) =>
-			button.setButtonText('Learn More').onClick(() => {
-				window.open('https://ai.google.dev/gemini-api/docs/models/gemini');
-			})
-		);
+	if (plugin.settings.provider === 'ollama') {
+		new Setting(containerEl)
+			.setName('Ollama Base URL')
+			.setDesc('HTTP endpoint of your local Ollama daemon. Default is http://localhost:11434.')
+			.addText((text) =>
+				text
+					.setPlaceholder('http://localhost:11434')
+					.setValue(plugin.settings.ollamaBaseUrl)
+					.onChange((value) => {
+						plugin.settings.ollamaBaseUrl = value.trim() || 'http://localhost:11434';
+						debouncedSave();
+					})
+			);
+
+		new Setting(containerEl)
+			.setName('Refresh model list')
+			.setDesc('Re-query the Ollama daemon for available models.')
+			.addButton((button) =>
+				button.setButtonText('Refresh').onClick(async () => {
+					try {
+						const manager = plugin.getModelManager();
+						manager.getOllamaModelsService().invalidate();
+						const models = await manager.getAvailableModels({ forceRefresh: true });
+						new Notice(`Found ${models.length} Ollama model${models.length === 1 ? '' : 's'}.`);
+						containerEl.empty();
+						await renderGeneralSettings(containerEl, plugin, app);
+					} catch (error) {
+						new Notice(`Failed to refresh: ${getErrorMessage(error)}`);
+					}
+				})
+			);
+
+		new Setting(containerEl)
+			.setName('Local-only feature notice')
+			.setDesc(
+				'Google Search, URL Context (web fetch), Deep Research, image generation, and RAG indexing are unavailable when using Ollama. They rely on Gemini built-in services.'
+			);
+	} else {
+		new Setting(containerEl)
+			.setName('API Key')
+			.setDesc(
+				'Link your Google Gemini API key. Click "Link..." and Obsidian will ask for a Secret Name (this is just a label — use any name like "gemini-api") and a Secret Value (paste your API key here). Get a key free at https://aistudio.google.com/apikey'
+			)
+			.addComponent((el) =>
+				new SecretComponent(app, el).setValue(plugin.settings.apiKeySecretName).onChange(async (secretName) => {
+					plugin.settings.apiKeySecretName = secretName;
+					await plugin.saveSettings();
+				})
+			);
+
+		// Add note about model version filtering
+		new Setting(containerEl)
+			.setName('Model Versions')
+			.setDesc(
+				'ℹ️ Only Gemini 2.5+ models are shown. Older model versions have been deprecated by Google and are no longer supported.'
+			)
+			.addButton((button) =>
+				button.setButtonText('Learn More').onClick(() => {
+					window.open('https://ai.google.dev/gemini-api/docs/models/gemini');
+				})
+			);
+	}
 
 	await selectModelSetting(
 		containerEl,
@@ -77,14 +135,16 @@ export async function renderGeneralSettings(containerEl: HTMLElement, plugin: Ob
 		'Completion Model',
 		'Model used for IDE-style inline completions as you type in notes.'
 	);
-	await selectModelSetting(
-		containerEl,
-		plugin,
-		'imageModelName',
-		'Image Model',
-		'Model used for image generation.',
-		'image'
-	);
+	if (plugin.settings.provider === 'gemini') {
+		await selectModelSetting(
+			containerEl,
+			plugin,
+			'imageModelName',
+			'Image Model',
+			'Model used for image generation.',
+			'image'
+		);
+	}
 
 	new Setting(containerEl)
 		.setName('Summary Frontmatter Key')

--- a/src/ui/settings-helpers.ts
+++ b/src/ui/settings-helpers.ts
@@ -8,7 +8,11 @@ export async function selectModelSetting(
 	plugin: ObsidianGemini,
 	settingName: NonNullable<
 		{
-			[K in keyof ObsidianGeminiSettings]: ObsidianGeminiSettings[K] extends string ? K : never;
+			// Reverse `extends` so we only match keys whose type is the broad
+			// `string` (e.g. `chatModelName`), not literal unions like
+			// `provider: 'gemini' | 'ollama'` which would otherwise pass the
+			// forward-extends check and break the assignment below.
+			[K in keyof ObsidianGeminiSettings]: string extends ObsidianGeminiSettings[K] ? K : never;
 		}[keyof ObsidianGeminiSettings]
 	>,
 	label: string,
@@ -58,7 +62,7 @@ export async function selectModelSetting(
 				plugin.logger.warn(
 					`${label}: Current value "${currentValue}" not found in available models. Defaulting to "${defaultValue}"`
 				);
-				(plugin.settings as any)[settingName] = defaultValue;
+				(plugin.settings as ObsidianGeminiSettings)[settingName] = defaultValue;
 				dropdown.setValue(defaultValue);
 				// Save the corrected setting
 				plugin.saveSettings().catch((e) => plugin.logger.error(`Failed to save corrected ${label} setting:`, e));
@@ -67,7 +71,7 @@ export async function selectModelSetting(
 			}
 
 			dropdown.onChange(async (value) => {
-				(plugin.settings as any)[settingName] = value;
+				(plugin.settings as ObsidianGeminiSettings)[settingName] = value;
 				await plugin.saveSettings();
 			});
 			return dropdown;

--- a/src/ui/settings-helpers.ts
+++ b/src/ui/settings-helpers.ts
@@ -58,7 +58,7 @@ export async function selectModelSetting(
 				plugin.logger.warn(
 					`${label}: Current value "${currentValue}" not found in available models. Defaulting to "${defaultValue}"`
 				);
-				(plugin.settings as ObsidianGeminiSettings)[settingName] = defaultValue;
+				(plugin.settings as any)[settingName] = defaultValue;
 				dropdown.setValue(defaultValue);
 				// Save the corrected setting
 				plugin.saveSettings().catch((e) => plugin.logger.error(`Failed to save corrected ${label} setting:`, e));
@@ -67,7 +67,7 @@ export async function selectModelSetting(
 			}
 
 			dropdown.onChange(async (value) => {
-				(plugin.settings as ObsidianGeminiSettings)[settingName] = value as string;
+				(plugin.settings as any)[settingName] = value;
 				await plugin.saveSettings();
 			});
 			return dropdown;

--- a/src/utils/error-utils.ts
+++ b/src/utils/error-utils.ts
@@ -120,13 +120,9 @@ export function getErrorMessage(error: unknown): string {
 
 	// Handle Error objects
 	if (error instanceof Error) {
-		// Check for HTTP status codes in the error
-		const statusCode = extractStatusCode(error);
-		if (statusCode) {
-			return getHttpErrorMessage(statusCode, error);
-		}
-
-		// Check for specific error patterns in the message
+		// Check for specific error patterns in the message FIRST so provider-specific
+		// guidance (e.g. Ollama 404 "try pulling it first") wins over the generic
+		// HTTP status-code mapping below.
 		const message = error.message;
 		const messageLower = message.toLowerCase();
 
@@ -181,7 +177,11 @@ export function getErrorMessage(error: unknown): string {
 			messageLower.includes('econnrefused') ||
 			messageLower.includes('etimedout')
 		) {
-			if (messageLower.includes('econnrefused') || messageLower.includes('localhost')) {
+			// Only attribute connection refusals to Ollama when the signal is
+			// specific (the message mentions Ollama or the default port). A bare
+			// `ECONNREFUSED` or `localhost` substring could come from any local
+			// proxy or test server, so we don't claim it's the daemon.
+			if (messageLower.includes('ollama') || messageLower.includes(':11434') || messageLower.includes('11434')) {
 				return 'Could not connect to the Ollama daemon. Make sure `ollama serve` is running and the base URL in settings is correct.';
 			}
 			return 'Network error: Unable to reach the model API. Please check your connection.';
@@ -200,6 +200,14 @@ export function getErrorMessage(error: unknown): string {
 		// Content filtering/safety
 		if (messageLower.includes('safety') || messageLower.includes('blocked')) {
 			return 'Content was blocked by safety filters. Please rephrase your request.';
+		}
+
+		// HTTP status code mapping runs after the message-based checks above so
+		// the provider-specific guidance (e.g. Ollama 404 "try pulling it first")
+		// wins over the generic 404 message.
+		const statusCode = extractStatusCode(error);
+		if (statusCode) {
+			return getHttpErrorMessage(statusCode, error);
 		}
 
 		// Token limit errors

--- a/src/utils/error-utils.ts
+++ b/src/utils/error-utils.ts
@@ -165,6 +165,12 @@ export function getErrorMessage(error: unknown): string {
 			messageLower.includes('model') &&
 			(messageLower.includes('not found') || messageLower.includes('does not exist'))
 		) {
+			// Ollama-specific guidance — its server returns "try pulling it first"
+			if (messageLower.includes('try pulling')) {
+				const match = error.message.match(/model\s+"?([\w./:-]+)"?/i);
+				const modelName = match ? match[1] : 'this model';
+				return `Ollama model not pulled. Run: ollama pull ${modelName}`;
+			}
 			return 'The selected model is not available. Please check your model settings.';
 		}
 
@@ -175,7 +181,10 @@ export function getErrorMessage(error: unknown): string {
 			messageLower.includes('econnrefused') ||
 			messageLower.includes('etimedout')
 		) {
-			return 'Network error: Unable to connect to Google Gemini API. Please check your internet connection.';
+			if (messageLower.includes('econnrefused') || messageLower.includes('localhost')) {
+				return 'Could not connect to the Ollama daemon. Make sure `ollama serve` is running and the base URL in settings is correct.';
+			}
+			return 'Network error: Unable to reach the model API. Please check your connection.';
 		}
 
 		// Timeout errors
@@ -265,6 +274,10 @@ export function extractStatusCode(error: any): number | null {
 	}
 	if (typeof error.statusCode === 'number') {
 		return error.statusCode;
+	}
+	// ollama-js throws ResponseError with `status_code`
+	if (typeof error.status_code === 'number') {
+		return error.status_code;
 	}
 	if (typeof error.code === 'number') {
 		return error.code;

--- a/src/utils/error-utils.ts
+++ b/src/utils/error-utils.ts
@@ -180,10 +180,13 @@ export function getErrorMessage(error: unknown): string {
 			messageLower.includes('etimedout')
 		) {
 			// Only attribute connection refusals to Ollama when the signal is
-			// specific (the message mentions Ollama or the default port). A bare
-			// `ECONNREFUSED` or `localhost` substring could come from any local
-			// proxy or test server, so we don't claim it's the daemon.
-			if (messageLower.includes('ollama') || messageLower.includes(':11434') || messageLower.includes('11434')) {
+			// specific. A bare `ECONNREFUSED` or `localhost` substring could
+			// come from any local proxy or test server, and a bare `11434`
+			// could appear in unrelated stack traces or paths, so we require
+			// either the Ollama keyword or a real `host:11434` endpoint shape.
+			const looksLikeOllamaEndpoint =
+				/(?:^|[\s(/])(?:https?:\/\/)?(?:localhost|127\.0\.0\.1|\[::1\]|[\w.-]+):11434\b/.test(messageLower);
+			if (messageLower.includes('ollama') || looksLikeOllamaEndpoint) {
 				return 'Could not connect to the Ollama daemon. Make sure `ollama serve` is running and the base URL in settings is correct.';
 			}
 			return 'Network error: Unable to reach the model API. Please check your connection.';

--- a/src/utils/error-utils.ts
+++ b/src/utils/error-utils.ts
@@ -132,7 +132,7 @@ export function getErrorMessage(error: unknown): string {
 			messageLower.includes('api_key') ||
 			messageLower.includes('invalid_api_key')
 		) {
-			return 'Invalid API key. Please check your Google Gemini API key in settings.';
+			return 'Invalid API key. Please check your model provider credentials in settings.';
 		}
 
 		// Authentication/permission errors
@@ -141,7 +141,7 @@ export function getErrorMessage(error: unknown): string {
 			messageLower.includes('forbidden') ||
 			messageLower.includes('unauthorized')
 		) {
-			return 'Authentication failed. Please verify your API key has access to the Gemini API.';
+			return 'Authentication failed. Please verify your model provider credentials and that your account has access to this model.';
 		}
 
 		// Rate limiting — distinguish transient from permanent quota exhaustion
@@ -336,9 +336,9 @@ function getHttpErrorMessage(statusCode: number, error: any): string {
 		case 400:
 			return 'Bad request: The API request was invalid. Please check your message and try again.';
 		case 401:
-			return 'Authentication failed: Invalid API key. Please check your Google Gemini API key in settings.';
+			return 'Authentication failed: Invalid API key. Please check your model provider credentials in settings.';
 		case 403:
-			return 'Access forbidden: Your API key does not have permission to use this model or feature.';
+			return 'Access forbidden: The model provider denied access to this model or feature.';
 		case 404:
 			return 'Model not found: The selected model is not available. Please check your model settings.';
 		case 429:

--- a/src/utils/error-utils.ts
+++ b/src/utils/error-utils.ts
@@ -163,7 +163,9 @@ export function getErrorMessage(error: unknown): string {
 		) {
 			// Ollama-specific guidance — its server returns "try pulling it first"
 			if (messageLower.includes('try pulling')) {
-				const match = error.message.match(/model\s+"?([\w./:-]+)"?/i);
+				// Ollama wraps model names in either single- or double-quotes
+				// (e.g. `model 'llama3.2' not found, try pulling it first`).
+				const match = error.message.match(/model\s+["']?([\w./:-]+)["']?/i);
 				const modelName = match ? match[1] : 'this model';
 				return `Ollama model not pulled. Run: ollama pull ${modelName}`;
 			}
@@ -194,7 +196,7 @@ export function getErrorMessage(error: unknown): string {
 
 		// Service unavailable
 		if (messageLower.includes('unavailable') || messageLower.includes('service')) {
-			return 'Google Gemini API is temporarily unavailable. Please try again later.';
+			return 'The model API is temporarily unavailable. Please try again later.';
 		}
 
 		// Content filtering/safety
@@ -225,7 +227,7 @@ export function getErrorMessage(error: unknown): string {
 		}
 
 		// Fallback for Error objects without useful message
-		return 'An error occurred while communicating with the Gemini API';
+		return 'An error occurred while communicating with the model API';
 	}
 
 	// Handle objects with error information
@@ -269,7 +271,7 @@ export function getErrorMessage(error: unknown): string {
 	}
 
 	// Final fallback
-	return 'An unknown error occurred while communicating with the Gemini API';
+	return 'An unknown error occurred while communicating with the model API';
 }
 
 /**
@@ -345,14 +347,14 @@ function getHttpErrorMessage(statusCode: number, error: any): string {
 			}
 			return 'Rate limit exceeded: Too many requests. Please wait a moment and try again.';
 		case 500:
-			return 'Server error: Google Gemini API encountered an internal error. Please try again later.';
+			return 'Server error: The model API encountered an internal error. Please try again later.';
 		case 503:
-			return 'Service unavailable: Google Gemini API is temporarily down. Please try again later.';
+			return 'Service unavailable: The model API is temporarily down. Please try again later.';
 		case 504:
 			return 'Gateway timeout: The API request took too long. Please try again.';
 		default:
 			if (statusCode >= 500) {
-				return `Server error (${statusCode}): Google Gemini API is experiencing issues. Please try again later.`;
+				return `Server error (${statusCode}): The model API is experiencing issues. Please try again later.`;
 			}
 			if (statusCode >= 400) {
 				return `Client error (${statusCode}): ${errorMessage || 'Please check your request and try again.'}`;

--- a/src/utils/error-utils.ts
+++ b/src/utils/error-utils.ts
@@ -276,6 +276,13 @@ export function getErrorMessage(error: unknown): string {
  * Extract HTTP status code from error object
  */
 export function extractStatusCode(error: any): number | null {
+	// Guard non-object inputs so callers passing `null`, `undefined`, or a
+	// primitive (this is an exported helper typed as `any`) don't trigger a
+	// secondary TypeError inside an already-failing error path.
+	if (!error || (typeof error !== 'object' && typeof error !== 'function')) {
+		return null;
+	}
+
 	// Check common status code properties
 	if (typeof error.status === 'number') {
 		return error.status;

--- a/test/api/ollama-client.test.ts
+++ b/test/api/ollama-client.test.ts
@@ -1,0 +1,255 @@
+import type { Mock } from 'vitest';
+import { OllamaClient, OllamaClientConfig } from '../../src/api/ollama-client';
+import { ExtendedModelRequest } from '../../src/api/interfaces/model-api';
+
+// vitest hoists vi.mock to the top of the file; vi.hoisted() lets us share
+// fixtures with the factory while keeping initialization order safe.
+const { ollamaCalls } = vi.hoisted(() => {
+	const ollamaCalls: { chat: Mock; generate: Mock; abort: Mock } = {
+		chat: vi.fn(),
+		generate: vi.fn(),
+		abort: vi.fn(),
+	};
+	return { ollamaCalls };
+});
+
+vi.mock('ollama/browser', () => ({
+	// Use function syntax so `new Ollama()` works under vitest 4 (arrow impls
+	// aren't constructable).
+	Ollama: vi.fn().mockImplementation(function () {
+		return {
+			chat: (...args: any[]) => ollamaCalls.chat(...args),
+			generate: (...args: any[]) => ollamaCalls.generate(...args),
+			abort: () => ollamaCalls.abort(),
+		};
+	}),
+}));
+
+const mockLogger = {
+	log: vi.fn(),
+	debug: vi.fn(),
+	warn: vi.fn(),
+	error: vi.fn(),
+};
+
+const buildPlugin = () =>
+	({
+		logger: mockLogger,
+		settings: {
+			provider: 'ollama',
+			ollamaBaseUrl: 'http://localhost:11434',
+			userName: 'Tester',
+			ragIndexing: { enabled: false },
+		},
+		agentsMemory: { read: vi.fn().mockResolvedValue('') },
+		skillManager: { getSkillSummaries: vi.fn().mockResolvedValue([]) },
+		ragIndexing: null,
+	}) as any;
+
+const baseConfig: OllamaClientConfig = {
+	baseUrl: 'http://localhost:11434',
+	model: 'llama3.2',
+	temperature: 0.4,
+	topP: 0.9,
+};
+
+describe('OllamaClient', () => {
+	let client: OllamaClient;
+
+	beforeEach(() => {
+		ollamaCalls.chat.mockReset();
+		ollamaCalls.generate.mockReset();
+		ollamaCalls.abort.mockReset();
+		mockLogger.error.mockReset();
+		client = new OllamaClient(baseConfig, undefined, buildPlugin());
+	});
+
+	describe('generateModelResponse (BaseModelRequest)', () => {
+		it('routes simple prompts through ollama.generate and forwards options', async () => {
+			ollamaCalls.generate.mockResolvedValue({
+				response: 'hello world',
+				prompt_eval_count: 10,
+				eval_count: 4,
+				done: true,
+			});
+
+			const response = await client.generateModelResponse({
+				prompt: 'say hi',
+				temperature: 0.2,
+			});
+
+			expect(ollamaCalls.generate).toHaveBeenCalledTimes(1);
+			const args = ollamaCalls.generate.mock.calls[0][0];
+			expect(args.model).toBe('llama3.2');
+			expect(args.prompt).toBe('say hi');
+			expect(args.stream).toBe(false);
+			expect(args.options.temperature).toBe(0.2);
+			expect(args.options.top_p).toBe(0.9);
+
+			expect(response.markdown).toBe('hello world');
+			expect(response.usageMetadata).toEqual({
+				promptTokenCount: 10,
+				candidatesTokenCount: 4,
+				totalTokenCount: 14,
+			});
+		});
+	});
+
+	describe('generateModelResponse (ExtendedModelRequest)', () => {
+		it('routes chat through ollama.chat with system + history + user message', async () => {
+			ollamaCalls.chat.mockResolvedValue({
+				message: { role: 'assistant', content: 'reply' },
+				prompt_eval_count: 50,
+				eval_count: 2,
+				done: true,
+			});
+
+			const request: ExtendedModelRequest = {
+				prompt: '',
+				userMessage: 'what is up',
+				conversationHistory: [
+					{ role: 'user', parts: [{ text: 'previous user turn' }] },
+					{ role: 'model', parts: [{ text: 'previous assistant turn' }] },
+				],
+			};
+
+			const response = await client.generateModelResponse(request);
+
+			expect(ollamaCalls.chat).toHaveBeenCalledTimes(1);
+			const args = ollamaCalls.chat.mock.calls[0][0];
+			expect(args.stream).toBe(false);
+			// system instruction always present (built from prompts module)
+			expect(args.messages[0].role).toBe('system');
+			expect(args.messages.some((m: any) => m.role === 'user' && m.content === 'previous user turn')).toBe(true);
+			expect(args.messages.some((m: any) => m.role === 'assistant' && m.content === 'previous assistant turn')).toBe(
+				true
+			);
+			expect(args.messages[args.messages.length - 1]).toEqual({ role: 'user', content: 'what is up' });
+			expect(response.markdown).toBe('reply');
+		});
+
+		it('maps tool calls in the assistant response', async () => {
+			ollamaCalls.chat.mockResolvedValue({
+				message: {
+					role: 'assistant',
+					content: '',
+					tool_calls: [{ function: { name: 'read_file', arguments: { path: 'foo.md' } } }],
+				},
+				prompt_eval_count: 1,
+				eval_count: 1,
+				done: true,
+			});
+
+			const response = await client.generateModelResponse({
+				prompt: '',
+				userMessage: 'read foo',
+				conversationHistory: [],
+				availableTools: [
+					{
+						name: 'read_file',
+						description: 'reads a file',
+						parameters: { type: 'object', properties: { path: { type: 'string' } }, required: ['path'] },
+					},
+				],
+			});
+
+			expect(response.toolCalls).toEqual([{ name: 'read_file', arguments: { path: 'foo.md' } }]);
+			expect(ollamaCalls.chat.mock.calls[0][0].tools).toEqual([
+				{
+					type: 'function',
+					function: {
+						name: 'read_file',
+						description: 'reads a file',
+						parameters: { type: 'object', properties: { path: { type: 'string' } }, required: ['path'] },
+					},
+				},
+			]);
+		});
+
+		it('attaches image inline data to the user message', async () => {
+			ollamaCalls.chat.mockResolvedValue({
+				message: { role: 'assistant', content: 'ok' },
+				prompt_eval_count: 1,
+				eval_count: 1,
+				done: true,
+			});
+
+			await client.generateModelResponse({
+				prompt: '',
+				userMessage: 'what is in this picture',
+				conversationHistory: [],
+				inlineAttachments: [{ mimeType: 'image/png', base64: 'b64data' }],
+			});
+
+			const args = ollamaCalls.chat.mock.calls[0][0];
+			const userTurn = args.messages[args.messages.length - 1];
+			expect(userTurn.images).toEqual(['b64data']);
+		});
+
+		it('rejects non-image attachments with a clear error', async () => {
+			await expect(
+				client.generateModelResponse({
+					prompt: '',
+					userMessage: 'read this',
+					conversationHistory: [],
+					inlineAttachments: [{ mimeType: 'application/pdf', base64: 'b64data' }],
+				})
+			).rejects.toThrow(/Ollama only supports image attachments/);
+		});
+	});
+
+	describe('generateStreamingResponse', () => {
+		it('accumulates chunks and reports usageMetadata at done', async () => {
+			async function* chatStream() {
+				yield { message: { content: 'hel' }, done: false };
+				yield { message: { content: 'lo' }, done: false };
+				yield {
+					message: { content: '!' },
+					done: true,
+					prompt_eval_count: 5,
+					eval_count: 3,
+				};
+			}
+			const stream: any = chatStream();
+			stream.abort = vi.fn();
+			ollamaCalls.chat.mockResolvedValue(stream);
+
+			const chunks: string[] = [];
+			const streaming = client.generateStreamingResponse(
+				{ prompt: '', userMessage: 'hi', conversationHistory: [] },
+				(chunk) => chunks.push(chunk.text)
+			);
+			const result = await streaming.complete;
+
+			expect(chunks.join('')).toBe('hello!');
+			expect(result.markdown).toBe('hello!');
+			expect(result.usageMetadata).toEqual({
+				promptTokenCount: 5,
+				candidatesTokenCount: 3,
+				totalTokenCount: 8,
+			});
+		});
+
+		it('cancel() aborts the underlying stream', async () => {
+			const abort = vi.fn();
+			async function* slowStream() {
+				yield { message: { content: 'a' }, done: false };
+				// never reaches done
+			}
+			const stream: any = slowStream();
+			stream.abort = abort;
+			ollamaCalls.chat.mockResolvedValue(stream);
+
+			const streaming = client.generateStreamingResponse(
+				{ prompt: '', userMessage: 'hi', conversationHistory: [] },
+				() => {}
+			);
+			// Allow the first chunk to be consumed
+			await new Promise((r) => setTimeout(r, 0));
+			streaming.cancel();
+			await streaming.complete;
+
+			expect(abort).toHaveBeenCalled();
+		});
+	});
+});

--- a/test/api/ollama-client.test.ts
+++ b/test/api/ollama-client.test.ts
@@ -251,5 +251,29 @@ describe('OllamaClient', () => {
 
 			expect(abort).toHaveBeenCalled();
 		});
+
+		it('omits usageMetadata when the stream cancels before the done chunk', async () => {
+			// Ollama only emits prompt_eval_count / eval_count on the terminal
+			// done chunk. If the user cancels first, we should not synthesize a
+			// {0,0,0} payload — that would look like a real zero-token run in
+			// the token UI / eval reporter. usageMetadata should be omitted.
+			async function* slowStream() {
+				yield { message: { content: 'partial' }, done: false };
+			}
+			const stream: any = slowStream();
+			stream.abort = vi.fn();
+			ollamaCalls.chat.mockResolvedValue(stream);
+
+			const streaming = client.generateStreamingResponse(
+				{ prompt: '', userMessage: 'hi', conversationHistory: [] },
+				() => {}
+			);
+			await new Promise((r) => setTimeout(r, 0));
+			streaming.cancel();
+			const result = await streaming.complete;
+
+			expect(result.markdown).toBe('partial');
+			expect(result.usageMetadata).toBeUndefined();
+		});
 	});
 });

--- a/test/models.test.ts
+++ b/test/models.test.ts
@@ -249,6 +249,9 @@ describe('getUpdatedModelSettings', () => {
 		const result = getUpdatedModelSettings(currentSettings);
 		expect(result.settingsChanged).toBe(false);
 		expect(result.updatedSettings.chatModelName).toBe('');
+		expect(result.updatedSettings.summaryModelName).toBe('');
+		expect(result.updatedSettings.completionsModelName).toBe('');
+		expect(result.changedSettingsInfo).toEqual([]);
 	});
 
 	it('backfills empty Ollama model names once the model list has loaded', () => {

--- a/test/models.test.ts
+++ b/test/models.test.ts
@@ -235,6 +235,41 @@ describe('getUpdatedModelSettings', () => {
 		]);
 	});
 
+	it('tolerates empty Ollama model names while the model list has not loaded yet', () => {
+		setTestModels([]); // Simulates Ollama before /api/tags responds — no models registered
+		const currentSettings = {
+			provider: 'ollama',
+			chatModelName: '', // Empty after a previous reconcile cleared a stale Gemini value
+			summaryModelName: '',
+			completionsModelName: '',
+		};
+		// Should NOT throw; empty values are allowed when the daemon hasn't reported
+		// any models yet (the throw only fires when an empty needs replacing AND no
+		// models are available, but for Ollama the "we'll backfill later" path wins).
+		const result = getUpdatedModelSettings(currentSettings);
+		expect(result.settingsChanged).toBe(false);
+		expect(result.updatedSettings.chatModelName).toBe('');
+	});
+
+	it('backfills empty Ollama model names once the model list has loaded', () => {
+		setTestModels([
+			{ value: 'llama3.2', label: 'Llama 3.2', provider: 'ollama' as const, defaultForRoles: ['chat'] },
+			{ value: 'mistral', label: 'Mistral', provider: 'ollama' as const, defaultForRoles: ['summary'] },
+			{ value: 'qwen2.5', label: 'Qwen 2.5', provider: 'ollama' as const, defaultForRoles: ['completions'] },
+		]);
+		const currentSettings = {
+			provider: 'ollama',
+			chatModelName: '', // Cleared on an earlier reconcile when daemon was unreachable
+			summaryModelName: '',
+			completionsModelName: '',
+		};
+		const result = getUpdatedModelSettings(currentSettings);
+		expect(result.settingsChanged).toBe(true);
+		expect(result.updatedSettings.chatModelName).toBe('llama3.2');
+		expect(result.updatedSettings.summaryModelName).toBe('mistral');
+		expect(result.updatedSettings.completionsModelName).toBe('qwen2.5');
+	});
+
 	it('should propagate error if GEMINI_MODELS is empty and a model update is attempted', () => {
 		setTestModels([]); // GEMINI_MODELS is empty
 		const currentSettings = {

--- a/test/services/context-manager.test.ts
+++ b/test/services/context-manager.test.ts
@@ -37,6 +37,7 @@ describe('ContextManager', () => {
 			apiKey: 'test-api-key',
 			logger: mockLogger,
 			settings: {
+				provider: 'gemini',
 				contextCompactionThreshold: 20,
 				chatModelName: 'gemini-2.5-flash',
 			},

--- a/test/services/context-manager.test.ts
+++ b/test/services/context-manager.test.ts
@@ -246,6 +246,27 @@ describe('ContextManager', () => {
 			expect(result).toBe(3000);
 			expect(mockLogger.error).toHaveBeenCalledWith('[ContextManager] countTokens failed:', expect.any(Error));
 		});
+
+		test('Ollama provider: estimates from char count instead of calling Gemini SDK', async () => {
+			// Build a fresh ContextManager scoped to provider=ollama; the constructor
+			// must not instantiate the Gemini SDK and countTokens must not call it.
+			const ollamaPlugin = {
+				...mockPlugin,
+				apiKey: '',
+				settings: { ...mockPlugin.settings, provider: 'ollama' },
+			};
+			const ollamaCtx = new ContextManager(ollamaPlugin as any, mockLogger);
+
+			const result = await ollamaCtx.countTokens('llama3.2', [{ role: 'user', parts: [{ text: 'hello world' }] }]);
+
+			// Heuristic is Math.ceil(JSON.stringify(sanitized).length / 4); the exact
+			// value isn't important, only that it is a positive integer derived
+			// locally without hitting the SDK.
+			expect(result).toBeGreaterThan(0);
+			expect(Number.isInteger(result)).toBe(true);
+			expect(mockCountTokens).not.toHaveBeenCalled();
+			expect(mockLogger.log).toHaveBeenCalledWith(expect.stringContaining('countTokens (Ollama estimate)'));
+		});
 	});
 
 	describe('prepareHistory', () => {

--- a/test/services/lifecycle-service.test.ts
+++ b/test/services/lifecycle-service.test.ts
@@ -300,7 +300,11 @@ describe('LifecycleService', () => {
 
 			// Access the ToolRegistrar instance created in the LifecycleService constructor
 			const registrarInstance = (ToolRegistrar as unknown as Mock).mock.results[0].value;
-			expect(registrarInstance.registerAll).toHaveBeenCalledWith(mockPlugin.toolRegistry, mockPlugin.logger);
+			expect(registrarInstance.registerAll).toHaveBeenCalledWith(
+				mockPlugin.toolRegistry,
+				mockPlugin.logger,
+				mockPlugin
+			);
 		});
 
 		it('should create ProjectActivationSubscriber with plugin', async () => {

--- a/test/services/ollama-models-service.test.ts
+++ b/test/services/ollama-models-service.test.ts
@@ -44,7 +44,7 @@ describe('OllamaModelsService', () => {
 		expect(models[1].supportsVision).toBe(false);
 	});
 
-	it('returns empty list and logs when the daemon is unreachable', async () => {
+	it('returns empty list when the daemon responds with an error status', async () => {
 		mockedRequestUrl.mockResolvedValue({ status: 500, json: null });
 		const svc = new OllamaModelsService(buildPlugin());
 		const models = await svc.getModels();

--- a/test/services/ollama-models-service.test.ts
+++ b/test/services/ollama-models-service.test.ts
@@ -1,0 +1,82 @@
+import type { Mock } from 'vitest';
+import { requestUrl } from 'obsidian';
+import { OllamaModelsService } from '../../src/services/ollama-models-service';
+
+const mockedRequestUrl = requestUrl as unknown as Mock;
+
+const buildPlugin = () =>
+	({
+		logger: { log: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() },
+		settings: { ollamaBaseUrl: 'http://localhost:11434' },
+	}) as any;
+
+describe('OllamaModelsService', () => {
+	beforeEach(() => {
+		mockedRequestUrl.mockReset();
+	});
+
+	it('parses /api/tags response into GeminiModel entries', async () => {
+		mockedRequestUrl.mockResolvedValue({
+			status: 200,
+			json: {
+				models: [
+					{ name: 'llama3.2:3b', details: { parameter_size: '3.2B' } },
+					{ name: 'qwen2.5:7b', details: { parameter_size: '7B' } },
+					{ name: 'llava:13b', details: { parameter_size: '13B' } },
+				],
+			},
+		});
+
+		const svc = new OllamaModelsService(buildPlugin());
+		const models = await svc.getModels();
+
+		expect(models).toHaveLength(3);
+		expect(models[0]).toMatchObject({
+			value: 'llama3.2:3b',
+			label: 'llama3.2:3b (3.2B)',
+			provider: 'ollama',
+			supportsTools: true,
+			defaultForRoles: ['completions'], // 3b matches the small-model heuristic
+		});
+		// Vision detection
+		expect(models[2].supportsVision).toBe(true);
+		// Non-vision
+		expect(models[1].supportsVision).toBe(false);
+	});
+
+	it('returns empty list and logs when the daemon is unreachable', async () => {
+		mockedRequestUrl.mockResolvedValue({ status: 500, json: null });
+		const svc = new OllamaModelsService(buildPlugin());
+		const models = await svc.getModels();
+		expect(models).toEqual([]);
+	});
+
+	it('caches results and only re-fetches after invalidate()', async () => {
+		mockedRequestUrl.mockResolvedValue({
+			status: 200,
+			json: { models: [{ name: 'llama3.2' }] },
+		});
+
+		const svc = new OllamaModelsService(buildPlugin());
+		await svc.getModels();
+		await svc.getModels();
+		expect(mockedRequestUrl).toHaveBeenCalledTimes(1);
+
+		svc.invalidate();
+		await svc.getModels();
+		expect(mockedRequestUrl).toHaveBeenCalledTimes(2);
+	});
+
+	it('invalidates the cache when the base URL changes', async () => {
+		const plugin = buildPlugin();
+		mockedRequestUrl.mockResolvedValue({ status: 200, json: { models: [] } });
+
+		const svc = new OllamaModelsService(plugin);
+		await svc.getModels();
+		expect(mockedRequestUrl).toHaveBeenCalledTimes(1);
+
+		plugin.settings.ollamaBaseUrl = 'http://10.0.0.1:11434';
+		await svc.getModels();
+		expect(mockedRequestUrl).toHaveBeenCalledTimes(2);
+	});
+});

--- a/test/services/ollama-models-service.test.ts
+++ b/test/services/ollama-models-service.test.ts
@@ -79,4 +79,25 @@ describe('OllamaModelsService', () => {
 		await svc.getModels();
 		expect(mockedRequestUrl).toHaveBeenCalledTimes(2);
 	});
+
+	it('does not return stale models from a previous base URL after a failed refresh', async () => {
+		const plugin = buildPlugin();
+
+		// First daemon: warm the cache with two models
+		mockedRequestUrl.mockResolvedValueOnce({
+			status: 200,
+			json: { models: [{ name: 'old-only-model' }, { name: 'shared-model' }] },
+		});
+		const svc = new OllamaModelsService(plugin);
+		const initial = await svc.getModels();
+		expect(initial).toHaveLength(2);
+
+		// Switch to a new daemon that refuses the connection
+		plugin.settings.ollamaBaseUrl = 'http://10.0.0.1:11434';
+		mockedRequestUrl.mockRejectedValueOnce(new Error('ECONNREFUSED'));
+		const afterFailure = await svc.getModels();
+
+		// Must not surface the previous daemon's models as choices for the new one
+		expect(afterFailure).toEqual([]);
+	});
 });

--- a/test/services/tool-registrar.test.ts
+++ b/test/services/tool-registrar.test.ts
@@ -33,6 +33,7 @@ describe('ToolRegistrar', () => {
 	let registrar: ToolRegistrar;
 	let mockRegistry: any;
 	let mockLogger: any;
+	let mockPlugin: any;
 
 	beforeEach(() => {
 		vi.clearAllMocks();
@@ -47,11 +48,12 @@ describe('ToolRegistrar', () => {
 			error: vi.fn(),
 			warn: vi.fn(),
 		};
+		mockPlugin = { settings: { provider: 'gemini' } };
 	});
 
 	describe('registerAll', () => {
 		it('should register tools from all core sources', async () => {
-			await registrar.registerAll(mockRegistry, mockLogger);
+			await registrar.registerAll(mockRegistry, mockLogger, mockPlugin);
 
 			expect(mockRegistry.registerTool).toHaveBeenCalledWith(expect.objectContaining({ name: 'read_file' }));
 			expect(mockRegistry.registerTool).toHaveBeenCalledWith(expect.objectContaining({ name: 'write_file' }));
@@ -64,10 +66,22 @@ describe('ToolRegistrar', () => {
 		});
 
 		it('should register the correct total number of tools', async () => {
-			await registrar.registerAll(mockRegistry, mockLogger);
+			await registrar.registerAll(mockRegistry, mockLogger, mockPlugin);
 
 			// 2 vault + 1 extended + 1 web + 1 memory + 1 image + 1 skill + 1 session-recall = 8
 			expect(mockRegistry.registerTool).toHaveBeenCalledTimes(8);
+		});
+
+		it('should skip Gemini-only sources when provider is ollama', async () => {
+			mockPlugin.settings.provider = 'ollama';
+			await registrar.registerAll(mockRegistry, mockLogger, mockPlugin);
+
+			// Web tools (google_search) and image tools (generate_image) should be skipped
+			expect(mockRegistry.registerTool).not.toHaveBeenCalledWith(expect.objectContaining({ name: 'google_search' }));
+			expect(mockRegistry.registerTool).not.toHaveBeenCalledWith(expect.objectContaining({ name: 'generate_image' }));
+			// Vault, memory, skill, session-recall still register
+			expect(mockRegistry.registerTool).toHaveBeenCalledWith(expect.objectContaining({ name: 'read_file' }));
+			expect(mockRegistry.registerTool).toHaveBeenCalledWith(expect.objectContaining({ name: 'save_memory' }));
 		});
 
 		it('should continue registering other sources if one fails', async () => {
@@ -78,7 +92,7 @@ describe('ToolRegistrar', () => {
 				}
 			});
 
-			await registrar.registerAll(mockRegistry, mockLogger);
+			await registrar.registerAll(mockRegistry, mockLogger, mockPlugin);
 
 			// Should log the error for the vault-extended source
 			expect(mockLogger.error).toHaveBeenCalledWith('Failed to register vault-extended tools:', expect.any(Error));

--- a/test/utils/error-utils.test.ts
+++ b/test/utils/error-utils.test.ts
@@ -156,8 +156,15 @@ describe('error-utils', () => {
 				);
 			});
 
-			test('ECONNREFUSED error', () => {
+			test('ECONNREFUSED to a non-Ollama localhost endpoint stays generic', () => {
 				const error = new Error('ECONNREFUSED: Connection refused');
+				expect(getErrorMessage(error)).toBe(
+					'Network error: Unable to reach the model API. Please check your connection.'
+				);
+			});
+
+			test('ECONNREFUSED to the Ollama daemon (port 11434)', () => {
+				const error = new Error('fetch failed: ECONNREFUSED 127.0.0.1:11434');
 				expect(getErrorMessage(error)).toBe(
 					'Could not connect to the Ollama daemon. Make sure `ollama serve` is running and the base URL in settings is correct.'
 				);

--- a/test/utils/error-utils.test.ts
+++ b/test/utils/error-utils.test.ts
@@ -176,6 +176,16 @@ describe('error-utils', () => {
 				);
 			});
 
+			test('Bare "11434" in unrelated text does not trigger Ollama copy', () => {
+				// E.g. a stack trace or path containing the digits but no host:port.
+				// Without a real `host:11434` shape we should fall back to the
+				// generic network-error message.
+				const error = new Error('fetch failed at /var/cache/run-11434/tmp');
+				expect(getErrorMessage(error)).toBe(
+					'Network error: Unable to reach the model API. Please check your connection.'
+				);
+			});
+
 			test('ETIMEDOUT error', () => {
 				const error = new Error('ETIMEDOUT: Request timed out');
 				expect(getErrorMessage(error)).toBe(

--- a/test/utils/error-utils.test.ts
+++ b/test/utils/error-utils.test.ts
@@ -13,14 +13,14 @@ describe('error-utils', () => {
 			test('401 Unauthorized', () => {
 				const error = { status: 401, message: 'Unauthorized' };
 				expect(getErrorMessage(error)).toBe(
-					'Authentication failed: Invalid API key. Please check your Google Gemini API key in settings.'
+					'Authentication failed: Invalid API key. Please check your model provider credentials in settings.'
 				);
 			});
 
 			test('403 Forbidden', () => {
 				const error = { status: 403, message: 'Forbidden' };
 				expect(getErrorMessage(error)).toBe(
-					'Access forbidden: Your API key does not have permission to use this model or feature.'
+					'Access forbidden: The model provider denied access to this model or feature.'
 				);
 			});
 
@@ -107,25 +107,29 @@ describe('error-utils', () => {
 		describe('Error message pattern matching', () => {
 			test('API key error', () => {
 				const error = new Error('Invalid API key provided');
-				expect(getErrorMessage(error)).toBe('Invalid API key. Please check your Google Gemini API key in settings.');
+				expect(getErrorMessage(error)).toBe(
+					'Invalid API key. Please check your model provider credentials in settings.'
+				);
 			});
 
 			test('API_KEY error code', () => {
 				const error = new Error('INVALID_API_KEY: The key is not valid');
-				expect(getErrorMessage(error)).toBe('Invalid API key. Please check your Google Gemini API key in settings.');
+				expect(getErrorMessage(error)).toBe(
+					'Invalid API key. Please check your model provider credentials in settings.'
+				);
 			});
 
 			test('Permission denied error', () => {
 				const error = new Error('Permission denied to access this resource');
 				expect(getErrorMessage(error)).toBe(
-					'Authentication failed. Please verify your API key has access to the Gemini API.'
+					'Authentication failed. Please verify your model provider credentials and that your account has access to this model.'
 				);
 			});
 
 			test('Forbidden error', () => {
 				const error = new Error('Access forbidden for this model');
 				expect(getErrorMessage(error)).toBe(
-					'Authentication failed. Please verify your API key has access to the Gemini API.'
+					'Authentication failed. Please verify your model provider credentials and that your account has access to this model.'
 				);
 			});
 
@@ -157,7 +161,9 @@ describe('error-utils', () => {
 			});
 
 			test('ECONNREFUSED to a non-Ollama localhost endpoint stays generic', () => {
-				const error = new Error('ECONNREFUSED: Connection refused');
+				// Mention a non-11434 localhost target so this would actually catch a
+				// regression of the old "any localhost ECONNREFUSED is Ollama" heuristic.
+				const error = new Error('fetch failed: ECONNREFUSED 127.0.0.1:3000');
 				expect(getErrorMessage(error)).toBe(
 					'Network error: Unable to reach the model API. Please check your connection.'
 				);

--- a/test/utils/error-utils.test.ts
+++ b/test/utils/error-utils.test.ts
@@ -151,7 +151,9 @@ describe('error-utils', () => {
 
 			test('Network fetch error', () => {
 				const error = new Error('fetch failed: Connection refused');
-				expect(getErrorMessage(error)).toBe('Network error: Unable to reach the model API. Please check your connection.');
+				expect(getErrorMessage(error)).toBe(
+					'Network error: Unable to reach the model API. Please check your connection.'
+				);
 			});
 
 			test('ECONNREFUSED error', () => {
@@ -163,7 +165,9 @@ describe('error-utils', () => {
 
 			test('ETIMEDOUT error', () => {
 				const error = new Error('ETIMEDOUT: Request timed out');
-				expect(getErrorMessage(error)).toBe('Network error: Unable to reach the model API. Please check your connection.');
+				expect(getErrorMessage(error)).toBe(
+					'Network error: Unable to reach the model API. Please check your connection.'
+				);
 			});
 
 			test('Timeout error', () => {

--- a/test/utils/error-utils.test.ts
+++ b/test/utils/error-utils.test.ts
@@ -57,14 +57,14 @@ describe('error-utils', () => {
 			test('500 Internal Server Error', () => {
 				const error = { status: 500, message: 'Internal error' };
 				expect(getErrorMessage(error)).toBe(
-					'Server error: Google Gemini API encountered an internal error. Please try again later.'
+					'Server error: The model API encountered an internal error. Please try again later.'
 				);
 			});
 
 			test('503 Service Unavailable', () => {
 				const error = { status: 503, message: 'Service unavailable' };
 				expect(getErrorMessage(error)).toBe(
-					'Service unavailable: Google Gemini API is temporarily down. Please try again later.'
+					'Service unavailable: The model API is temporarily down. Please try again later.'
 				);
 			});
 
@@ -184,7 +184,7 @@ describe('error-utils', () => {
 
 			test('Service unavailable error', () => {
 				const error = new Error('Service temporarily unavailable');
-				expect(getErrorMessage(error)).toBe('Google Gemini API is temporarily unavailable. Please try again later.');
+				expect(getErrorMessage(error)).toBe('The model API is temporarily unavailable. Please try again later.');
 			});
 
 			test('Safety filter error', () => {
@@ -239,12 +239,12 @@ describe('error-utils', () => {
 
 			test('Empty string error', () => {
 				const error = new Error('');
-				expect(getErrorMessage(error)).toBe('An error occurred while communicating with the Gemini API');
+				expect(getErrorMessage(error)).toBe('An error occurred while communicating with the model API');
 			});
 
 			test('Error without message property', () => {
 				const error = {} as Error;
-				expect(getErrorMessage(error)).toBe('An unknown error occurred while communicating with the Gemini API');
+				expect(getErrorMessage(error)).toBe('An unknown error occurred while communicating with the model API');
 			});
 
 			test('Object with nested error message', () => {
@@ -259,7 +259,7 @@ describe('error-utils', () => {
 
 			test('Empty object', () => {
 				const error = {};
-				expect(getErrorMessage(error)).toBe('An unknown error occurred while communicating with the Gemini API');
+				expect(getErrorMessage(error)).toBe('An unknown error occurred while communicating with the model API');
 			});
 
 			test('Complex object with toString', () => {

--- a/test/utils/error-utils.test.ts
+++ b/test/utils/error-utils.test.ts
@@ -151,23 +151,19 @@ describe('error-utils', () => {
 
 			test('Network fetch error', () => {
 				const error = new Error('fetch failed: Connection refused');
-				expect(getErrorMessage(error)).toBe(
-					'Network error: Unable to connect to Google Gemini API. Please check your internet connection.'
-				);
+				expect(getErrorMessage(error)).toBe('Network error: Unable to reach the model API. Please check your connection.');
 			});
 
 			test('ECONNREFUSED error', () => {
 				const error = new Error('ECONNREFUSED: Connection refused');
 				expect(getErrorMessage(error)).toBe(
-					'Network error: Unable to connect to Google Gemini API. Please check your internet connection.'
+					'Could not connect to the Ollama daemon. Make sure `ollama serve` is running and the base URL in settings is correct.'
 				);
 			});
 
 			test('ETIMEDOUT error', () => {
 				const error = new Error('ETIMEDOUT: Request timed out');
-				expect(getErrorMessage(error)).toBe(
-					'Network error: Unable to connect to Google Gemini API. Please check your internet connection.'
-				);
+				expect(getErrorMessage(error)).toBe('Network error: Unable to reach the model API. Please check your connection.');
 			});
 
 			test('Timeout error', () => {


### PR DESCRIPTION
## Summary

Adds [Ollama](https://ollama.com) as an alternative model provider so users can run chat, summary, completions, rewrite, and agent tool-calling against a local model instead of the Gemini API. Closes the local-model ask in discussion #576 (Phase 1).

The seam is the existing `ModelApi` interface — a new `OllamaClient` implements it via the `ollama` (browser entry) package, and `GeminiClientFactory.createFromPlugin` routes to either client based on a plugin-wide `provider` setting. `RetryDecorator` is reused unchanged.

## What works on Ollama

- Agent chat with streaming, tool calling, and conversation memory
- File summarization, IDE-style completions, selection rewriting
- Image attachments to vision models (e.g. `llava`, `moondream`, `qwen2.5-vl`)
- Custom prompts, projects, agent skills, scheduled tasks, MCP servers
- Live model discovery via `GET /api/tags` (with manual refresh)

## What's gated off under Ollama (Phase 1)

These rely on Gemini built-in services with no Ollama equivalent and are hidden in settings + skipped at lifecycle init:

| Feature | Reason | Phase-2 path |
| --- | --- | --- |
| Google Search tool | Gemini `googleSearch` grounding | External search API |
| URL Context (web fetch) | Gemini URL Context | `requestUrl` + readability |
| Deep Research | Gemini multi-step search | Custom orchestration |
| Image generation | No Ollama image-gen API | n/a |
| RAG indexing | Uses Gemini File Search Store | Wire `ollama.embed()` |
| PDF / audio / video attachments | Ollama only accepts images | Convert externally |

## Implementation notes

- **New files:** `src/api/ollama-client.ts`, `src/services/ollama-models-service.ts`
- **Provider routing:** `simple-factory.ts` branches in `createFromPlugin`; `ToolRegistrar` filters per-provider tool sources; `LifecycleService` skips `ImageGeneration` and `RagIndexingService` when provider is Ollama
- **Token counting:** `ContextManager` falls back to a chars/4 estimate when running on Ollama (no `countTokens` endpoint) with a conservative 32k default context window. Summarization is routed through the factory so it picks up whichever provider is active.
- **Errors:** `extractStatusCode` now reads ollama-js' `status_code`; `getErrorMessage` recognises "model not pulled" and "daemon unreachable" cases with actionable messages
- **Settings UI:** Provider dropdown, Ollama Base URL field, "Refresh model list" button, and a single notice listing disabled features when Ollama is selected

## Test plan

- [x] `npm test` — 1,439 tests pass (includes 11 new tests for `OllamaClient` + `OllamaModelsService`)
- [x] `npm run build` — typecheck + esbuild succeed
- [x] Manual: `ollama pull llama3.2` + switch provider, send agent chat with tool call
- [ ] Manual: drop image attachment with `llava:13b`, verify it reaches the model
- [ ] Manual: drop a PDF, verify clean "not supported" error
- [ ] Manual: stop daemon mid-session, verify retry surfaces a readable notice
- [ ] Manual: switch back to Gemini, verify all features re-enable

## Documentation

- `README.md` — Quick Start mentions Ollama; Configure Plugin Settings notes the Provider dropdown
- `docs/guide/ollama-setup.md` (new) — install / pull / configure / feature parity table
- `docs/guide/getting-started.md` — Quick Start + sidebar entry
- `docs/reference/settings.md` — `provider` and `ollamaBaseUrl` documented
- `docs/.vitepress/config.mts` — sidebar updated

Release notes deliberately not bumped here — to be added at version-bump time.

https://claude.ai/code/session_01JjwjymftDAvGaVsHRZ8scJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01JjwjymftDAvGaVsHRZ8scJ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add Ollama (local) provider: provider selector, Ollama base URL, model discovery/refresh, and provider-specific UI (hides Gemini-only controls like API key and image model)

* **Behavior**
  * Provider-aware model selection, token estimation, tool availability, lifecycle flows, image-generation gating, streaming/cancellation, and eval reporting/costs

* **Documentation**
  * New Ollama setup guide, updated onboarding, settings reference, parity notes, and evals docs

* **Tests**
  * New/updated tests for Ollama client, model discovery, tooling, token counting, and error messaging

* **Chores**
  * Add Ollama runtime dependency
<!-- end of auto-generated comment: release notes by coderabbit.ai -->