### PR TITLE
ix: prevent ScheduledTaskManager double-init on plugin reload (#678)

### DIFF
--- a/src/services/lifecycle-service.ts
+++ b/src/services/lifecycle-service.ts
@@ -90,7 +90,7 @@ export class LifecycleService {
 					}
 				}
 			}
-			await plugin.scheduledTaskManager.initialize();
+			await plugin.scheduledTaskManager.initialize({ refresh: true });
 			plugin.scheduledTaskManager.start();
 		}
 	}

--- a/src/services/scheduled-task-manager.ts
+++ b/src/services/scheduled-task-manager.ts
@@ -162,10 +162,19 @@ export class ScheduledTaskManager {
 
 	/**
 	 * Discover task definition files and load the sidecar state.
-	 * Idempotent — safe to call again after a settings change (e.g. historyFolder
-	 * rename). Re-registers the metadata cache listener and re-discovers tasks.
+	 *
+	 * On a fresh plugin load this is called once from onLayoutReady().
+	 * On a settings-save re-init it is called from LifecycleService.setup()
+	 * with refresh: true so that historyFolder changes are picked up without
+	 * requiring a full plugin restart.
+	 *
+	 * Passing no arguments (or refresh: false) after the first successful
+	 * initialization is a no-op — this prevents the double-init that occurs
+	 * when setup() runs with layoutReady === true and onLayoutReady() fires
+	 * immediately afterwards.
 	 */
-	async initialize(): Promise<void> {
+	async initialize(options?: { refresh?: boolean }): Promise<void> {
+		if (this.initialized && !options?.refresh) return;
 		// Unregister previous listeners before re-registering so settings
 		// changes (e.g. historyFolder rename) don't leave stale handlers active.
 		if (this.metadataCacheHandler) {

--- a/test/services/scheduled-task-manager.test.ts
+++ b/test/services/scheduled-task-manager.test.ts
@@ -136,6 +136,30 @@ describe('ScheduledTaskManager', () => {
 		});
 	});
 
+	// ── Double-init guard ───────────────────────────────────────────────────
+
+	describe('initialize() idempotency', () => {
+		it('runs only once when called twice without refresh flag (plugin:reload path)', async () => {
+			const { manager, plugin } = makeManager();
+			await manager.initialize();
+			const callsAfterFirst = plugin.app.vault.getMarkdownFiles.mock.calls.length;
+
+			// Second call — simulates onLayoutReady() firing after setup() already ran
+			await manager.initialize();
+			expect(plugin.app.vault.getMarkdownFiles.mock.calls.length).toBe(callsAfterFirst);
+		});
+
+		it('re-runs when refresh: true is passed (settings-save path)', async () => {
+			const { manager, plugin } = makeManager();
+			await manager.initialize();
+			const callsAfterFirst = plugin.app.vault.getMarkdownFiles.mock.calls.length;
+
+			// refresh: true — simulates LifecycleService.setup() on settings change
+			await manager.initialize({ refresh: true });
+			expect(plugin.app.vault.getMarkdownFiles.mock.calls.length).toBeGreaterThan(callsAfterFirst);
+		});
+	});
+
 	// ── State read / write ──────────────────────────────────────────────────
 
 	describe('sidecar state', () => {


### PR DESCRIPTION
## Summary

Fixes the `ScheduledTaskManager` double-initialisation that occurred on every plugin reload when `layoutReady` was already `true`. Closes #678.

## Before / After Behaviour

**Before (broken):**

On `plugin:reload` (or disable → enable) with Obsidian's workspace already
ready, both `LifecycleService.setup()` and `LifecycleService.onLayoutReady()`
independently called `initialize()` + `start()`, producing:

```
[Gemini Scribe] [ScheduledTaskManager] Initialized with 1 task(s)
[Gemini Scribe] [ScheduledTaskManager] Tick loop started
[Gemini Scribe] [ScheduledTaskManager] Initialized with 1 task(s)   ← duplicate
[Gemini Scribe] [ScheduledTaskManager] Tick loop started             ← duplicate
```

Side effects of the duplicate call:
- A redundant `vault.getMarkdownFiles()` scan on every reload
- A second `saveState()` write against the already-loaded state
- Noisy log output making it harder to diagnose real issues

**After (fixed):**

```
[Gemini Scribe] [ScheduledTaskManager] Destroyed
[Gemini Scribe] [ScheduledTaskManager] Initialized with 1 task(s)   ← once only
[Gemini Scribe] [ScheduledTaskManager] Tick loop started             ← once only
```

The settings-save re-init path still works correctly — changing a setting
such as `historyFolder` triggers a full refresh via `{ refresh: true }`.

## Changes

- `src/services/scheduled-task-manager.ts` — `initialize()` accepts an
  optional `{ refresh?: boolean }` parameter and early-returns when already
  initialised unless `refresh: true` is explicitly passed
- `src/services/lifecycle-service.ts` — the settings-change branch in
  `setup()` now passes `{ refresh: true }` to `initialize()` so that
  historyFolder renames and other setting changes are still picked up without
  a full plugin restart; `onLayoutReady()` continues to call `initialize()`
  without the flag, making it a no-op after the first run
- `test/services/scheduled-task-manager.test.ts` — two new regression tests:
  one verifying the no-op behaviour on a plain second call, one verifying that
  `{ refresh: true }` forces a re-run

## Screenshots / Screencast

No UI changes — backend/internal fix only.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards)
- [x] Documentation has been updated (n/a — no user-facing or settings changes)
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude (claude-sonnet-4-6 via Claude Code)
- [x] I have reviewed and understand all AI-generated code in this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced app initialization by preventing unnecessary task manager reinitialization during startup and lifecycle transitions, improving overall performance.
  * Folder configuration changes are now properly applied immediately when saved, without requiring the application to restart.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->