### PR TITLE
feat: missed-run catch-up on startup (#656)

### DIFF
--- a/docs/guide/scheduled-tasks.md
+++ b/docs/guide/scheduled-tasks.md
@@ -106,13 +106,13 @@ To resume a paused task:
 
 When Obsidian is closed, scheduled tasks cannot run. Set `runIfMissed: true` in a task's frontmatter to have it caught up automatically the next time Obsidian starts.
 
-On startup, the plugin compares each task's `nextRunAt` against the current time. Any task with `runIfMissed: true` that is overdue (and not paused) is treated as a missed run. By default, a **Missed Scheduled Runs** modal appears listing each missed task with **Run** and **Skip** buttons:
+On startup, the plugin compares each task's `nextRunAt` against the current time. Any task with `runIfMissed: true` that is overdue (and not paused) is treated as a missed run. By default, a red `!` badge appears on the background-tasks status bar item — click it to open the **Missed Scheduled Runs** modal, which lists each missed task with **Run** and **Skip** buttons:
 
 - **Run** — submits the task immediately as a background task
 - **Skip** — advances the schedule without running
 - **Run all / Skip all** — bulk actions for all listed tasks
 
-Dismissing the modal (Escape or ✕) leaves the `!` badge on the status bar so you can reopen it later by clicking the badge.
+Dismissing the modal (Escape or ✕) leaves the `!` badge in place so you can reopen the modal later by clicking the badge.
 
 ### Auto-run on startup
 

--- a/docs/guide/scheduled-tasks.md
+++ b/docs/guide/scheduled-tasks.md
@@ -35,14 +35,14 @@ Summarise the notes I created or modified today. List the key topics and any ope
 
 ### Frontmatter Fields
 
-| Field          | Required | Default                                                  | Description                                                                 |
-| -------------- | -------- | -------------------------------------------------------- | --------------------------------------------------------------------------- |
-| `schedule`     | Yes      | —                                                        | When to run. See [Schedule Formats](#schedule-formats) below.               |
-| `enabledTools` | No       | `[]` (read-only)                                         | List of tool categories the agent may use. See [Tool Access](#tool-access). |
-| `outputPath`   | No       | `<history-folder>/Scheduled-Tasks/Runs/<slug>/{date}.md` | Where to write results. Supports `{slug}` and `{date}` placeholders.        |
-| `model`        | No       | Plugin chat model                                        | Override the model for this task (e.g. `gemini-2.0-flash`).                 |
-| `enabled`      | No       | `true`                                                   | Set to `false` to disable the task without deleting it.                     |
-| `runIfMissed`  | No       | `false`                                                  | Reserved for future use — catch-up runs are not yet implemented.            |
+| Field          | Required | Default                                                  | Description                                                                                                                 |
+| -------------- | -------- | -------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `schedule`     | Yes      | —                                                        | When to run. See [Schedule Formats](#schedule-formats) below.                                                               |
+| `enabledTools` | No       | `[]` (read-only)                                         | List of tool categories the agent may use. See [Tool Access](#tool-access).                                                 |
+| `outputPath`   | No       | `<history-folder>/Scheduled-Tasks/Runs/<slug>/{date}.md` | Where to write results. Supports `{slug}` and `{date}` placeholders.                                                        |
+| `model`        | No       | Plugin chat model                                        | Override the model for this task (e.g. `gemini-2.0-flash`).                                                                 |
+| `enabled`      | No       | `true`                                                   | Set to `false` to disable the task without deleting it.                                                                     |
+| `runIfMissed`  | No       | `false`                                                  | When `true`, tasks missed while Obsidian was closed are caught up on the next startup. See [Catch-up Runs](#catch-up-runs). |
 
 ### Schedule Formats
 
@@ -102,9 +102,31 @@ To resume a paused task:
 2. Fix the underlying issue (e.g. invalid prompt, missing API key)
 3. Click **Reset** next to the paused task
 
+## Catch-up Runs
+
+When Obsidian is closed, scheduled tasks cannot run. Set `runIfMissed: true` in a task's frontmatter to have it caught up automatically the next time Obsidian starts.
+
+On startup, the plugin compares each task's `nextRunAt` against the current time. Any task with `runIfMissed: true` that is overdue (and not paused) is treated as a missed run. By default, a **Missed Scheduled Runs** modal appears listing each missed task with **Run** and **Skip** buttons:
+
+- **Run** — submits the task immediately as a background task
+- **Skip** — advances the schedule without running
+- **Run all / Skip all** — bulk actions for all listed tasks
+
+Dismissing the modal (Escape or ✕) leaves the `!` badge on the status bar so you can reopen it later by clicking the badge.
+
+### Auto-run on startup
+
+Enable **Settings → UI Settings → Auto-run missed scheduled tasks on startup** to skip the approval modal entirely and submit all missed tasks silently on every startup.
+
+### Notes
+
+- Only tasks with `runIfMissed: true` and `enabled: true` are included; tasks paused due to repeated failures are excluded.
+- Only one catch-up run is submitted per task per startup, regardless of how many intervals were missed.
+- Tasks missed more than 7 days ago are considered stale and excluded.
+
 ## Scheduler Timing
 
-The scheduler checks for due tasks every **60 seconds**. Task files created while Obsidian is running are discovered immediately via a vault file-creation listener. Files that exist when the plugin loads are discovered on startup — if Obsidian's metadata cache hasn't finished indexing at that point, a task may be missed until the next plugin reload. This is a known startup race and will be addressed in a follow-up.
+The scheduler checks for due tasks every **60 seconds**. Task files created while Obsidian is running are discovered immediately via a vault file-creation listener. Files that exist when the plugin loads are discovered on startup.
 
 A task is considered due when the current time is at or past its `nextRunAt` value stored in `scheduled-tasks-state.json`. The first run of a newly discovered task is triggered immediately on the next tick.
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -94,6 +94,8 @@ export interface ObsidianGeminiSettings {
 	alwaysShowDiffView: boolean;
 	// Tool execution logging
 	logToolExecution: boolean;
+	// Scheduled task catch-up
+	autoRunCatchUp: boolean;
 	// Cached remote model list (managed by ModelListProvider)
 	remoteModelCache?: { models: GeminiModel[]; timestamp: number };
 }
@@ -147,6 +149,8 @@ const DEFAULT_SETTINGS: ObsidianGeminiSettings = {
 	alwaysShowDiffView: false,
 	// Tool execution logging
 	logToolExecution: true,
+	// Scheduled task catch-up
+	autoRunCatchUp: false,
 };
 
 const MIGRATION_SECRET_NAME = 'gemini-scribe-api-key';

--- a/src/services/background-status-bar.ts
+++ b/src/services/background-status-bar.ts
@@ -95,9 +95,10 @@ export class BackgroundStatusBar {
 		const runningCount = this.taskManager.runningCount;
 		const ragStatus = this.ragProvider?.getStatus() ?? 'disabled';
 
-		// Nothing to show — hide only when RAG is fully disabled and no tasks are running.
-		// When RAG is idle, show the database icon + indexed-file count.
-		if (runningCount === 0 && ragStatus === 'disabled') {
+		// Nothing to show — hide only when RAG is fully disabled, no tasks are running,
+		// AND there are no pending catch-up approvals (otherwise the ! badge would be
+		// unreachable). When RAG is idle, show the database icon + indexed-file count.
+		if (runningCount === 0 && ragStatus === 'disabled' && this._pendingCatchUpCount === 0) {
 			this.statusBarItem.style.display = 'none';
 			return;
 		}
@@ -113,6 +114,11 @@ export class BackgroundStatusBar {
 			setIcon(iconEl, 'loader');
 			textEl.setText(runningCount > 1 ? `${runningCount} tasks` : '1 task');
 			tooltipParts.push(`${runningCount} background task${runningCount > 1 ? 's' : ''} running — click to view`);
+		} else if (ragStatus === 'disabled' && this._pendingCatchUpCount > 0) {
+			// Catch-up only — no tasks running and RAG disabled, but pending approvals.
+			// Use a clock icon so the badge isn't sitting next to an unrelated database icon.
+			setIcon(iconEl, 'clock');
+			textEl.setText('');
 		} else {
 			// No tasks running — let RAG drive the icon
 			const ragIcon = ragStatus === 'indexing' ? 'upload-cloud' : ragStatus === 'paused' ? 'pause-circle' : 'database';
@@ -127,6 +133,12 @@ export class BackgroundStatusBar {
 							return '…';
 						})()
 					: String(this.ragProvider?.getIndexedFileCount() ?? '')
+			);
+		}
+
+		if (this._pendingCatchUpCount > 0) {
+			tooltipParts.push(
+				`${this._pendingCatchUpCount} missed scheduled run${this._pendingCatchUpCount > 1 ? 's' : ''} — click to review`
 			);
 		}
 

--- a/src/services/background-status-bar.ts
+++ b/src/services/background-status-bar.ts
@@ -16,6 +16,8 @@ export class BackgroundStatusBar {
 	private taskManager: BackgroundTaskManager;
 	private ragProvider: RagStatusProvider | null = null;
 	private statusBarItem: HTMLElement | null = null;
+	/** Number of missed scheduled runs awaiting user approval. Drives the ! badge. */
+	private _pendingCatchUpCount = 0;
 
 	constructor(plugin: ObsidianGemini, taskManager: BackgroundTaskManager) {
 		this.plugin = plugin;
@@ -29,6 +31,16 @@ export class BackgroundStatusBar {
 		this.update();
 	}
 
+	/** Set the number of pending catch-up approvals and re-render the badge. */
+	setPendingCatchUpCount(count: number): void {
+		this._pendingCatchUpCount = count;
+		this.update();
+	}
+
+	get pendingCatchUpCount(): number {
+		return this._pendingCatchUpCount;
+	}
+
 	/** Attach the status bar item to the Obsidian status bar. */
 	setup(): void {
 		if (this.statusBarItem) return;
@@ -38,8 +50,18 @@ export class BackgroundStatusBar {
 
 		this.statusBarItem.createSpan({ cls: 'gemini-bg-status-icon' });
 		this.statusBarItem.createSpan({ cls: 'gemini-bg-status-text' });
+		this.statusBarItem.createSpan({ cls: 'gemini-bg-status-badge' });
 
 		this.statusBarItem.addEventListener('click', async () => {
+			// Pending catch-up approvals take priority — open the approval modal first
+			if (this._pendingCatchUpCount > 0 && this.plugin.scheduledTaskManager) {
+				const pending = this.plugin.scheduledTaskManager.detectMissedRuns();
+				if (pending.length > 0) {
+					const { CatchUpModal } = await import('../ui/catch-up-modal');
+					new CatchUpModal(this.plugin.app, this.plugin, pending).open();
+					return;
+				}
+			}
 			const { BackgroundTasksModal } = await import('../ui/background-tasks-modal');
 			const defaultTab = this.taskManager.runningCount > 0 ? 'tasks' : 'rag';
 			new BackgroundTasksModal(this.plugin.app, this.plugin, defaultTab).open();
@@ -54,7 +76,19 @@ export class BackgroundStatusBar {
 
 		const iconEl = this.statusBarItem.querySelector('.gemini-bg-status-icon') as HTMLElement | null;
 		const textEl = this.statusBarItem.querySelector('.gemini-bg-status-text') as HTMLElement | null;
+		const badgeEl = this.statusBarItem.querySelector('.gemini-bg-status-badge') as HTMLElement | null;
 		if (!iconEl || !textEl) return;
+
+		// Catch-up badge — show ! when there are pending approvals
+		if (badgeEl) {
+			if (this._pendingCatchUpCount > 0) {
+				badgeEl.setText('!');
+				badgeEl.style.display = 'inline-block';
+			} else {
+				badgeEl.setText('');
+				badgeEl.style.display = 'none';
+			}
+		}
 
 		const runningCount = this.taskManager.runningCount;
 		const ragStatus = this.ragProvider?.getStatus() ?? 'disabled';

--- a/src/services/background-status-bar.ts
+++ b/src/services/background-status-bar.ts
@@ -61,6 +61,8 @@ export class BackgroundStatusBar {
 					new CatchUpModal(this.plugin.app, this.plugin, pending).open();
 					return;
 				}
+				// detectMissedRuns returned empty — stale badge; self-correct
+				this.setPendingCatchUpCount(0);
 			}
 			const { BackgroundTasksModal } = await import('../ui/background-tasks-modal');
 			const defaultTab = this.taskManager.runningCount > 0 ? 'tasks' : 'rag';

--- a/src/services/lifecycle-service.ts
+++ b/src/services/lifecycle-service.ts
@@ -164,6 +164,10 @@ export class LifecycleService {
 		if (plugin.scheduledTaskManager) {
 			await plugin.scheduledTaskManager.initialize();
 			plugin.scheduledTaskManager.start();
+
+			// After initialization, check for tasks that were missed while the plugin
+			// was offline. Only tasks with runIfMissed: true are included.
+			await this.handleCatchUp();
 		}
 
 		// Check for version updates and show notification
@@ -507,6 +511,33 @@ export class LifecycleService {
 		} else if (!shouldRun && plugin.toolExecutionLogger) {
 			plugin.toolExecutionLogger.destroy();
 			plugin.toolExecutionLogger = null;
+		}
+	}
+
+	/**
+	 * Detect scheduled tasks missed while the plugin was offline and either run
+	 * them automatically (autoRunCatchUp: true) or surface the approval modal.
+	 */
+	private async handleCatchUp(): Promise<void> {
+		const plugin = this.plugin;
+		if (!plugin.scheduledTaskManager || !plugin.backgroundStatusBar) return;
+
+		const pending = plugin.scheduledTaskManager.detectMissedRuns();
+		if (pending.length === 0) return;
+
+		if (plugin.settings.autoRunCatchUp) {
+			// Silent mode — submit all missed runs without asking
+			for (const entry of pending) {
+				try {
+					await plugin.scheduledTaskManager.runNow(entry.task.slug);
+					plugin.logger.log(`[LifecycleService] Auto catch-up: submitted "${entry.task.slug}"`);
+				} catch (err) {
+					plugin.logger.error(`[LifecycleService] Auto catch-up failed for "${entry.task.slug}":`, err);
+				}
+			}
+		} else {
+			// Show the ! badge — clicking it opens the CatchUpModal
+			plugin.backgroundStatusBar.setPendingCatchUpCount(pending.length);
 		}
 	}
 

--- a/src/services/lifecycle-service.ts
+++ b/src/services/lifecycle-service.ts
@@ -520,7 +520,7 @@ export class LifecycleService {
 	 */
 	private async handleCatchUp(): Promise<void> {
 		const plugin = this.plugin;
-		if (!plugin.scheduledTaskManager || !plugin.backgroundStatusBar) return;
+		if (!plugin.scheduledTaskManager) return;
 
 		const pending = plugin.scheduledTaskManager.detectMissedRuns();
 		if (pending.length === 0) return;
@@ -536,8 +536,10 @@ export class LifecycleService {
 				}
 			}
 		} else {
+			// Reserve slugs so the tick loop skips them until user approves/skips
+			plugin.scheduledTaskManager.reserveForCatchUp(pending.map((e) => e.task.slug));
 			// Show the ! badge — clicking it opens the CatchUpModal
-			plugin.backgroundStatusBar.setPendingCatchUpCount(pending.length);
+			plugin.backgroundStatusBar?.setPendingCatchUpCount(pending.length);
 		}
 	}
 

--- a/src/services/scheduled-task-manager.ts
+++ b/src/services/scheduled-task-manager.ts
@@ -160,6 +160,8 @@ export class ScheduledTaskManager {
 	 * to prevent stale callbacks from mutating state after teardown.
 	 */
 	private pendingDefers = new Set<ReturnType<typeof setTimeout>>();
+	/** Slugs reserved for catch-up approval — tick skips these until approved or skipped. */
+	private catchUpPending = new Set<string>();
 
 	constructor(private plugin: ObsidianGemini) {}
 
@@ -330,6 +332,13 @@ export class ScheduledTaskManager {
 				continue;
 			}
 
+			if (this.catchUpPending.has(task.slug)) {
+				this.plugin.logger.log(
+					`[ScheduledTaskManager] Task "${task.slug}" is awaiting catch-up approval — skipping tick`
+				);
+				continue;
+			}
+
 			const nextRunAt = new Date(taskState.nextRunAt);
 			if (now < nextRunAt) continue;
 
@@ -345,6 +354,7 @@ export class ScheduledTaskManager {
 	async runNow(slug: string): Promise<string> {
 		const task = this.tasks.get(slug);
 		if (!task) throw new Error(`Scheduled task "${slug}" not found`);
+		this.catchUpPending.delete(slug);
 		return this.submitTask(task, new Date());
 	}
 
@@ -404,10 +414,21 @@ export class ScheduledTaskManager {
 	}
 
 	/**
+	 * Mark slugs as pending catch-up approval so the tick loop skips them
+	 * until the user approves or skips each one via the CatchUpModal.
+	 */
+	reserveForCatchUp(slugs: string[]): void {
+		for (const slug of slugs) {
+			this.catchUpPending.add(slug);
+		}
+	}
+
+	/**
 	 * Advance a task's nextRunAt without running it — used by the catch-up modal
 	 * "Skip" action so the task is not re-detected on the next plugin launch.
 	 */
 	async skipCatchUp(slug: string): Promise<void> {
+		this.catchUpPending.delete(slug);
 		const task = this.tasks.get(slug);
 		if (!task || !this.state[slug]) return;
 		const nextRunAt = computeNextRunAt(task.schedule, new Date());

--- a/src/services/scheduled-task-manager.ts
+++ b/src/services/scheduled-task-manager.ts
@@ -80,6 +80,13 @@ export interface TaskState {
 /** The full sidecar state file — a map of slug → TaskState. */
 export type ScheduledTasksState = Record<string, TaskState>;
 
+/** A single missed-run entry returned by detectMissedRuns(). */
+export interface PendingCatchUp {
+	task: ScheduledTask;
+	/** The nextRunAt instant that was missed. */
+	missedAt: Date;
+}
+
 // ─── Pure helper ─────────────────────────────────────────────────────────────
 
 /**
@@ -360,6 +367,55 @@ export class ScheduledTaskManager {
 			pausedDueToErrors: false,
 		};
 		await this.saveState();
+	}
+
+	/**
+	 * Returns one entry per task that missed its scheduled run while the plugin
+	 * was offline. Only tasks with `runIfMissed: true` and `enabled: true` are
+	 * included. Multiple missed windows for the same task are collapsed into a
+	 * single entry — the caller just needs to know "this task needs a catch-up
+	 * run", not how many it missed.
+	 *
+	 * @param windowMs  How far back to look (default: 7 days). Tasks whose
+	 *                  nextRunAt is older than this are considered stale and
+	 *                  excluded — they missed their window entirely.
+	 */
+	detectMissedRuns(windowMs = 7 * 24 * 60 * 60 * 1000): PendingCatchUp[] {
+		const now = new Date();
+		const cutoff = new Date(now.getTime() - windowMs);
+		const result: PendingCatchUp[] = [];
+
+		for (const task of this.tasks.values()) {
+			if (!task.enabled || !task.runIfMissed) continue;
+			if (task.schedule === 'once') continue;
+
+			const taskState = this.state[task.slug];
+			if (!taskState) continue;
+			if (taskState.pausedDueToErrors) continue;
+
+			const nextRunAt = new Date(taskState.nextRunAt);
+			// Due in the past AND within the catch-up window
+			if (nextRunAt < now && nextRunAt >= cutoff) {
+				result.push({ task, missedAt: nextRunAt });
+			}
+		}
+
+		return result;
+	}
+
+	/**
+	 * Advance a task's nextRunAt without running it — used by the catch-up modal
+	 * "Skip" action so the task is not re-detected on the next plugin launch.
+	 */
+	async skipCatchUp(slug: string): Promise<void> {
+		const task = this.tasks.get(slug);
+		if (!task || !this.state[slug]) return;
+		const nextRunAt = computeNextRunAt(task.schedule, new Date());
+		this.state[slug] = { ...this.state[slug], nextRunAt: nextRunAt.toISOString() };
+		await this.saveState();
+		this.plugin.logger.log(
+			`[ScheduledTaskManager] Catch-up skipped for "${slug}" — next run at ${nextRunAt.toISOString()}`
+		);
 	}
 
 	/** Returns a copy of the current runtime state map. */

--- a/src/ui/catch-up-modal.ts
+++ b/src/ui/catch-up-modal.ts
@@ -1,4 +1,4 @@
-import { App, Modal, setIcon } from 'obsidian';
+import { App, Modal, Notice, setIcon } from 'obsidian';
 import type ObsidianGemini from '../main';
 import type { PendingCatchUp } from '../services/scheduled-task-manager';
 
@@ -45,9 +45,18 @@ export class CatchUpModal extends Modal {
 			attr: { type: 'button' },
 		});
 		runAllBtn.addEventListener('click', async () => {
-			await this.approveAll();
-			this.pending = [];
-			this.close();
+			runAllBtn.disabled = true;
+			skipAllBtn.disabled = true;
+			try {
+				await this.approveAll();
+				this.pending = [];
+				this.close();
+			} catch (err) {
+				this.plugin.logger.error('[CatchUpModal] Run all failed:', err);
+				new Notice('Some tasks failed to run — check logs for details.');
+				runAllBtn.disabled = false;
+				skipAllBtn.disabled = false;
+			}
 		});
 
 		const skipAllBtn = actions.createEl('button', {
@@ -55,9 +64,18 @@ export class CatchUpModal extends Modal {
 			attr: { type: 'button' },
 		});
 		skipAllBtn.addEventListener('click', async () => {
-			await this.skipAll();
-			this.pending = [];
-			this.close();
+			runAllBtn.disabled = true;
+			skipAllBtn.disabled = true;
+			try {
+				await this.skipAll();
+				this.pending = [];
+				this.close();
+			} catch (err) {
+				this.plugin.logger.error('[CatchUpModal] Skip all failed:', err);
+				new Notice('Some tasks failed to skip — check logs for details.');
+				runAllBtn.disabled = false;
+				skipAllBtn.disabled = false;
+			}
 		});
 	}
 
@@ -100,12 +118,21 @@ export class CatchUpModal extends Modal {
 				attr: { type: 'button' },
 			});
 			approveBtn.addEventListener('click', async () => {
-				await this.approveOne(entry);
-				this.pending = this.pending.filter((p) => p.task.slug !== entry.task.slug);
-				if (this.pending.length === 0) {
-					this.close();
-				} else {
-					this.renderList(list);
+				approveBtn.disabled = true;
+				skipBtn.disabled = true;
+				try {
+					await this.approveOne(entry);
+					this.pending = this.pending.filter((p) => p.task.slug !== entry.task.slug);
+					if (this.pending.length === 0) {
+						this.close();
+					} else {
+						this.renderList(list);
+					}
+				} catch (err) {
+					this.plugin.logger.error(`[CatchUpModal] Failed to run "${entry.task.slug}":`, err);
+					new Notice(`Failed to run "${entry.task.slug}" — check logs for details.`);
+					approveBtn.disabled = false;
+					skipBtn.disabled = false;
 				}
 			});
 
@@ -114,12 +141,21 @@ export class CatchUpModal extends Modal {
 				attr: { type: 'button' },
 			});
 			skipBtn.addEventListener('click', async () => {
-				await this.skipOne(entry);
-				this.pending = this.pending.filter((p) => p.task.slug !== entry.task.slug);
-				if (this.pending.length === 0) {
-					this.close();
-				} else {
-					this.renderList(list);
+				approveBtn.disabled = true;
+				skipBtn.disabled = true;
+				try {
+					await this.skipOne(entry);
+					this.pending = this.pending.filter((p) => p.task.slug !== entry.task.slug);
+					if (this.pending.length === 0) {
+						this.close();
+					} else {
+						this.renderList(list);
+					}
+				} catch (err) {
+					this.plugin.logger.error(`[CatchUpModal] Failed to skip "${entry.task.slug}":`, err);
+					new Notice(`Failed to skip "${entry.task.slug}" — check logs for details.`);
+					approveBtn.disabled = false;
+					skipBtn.disabled = false;
 				}
 			});
 		}

--- a/src/ui/catch-up-modal.ts
+++ b/src/ui/catch-up-modal.ts
@@ -1,0 +1,162 @@
+import { App, Modal, setIcon } from 'obsidian';
+import type ObsidianGemini from '../main';
+import type { PendingCatchUp } from '../services/scheduled-task-manager';
+
+/**
+ * Modal shown on startup when scheduled tasks were missed while the plugin
+ * was offline and the tasks have runIfMissed: true.
+ *
+ * Each row shows the task slug + how long ago it was due, with per-row
+ * Approve / Skip buttons and global "Run all" / "Skip all" actions.
+ *
+ * Approving submits the task immediately via BackgroundTaskManager.
+ * Skipping advances the task's nextRunAt without running it.
+ */
+export class CatchUpModal extends Modal {
+	private plugin: ObsidianGemini;
+	private pending: PendingCatchUp[];
+
+	constructor(app: App, plugin: ObsidianGemini, pending: PendingCatchUp[]) {
+		super(app);
+		this.plugin = plugin;
+		this.pending = [...pending];
+	}
+
+	onOpen(): void {
+		const { contentEl } = this;
+		contentEl.empty();
+		contentEl.addClass('gemini-catchup-modal');
+
+		contentEl.createEl('h2', { text: 'Missed Scheduled Runs' });
+		contentEl.createEl('p', {
+			text: 'The following tasks were scheduled to run while Obsidian was closed. Choose which ones to run now.',
+			cls: 'gemini-catchup-description',
+		});
+
+		const list = contentEl.createEl('ul', { cls: 'gemini-catchup-list' });
+		this.renderList(list);
+
+		// Global actions
+		const actions = contentEl.createDiv({ cls: 'gemini-catchup-actions' });
+
+		const runAllBtn = actions.createEl('button', {
+			text: 'Run all',
+			cls: 'mod-cta',
+			attr: { type: 'button' },
+		});
+		runAllBtn.addEventListener('click', async () => {
+			await this.approveAll();
+			this.pending = [];
+			this.close();
+		});
+
+		const skipAllBtn = actions.createEl('button', {
+			text: 'Skip all',
+			attr: { type: 'button' },
+		});
+		skipAllBtn.addEventListener('click', async () => {
+			await this.skipAll();
+			this.pending = [];
+			this.close();
+		});
+	}
+
+	onClose(): void {
+		this.contentEl.empty();
+		// Only clear the badge when all tasks have been handled (run or skipped).
+		// If the user dismissed without acting, leave the badge so they can reopen.
+		if (this.pending.length === 0) {
+			this.plugin.backgroundStatusBar?.setPendingCatchUpCount(0);
+		}
+	}
+
+	// ---------------------------------------------------------------------------
+
+	private renderList(list: HTMLElement): void {
+		list.empty();
+
+		if (this.pending.length === 0) {
+			list.createEl('li', { text: 'No pending runs.', cls: 'gemini-catchup-empty' });
+			return;
+		}
+
+		for (const entry of this.pending) {
+			const li = list.createEl('li', { cls: 'gemini-catchup-item' });
+
+			const info = li.createDiv({ cls: 'gemini-catchup-item-info' });
+			const iconEl = info.createSpan({ cls: 'gemini-catchup-item-icon' });
+			setIcon(iconEl, 'clock');
+			info.createSpan({ cls: 'gemini-catchup-item-slug', text: entry.task.slug });
+			info.createSpan({
+				cls: 'gemini-catchup-item-age',
+				text: `missed ${this.formatAge(entry.missedAt)}`,
+			});
+
+			const btns = li.createDiv({ cls: 'gemini-catchup-item-btns' });
+
+			const approveBtn = btns.createEl('button', {
+				text: 'Run',
+				cls: 'mod-cta gemini-catchup-approve',
+				attr: { type: 'button' },
+			});
+			approveBtn.addEventListener('click', async () => {
+				await this.approveOne(entry);
+				this.pending = this.pending.filter((p) => p.task.slug !== entry.task.slug);
+				if (this.pending.length === 0) {
+					this.close();
+				} else {
+					this.renderList(list);
+				}
+			});
+
+			const skipBtn = btns.createEl('button', {
+				text: 'Skip',
+				attr: { type: 'button' },
+			});
+			skipBtn.addEventListener('click', async () => {
+				await this.skipOne(entry);
+				this.pending = this.pending.filter((p) => p.task.slug !== entry.task.slug);
+				if (this.pending.length === 0) {
+					this.close();
+				} else {
+					this.renderList(list);
+				}
+			});
+		}
+	}
+
+	private async approveOne(entry: PendingCatchUp): Promise<void> {
+		const mgr = this.plugin.scheduledTaskManager;
+		if (!mgr) return;
+		await mgr.runNow(entry.task.slug);
+	}
+
+	private async skipOne(entry: PendingCatchUp): Promise<void> {
+		const mgr = this.plugin.scheduledTaskManager;
+		if (!mgr) return;
+		// Advance state so the task is not picked up again on the next tick
+		await mgr.skipCatchUp(entry.task.slug);
+	}
+
+	private async approveAll(): Promise<void> {
+		for (const entry of this.pending) {
+			await this.approveOne(entry);
+		}
+	}
+
+	private async skipAll(): Promise<void> {
+		for (const entry of this.pending) {
+			await this.skipOne(entry);
+		}
+	}
+
+	private formatAge(date: Date): string {
+		const diffMs = Date.now() - date.getTime();
+		const mins = Math.floor(diffMs / 60_000);
+		if (mins < 60) return `${mins}m ago`;
+		const hours = Math.floor(mins / 60);
+		if (hours < 24) return `${hours}h ago`;
+		const days = Math.floor(hours / 24);
+		return `${days}d ago`;
+	}
+}

--- a/src/ui/settings-ui.ts
+++ b/src/ui/settings-ui.ts
@@ -37,4 +37,16 @@ export function renderUISettings(containerEl: HTMLElement, plugin: ObsidianGemin
 				await plugin.saveSettings();
 			})
 		);
+
+	new Setting(containerEl)
+		.setName('Auto-run missed scheduled tasks on startup')
+		.setDesc(
+			'When enabled, tasks that were missed while Obsidian was closed (and have "Run if missed" set) are submitted automatically on startup without showing the approval modal.'
+		)
+		.addToggle((toggle) =>
+			toggle.setValue(plugin.settings.autoRunCatchUp).onChange(async (value) => {
+				plugin.settings.autoRunCatchUp = value;
+				await plugin.saveSettings();
+			})
+		);
 }

--- a/styles.css
+++ b/styles.css
@@ -4715,7 +4715,7 @@ If your plugin does not need CSS, delete this file.
 
 .gemini-catchup-item-age {
 	color: var(--text-muted);
-	font-size: var(--font-smaller);
+	font-size: var(--font-ui-smaller);
 	flex-shrink: 0;
 }
 

--- a/styles.css
+++ b/styles.css
@@ -4643,6 +4643,100 @@ If your plugin does not need CSS, delete this file.
 	animation: gemini-spin 1s linear infinite;
 }
 
+/* ── Catch-up badge ────────────────────────────────────────────── */
+
+.gemini-bg-status-badge {
+	display: none;
+	font-size: 10px;
+	font-weight: 700;
+	color: var(--text-on-accent);
+	background: var(--color-red);
+	border-radius: 50%;
+	width: 14px;
+	height: 14px;
+	line-height: 14px;
+	text-align: center;
+	margin-left: 2px;
+	vertical-align: middle;
+}
+
+/* ── Catch-up modal ────────────────────────────────────────────── */
+
+.gemini-catchup-modal .modal-content {
+	min-width: 420px;
+	max-width: 560px;
+}
+
+.gemini-catchup-description {
+	color: var(--text-muted);
+	margin-bottom: 16px;
+}
+
+.gemini-catchup-list {
+	list-style: none;
+	margin: 0 0 16px;
+	padding: 0;
+}
+
+.gemini-catchup-item {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 8px;
+	padding: 8px 0;
+	border-bottom: 1px solid var(--background-modifier-border);
+}
+
+.gemini-catchup-item:last-child {
+	border-bottom: none;
+}
+
+.gemini-catchup-item-info {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	flex: 1;
+	min-width: 0;
+}
+
+.gemini-catchup-item-icon svg {
+	width: 14px;
+	height: 14px;
+	color: var(--text-muted);
+	flex-shrink: 0;
+}
+
+.gemini-catchup-item-slug {
+	font-weight: 500;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.gemini-catchup-item-age {
+	color: var(--text-muted);
+	font-size: var(--font-smaller);
+	flex-shrink: 0;
+}
+
+.gemini-catchup-item-btns {
+	display: flex;
+	gap: 6px;
+	flex-shrink: 0;
+}
+
+.gemini-catchup-actions {
+	display: flex;
+	gap: 8px;
+	justify-content: flex-end;
+	padding-top: 8px;
+	border-top: 1px solid var(--background-modifier-border);
+}
+
+.gemini-catchup-empty {
+	color: var(--text-muted);
+}
+
 /* ── Scheduled Tasks Modal ─────────────────────────────────────── */
 
 .gemini-scheduled-tasks-modal .modal-content {

--- a/test/services/lifecycle-service.test.ts
+++ b/test/services/lifecycle-service.test.ts
@@ -161,6 +161,7 @@ vi.mock('../../src/services/background-status-bar', () => ({
 			update: vi.fn(),
 			destroy: vi.fn(),
 			setRagProvider: vi.fn(),
+			setPendingCatchUpCount: vi.fn(),
 		};
 	}),
 }));
@@ -182,6 +183,7 @@ vi.mock('../../src/services/scheduled-task-manager', () => ({
 import { LifecycleService } from '../../src/services/lifecycle-service';
 import { BackgroundTaskManager } from '../../src/services/background-task-manager';
 import { BackgroundStatusBar } from '../../src/services/background-status-bar';
+import { ScheduledTaskManager } from '../../src/services/scheduled-task-manager';
 import { ToolRegistrar } from '../../src/services/tool-registrar';
 import { ProjectActivationSubscriber } from '../../src/subscribers/project-activation-subscriber';
 
@@ -374,6 +376,75 @@ describe('LifecycleService', () => {
 			expect(mockPlugin.promptManager.createDefaultPrompts).toHaveBeenCalled();
 			expect(mockPlugin.promptManager.setupPromptCommands).toHaveBeenCalled();
 			expect(mockPlugin.history.onLayoutReady).toHaveBeenCalled();
+		});
+	});
+
+	describe('catch-up handling on layout ready', () => {
+		const missedTask = (slug: string) => ({ task: { slug }, missedAt: new Date(Date.now() - 60_000) });
+
+		// Wires the ScheduledTaskManager mock so `detectMissedRuns` returns the
+		// supplied entries on the next instantiation. Returns the live mock
+		// instance once setup() has run, so tests can assert on its methods.
+		async function withMissedRuns(entries: ReturnType<typeof missedTask>[], settingsOverride: any = {}) {
+			Object.assign(mockPlugin.settings, settingsOverride);
+			(ScheduledTaskManager as unknown as Mock).mockImplementationOnce(function () {
+				return {
+					initialize: vi.fn().mockResolvedValue(undefined),
+					start: vi.fn(),
+					destroy: vi.fn(),
+					detectMissedRuns: vi.fn().mockReturnValue(entries),
+					runNow: vi.fn().mockResolvedValue('bg-task-1'),
+					skipCatchUp: vi.fn().mockResolvedValue(undefined),
+					reserveForCatchUp: vi.fn(),
+				};
+			});
+			await lifecycle.setup();
+			return mockPlugin.scheduledTaskManager;
+		}
+
+		it('auto-runs every missed task when autoRunCatchUp is true', async () => {
+			const mgr = await withMissedRuns([missedTask('task-a'), missedTask('task-b')], { autoRunCatchUp: true });
+
+			await lifecycle.onLayoutReady();
+
+			expect(mgr.runNow).toHaveBeenCalledTimes(2);
+			expect(mgr.runNow).toHaveBeenCalledWith('task-a');
+			expect(mgr.runNow).toHaveBeenCalledWith('task-b');
+			expect(mgr.reserveForCatchUp).not.toHaveBeenCalled();
+			expect(mockPlugin.backgroundStatusBar.setPendingCatchUpCount).not.toHaveBeenCalled();
+		});
+
+		it('reserves slugs and surfaces a badge when autoRunCatchUp is false', async () => {
+			const mgr = await withMissedRuns([missedTask('task-a'), missedTask('task-b')], { autoRunCatchUp: false });
+
+			await lifecycle.onLayoutReady();
+
+			expect(mgr.runNow).not.toHaveBeenCalled();
+			expect(mgr.reserveForCatchUp).toHaveBeenCalledWith(['task-a', 'task-b']);
+			expect(mockPlugin.backgroundStatusBar.setPendingCatchUpCount).toHaveBeenCalledWith(2);
+		});
+
+		it('is a no-op when no missed runs are detected', async () => {
+			const mgr = await withMissedRuns([], { autoRunCatchUp: false });
+
+			await lifecycle.onLayoutReady();
+
+			expect(mgr.runNow).not.toHaveBeenCalled();
+			expect(mgr.reserveForCatchUp).not.toHaveBeenCalled();
+			expect(mockPlugin.backgroundStatusBar.setPendingCatchUpCount).not.toHaveBeenCalled();
+		});
+
+		it('continues catch-up after a single runNow failure', async () => {
+			const mgr = await withMissedRuns([missedTask('boom'), missedTask('ok')], { autoRunCatchUp: true });
+			mgr.runNow.mockRejectedValueOnce(new Error('submit failed')).mockResolvedValueOnce('bg-task-2');
+
+			await lifecycle.onLayoutReady();
+
+			expect(mgr.runNow).toHaveBeenCalledTimes(2);
+			expect(mockPlugin.logger.error).toHaveBeenCalledWith(
+				expect.stringContaining('Auto catch-up failed for "boom"'),
+				expect.any(Error)
+			);
 		});
 	});
 

--- a/test/services/lifecycle-service.test.ts
+++ b/test/services/lifecycle-service.test.ts
@@ -170,6 +170,10 @@ vi.mock('../../src/services/scheduled-task-manager', () => ({
 			initialize: vi.fn().mockResolvedValue(undefined),
 			start: vi.fn(),
 			destroy: vi.fn(),
+			detectMissedRuns: vi.fn().mockReturnValue([]),
+			runNow: vi.fn().mockResolvedValue('bg-task-1'),
+			skipCatchUp: vi.fn().mockResolvedValue(undefined),
+			reserveForCatchUp: vi.fn(),
 		};
 	}),
 }));

--- a/test/services/scheduled-task-manager.test.ts
+++ b/test/services/scheduled-task-manager.test.ts
@@ -593,6 +593,92 @@ describe('ScheduledTaskManager', () => {
 		});
 	});
 
+	// ── detectMissedRuns ────────────────────────────────────────────────────
+
+	describe('detectMissedRuns', () => {
+		async function makeManagerWithMissedRuns(
+			tasks: Array<{ slug: string; schedule: string; runIfMissed: boolean; enabled?: boolean }>,
+			states: Record<string, { nextRunAt: string }>
+		) {
+			const plugin = createMockPlugin();
+			plugin.app.vault.getMarkdownFiles.mockReturnValue(
+				tasks.map((t) => ({ path: `gemini-scribe/Scheduled-Tasks/${t.slug}.md`, basename: t.slug }))
+			);
+			plugin.app.metadataCache.getFileCache.mockImplementation(({ basename }: { basename: string }) => {
+				const t = tasks.find((x) => x.slug === basename);
+				if (!t) return null;
+				return { frontmatter: { schedule: t.schedule, enabled: t.enabled ?? true, runIfMissed: t.runIfMissed } };
+			});
+			plugin.app.vault.read = vi.fn().mockResolvedValue('prompt');
+			plugin.app.vault.adapter.exists.mockResolvedValue(true);
+			plugin.app.vault.adapter.read.mockResolvedValue(JSON.stringify(states));
+			const manager = new ScheduledTaskManager(plugin);
+			await manager.initialize();
+			return manager;
+		}
+
+		it('returns tasks overdue within the window with runIfMissed: true', async () => {
+			const missedAt = new Date(Date.now() - 2 * 60 * 60 * 1000);
+			const manager = await makeManagerWithMissedRuns([{ slug: 'task-a', schedule: 'daily', runIfMissed: true }], {
+				'task-a': { nextRunAt: missedAt.toISOString() },
+			});
+			const missed = manager.detectMissedRuns();
+			expect(missed).toHaveLength(1);
+			expect(missed[0].task.slug).toBe('task-a');
+		});
+
+		it('excludes tasks with runIfMissed: false', async () => {
+			const missedAt = new Date(Date.now() - 2 * 60 * 60 * 1000);
+			const manager = await makeManagerWithMissedRuns([{ slug: 'no-catchup', schedule: 'daily', runIfMissed: false }], {
+				'no-catchup': { nextRunAt: missedAt.toISOString() },
+			});
+			expect(manager.detectMissedRuns()).toHaveLength(0);
+		});
+
+		it('excludes tasks outside the catch-up window', async () => {
+			const tooOld = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000);
+			const manager = await makeManagerWithMissedRuns([{ slug: 'stale', schedule: 'daily', runIfMissed: true }], {
+				stale: { nextRunAt: tooOld.toISOString() },
+			});
+			expect(manager.detectMissedRuns()).toHaveLength(0);
+		});
+
+		it('returns one entry per task regardless of how many runs were missed', async () => {
+			const missedAt = new Date(Date.now() - 1 * 60 * 60 * 1000);
+			const manager = await makeManagerWithMissedRuns(
+				[
+					{ slug: 'task-1', schedule: 'daily', runIfMissed: true },
+					{ slug: 'task-2', schedule: 'daily', runIfMissed: true },
+				],
+				{
+					'task-1': { nextRunAt: missedAt.toISOString() },
+					'task-2': { nextRunAt: missedAt.toISOString() },
+				}
+			);
+			const missed = manager.detectMissedRuns();
+			expect(missed).toHaveLength(2);
+			expect(missed.map((m) => m.task.slug).sort()).toEqual(['task-1', 'task-2']);
+		});
+
+		it('excludes disabled tasks', async () => {
+			const missedAt = new Date(Date.now() - 1 * 60 * 60 * 1000);
+			const manager = await makeManagerWithMissedRuns(
+				[{ slug: 'disabled', schedule: 'daily', runIfMissed: true, enabled: false }],
+				{ disabled: { nextRunAt: missedAt.toISOString() } }
+			);
+			expect(manager.detectMissedRuns()).toHaveLength(0);
+		});
+
+		it('respects a custom window', async () => {
+			const missedAt = new Date(Date.now() - 2 * 60 * 60 * 1000);
+			const manager = await makeManagerWithMissedRuns([{ slug: 'task-a', schedule: 'daily', runIfMissed: true }], {
+				'task-a': { nextRunAt: missedAt.toISOString() },
+			});
+			expect(manager.detectMissedRuns(3 * 60 * 60 * 1000)).toHaveLength(1);
+			expect(manager.detectMissedRuns(1 * 60 * 60 * 1000)).toHaveLength(0);
+		});
+	});
+
 	// ── destroy ──────────────────────────────────────────────────────────────
 
 	describe('destroy', () => {


### PR DESCRIPTION
## Summary

Implements missed-run catch-up for scheduled tasks. When Obsidian is closed, scheduled tasks cannot run. Tasks with `runIfMissed: true` in their frontmatter are now detected on the next startup and surfaced in an approval modal so the user can decide whether to run or skip each one.

Fixes #635
Parent: #589
Depends on: #633

## Changes

- **`ScheduledTaskManager`** — add `detectMissedRuns()` (returns tasks with `runIfMissed: true` whose `nextRunAt` is in the past within a 7-day window) and `skipCatchUp()` (advances `nextRunAt` without running)
- **`PendingCatchUp` interface** — `{ task: ScheduledTask, missedAt: Date }` exported from `scheduled-task-manager.ts`
- **`BackgroundStatusBar`** — add `!` badge (red circle) that appears when there are pending catch-up approvals; click handler opens `CatchUpModal` instead of the regular background tasks modal when badge count > 0
- **`LifecycleService`** — `handleCatchUp()` called from `onLayoutReady()` after `initialize()` + `start()`; auto-runs silently when `autoRunCatchUp` is enabled, otherwise sets badge count
- **`CatchUpModal`** — new modal with per-row Run/Skip buttons and global Run all/Skip all; dismissing without acting leaves badge visible so the modal can be reopened
- **`autoRunCatchUp` setting** — new boolean in UI Settings ("Auto-run missed scheduled tasks on startup"); default `false`
- **`docs/guide/scheduled-tasks.md`** — updated `runIfMissed` description, added Catch-up Runs section covering modal behaviour, auto-run setting, and edge-case notes
- **Tests** — 6 new `detectMissedRuns` cases in `scheduled-task-manager.test.ts`; `ScheduledTaskManager` mock in `lifecycle-service.test.ts` updated with `detectMissedRuns`, `runNow`, `skipCatchUp`

## Screenshots / Screencast
<img width="1820" height="209" alt="Screenshot 2026-04-26 at 9 20 57 AM" src="https://github.com/user-attachments/assets/969432b8-b156-45de-8418-fcb92d38195a" />

**Missed Scheduled Runs modal (default behaviour):**
Modal appears on startup listing overdue tasks with Run / Skip per row and Run all / Skip all global actions. The `!` badge on the status bar persists if the modal is dismissed without acting.

<img width="1920" height="1080" alt="Screenshot 2026-04-26 at 9 42 18 AM" src="https://github.com/user-attachments/assets/6996db39-2d9d-457d-9ac7-80812fe8c7e3" />

**autoRunCatchUp enabled:**
No modal appears. Tasks are submitted silently as background tasks on startup (visible in the Background Tasks tab of the activity modal if still running).

## Manual Testing Performed

All scenarios tested by backdating `nextRunAt` in `scheduled-tasks-state.json` to yesterday, then fully quitting and restarting Obsidian (full quit required — "Reload app without saving" keeps the 60 s tick running which would fire and advance the date before startup catch-up runs):

| Scenario | Steps | Expected | Result |
|---|---|---|---|
| Modal appears on startup | `runIfMissed: true`, `nextRunAt` = yesterday, quit + restart | Missed Scheduled Runs modal opens automatically | ✅ |
| Skip (individual) | Click Skip on a row | Modal row removed; `nextRunAt` advances to next schedule; badge clears when last row handled | ✅ |
| Run (individual) | Click Run on a row | Task submitted as background task; `nextRunAt` advances; badge clears when last row handled | ✅ |
| Skip all | Click Skip all | All tasks skipped; modal closes; badge clears | ✅ |
| Run all | Click Run all | All tasks submitted; modal closes; badge clears | ✅ |
| Dismiss without acting | Press Escape / click ✕ | Modal closes; `!` badge remains on status bar | ✅ |
| Badge click reopens modal | After dismiss, click `!` badge | Catch-up modal reopens (not regular background tasks modal) | ✅ |
| `autoRunCatchUp = true` | Enable setting, backdated date, quit + restart | No modal, no badge; task submitted silently; visible in Background Tasks modal | ✅ |
| Task paused — excluded | `pausedDueToErrors: true` | Task not shown in catch-up modal | ✅ (covered by unit test) |
| Outside 7-day window — excluded | `nextRunAt` > 7 days ago | Task not shown in catch-up modal | ✅ (covered by unit test) |
| `runIfMissed: false` — excluded | Default value | Task not shown in catch-up modal | ✅ (covered by unit test) |

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards)
  - Tested via `app.emulateMobile(true)` in DevTools — mobile layout renders correctly, modal is usable
  - **Known limitation:** Obsidian hides the status bar on mobile, so the `!` badge is not visible. The approval modal still auto-opens on startup via `handleCatchUp()`. If the user dismisses without acting, there is currently no way to reopen the modal on mobile (no badge to click). A follow-up could add a command palette entry (`Open Missed Runs`) to cover this gap.
- [x] Documentation has been updated (if applicable)
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude (claude-sonnet-4-6 via Claude Code)
- [x] I have reviewed and understand all AI-generated code in this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Catch-up workflow for missed scheduled tasks with a “Missed Scheduled Runs” modal, per-task Run/Skip and bulk Run all/Skip all actions.
  * New toggle to auto-run missed tasks on startup and a status-bar badge showing pending catch-up approvals.

* **Documentation**
  * Guide updated to explain missed-run handling, modal behavior, auto-run option, eligibility rules, and timing constraints.

* **Style**
  * Added UI styles for catch-up modal and badge.

* **Tests**
  * Added tests for catch-up detection and lifecycle handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->