### PR TITLE
feat(skills): daily-update orchestrator + per-day housekeeping skills

### DIFF
--- a/.agents/skills/audit-docs/SKILL.md
+++ b/.agents/skills/audit-docs/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: audit-docs
+description: Walk every user-facing doc in `docs/guide/`, `docs/reference/`, plus `README.md` and `AGENTS.md`, and validate each factual claim against the code (settings names + defaults, command-palette IDs, file paths, schedule formats, tool names). Patch drift in place; add new docs only for user-visible features that aren't covered. Use when the user asks to "audit the docs", "review the docs", "validate docs against the code", "find doc gaps", "sync docs with the codebase", or similar. Writes drift fixes + new docs to the working tree and stops; the caller (a human, or the `daily-update` meta-skill) is responsible for committing and opening a PR.
+---
+
+# Audit and extend the user-facing documentation
+
+`docs/` is the canonical home for user-facing documentation in this repo (rendered to the public docs site via vitepress). `README.md` is the GitHub landing page; `AGENTS.md`/`CLAUDE.md` is the contributor handbook (CLAUDE.md is `@AGENTS.md`, so editing AGENTS.md updates both). This skill keeps all four honest: it verifies what's written still matches the code, and fills in docs for user-visible features the directory doesn't cover yet.
+
+The docs are prose-forward and pragmatic — match that voice in anything you write. They are read by users (who have not seen the code) and by external contributors (who are about to read it). Optimize for both.
+
+## Out-of-scope: bundled help references
+
+`scripts/generate-help-references.mjs` runs at build time and regenerates `src/services/generated-help-references.ts` from `docs/guide/` and `docs/reference/`. **Do not hand-edit that file.** Adding or removing a markdown file in those directories automatically updates the in-app help skill — that's the whole point. If something looks stale in the bundled help, the fix is in the markdown source, not the generated TS.
+
+## Workflow
+
+Do these steps in order. Use `TodoWrite` to track them — long doc audits benefit from visible progress.
+
+### 1. Read every targeted doc
+
+Glob the four surfaces:
+
+```bash
+ls docs/guide/ docs/reference/ docs/contributing/
+```
+
+Read each file in `docs/guide/`, `docs/reference/`, plus `README.md` and `AGENTS.md` in full. Build a mental index keyed by surface: what each doc claims, what it says is shipped vs. deferred, what it says is out of scope.
+
+`docs/contributing/` is also fair game (testing.md, tool-development.md, ai-policy.md, contributing.md) but the bar for "drift" there is whether the _workflow_ still matches reality, not whether every code reference is current. Skim, don't audit line-by-line.
+
+### 2. Validate each doc against the code
+
+For every factual claim a doc makes, confirm it in the tree. Examples of claims worth checking (non-exhaustive — these are the categories that drift fastest in this repo):
+
+- **Settings names + defaults** — `docs/reference/settings.md` and `docs/reference/advanced-settings.md` claim a name and default for each setting. Compare against `src/settings.ts` (the `GeminiSettings` interface and `DEFAULT_SETTINGS` object). Watch for renames and migration entries.
+- **Command palette IDs and labels** — every doc that says "Command Palette → X" implies a command exists with that name. `Grep` for `addCommand({` in `src/main.ts` and verify each `id` + `name` referenced.
+- **Schedule formats** — `docs/guide/scheduled-tasks.md` lists `once`, `daily`, `weekly`, `interval:Xm`, `interval:Xh`. Compare against the schedule parser in `src/services/scheduled-task-manager.ts`.
+- **Frontmatter fields** — task frontmatter (`schedule`, `enabledTools`, `outputPath`, `model`, `enabled`, `runIfMissed`) and any other YAML schema documented. Verify every documented field is read by the code, and every code-read field is documented.
+- **Tool names** — `docs/guide/agent-mode.md` lists agent tools. Compare against actual tool registrations in `src/tools/`.
+- **Folder paths** — `[state-folder]/History/`, `[state-folder]/Prompts/`, `[state-folder]/Agent-Sessions/`, `[state-folder]/Skills/`. Verify the code creates the same paths.
+- **Model lists** — `src/models.ts` is the source of truth for available models and their capabilities. Drift here breaks user expectations.
+- **Permission tier names** — `read_only`, `read_write`, `destructive`. These appear in multiple docs; one rename in code can leave several docs stale.
+- **Tool gestures and UX claims** — drag-drop behavior, paste behavior, attachment limits (e.g. "20 MB cumulative"), file extensions classified as text vs. binary. Compare against `src/utils/file-classification.ts` and `src/ui/agent-view/`.
+- **Loop detection thresholds** — `docs/reference/loop-detection.md` claims specific thresholds. Verify against `src/agent/agent-loop.ts` and tool loop config.
+
+Record each discrepancy with file + line references. Don't fix drift inline as you find it; collect them and patch in step 4 so the reviewer sees a single tight diff per doc.
+
+### 3. Identify user-visible features not covered
+
+For each new feature shipped recently (use `git log --since="3 months ago" -- src/ | grep -E "^\s*(feat|feature)"` plus the existing `planning/changelog/` files if present), ask: _is there a guide or reference doc whose scope is mostly this feature?_
+
+A feature is a candidate for a new doc when **all** are true:
+
+1. It's user-visible (settings page, command palette, agent tool, frontmatter field, etc.) — not a refactor.
+2. It's load-bearing — a primary surface, not a one-off helper.
+3. Its current documentation is _zero_ — not "thin", "zero". Thin docs get expanded in place; missing docs get a new file.
+
+The form of the feature matters: agent tools belong in `docs/guide/agent-mode.md` (one section per tool, not a new file). New top-level features (a new mode like "Projects", a new pipeline like the attachment classifier) warrant their own file under `docs/guide/`.
+
+Don't create reference docs for internal abstractions (factory pattern, decorator, AgentLoop) — those belong in `AGENTS.md`. The `docs/reference/` directory is for user-facing references (settings, advanced settings, loop detection), not internal architecture.
+
+### 4. Patch drift in existing docs
+
+For each discrepancy collected in step 2, `Edit` the existing doc in place. Keep diffs minimal — one or two lines per drift item is typical. If the drift is conceptual (wrong claim about behavior, not just a stale name), call it out in the report so the commit message and PR body explicitly flag it.
+
+If a setting was renamed and both the old and new name appear scattered through the docs, fix every occurrence in this pass — readers get whiplash from a half-renamed surface.
+
+### 5. Write new docs
+
+One markdown file per uncovered feature, placed in `docs/guide/` (for user-flow docs) or `docs/reference/` (for reference tables). Filename is kebab-case and matches the feature name (`projects.md`, not `04-projects.md`).
+
+Match the structure of an existing similar doc — read `docs/guide/scheduled-tasks.md` or `docs/guide/agent-mode.md` to see the voice. Typical shape:
+
+```markdown
+# <Feature name>
+
+<One-paragraph framing: what it does, why a user would reach for it.>
+
+## Overview
+
+<2–4 paragraphs of context. Where the feature lives in the UI; what files
+or settings back it; where its output goes.>
+
+## <Tasks the user can perform>
+
+<Step-by-step or table-driven sections describing the user's actions.>
+
+## <Reference table if the feature has structured config>
+
+| Field | Required | Default | Description |
+
+## Tips / Gotchas
+
+<Bulleted list of non-obvious behaviors.>
+```
+
+Writing guidance:
+
+- **Explain the why, not just the what.** The UI shows _what_; the doc's value is _why_ a user would reach for this and what the trade-offs are.
+- **Show the path through the UI.** "Command Palette → Open Scheduler → New task" beats abstract description.
+- **Link to neighbors.** Cross-reference other guides when a concept spans them.
+- **Don't dump code into a user-facing doc.** Frontmatter examples are fine; TypeScript snippets are not.
+- **Keep each doc focused.** 100–250 lines is the sweet spot; split if it sprawls.
+
+If the new doc lives in `docs/guide/` or `docs/reference/`, the build step automatically picks it up for the bundled help skill — no extra wiring needed.
+
+### 6. Stop — leave the changes in the working tree
+
+This skill writes to the working tree and stops. Don't commit, don't push, don't open a PR — the caller owns that:
+
+- **Invoked by `daily-update`:** the meta-skill packages everything into one PR alongside the other daily sub-skills' changes. Don't try to commit yourself or you'll fight it.
+- **Invoked manually by the user:** they'll review the diff and either run `create-pr` or commit by hand. If the user explicitly asks for a PR, hand off to `create-pr`; don't reimplement the PR-opening dance here.
+
+Before you stop, **report what you changed** so the caller can write a useful commit message — list new docs by filename + one-line purpose, and drift fixes by filename + what conceptually was wrong. If conceptual drift was found (wrong behavior claim, not just a stale name), call it out explicitly so it lands in the commit message that follows.
+
+If nothing drifted and no new docs were warranted (a quiet day), say so plainly. Don't pad with "everything looks great." The caller may decide to skip committing entirely.
+
+## What not to do
+
+- **Don't edit `src/services/generated-help-references.ts`.** It's regenerated by `scripts/generate-help-references.mjs` at build time. Editing the markdown sources is the correct fix.
+- **Don't fix code drift by editing code** as part of this task. Drift fixes belong in separate PRs with their own review. Docs work shouldn't hide code changes.
+- **Don't update `src/release-notes.json` or `docs/changelog.md`.** Those are the version-release surface, not where doc updates land. The `release-process` skill owns them on version-bump days.
+- **Don't invent settings or commands.** If a doc references something that doesn't exist in the code, the doc is wrong — delete the reference, don't make the code match the doc.
+- **Don't write internal-architecture docs in `docs/`.** The factory/decorator pattern, the `AgentLoop` design, the AgentLoopHooks contract — those belong in `AGENTS.md`, which is already tracked in the repo for contributors.
+- **Don't change voice.** If a doc reads like a user guide today, keep it that way. If you're tempted to add a "Why we built this" section, ask whether the user actually needs that, or whether you're adding it for yourself.
+
+## Calibrating scope
+
+A typical daily run will find 0–3 drift items (mostly stale defaults or recently-renamed settings) and need 0 new docs. A monthly or post-release run may find more. If the diff is sprawling, slow down and ask the caller whether to split it into themed PRs — one mass "audit fixes" PR is hard to review.

--- a/.agents/skills/daily-changelog/SKILL.md
+++ b/.agents/skills/daily-changelog/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: daily-changelog
+description: Generate a daily changelog from the PRs that merged on a given date and write it to `planning/changelog/YYYY-MM-DD.md`. Use when the user asks for "the daily changelog", "what shipped today/yesterday", "what landed on <date>", "write up today's changes", "summarize the day's PRs", or any variant of "what merged on <date>". Defaults to yesterday when no date is given. Distinct from `src/release-notes.json` (per-version, user-facing) and `docs/changelog.md` (the rendered version stream) — this is an internal day-by-day record. Always writes one markdown file per day to `planning/changelog/`.
+---
+
+# Daily changelog
+
+This skill turns a day's worth of merged PRs into a short, readable changelog at `planning/changelog/YYYY-MM-DD.md`. It exists because obsidian-gemini ships through PRs (per `AGENTS.md` and team convention — no direct pushes to master), so "what shipped on day X" is exactly "which PRs merged on day X."
+
+The output is for humans skimming the project's history later — not for marketing, and not for users. **It is distinct from**:
+
+- `src/release-notes.json` — the source of truth for the in-app modal and the rendered docs site changelog. That file is updated only when a new plugin **version** ships (see the `release-process` skill).
+- `docs/changelog.md` — the vitepress page that renders `src/release-notes.json` for the docs site.
+
+The daily changelog is internal. It captures the day-by-day flow between version bumps. Optimize for _what changed and why_, with enough detail that a reader can decide whether to dig into the PR.
+
+## Workflow
+
+### 1. Pick the date
+
+If the user named a date, use it. Otherwise default to **yesterday in the user's local timezone** — today's work is usually still in flight, and "daily changelog" is a retrospective format.
+
+Resolve the date to ISO `YYYY-MM-DD`. Today's date is in the system context; subtract one day for the default.
+
+If the user says something ambiguous like "this week" or "the last few days", ask which single day they want — this skill writes one file per day. Offer to run it once per day in the range if they want a batch.
+
+### 2. Find the PRs that merged that day
+
+GitHub's `merged:YYYY-MM-DD` shorthand interprets the date in UTC, which silently misclassifies PRs merged late local-evening for anyone west of UTC. Always use a local-timezone-anchored ISO range so the day boundary matches what the user means by "today" / "yesterday":
+
+```bash
+TZ_OFFSET=$(date +%z)        # e.g. "-0700"
+TZ_FORMATTED="${TZ_OFFSET:0:3}:${TZ_OFFSET:3}"  # → "-07:00"
+
+gh pr list --repo allenhutchison/obsidian-gemini \
+  --state merged \
+  --search "merged:YYYY-MM-DDT00:00:00${TZ_FORMATTED}..YYYY-MM-DDT23:59:59${TZ_FORMATTED}" \
+  --limit 200 \
+  --json number,title,url,author,mergedAt,body,headRefName,additions,deletions
+```
+
+`--limit 200` is well above any realistic per-day PR count for this project. **After fetching, check whether the returned count equals the limit** — if `len(results) == 200`, you've hit the _local_ fetch cap, so bump `--limit` and re-fetch. Separately, the GitHub Search API hard-caps results at 1000 even with paging; if you ever approach that on a single day (extremely unusual here), narrow the window — split the day into morning/afternoon halves and run two queries.
+
+If the result is empty, write the file anyway with a one-line "no PRs merged" entry. An empty day is itself signal (was the maintainer out? freeze?) and the file's existence keeps the daily cadence visible.
+
+### 3. Pull the body for each PR
+
+The list query above already includes `body`. If you need more (review comments, the actual diff stat by file, linked issues), use:
+
+```bash
+gh pr view <N> --json title,body,commits,files,reviews
+```
+
+You usually don't need this — the PR title plus body is enough for the summary. Only dig in if a PR's body is empty or unhelpful.
+
+**Ignore the CodeRabbit auto-generated block at the end of every body.** It starts with `<!-- This is an auto-generated comment: release notes by coderabbit.ai -->` followed by `## Summary by CodeRabbit`, and it's a generic restatement of what the human Summary already covered. Paraphrasing both produces redundant, marketing-flavored notes. Read only the human-authored sections (typically `## Summary`, `## Changes`, `## Test plan` per the repo's PR template).
+
+### 4. Credit external contributors
+
+obsidian-gemini accepts external contributions (saheersk and others have shipped multiple PRs). When the PR's `author.login` is not `allenhutchison`:
+
+- Mention the contributor in the entry: `Contributed by @<login>.`
+- Don't editorialize about the maintainer's takeover/cleanup — that's PR-thread context, not changelog content.
+
+### 5. Write the Markdown
+
+File path: `planning/changelog/YYYY-MM-DD.md`. Create `planning/changelog/` if it doesn't exist.
+
+If the file already exists, **read it first**. The user may have hand-edited prior notes; don't blow that away. Default behavior: regenerate fresh and overwrite, but call out in your reply that you replaced the file. If the user wants merge-don't-replace behavior, they'll say so.
+
+Use this template:
+
+```markdown
+# Daily changelog — <Month DD, YYYY>
+
+**Date:** YYYY-MM-DD
+**PRs merged:** <N>
+
+---
+
+## Summary
+
+<One short paragraph (2–4 sentences) framing the day. Lead with the most consequential change. If the day was thin, say "Quiet day — <one-liner>." Don't pad.>
+
+## What shipped
+
+### [#<num> <PR title>](url)
+
+<1–3 sentences describing what the PR does and _why_, drawn from the PR body. If the PR body is empty or just "see commit", fall back to the title and `gh pr view`'s commit messages.>
+
+<Optional second paragraph if the PR has a non-obvious follow-up, caveat, or migration step worth flagging.>
+
+<Optional `Contributed by @<login>.` line for external contributors.>
+
+### [#<num> <PR title>](url)
+
+...
+```
+
+Order PRs by `mergedAt` ascending (chronological). Don't try to invent thematic groupings unless the day genuinely clusters into 2–3 themes — chronological is honest and easy to scan.
+
+### 6. Tell the user what you wrote
+
+After writing, reply with:
+
+- The file path
+- The PR count
+- One line on the day's shape (e.g., "mostly bugfixes" / "feature-heavy day" / "scheduler infra cleanup")
+
+Don't paste the whole file back. The user can open it.
+
+## Voice and style
+
+Match the PR-template voice — prose-forward, explains the _why_, doesn't shout in all-caps. A few specifics:
+
+- **No emojis** in the file. The PR template doesn't use them and neither should this.
+- **No marketing language** ("excited to announce", "powerful new"). State what changed.
+- **Link to the PR**, always. The PR is the source of truth; the changelog entry is a pointer.
+- **Don't list every commit.** A PR can have 12 commits; the reader cares about the PR's net effect, not the commit-by-commit history. Use commits only when the PR body is unhelpful and you need to reconstruct what happened.
+- **Quote the PR body sparingly.** Paraphrase to one tight paragraph. If the PR body is already a clean two-sentence Summary, you can lift it nearly verbatim — but trim ceremony.
+- **Be honest about scope.** A PR that's "Address CR feedback" is a fixup, not a feature. Say so. Trivial PRs can collapse to a single line.
+
+## What not to do
+
+- **Don't write release notes for an arbitrary date range in one file.** One date → one file. If asked for a week, generate seven files (or ask the user to pick a single day).
+- **Don't include direct commits to master.** The repo's convention is PR-only (per `AGENTS.md`). If a stray non-merge commit landed on master on that date, mention it in the Summary as an exception, but don't fabricate a "PR" entry for it.
+- **Don't fetch the full diff** unless a PR body is actively unhelpful. The diff is large and you rarely need it; the PR body and commit messages are usually sufficient.
+- **Don't commit the file** as part of this skill unless the user asks. Just write it. When invoked by `daily-update`, the wrapper handles the commit + PR flow. When invoked manually, the user reviews and decides.
+- **Don't update `src/release-notes.json` or `docs/changelog.md`.** Those are the user-facing version-release surface, not the daily activity log. They're handled by the `release-process` skill on version-bump days.
+- **Don't generate "Future work" or "Next steps" sections.** This is a retrospective of what shipped, not a plan. Forward-looking content lives in PR descriptions and issues.
+
+## Edge cases
+
+- **Squash-merged PRs with no merge commit.** Doesn't matter — `gh pr list --search "merged:DATE"` finds them by merge timestamp regardless of merge strategy. The repo predominantly uses squash merges.
+- **PRs merged across midnight UTC.** Already handled by the local-tz query in step 2 — every PR sorts onto the user-local day it actually shipped on. Nothing extra to do here.
+- **Reverts.** Treat the revert PR as its own entry. Don't try to silently retract the original PR's entry from a prior day's file.
+- **Dependabot / automated PRs.** Include them. Group multiple bot PRs under one entry if there are many on the same day ("Dependency bumps: #X, #Y, #Z — minor/patch updates to A, B, C"). The repo's auto-applied `dependencies` label makes them easy to spot.
+- **Version-bump PRs.** When a PR is the version-bump that triggers a release (touches `package.json`, `manifest.json`, `versions.json`, `src/release-notes.json`), call out the new version in the entry. The reader benefits from the version landmark.

--- a/.agents/skills/daily-update/SKILL.md
+++ b/.agents/skills/daily-update/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: daily-update
+description: Run obsidian-gemini's per-day housekeeping skills (daily-changelog, audit-docs, triage-issues) and package whatever they wrote into one PR. Use when the user asks to "do the daily update", "run the daily skills", "morning sweep", "end-of-day cleanup", or when invoked by a scheduled remote agent doing the daily run. Bundles the per-day skills behind one entry point so a single /schedule slot covers the whole routine. Safe to invoke manually at any time.
+---
+
+# Daily update — orchestrate per-day housekeeping skills
+
+The user's `/schedule` slots are limited (~15), so this skill bundles the per-day housekeeping skills behind one entry point. It runs each sub-skill in sequence, lets each one write to the working tree (or, in the case of `triage-issues`, apply labels directly on GitHub), and packages the combined diff into a single PR at the end.
+
+The working-tree sub-skills are deliberately "write-only" — they don't commit or push. That's this skill's job. Centralizing the side-effects means: one PR per daily run (easy to review), no empty PRs on quiet days (don't commit if nothing changed), and adding a new daily sub-skill is a one-line list edit here rather than another /schedule slot.
+
+## The sub-skills
+
+Run these in order. Each one's full workflow lives in its own SKILL.md — read it and execute it as if it had been invoked directly. Do not re-implement the logic here.
+
+1. **`daily-changelog`** → `.agents/skills/daily-changelog/SKILL.md`
+   - Default: yesterday in the user's local timezone.
+   - Writes one file: `planning/changelog/YYYY-MM-DD.md`.
+
+2. **`audit-docs`** → `.agents/skills/audit-docs/SKILL.md`
+   - Audits `docs/guide/`, `docs/reference/`, `README.md`, and `AGENTS.md` against the code; writes drift fixes and any new docs.
+   - On a quiet day, may write nothing — that's fine.
+
+3. **`triage-issues`** → `.agents/skills/triage-issues/SKILL.md`
+   - Lists open issues with no labels and applies appropriate labels via `gh`.
+   - This sub-skill has GitHub side-effects — labels are applied directly. The working tree is unaffected.
+   - Capture the count of issues labeled and the labels applied; surface it in the PR body even when the working tree is clean.
+
+When adding a new daily sub-skill in the future, append it here with the same shape (name → path → one-line outcome). Order matters only when sub-skills overlap on output paths (today they don't).
+
+## Workflow
+
+### 1. Start a fresh branch off master
+
+```bash
+git checkout master && git pull
+git checkout -b daily-update-$(date +%Y-%m-%d)
+```
+
+If a branch by that exact name already exists locally (the cron fired twice, or a manual run already happened today), append `-2`, `-3`, etc. — never reuse a branch from a previous run; the diff would conflate two days.
+
+### 2. Run each sub-skill in sequence
+
+For each sub-skill in the list above:
+
+- Read its `SKILL.md`.
+- Execute the workflow it describes, writing to the working tree (or applying labels, in the case of `triage-issues`).
+- When it's done, capture a one-line outcome ("wrote planning/changelog/2026-04-25.md, 6 PRs" / "no drift, no new docs warranted" / "labeled 4 issues: #710 enhancement+agent-config, ..."). You'll need these for the commit message and the PR body.
+
+If a sub-skill errors out partway, **don't abort the whole run**. Capture the error, move on to the next sub-skill. A daily run that flags one broken sub-skill is more useful than a daily run that breaks halfway and leaves the others un-attempted.
+
+### 3. Package the changes
+
+Check what's in the working tree:
+
+```bash
+git status --short
+```
+
+Decide what to do based on three cases:
+
+**Case A — the working tree is clean and `triage-issues` did nothing.** Quiet day:
+
+- Don't commit. Don't push. Don't open a PR. Empty PRs are noise.
+- Delete the branch you just created (`git checkout master && git branch -D daily-update-YYYY-MM-DD`) so the local branch list stays clean.
+- Report "no daily changes" and stop. The cron's job is done; absence of a PR is the signal.
+
+**Case B — the working tree is clean but `triage-issues` applied labels.** Report-only day:
+
+- Don't open a PR. Labels on GitHub are already applied — opening an empty-diff PR just to write a summary is more friction than it's worth.
+- Delete the branch (same as Case A).
+- Reply with the triage summary so a human can audit the labels if they want.
+
+**Case C — the working tree has changes.** Commit them all in one commit:
+
+```text
+chore(daily): YYYY-MM-DD daily update
+
+- daily-changelog: <one-line outcome>
+- audit-docs: <one-line outcome>
+- triage-issues: <one-line outcome>
+
+[any errors that occurred during sub-skill execution]
+```
+
+Then push and hand off to the **`create-pr`** skill (`.agents/skills/create-pr/SKILL.md`) to open the PR. That skill enforces the repo's PR template and runs the pre-flight checks (`npm run format-check`, `npm run build`, `npm test`). Do not bypass it — the daily PR plays by the same rules as any other.
+
+PR body should list each sub-skill's outcome again with the file paths it touched (and, for `triage-issues`, the issue numbers labeled and what label was applied to each), so a reviewer can navigate the diff by sub-skill. A regular (non-draft) PR is fine; mark draft only if `audit-docs` made conceptual drift fixes that benefit from a slower read.
+
+### 4. Report
+
+Reply to the caller with:
+
+- One line per sub-skill: ok / no-op / error (with the message if errored).
+- The PR URL, or "no PR — labels-only run, see triage summary above" / "no changes — no PR" depending on the case.
+
+That's it. Don't paste the PR body or the commit message back — the URL is enough for a human, and the cron only needs the success/failure signal.
+
+## What not to do
+
+- **Don't bundle sub-skill changes into separate commits.** One commit per daily run. The PR is the unit of review.
+- **Don't open a PR with no diff.** Quiet days are valid signal; the absence of a PR is the message. Triage-only days report inline, no PR.
+- **Don't push to master.** Always a branch + PR per repo convention (see `AGENTS.md`).
+- **Don't skip the pre-flight checks.** `create-pr` runs `npm run format-check`, `npm run build`, `npm test` for a reason. If `audit-docs` added a new markdown file that breaks vitepress, you want to know before the PR is open.
+- **Don't reuse a branch from a prior daily run.** Each run gets its own branch; same-day re-runs append a suffix.
+- **Don't try to "fix" a failing sub-skill from inside this skill.** Capture the error, move on, and let a human triage it from the run report.
+- **Don't reimplement sub-skill logic here.** Read the sub-skill's SKILL.md and follow it. If a sub-skill needs a behavior change, edit _that_ skill's SKILL.md and ship it as a separate PR.
+- **Don't apply documentation changes from `audit-docs` and forget to update `src/release-notes.json`.** The audit skill works against rendered docs; if it surfaces a user-visible behavior gap, file an issue rather than backfilling release notes after the fact. Daily-update is housekeeping, not feature work.
+
+## When sub-skills fight
+
+Today the three sub-skills write to disjoint surfaces (`planning/changelog/`, `docs/`+`README.md`+`AGENTS.md`, GitHub labels). If a future sub-skill ends up touching the same files as another, run them in dependency order (whoever generates the input first) and call out the dependency in the list above. If two sub-skills genuinely conflict on the same file, that's a sign one of them is mis-scoped — flag it and stop, don't paper over it with merge logic in this skill.

--- a/.agents/skills/daily-update/SKILL.md
+++ b/.agents/skills/daily-update/SKILL.md
@@ -34,10 +34,11 @@ When adding a new daily sub-skill in the future, append it here with the same sh
 
 ```bash
 git checkout master && git pull
-git checkout -b daily-update-$(date +%Y-%m-%d)
+BRANCH_NAME="daily-update-$(date +%Y-%m-%d)"
+git checkout -b "$BRANCH_NAME"
 ```
 
-If a branch by that exact name already exists locally (the cron fired twice, or a manual run already happened today), append `-2`, `-3`, etc. — never reuse a branch from a previous run; the diff would conflate two days.
+If a branch by that exact name already exists locally (the cron fired twice, or a manual run already happened today), append `-2`, `-3`, etc. — never reuse a branch from a previous run; the diff would conflate two days. Update `BRANCH_NAME` to the chosen suffix so the cleanup steps below find the right branch.
 
 ### 2. Run each sub-skill in sequence
 
@@ -62,13 +63,13 @@ Decide what to do based on three cases:
 **Case A — the working tree is clean and `triage-issues` did nothing.** Quiet day:
 
 - Don't commit. Don't push. Don't open a PR. Empty PRs are noise.
-- Delete the branch you just created (`git checkout master && git branch -D daily-update-YYYY-MM-DD`) so the local branch list stays clean.
+- Delete the branch you just created (`git checkout master && git branch -D "$BRANCH_NAME"`) so the local branch list stays clean.
 - Report "no daily changes" and stop. The cron's job is done; absence of a PR is the signal.
 
 **Case B — the working tree is clean but `triage-issues` applied labels.** Report-only day:
 
 - Don't open a PR. Labels on GitHub are already applied — opening an empty-diff PR just to write a summary is more friction than it's worth.
-- Delete the branch (same as Case A).
+- Delete the branch (same as Case A: `git checkout master && git branch -D "$BRANCH_NAME"`).
 - Reply with the triage summary so a human can audit the labels if they want.
 
 **Case C — the working tree has changes.** Commit them all in one commit:

--- a/.agents/skills/triage-issues/SKILL.md
+++ b/.agents/skills/triage-issues/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: triage-issues
+description: Walk every open issue with no labels and apply appropriate labels via `gh`. Conservative — never closes, reassigns, or invents labels; only adds existing ones. Use when the user asks to "triage issues", "label issues", "do issue triage", "label the unlabeled issues", "clean up the issue tracker", or similar. Has direct GitHub side-effects (label mutations); the working tree is unaffected. Reports a structured summary so the `daily-update` meta-skill or a human caller can audit what was applied.
+---
+
+# Triage open issues
+
+obsidian-gemini's issue tracker accumulates issues from users, contributors, and the maintainer. Many land without labels, which makes filtering and reporting harder later. This skill works through the unlabeled backlog and applies labels from the repo's existing label vocabulary based on the issue's content.
+
+This skill is **deliberately conservative**:
+
+- It only **applies** labels — never closes, reassigns, links, or comments.
+- It only uses labels that already exist in the repo.
+- When the issue is ambiguous, it abstains rather than guess.
+- It is safe to run repeatedly; previously-labeled issues are skipped automatically.
+
+## Workflow
+
+### 1. Load the repo's label vocabulary
+
+```bash
+gh label list --repo allenhutchison/obsidian-gemini --limit 100 \
+  --json name,description
+```
+
+Hold this list in working memory. **Do not invent labels.** If the issue genuinely needs a label that doesn't exist, flag it in the report and let the human decide whether to create it (label creation is out of scope for this skill).
+
+The repo currently has two practical label families. Check the live list each run; the exact set drifts:
+
+- **General intent**: `bug`, `enhancement`, `documentation`, `question`, `help wanted`, `good first issue`, `duplicate`, `invalid`, `wontfix`
+- **Area**: `agent-config`, `architecture`, `chat-ux`, `file-context`, `tool-execution`, `models`, `quick-win`, `epic`
+- **Auto-applied** (do not apply by hand): `codex`, `automated`, `dependencies`, `javascript`, `github_actions` — these are set by automation and labelling them manually adds noise.
+
+### 2. List unlabeled open issues
+
+```bash
+gh issue list --repo allenhutchison/obsidian-gemini \
+  --state open --search "no:label" \
+  --limit 100 \
+  --json number,title,body,author,createdAt
+```
+
+If the result is empty, write a one-line "no unlabeled issues" report and stop. This is the common case on a well-tended tracker.
+
+If the count is unusually large (>20 in a single run), still process them, but flag the pile-up in the report — it usually means triage hasn't run recently, or new issues are arriving faster than expected.
+
+### 3. Read and classify each issue
+
+For each issue:
+
+1. **Read the title and body in full.** Don't classify from the title alone — bug reports and feature requests can look identical at a glance.
+2. **Decide the intent label** (exactly one):
+   - `bug` — describes broken behavior, includes reproduction steps or "expected vs. actual"
+   - `enhancement` — proposes new functionality or an improvement to existing functionality
+   - `documentation` — reports a doc problem or asks for documentation
+   - `question` — asks how to do something, or seeks clarification on existing behavior
+   - **abstain** if the issue is too vague to classify (very short, no context, or genuinely ambiguous) — leave it unlabeled and surface in the report
+3. **Decide area label(s)** (zero or more, additive):
+   - `agent-config` — agent prompts, system prompt, model selection, agent profiles, projects
+   - `tool-execution` — tool calls, tool registry, tool safety, loop detection, tool permission tiers
+   - `file-context` — context system, file linking, attachment pipeline, drag-and-drop
+   - `chat-ux` — chat view UI, agent view UI, modals, status bar, ergonomics
+   - `architecture` — plumbing, services, lifecycle, refactors, internal structure
+   - `models` — model availability, model migration, model-specific bugs
+   - `quick-win` — only if the issue is small and self-contained AND the maintainer would likely accept the change without further design discussion
+   - `epic` — only for explicit tracking issues that group multiple sub-issues together; very rarely the right call from triage
+4. **Hold the proposed labels in memory.** Don't apply yet — apply in step 4 so the report reflects what was actually requested.
+
+Calibration:
+
+- A bug _can_ have an area label, and usually does.
+- A `question` rarely needs an area label — it's usually best left as a single label until the user clarifies what they're asking about.
+- Don't reach for `quick-win` unless the issue is genuinely small. The label exists to help contributors find approachable work; mislabelling it teaches contributors to ignore the label.
+- `documentation` issues should also get an area label when the affected doc is area-specific (`docs/guide/agent-mode.md` → `agent-config`); skip it for cross-cutting doc changes.
+
+### 4. Apply the labels
+
+For each issue with at least one proposed label, apply them:
+
+```bash
+gh issue edit <NUMBER> --repo allenhutchison/obsidian-gemini \
+  --add-label "<label1>" --add-label "<label2>"
+```
+
+`gh issue edit --add-label` is idempotent — re-running on an already-labeled issue is a no-op. The "no:label" filter in step 2 should already exclude these, but the idempotency is a useful safety net if a previous run was partial.
+
+Capture each application as `(issue_number, [labels_applied], one-line-rationale)` for the report.
+
+If `gh` errors on a particular issue (rate limit, transient failure), capture the error, **continue with the next issue**, and surface the failed issue in the report. A failed run partway through is worse than a complete-with-warnings run.
+
+### 5. Report
+
+Print a structured summary so the caller (a human, or the `daily-update` meta-skill) can audit:
+
+```text
+Triage report — YYYY-MM-DD
+
+Issues processed: N
+Issues labeled: M
+Issues abstained: K (left unlabeled, see below)
+Errors: E
+
+Labeled:
+- #710 bug + tool-execution — "tool call hangs after model returns empty function-call array"
+- #715 enhancement + agent-config — "let me share an agent profile via deep link"
+- ...
+
+Abstained (need human review):
+- #720 — "this is great" (no actionable content)
+- ...
+
+Suggested new labels (issue mentioned a category that doesn't exist):
+- "ios-mobile" suggested by 3 issues; not currently a label
+- ...
+
+Errors:
+- #722 — gh returned 502; retry needed
+```
+
+When invoked by `daily-update`, this report becomes the "triage-issues" line in the day's PR body — the meta-skill paraphrases the structured form into prose for the PR, but should preserve the issue numbers and applied labels verbatim so a reviewer can audit.
+
+## What not to do
+
+- **Don't close issues.** Even obvious "no longer relevant" cases get a `wontfix` label at most, and even then only if the maintainer has previously closed similar issues — not on this skill's first hunch. Closing is a maintainer call.
+- **Don't reassign issues** or set milestones. This skill is read-and-label only.
+- **Don't comment on issues.** Triage labels are silent — they don't notify the reporter, which is the right behavior. A comment turns a quiet curation pass into noise in the reporter's notifications.
+- **Don't invent labels.** If the issue genuinely calls for a category that doesn't exist (`mobile`, `windows`, `gemini-2.5`), surface it in the "Suggested new labels" section of the report. Let the maintainer decide whether to create the label.
+- **Don't reapply auto-labels.** `codex`, `automated`, `dependencies`, `javascript`, `github_actions` are owned by automation. If they're missing from a bot-generated PR or issue, that's a CI bug, not a triage gap.
+- **Don't process pull requests.** This skill operates on issues only. PR labels are a different vocabulary (auto-applied by Dependabot, CodeRabbit, etc.) and editing them would interfere with that automation. If you accidentally pull PRs in the listing, filter them client-side (`gh issue list` should not include PRs, but verify the result shape).
+- **Don't update the daily changelog or docs.** This skill has GitHub side-effects, not working-tree side-effects. The `daily-update` meta-skill includes the triage summary in the daily PR body even when the working tree is clean.
+
+## Calibrating scope
+
+A healthy tracker accumulates 0–3 unlabeled issues per day. A run that processes that many is the steady state. A run that finds >10 means the backlog has grown — flag it so the maintainer knows to look. A run that finds 0 is a no-op; report and stop.

--- a/.claude/skills/audit-docs
+++ b/.claude/skills/audit-docs
@@ -1,0 +1,1 @@
+../../.agents/skills/audit-docs

--- a/.claude/skills/daily-changelog
+++ b/.claude/skills/daily-changelog
@@ -1,0 +1,1 @@
+../../.agents/skills/daily-changelog

--- a/.claude/skills/daily-update
+++ b/.claude/skills/daily-update
@@ -1,0 +1,1 @@
+../../.agents/skills/daily-update

--- a/.claude/skills/triage-issues
+++ b/.claude/skills/triage-issues
@@ -1,0 +1,1 @@
+../../.agents/skills/triage-issues

--- a/planning/changelog/2026-04-25.md
+++ b/planning/changelog/2026-04-25.md
@@ -1,0 +1,36 @@
+# Daily changelog — April 25, 2026
+
+**Date:** 2026-04-25
+**PRs merged:** 4
+
+---
+
+## Summary
+
+Scheduler-and-lifecycle cleanup day: three back-to-back fixes from @saheersk closed out the lifecycle issues exposed by the recent `ScheduledTaskManager` work (#656, #678, #680), while the maintainer landed a help-skill change so the agent can read its own debug log when users report bugs.
+
+## What shipped
+
+### [#674 feat: unified activity modal with Background Tasks + RAG tabs (#656)](https://github.com/allenhutchison/obsidian-gemini/pull/674)
+
+Restores the RAG stats affordance that was lost when #632 collapsed the separate RAG status bar into a single background-task icon. `BackgroundTasksModal` is rewritten as a unified two-tab "Gemini Activity" modal: Background Tasks (live-updating running/recent list) and RAG (Overview / Files / Failures sub-tabs with debounced search, Sync Now, Reindex All, Settings actions). Status-bar click now picks the default tab based on whether any task is running.
+
+Also picks up a related fix in `obsidian-file-adapter.computeHash()` — `vault.readBinary()` throws on virtual Obsidian files (built-in tutorial notes etc.), which was producing noisy RAG upload errors. The hash now falls back to an `mtime+size` proxy when `readBinary()` fails so smart sync keeps tracking those files. Per-file uploader errors downgraded from `error` to `warn` since failures are already surfaced in the Failures tab.
+
+Contributed by @saheersk.
+
+### [#695 ix: prevent ScheduledTaskManager double-init on plugin reload (#678)](https://github.com/allenhutchison/obsidian-gemini/pull/695)
+
+Fixes a double-initialisation that fired on every plugin reload when `layoutReady` was already `true`: both `LifecycleService.setup()` and `LifecycleService.onLayoutReady()` were independently calling `initialize()` + `start()`, producing duplicate vault scans, a redundant `saveState()` write, and noisy logs. `initialize()` now early-returns when already initialised; the settings-change branch passes an explicit `{ refresh: true }` flag to force a re-run when something like `historyFolder` changes. (Title was merged with an "ix:" typo for "fix:".)
+
+Contributed by @saheersk.
+
+### [#697 fix: await task drain before ScheduledTaskManager re-init (#680)](https://github.com/allenhutchison/obsidian-gemini/pull/697)
+
+Adds a `BackgroundTaskManager.drain(type?)` method and uses it in `LifecycleService.setup()` to guarantee that all cancelled `scheduled-task` background jobs have fully settled before `ScheduledTaskManager.initialize()` reloads state on a settings-save re-init. Without the drain, stale task callbacks could overwrite freshly reloaded state in a settings-save → cancel → re-init race. Three new regression tests cover the no-task case, ordering after cancel + drain, and type-filtered drain.
+
+Contributed by @saheersk.
+
+### [#698 feat(help-skill): expose debug.log for agent self-diagnosis](https://github.com/allenhutchison/obsidian-gemini/pull/698)
+
+Closes #586 by routing debug-log access through the bundled `gemini-scribe-help` skill instead of the agent's vault tools, which are blocked from the state folder. When **Log to File** is enabled, `debug.log` and (post-rotation) `debug.log.old` appear as activatable resources on the help skill — the agent reads them via `activate_skill(name: "gemini-scribe-help", resource_path: "debug.log")`. The skill description was also rewritten with stronger diagnostic-language triggers ("I had an error", "what just happened?", "check the debug log") so the agent stops doing 3–4 wasted file-search calls before activating it. `docs/reference/settings.md` was updated to drop the previous (incorrect) claim that the agent could read logs via vault tools directly.


### PR DESCRIPTION
## Summary

Adds a `daily-update` orchestrator skill and three per-day sub-skills to automate the housekeeping the maintainer does by hand today. Adapted from the same-named skills in the `pepper` repo; key adaptations are documented inline in each SKILL.md.

The intent is to register `daily-update` as a single `/schedule` slot that runs every evening, so a remote agent can sweep up PR-merge changelogs, doc drift, and issue triage without burning multiple slots.

Closes #718.

## Changes

Four skills under `.agents/skills/` (linked from `.claude/skills/` per repo convention):

- **`daily-changelog`** — generates `planning/changelog/YYYY-MM-DD.md` from PRs merged on a given date (default: yesterday in local TZ). Uses local-TZ-anchored ISO ranges in `gh pr list` to avoid the silent UTC-day misclassification. Credits external contributors. Explicitly distinct from `src/release-notes.json` (per-version) and `docs/changelog.md` (rendered).
- **`audit-docs`** — validates `docs/guide/`, `docs/reference/`, `README.md`, `AGENTS.md` against the code (settings, command IDs, schedule formats, tool names, model lists, attachment limits, loop-detection thresholds). Working-tree only — does not commit. Carves out `src/services/generated-help-references.ts` since it's auto-regenerated.
- **`triage-issues`** — labels unlabeled open issues via `gh issue edit --add-label`. Conservative: never closes, reassigns, comments, or invents labels. Lists the auto-applied labels (`codex`, `automated`, `dependencies`, `javascript`, `github_actions`) as do-not-touch so we don't fight CI/Dependabot/CodeRabbit. Reports a structured summary keyed by issue number.
- **`daily-update`** — orchestrator. Branches off master, runs the three sub-skills, captures one-line outcomes, and:
  - Quiet day (no working-tree changes, no triage activity) → no PR, delete branch.
  - Triage-only day (labels applied, no working-tree changes) → no PR, report inline.
  - Working-tree changes → hand off to the existing `create-pr` skill (enforces PR template + pre-flight checks).

Also includes one real run of `daily-changelog`: `planning/changelog/2026-04-25.md` (4 PRs).

## Test plan

- [x] `npm run format-check` — clean
- [x] `npm run build` — clean (tsc + esbuild)
- [x] `npm test` — 1490 passing, 5 skipped (no new tests added; these are markdown skill files)
- [x] Test-drove `daily-changelog` for 2026-04-25; output committed as `planning/changelog/2026-04-25.md` for review
- [x] `triage-issues` and `audit-docs` will be exercised in a follow-up daily run; not exercised in this PR to keep the diff small

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer (#718)
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop — N/A: skill files are agent-side, not plugin code
- [x] I have verified this change does not break Mobile — N/A: agent-side skill files, no plugin code touched
- [x] Documentation has been updated — N/A: this PR adds internal devtools (skill files), not user-facing features. The skills themselves are self-documenting via their SKILL.md frontmatter and bodies.
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (claude-opus-4-7)
- [x] I have reviewed and understand all AI-generated code in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Unified "Gemini Activity" modal consolidating RAG stats and background task monitoring into tab-based interface.
  * Help-skill enhancement enabling debug log access when file logging is enabled.

* **Bug Fixes**
  * Fixed ScheduledTaskManager double initialization on plugin reload.
  * Added fallback for computeHash errors on virtual files to reduce noise.
  * Downgraded per-file uploader errors from error to warning level.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->