### PR TITLE
fix: await task drain before ScheduledTaskManager re-init (#680)

### DIFF
--- a/src/services/background-task-manager.ts
+++ b/src/services/background-task-manager.ts
@@ -30,6 +30,12 @@ export class BackgroundTaskManager {
 	private eventBus: AgentEventBus;
 	private tasks = new Map<string, BackgroundTask>();
 	private cancellationFlags = new Map<string, boolean>();
+	/**
+	 * Tracks the in-flight Promise returned by run() for each active task.
+	 * Populated in submit(), cleaned up in run()'s finally block.
+	 * Used by drain() to await full settlement after cancellation.
+	 */
+	private runPromises = new Map<string, Promise<void>>();
 	/** Maximum number of completed/failed tasks kept in memory for the monitoring modal. */
 	private static readonly MAX_RECENT = 20;
 	private nextId = 1;
@@ -64,8 +70,10 @@ export class BackgroundTaskManager {
 		this.tasks.set(id, task);
 		this.cancellationFlags.set(id, false);
 
-		// Fire-and-forget — intentionally not awaited by the caller
-		this.run(id, work);
+		// Fire-and-forget for the caller, but the promise is stored in runPromises so
+		// drain() can await full settlement (e.g. after cancel()) without blocking submit().
+		const p = this.run(id, work);
+		this.runPromises.set(id, p);
 
 		return id;
 	}
@@ -195,6 +203,7 @@ export class BackgroundTaskManager {
 
 			new Notice(`Background task failed: ${task.label}\n${task.error}`, 8000);
 		} finally {
+			this.runPromises.delete(id);
 			this.cancellationFlags.delete(id);
 			this.pruneOldTasks();
 			this.notifyStatusChange();
@@ -234,6 +243,28 @@ export class BackgroundTaskManager {
 	 */
 	private notifyStatusChange(): void {
 		this.plugin.backgroundStatusBar?.update();
+	}
+
+	/**
+	 * Wait for all currently in-flight tasks of the given type to finish.
+	 *
+	 * Intended for callers that cancel() a group of tasks and then need to be
+	 * certain those tasks have fully settled before proceeding (e.g. before
+	 * re-initializing a manager whose state the tasks write to).
+	 *
+	 * @param type  If provided, only tasks of this type are awaited.
+	 *              If omitted, all in-flight tasks are awaited.
+	 */
+	async drain(type?: string): Promise<void> {
+		const promises: Promise<void>[] = [];
+		for (const [id, promise] of this.runPromises) {
+			if (type === undefined || this.tasks.get(id)?.type === type) {
+				promises.push(promise);
+			}
+		}
+		if (promises.length > 0) {
+			await Promise.allSettled(promises);
+		}
 	}
 
 	destroy(): void {

--- a/src/services/lifecycle-service.ts
+++ b/src/services/lifecycle-service.ts
@@ -79,16 +79,21 @@ export class LifecycleService {
 		// settings save), refresh the scheduled task manager so it picks up any
 		// historyFolder or other setting changes without requiring a restart.
 		if (plugin.app.workspace.layoutReady && plugin.scheduledTaskManager) {
-			// Cancel any in-flight scheduled-task background jobs before reinitialising.
-			// Without this, an older run's executeTask callback can call saveState()
-			// against the refreshed manager after initialize() reloads state, corrupting
-			// the new state (e.g. writing lastRunAt to the wrong historyFolder path).
+			// Cancel any in-flight scheduled-task background jobs before reinitialising,
+			// then drain them so we are certain every executeTask callback has finished
+			// before initialize() reloads state.  Without the drain, a cancelled task
+			// that resumes after initialize() could still call saveState() against the
+			// freshly-loaded state, corrupting it (e.g. writing lastRunAt to a stale
+			// historyFolder path).  cancel() only sets a flag — it does not await; the
+			// task cooperative-cancels at its next isCancelled() poll.  drain() gives us
+			// the guarantee that all such tasks have fully settled before we proceed.
 			if (plugin.backgroundTaskManager) {
 				for (const task of plugin.backgroundTaskManager.getActiveTasks()) {
 					if (task.type === 'scheduled-task') {
 						plugin.backgroundTaskManager.cancel(task.id);
 					}
 				}
+				await plugin.backgroundTaskManager.drain('scheduled-task');
 			}
 			await plugin.scheduledTaskManager.initialize();
 			plugin.scheduledTaskManager.start();

--- a/test/services/background-task-manager.test.ts
+++ b/test/services/background-task-manager.test.ts
@@ -269,6 +269,83 @@ describe('BackgroundTaskManager', () => {
 		});
 	});
 
+	describe('drain', () => {
+		it('resolves immediately when there are no active tasks', async () => {
+			const { manager } = makeManager();
+			// No tasks submitted — drain should resolve without hanging
+			await expect(manager.drain()).resolves.toBeUndefined();
+		});
+
+		it('waits for a cancelled task to fully settle before resolving', async () => {
+			const { manager } = makeManager();
+			const settled: string[] = [];
+
+			let resolveFn!: () => void;
+			const blocker = new Promise<void>((r) => (resolveFn = r));
+
+			const id = manager.submit('scheduled-task', 'Slow task', async (isCancelled) => {
+				await blocker;
+				settled.push('work-done');
+				if (isCancelled()) return undefined;
+				return 'output.md';
+			});
+
+			// Cancel the task (flag only — does NOT await the work)
+			manager.cancel(id);
+
+			// Start draining while the work is still blocked
+			const drainPromise = manager.drain('scheduled-task');
+			let drainResolved = false;
+			drainPromise.then(() => {
+				drainResolved = true;
+			});
+
+			// Allow the event loop to tick — drain should still be waiting
+			await Promise.resolve();
+			expect(drainResolved).toBe(false);
+			expect(settled).toHaveLength(0);
+
+			// Unblock the work — now both the work and drain should settle
+			resolveFn();
+			await drainPromise;
+
+			expect(drainResolved).toBe(true);
+			expect(settled).toEqual(['work-done']);
+		});
+
+		it('drain() with a type filter only awaits matching tasks', async () => {
+			const { manager } = makeManager();
+
+			let resolveScheduled!: () => void;
+			let resolveOther!: () => void;
+			const scheduledBlocker = new Promise<void>((r) => (resolveScheduled = r));
+			const otherBlocker = new Promise<void>((r) => (resolveOther = r));
+
+			const scheduledId = manager.submit('scheduled-task', 'Scheduled', async (isCancelled) => {
+				await scheduledBlocker;
+				if (isCancelled()) return undefined;
+				return undefined;
+			});
+			manager.submit('other-type', 'Other', async () => {
+				await otherBlocker;
+				return undefined;
+			});
+
+			manager.cancel(scheduledId);
+
+			// drain only the scheduled-task type — should not wait for the other task
+			const drainPromise = manager.drain('scheduled-task');
+			resolveScheduled(); // unblock scheduled task
+			await drainPromise; // should resolve now even though 'other' is still running
+
+			expect(manager.getActiveTasks().some((t) => t.type === 'other-type')).toBe(true);
+
+			// cleanup
+			resolveOther();
+			await flushAsync();
+		});
+	});
+
 	describe('destroy', () => {
 		it('cancels active tasks and clears state', async () => {
 			const { manager } = makeManager();


### PR DESCRIPTION
## Summary

Adds a `drain()` method to `BackgroundTaskManager` and uses it in
`LifecycleService.setup()` to guarantee that all cancelled
`scheduled-task` background jobs have fully settled before
`ScheduledTaskManager.initialize()` reloads state on a settings-save
re-init. Closes #680.

## Changes

- `src/services/background-task-manager.ts` — added `private runPromises`
  map to track each `run()` promise; new public `async drain(type?)` method
  awaits `Promise.allSettled` on in-flight tasks, optionally filtered by type
- `src/services/lifecycle-service.ts` — added
  `await plugin.backgroundTaskManager.drain('scheduled-task')` after the
  cancel loop and before `initialize()` in the settings-save re-init path
- `test/services/background-task-manager.test.ts` — three new regression
  tests: immediate resolution with no tasks, ordering guarantee after
  cancel + drain, type-filtered drain

## Screenshots / Screencast

No UI changes — backend/internal fix only.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards)
- [x] Documentation has been updated (n/a — no user-facing or settings changes)
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude (claude-sonnet-4-6 via Claude Code)
- [x] I have reviewed and understand all AI-generated code in this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an API to explicitly wait for background task completion or cancellation.

* **Bug Fixes**
  * Fixed a race condition during service reinitialization where stale task callbacks could overwrite freshly reloaded state.

* **Tests**
  * Added comprehensive test coverage for task completion waiting functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->