### PR TITLE
test: migrate scheduled-task-manager tests from jest to vitest

### DIFF
--- a/test/services/scheduled-task-manager.test.ts
+++ b/test/services/scheduled-task-manager.test.ts
@@ -380,28 +380,27 @@ describe('ScheduledTaskManager', () => {
 			await manager.initialize();
 
 			// Capture both handlers registered during initialize()
-			const vaultOnCalls = (plugin.app.vault.on as jest.Mock).mock.calls;
-			const createHandler = vaultOnCalls.find(([e]: [string]) => e === 'create')?.[1] as (...a: unknown[]) => unknown;
-			const cacheOnCalls = (plugin.app.metadataCache.on as jest.Mock).mock.calls;
-			const changedHandler = cacheOnCalls.find(([e]: [string]) => e === 'changed')?.[1] as (...a: unknown[]) => unknown;
+			const vaultOnCalls = (plugin.app.vault.on as Mock).mock.calls;
+			const createHandler = vaultOnCalls.find(([e]: any[]) => e === 'create')?.[1] as (...a: unknown[]) => unknown;
+			const cacheOnCalls = (plugin.app.metadataCache.on as Mock).mock.calls;
+			const changedHandler = cacheOnCalls.find(([e]: any[]) => e === 'changed')?.[1] as (...a: unknown[]) => unknown;
 			expect(createHandler).toBeDefined();
 			expect(changedHandler).toBeDefined();
 
-			const { TFile: MockTFile } = jest.requireMock('obsidian');
 			const newFile = Object.assign(new MockTFile(), {
 				path: 'gemini-scribe/Scheduled-Tasks/new-task.md',
 				basename: 'new-task',
 				extension: 'md',
 			});
 			plugin.app.metadataCache.getFileCache.mockReturnValue({ frontmatter: { schedule: 'daily' } });
-			plugin.app.vault.read = jest.fn().mockResolvedValue('Do something.');
+			plugin.app.vault.read = vi.fn().mockResolvedValue('Do something.');
 
 			// Fire create then changed (as Obsidian would)
-			jest.useFakeTimers();
+			vi.useFakeTimers();
 			createHandler(newFile);
 			changedHandler(newFile); // fires before the 500 ms defer
-			jest.advanceTimersByTime(600);
-			jest.useRealTimers();
+			vi.advanceTimersByTime(600);
+			vi.useRealTimers();
 			await Promise.resolve();
 			await Promise.resolve();
 
@@ -416,20 +415,19 @@ describe('ScheduledTaskManager', () => {
 				{ path: 'gemini-scribe/Scheduled-Tasks/existing-task.md', basename: 'existing-task' },
 			]);
 			plugin.app.metadataCache.getFileCache.mockReturnValue({ frontmatter: { schedule: 'daily' } });
-			plugin.app.vault.read = jest.fn().mockResolvedValue('Original prompt.');
+			plugin.app.vault.read = vi.fn().mockResolvedValue('Original prompt.');
 			const manager = new ScheduledTaskManager(plugin);
 			await manager.initialize();
 
 			// Simulate an edit to the existing file (only changed fires, not create)
-			const cacheOnCalls = (plugin.app.metadataCache.on as jest.Mock).mock.calls;
-			const changedHandler = cacheOnCalls.find(([e]: [string]) => e === 'changed')?.[1] as (...a: unknown[]) => unknown;
-			const { TFile: MockTFile } = jest.requireMock('obsidian');
+			const cacheOnCalls = (plugin.app.metadataCache.on as Mock).mock.calls;
+			const changedHandler = cacheOnCalls.find(([e]: any[]) => e === 'changed')?.[1] as (...a: unknown[]) => unknown;
 			const existingFile = Object.assign(new MockTFile(), {
 				path: 'gemini-scribe/Scheduled-Tasks/existing-task.md',
 				basename: 'existing-task',
 				extension: 'md',
 			});
-			plugin.app.vault.read = jest.fn().mockResolvedValue('Updated prompt.');
+			plugin.app.vault.read = vi.fn().mockResolvedValue('Updated prompt.');
 			changedHandler(existingFile);
 			await Promise.resolve();
 			await Promise.resolve();
@@ -449,27 +447,26 @@ describe('ScheduledTaskManager', () => {
 			const manager = new ScheduledTaskManager(plugin);
 			await manager.initialize();
 
-			const vaultOnCalls = (plugin.app.vault.on as jest.Mock).mock.calls;
-			const createHandler = vaultOnCalls.find(([e]: [string]) => e === 'create')?.[1] as (...a: unknown[]) => unknown;
+			const vaultOnCalls = (plugin.app.vault.on as Mock).mock.calls;
+			const createHandler = vaultOnCalls.find(([e]: any[]) => e === 'create')?.[1] as (...a: unknown[]) => unknown;
 			expect(createHandler).toBeDefined();
 
-			const { TFile: MockTFile } = jest.requireMock('obsidian');
 			const newFile = Object.assign(new MockTFile(), {
 				path: 'gemini-scribe/Scheduled-Tasks/late-task.md',
 				basename: 'late-task',
 				extension: 'md',
 			});
-			plugin.app.vault.read = jest.fn().mockResolvedValue('Prompt body.');
+			plugin.app.vault.read = vi.fn().mockResolvedValue('Prompt body.');
 			plugin.app.metadataCache.getFileCache.mockReturnValue({ frontmatter: { schedule: 'daily' } });
 
-			jest.useFakeTimers();
+			vi.useFakeTimers();
 			// Fire create — starts the 500 ms defer
 			createHandler(newFile);
 			// destroy() before the defer fires
 			manager.destroy();
 			// Advance past the defer window — the cancelled timer must not fire
-			jest.advanceTimersByTime(600);
-			jest.useRealTimers();
+			vi.advanceTimersByTime(600);
+			vi.useRealTimers();
 			await Promise.resolve();
 			await Promise.resolve();
 
@@ -483,28 +480,27 @@ describe('ScheduledTaskManager', () => {
 			const manager = new ScheduledTaskManager(plugin);
 			await manager.initialize();
 
-			const vaultOnCalls = (plugin.app.vault.on as jest.Mock).mock.calls;
-			const createHandler = vaultOnCalls.find(([e]: [string]) => e === 'create')?.[1] as (...a: unknown[]) => unknown;
+			const vaultOnCalls = (plugin.app.vault.on as Mock).mock.calls;
+			const createHandler = vaultOnCalls.find(([e]: any[]) => e === 'create')?.[1] as (...a: unknown[]) => unknown;
 			expect(createHandler).toBeDefined();
 
-			const { TFile: MockTFile } = jest.requireMock('obsidian');
 			const newFile = Object.assign(new MockTFile(), {
 				path: 'gemini-scribe/Scheduled-Tasks/stale-task.md',
 				basename: 'stale-task',
 				extension: 'md',
 			});
-			plugin.app.vault.read = jest.fn().mockResolvedValue('Prompt body.');
+			plugin.app.vault.read = vi.fn().mockResolvedValue('Prompt body.');
 			plugin.app.metadataCache.getFileCache.mockReturnValue({ frontmatter: { schedule: 'daily' } });
 
-			jest.useFakeTimers();
+			vi.useFakeTimers();
 			// Fire create — starts the 500 ms defer
 			createHandler(newFile);
 			// Re-initialize before the defer fires — should cancel the pending timer
-			jest.useRealTimers();
+			vi.useRealTimers();
 			await manager.initialize();
-			jest.useFakeTimers();
-			jest.advanceTimersByTime(600);
-			jest.useRealTimers();
+			vi.useFakeTimers();
+			vi.advanceTimersByTime(600);
+			vi.useRealTimers();
 			await Promise.resolve();
 			await Promise.resolve();
 

--- a/test/services/scheduled-task-manager.test.ts
+++ b/test/services/scheduled-task-manager.test.ts
@@ -493,14 +493,20 @@ describe('ScheduledTaskManager', () => {
 			plugin.app.metadataCache.getFileCache.mockReturnValue({ frontmatter: { schedule: 'daily' } });
 
 			vi.useFakeTimers();
-			// Fire create — starts the 500 ms defer
-			createHandler(newFile);
-			// Re-initialize before the defer fires — should cancel the pending timer
-			vi.useRealTimers();
-			await manager.initialize();
-			vi.useFakeTimers();
-			vi.advanceTimersByTime(600);
-			vi.useRealTimers();
+			try {
+				// Fire create — starts the 500 ms defer
+				createHandler(newFile);
+				// Re-initialize before the defer fires — should cancel the pending timer.
+				// Pass refresh: true; without it initialize() short-circuits on
+				// already-initialized state and never runs the cancellation loop.
+				// Stay on fake timers throughout: under vitest 4, toggling
+				// fake → real → fake discards the pending defer, which would make
+				// this test pass trivially instead of verifying initialize()'s cancel.
+				await manager.initialize({ refresh: true });
+				vi.advanceTimersByTime(600);
+			} finally {
+				vi.useRealTimers();
+			}
 			await Promise.resolve();
 			await Promise.resolve();
 


### PR DESCRIPTION
## Summary

Hotfix for master CI: PR #696 added new tests using jest syntax before PR #699 migrated the test runner to vitest. The two PRs were in flight in opposite directions, so #699's mass jest→vi conversion didn't catch the new tests #696 was adding. After both merged, master ended up with **5 failing tests and 10 typecheck errors** in `test/services/scheduled-task-manager.test.ts`.

This PR converts the remaining jest references to their vitest equivalents.

## Changes

- `test/services/scheduled-task-manager.test.ts`:
  - `as jest.Mock` → `as Mock` (uses the existing top-of-file `import type { Mock } from 'vitest'`)
  - `jest.fn()` → `vi.fn()`
  - `jest.useFakeTimers / advanceTimersByTime / useRealTimers` → `vi.*`
  - Removed redundant `const { TFile: MockTFile } = jest.requireMock('obsidian')` calls — `MockTFile` is already imported at the top of the file
  - Widened `find(([e]: [string]) => …)` to `find(([e]: any[]) => …)` to satisfy vitest's stricter `mock.calls` typing

No source changes — test-only migration.

## Test plan

- [x] `npm test` — 1447 passed / 5 skipped / 0 failed (was: 1442 passed / 5 failed / 5 skipped on master)
- [x] `npm run typecheck:test` — passes (was: 10 errors on master)
- [x] `npm run build` — passes
- [x] `npm run format-check` — passes

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A, hotfix for broken master CI
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A, test-only change
- [x] Documentation has been updated (if applicable) — N/A, test-only change
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (Opus 4.7)
- [x] I have reviewed and understand all AI-generated code in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Migrated test suite to a new test runner and updated timer control handling.
  * Improved test reinitialization flow and ensured timers are reliably restored.
  * Removed redundant mock setup by relying on existing test imports.

**Note:** No user-facing changes. Internal testing infrastructure and reliability have been modernized.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->