### PR TITLE
fix: deduplicate task file parse when vault.create and metadataCache.…

### DIFF
--- a/src/services/scheduled-task-manager.ts
+++ b/src/services/scheduled-task-manager.ts
@@ -195,7 +195,6 @@ export class ScheduledTaskManager {
 		this.pendingDefers.clear();
 		this.recentlyCreated.clear();
 
-
 		// Unregister previous listeners before re-registering so settings
 		// changes (e.g. historyFolder rename) don't leave stale handlers active.
 		if (this.metadataCacheHandler) {

--- a/src/services/scheduled-task-manager.ts
+++ b/src/services/scheduled-task-manager.ts
@@ -147,6 +147,12 @@ export class ScheduledTaskManager {
 	 * to avoid double-parsing when both events fire for the same new file.
 	 */
 	private recentlyCreated = new Set<string>();
+	/**
+	 * IDs of in-flight setTimeout calls from vaultCreateHandler defers.
+	 * Tracked so they can be cancelled by initialize() (on re-init) and destroy()
+	 * to prevent stale callbacks from mutating state after teardown.
+	 */
+	private pendingDefers = new Set<ReturnType<typeof setTimeout>>();
 
 	constructor(private plugin: ObsidianGemini) {}
 
@@ -181,6 +187,15 @@ export class ScheduledTaskManager {
 	 */
 	async initialize(options?: { refresh?: boolean }): Promise<void> {
 		if (this.initialized && !options?.refresh) return;
+		// Cancel any 500 ms defers still waiting from a previous initialization so
+		// stale callbacks cannot fire against the freshly-loaded state.
+		for (const id of this.pendingDefers) {
+			clearTimeout(id);
+		}
+		this.pendingDefers.clear();
+		this.recentlyCreated.clear();
+
+
 		// Unregister previous listeners before re-registering so settings
 		// changes (e.g. historyFolder rename) don't leave stale handlers active.
 		if (this.metadataCacheHandler) {
@@ -245,8 +260,14 @@ export class ScheduledTaskManager {
 				// (which fires before our 500 ms defer) skips this file.
 				this.recentlyCreated.add(file.basename);
 				// Defer until the metadata cache has indexed the new file's frontmatter.
-				setTimeout(() => {
+				// Track the timer so initialize() and destroy() can cancel it if they
+				// run before the 500 ms elapses.
+				const timerId = setTimeout(() => {
+					this.pendingDefers.delete(timerId);
 					this.recentlyCreated.delete(file.basename);
+					// Guard: if the manager was destroyed or re-initialized while the
+					// defer was pending, skip the parse — state has been reset.
+					if (!this.initialized) return;
 					this.parseTaskFile(file)
 						.then(async (task) => {
 							if (!task) return;
@@ -261,6 +282,7 @@ export class ScheduledTaskManager {
 							this.plugin.logger.warn(`[ScheduledTaskManager] Failed to parse new task ${file.path}:`, err)
 						);
 				}, 500);
+				this.pendingDefers.add(timerId);
 			}
 		};
 		this.plugin.app.vault.on('create', this.vaultCreateHandler);
@@ -359,6 +381,13 @@ export class ScheduledTaskManager {
 			this.plugin.app.vault.off('create', this.vaultCreateHandler);
 			this.vaultCreateHandler = null;
 		}
+		// Cancel any 500 ms defers still in flight — their callbacks check
+		// this.initialized before touching state, but clearing here is the
+		// belt-and-suspenders guarantee that no timer fires after teardown.
+		for (const id of this.pendingDefers) {
+			clearTimeout(id);
+		}
+		this.pendingDefers.clear();
 		this.tasks.clear();
 		this.state = {};
 		this.recentlyCreated.clear();

--- a/src/services/scheduled-task-manager.ts
+++ b/src/services/scheduled-task-manager.ts
@@ -141,6 +141,12 @@ export class ScheduledTaskManager {
 	private vaultCreateHandler: ((...data: unknown[]) => unknown) | null = null;
 	/** Slugs of tasks currently being submitted — prevents double-fire from tick + runNow race. */
 	private submitting = new Set<string>();
+	/**
+	 * Slugs claimed by the vault.on('create') handler while its 500 ms defer is
+	 * pending. The metadataCache.on('changed') handler skips any slug in this set
+	 * to avoid double-parsing when both events fire for the same new file.
+	 */
+	private recentlyCreated = new Set<string>();
 
 	constructor(private plugin: ObsidianGemini) {}
 
@@ -199,6 +205,9 @@ export class ScheduledTaskManager {
 			const runsPrefix = this.runsFolder + '/';
 			if (file?.path?.startsWith(prefix) && !file.path.startsWith(runsPrefix) && file.extension === 'md') {
 				const slug = file.basename;
+				// Skip if the vault create handler already claimed this slug — it will
+				// parse the file after its 500 ms defer, so we don't need to do it here.
+				if (this.recentlyCreated.has(slug)) return;
 				this.parseTaskFile(file)
 					.then(async (task) => {
 						if (task) {
@@ -232,8 +241,12 @@ export class ScheduledTaskManager {
 			const prefix = this.scheduledTasksFolder + '/';
 			const runsPrefix = this.runsFolder + '/';
 			if (file.path.startsWith(prefix) && !file.path.startsWith(runsPrefix) && file.extension === 'md') {
+				// Claim the slug immediately so the metadataCache 'changed' handler
+				// (which fires before our 500 ms defer) skips this file.
+				this.recentlyCreated.add(file.basename);
 				// Defer until the metadata cache has indexed the new file's frontmatter.
 				setTimeout(() => {
+					this.recentlyCreated.delete(file.basename);
 					this.parseTaskFile(file)
 						.then(async (task) => {
 							if (!task) return;
@@ -348,6 +361,7 @@ export class ScheduledTaskManager {
 		}
 		this.tasks.clear();
 		this.state = {};
+		this.recentlyCreated.clear();
 		this.initialized = false;
 		this.plugin.logger.log('[ScheduledTaskManager] Destroyed');
 	}

--- a/src/ui/background-tasks-modal.ts
+++ b/src/ui/background-tasks-modal.ts
@@ -134,6 +134,11 @@ export class BackgroundTasksModal extends Modal {
 
 			const activate = () => {
 				if (this.activeTab === id) return;
+				// Cancel any pending RAG search debounce so it doesn't fire against the new tab
+				if (this.ragDebounceTimer) {
+					clearTimeout(this.ragDebounceTimer);
+					this.ragDebounceTimer = null;
+				}
 				this.activeTab = id;
 				// Reset RAG inner state when switching to the RAG tab
 				if (id === 'rag') {
@@ -214,7 +219,11 @@ export class BackgroundTasksModal extends Modal {
 		if (recent.length > 0) {
 			const recentHeader = container.createDiv({ cls: 'gemini-bg-tasks-recent-header' });
 			recentHeader.createEl('h3', { text: 'Recent' });
-			const clearBtn = recentHeader.createEl('button', { text: 'Clear', cls: 'gemini-bg-tasks-clear' });
+			const clearBtn = recentHeader.createEl('button', {
+				text: 'Clear',
+				cls: 'gemini-bg-tasks-clear',
+				attr: { type: 'button' },
+			});
 			clearBtn.addEventListener('click', () => {
 				this.plugin.backgroundTaskManager?.clearFinished();
 				this.renderTabContent();
@@ -267,7 +276,11 @@ export class BackgroundTasksModal extends Modal {
 		}
 
 		if (canCancel) {
-			const btn = li.createEl('button', { text: 'Cancel', cls: 'gemini-bg-task-cancel mod-warning' });
+			const btn = li.createEl('button', {
+				text: 'Cancel',
+				cls: 'gemini-bg-task-cancel mod-warning',
+				attr: { type: 'button' },
+			});
 			btn.addEventListener('click', () => {
 				this.plugin.backgroundTaskManager?.cancel(task.id);
 				this.renderTabContent();
@@ -520,7 +533,7 @@ export class BackgroundTasksModal extends Modal {
 		for (const file of display) {
 			const item = container.createEl('button', {
 				cls: 'rag-status-file-item rag-status-file-item--clickable',
-				attr: { 'aria-label': `Open ${file.path}` },
+				attr: { type: 'button', 'aria-label': `Open ${file.path}` },
 			});
 			const pathEl = item.createSpan({ cls: 'rag-status-file-path' });
 			pathEl.setText(file.path);

--- a/test/services/scheduled-task-manager.test.ts
+++ b/test/services/scheduled-task-manager.test.ts
@@ -371,6 +371,74 @@ describe('ScheduledTaskManager', () => {
 		});
 	});
 
+	describe('double-parse guard on new file creation', () => {
+		it('parses exactly once when vault.create and metadataCache.changed both fire for a new file', async () => {
+			const plugin = createMockPlugin();
+			plugin.app.vault.getMarkdownFiles.mockReturnValue([]);
+			const manager = new ScheduledTaskManager(plugin);
+			await manager.initialize();
+
+			// Capture both handlers registered during initialize()
+			const vaultOnCalls = (plugin.app.vault.on as jest.Mock).mock.calls;
+			const createHandler = vaultOnCalls.find(([e]: [string]) => e === 'create')?.[1] as (...a: unknown[]) => unknown;
+			const cacheOnCalls = (plugin.app.metadataCache.on as jest.Mock).mock.calls;
+			const changedHandler = cacheOnCalls.find(([e]: [string]) => e === 'changed')?.[1] as (...a: unknown[]) => unknown;
+			expect(createHandler).toBeDefined();
+			expect(changedHandler).toBeDefined();
+
+			const { TFile: MockTFile } = jest.requireMock('obsidian');
+			const newFile = Object.assign(new MockTFile(), {
+				path: 'gemini-scribe/Scheduled-Tasks/new-task.md',
+				basename: 'new-task',
+				extension: 'md',
+			});
+			plugin.app.metadataCache.getFileCache.mockReturnValue({ frontmatter: { schedule: 'daily' } });
+			plugin.app.vault.read = jest.fn().mockResolvedValue('Do something.');
+
+			// Fire create then changed (as Obsidian would)
+			jest.useFakeTimers();
+			createHandler(newFile);
+			changedHandler(newFile); // fires before the 500 ms defer
+			jest.advanceTimersByTime(600);
+			jest.useRealTimers();
+			await Promise.resolve();
+			await Promise.resolve();
+
+			// vault.read is called inside parseTaskFile — must be exactly once
+			expect(plugin.app.vault.read).toHaveBeenCalledTimes(1);
+			expect(manager.getTasks().some((t) => t.slug === 'new-task')).toBe(true);
+		});
+
+		it('still re-parses when only metadataCache.changed fires (hot-reload of existing file)', async () => {
+			const plugin = createMockPlugin();
+			plugin.app.vault.getMarkdownFiles.mockReturnValue([
+				{ path: 'gemini-scribe/Scheduled-Tasks/existing-task.md', basename: 'existing-task' },
+			]);
+			plugin.app.metadataCache.getFileCache.mockReturnValue({ frontmatter: { schedule: 'daily' } });
+			plugin.app.vault.read = jest.fn().mockResolvedValue('Original prompt.');
+			const manager = new ScheduledTaskManager(plugin);
+			await manager.initialize();
+
+			// Simulate an edit to the existing file (only changed fires, not create)
+			const cacheOnCalls = (plugin.app.metadataCache.on as jest.Mock).mock.calls;
+			const changedHandler = cacheOnCalls.find(([e]: [string]) => e === 'changed')?.[1] as (...a: unknown[]) => unknown;
+			const { TFile: MockTFile } = jest.requireMock('obsidian');
+			const existingFile = Object.assign(new MockTFile(), {
+				path: 'gemini-scribe/Scheduled-Tasks/existing-task.md',
+				basename: 'existing-task',
+				extension: 'md',
+			});
+			plugin.app.vault.read = jest.fn().mockResolvedValue('Updated prompt.');
+			changedHandler(existingFile);
+			await Promise.resolve();
+			await Promise.resolve();
+
+			// parseTaskFile should have run again — vault.read called once more
+			expect(plugin.app.vault.read).toHaveBeenCalledTimes(1);
+			expect(manager.getTasks().find((t) => t.slug === 'existing-task')?.prompt).toBe('Updated prompt.');
+		});
+	});
+
 	// ── Tick behaviour ──────────────────────────────────────────────────────
 
 	describe('tick', () => {

--- a/test/services/scheduled-task-manager.test.ts
+++ b/test/services/scheduled-task-manager.test.ts
@@ -439,6 +439,79 @@ describe('ScheduledTaskManager', () => {
 		});
 	});
 
+	// ── Pending defer cancellation ───────────────────────────────────────────
+
+	describe('pending defer cancellation', () => {
+		it('does not mutate state when destroy() runs before the 500 ms defer fires', async () => {
+			const plugin = createMockPlugin();
+			plugin.app.vault.getMarkdownFiles.mockReturnValue([]);
+			const manager = new ScheduledTaskManager(plugin);
+			await manager.initialize();
+
+			const vaultOnCalls = (plugin.app.vault.on as jest.Mock).mock.calls;
+			const createHandler = vaultOnCalls.find(([e]: [string]) => e === 'create')?.[1] as (...a: unknown[]) => unknown;
+			expect(createHandler).toBeDefined();
+
+			const { TFile: MockTFile } = jest.requireMock('obsidian');
+			const newFile = Object.assign(new MockTFile(), {
+				path: 'gemini-scribe/Scheduled-Tasks/late-task.md',
+				basename: 'late-task',
+				extension: 'md',
+			});
+			plugin.app.vault.read = jest.fn().mockResolvedValue('Prompt body.');
+			plugin.app.metadataCache.getFileCache.mockReturnValue({ frontmatter: { schedule: 'daily' } });
+
+			jest.useFakeTimers();
+			// Fire create — starts the 500 ms defer
+			createHandler(newFile);
+			// destroy() before the defer fires
+			manager.destroy();
+			// Advance past the defer window — the cancelled timer must not fire
+			jest.advanceTimersByTime(600);
+			jest.useRealTimers();
+			await Promise.resolve();
+			await Promise.resolve();
+
+			// parseTaskFile (vault.read) must never have been called
+			expect(plugin.app.vault.read).not.toHaveBeenCalled();
+		});
+
+		it('does not mutate state when initialize() re-runs before the 500 ms defer fires', async () => {
+			const plugin = createMockPlugin();
+			plugin.app.vault.getMarkdownFiles.mockReturnValue([]);
+			const manager = new ScheduledTaskManager(plugin);
+			await manager.initialize();
+
+			const vaultOnCalls = (plugin.app.vault.on as jest.Mock).mock.calls;
+			const createHandler = vaultOnCalls.find(([e]: [string]) => e === 'create')?.[1] as (...a: unknown[]) => unknown;
+			expect(createHandler).toBeDefined();
+
+			const { TFile: MockTFile } = jest.requireMock('obsidian');
+			const newFile = Object.assign(new MockTFile(), {
+				path: 'gemini-scribe/Scheduled-Tasks/stale-task.md',
+				basename: 'stale-task',
+				extension: 'md',
+			});
+			plugin.app.vault.read = jest.fn().mockResolvedValue('Prompt body.');
+			plugin.app.metadataCache.getFileCache.mockReturnValue({ frontmatter: { schedule: 'daily' } });
+
+			jest.useFakeTimers();
+			// Fire create — starts the 500 ms defer
+			createHandler(newFile);
+			// Re-initialize before the defer fires — should cancel the pending timer
+			jest.useRealTimers();
+			await manager.initialize();
+			jest.useFakeTimers();
+			jest.advanceTimersByTime(600);
+			jest.useRealTimers();
+			await Promise.resolve();
+			await Promise.resolve();
+
+			// parseTaskFile (vault.read) must never have been called from the stale defer
+			expect(plugin.app.vault.read).not.toHaveBeenCalled();
+		});
+	});
+
 	// ── Tick behaviour ──────────────────────────────────────────────────────
 
 	describe('tick', () => {


### PR DESCRIPTION
## Summary

Fixes the double-parse that occurs when a new task file is created in
`Scheduled-Tasks/` — both the `vault.on('create')` handler and the
`metadataCache.on('changed')` handler react to the same file, causing
two vault reads, two parses, and potentially two `saveState()` writes
for a single file creation. Closes #679.

## Before / After Behaviour

**Before (broken):**

Creating a new valid task file in `Scheduled-Tasks/` produced two log
lines and two full parse + saveState cycles:

```
[Gemini Scribe] [ScheduledTaskManager] Task "my-task" reloaded from disk    ← metadataCache.changed
[Gemini Scribe] [ScheduledTaskManager] Task "my-task" discovered on create  ← vault.create (500 ms later)
```

**After (fixed):**

Only one parse runs — the `create` handler owns the file and the
`changed` handler skips it:

```
[Gemini Scribe] [ScheduledTaskManager] Task "my-task" discovered on create  ← once only
```

Hot-reload of existing files (editing frontmatter of an already-tracked
task) is unchanged — only `metadataCache.changed` fires in that path,
so the guard has no effect and the re-parse happens as before:

```
[Gemini Scribe] [ScheduledTaskManager] Task "my-task" reloaded from disk
```

## Why Option A (recentlyCreated set) and not Option B (drop vault.create)

The issue proposed two approaches:

**Option B** — remove the `vault.on('create')` handler entirely and rely
solely on `metadataCache.on('changed')`.
- Simpler code — one handler instead of two.
- BUT: `metadataCache.changed` only fires when Obsidian re-indexes
  frontmatter. If a user creates a task file without frontmatter first
  (e.g. creates an empty note and adds the `schedule:` property
  afterwards via the Properties panel), no `changed` event fires on
  creation, so the scheduler would silently miss the file until the
  next plugin reload.
- Also requires deleting the regression test added in #650 that
  specifically covers `vault.on('create')` hot-discovery.

**Option A** — keep both handlers, deduplicate with a `recentlyCreated` set.
- The `create` handler adds the slug to `recentlyCreated` immediately
  (synchronously, before the 500 ms defer).
- The `changed` handler checks the set and returns early if the slug
  is present — no vault read, no parse, no saveState.
- After 500 ms the `create` handler removes the slug from the set and
  runs the single parse.
- "Discover immediately on create" semantic is preserved for all files,
  including those created without frontmatter.
- The #650 regression test passes unchanged.

Option A was chosen because it eliminates the duplicate work without
giving up any existing behaviour or breaking existing tests.

## Changes

- `src/services/scheduled-task-manager.ts` — added `recentlyCreated`
  private Set; `vaultCreateHandler` adds the slug to the set before
  scheduling the 500 ms defer and removes it at the start of the
  timeout callback; `metadataCacheHandler` early-returns if the slug is
  in the set; `destroy()` clears the set on teardown
- `test/services/scheduled-task-manager.test.ts` — two new regression
  tests: one verifying a single parse when both `vault.create` and
  `metadataCache.changed` fire for the same new file; one verifying
  that the `changed`-only hot-reload path for existing files still works

## Screenshots / Screencast

No UI changes — backend/internal fix only.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards)
- [x] Documentation has been updated (n/a — no user-facing or settings changes)
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude (claude-sonnet-4-6 via Claude Code)
- [x] I have reviewed and understand all AI-generated code in this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents duplicate parsing when creating new scheduled tasks.
  * Ensures deferred/parsing timers are canceled on re-initialize or teardown to avoid stale work.
  * Stops delayed search renders when switching tabs in background tasks.

* **UI**
  * Buttons in the background tasks modal explicitly set as non-submit to avoid accidental form submissions.

* **Tests**
  * Added tests covering creation, hot-reload ordering, and deferred-cancel behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->