### PR TITLE
chore(daily): 2026-04-26 daily update

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ npm install          # Install dependencies
 npm run dev          # Development build with watch mode
 npm run build        # Production build (generates refs, runs TypeScript check, then bundles)
 npm run generate-refs # Regenerate help references from docs/ (runs automatically in build/dev)
-npm test             # Run Jest tests
+npm test             # Run Vitest tests
 npm run format       # Format code with Prettier
 npm run format-check # Check formatting without changes
 ```

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -145,6 +145,15 @@ See the [Custom Prompts Guide](/guide/custom-prompts) for detailed instructions.
 - **Description**: Enable streaming responses in the chat interface for a more interactive experience
 - **Note**: When disabled, full responses are displayed at once
 
+### Auto-run missed scheduled tasks on startup
+
+- **Setting**: `autoRunCatchUp`
+- **Type**: Boolean
+- **Default**: `false`
+- **Description**: When enabled, tasks with `runIfMissed: true` that were missed while Obsidian was closed are submitted silently as background tasks on startup, without showing the approval modal.
+- **When disabled**: The "Missed Scheduled Runs" modal appears on startup so you can choose Run or Skip per task. A red `!` badge on the status bar persists if the modal is dismissed without acting.
+- **See also**: [Catch-up Runs](/guide/scheduled-tasks#catch-up-runs)
+
 ## Context Management
 
 Context management automatically monitors and controls conversation size to prevent exceeding model token limits.

--- a/planning/changelog/2026-04-26.md
+++ b/planning/changelog/2026-04-26.md
@@ -1,0 +1,50 @@
+# Daily changelog — April 26, 2026
+
+**Date:** 2026-04-26
+**PRs merged:** 8
+
+---
+
+## Summary
+
+A very active day dominated by two major feature deliveries — Ollama local-model support and the full scheduler management UI — alongside the Jest-to-Vitest test runner migration and two housekeeping skills (daily-update orchestrator and a docs audit sweep). External contributor @saheersk shipped three PRs: a scheduler deduplication fix, the missed-run catch-up modal, and the scheduler management UI. The day ended with a CI hotfix to patch test files that the two migrations had left behind in each other's blind spots.
+
+## What shipped
+
+### [#696 fix: deduplicate task file parse when vault.create and metadataCache.…](https://github.com/allenhutchison/obsidian-gemini/pull/696)
+
+Fixes the double-parse that fired when a new task file was created in `Scheduled-Tasks/`: both the `vault.on('create')` handler and `metadataCache.on('changed')` reacted to the same file, producing two vault reads, two parses, and potentially two `saveState()` writes. The fix uses a `recentlyCreated` set — the create handler registers the slug before the 500 ms defer and removes it afterward; the changed handler skips any slug currently in the set. This preserves immediate discovery for files created without frontmatter (the reason `vault.create` was kept at all) without sacrificing the deduplication. Closes #679.
+
+Contributed by @saheersk.
+
+### [#699 Migrate test runner from ts-jest to Vitest](https://github.com/allenhutchison/obsidian-gemini/pull/699)
+
+Replaces the `ts-jest` + Jest pipeline with Vitest so the test toolchain aligns with the esbuild-based production build. All 1,443 existing tests pass under the new runner. The migration also drops the `ignoreDeprecations: "6.0"` workaround from `tsconfig.test.json`, unblocking the eventual TypeScript 7 upgrade. `jest.config.mjs` and `text-transformer.mjs` are deleted; a new `vitest.config.ts` takes their place with jsdom environment, path aliases, and an inline Vite plugin for `.hbs`/`.md`/`.txt` raw loading. Closes #629.
+
+### [#702 test: migrate scheduled-task-manager tests from jest to vitest](https://github.com/allenhutchison/obsidian-gemini/pull/702)
+
+Hotfix for broken master CI: #696 added new tests using jest syntax before #699 migrated the runner, so the two in-flight PRs ended up in opposite directions — master emerged with 5 failing tests and 10 typecheck errors in `test/services/scheduled-task-manager.test.ts`. This PR converts the remaining `jest.fn` / `jest.useFakeTimers` / `as jest.Mock` references to their vitest equivalents. Test-only change.
+
+### [#694 feat: add Ollama provider for local-model support](https://github.com/allenhutchison/obsidian-gemini/pull/694)
+
+Adds [Ollama](https://ollama.com) as an alternative model provider so users can run chat, summary, completions, rewrite, and agent tool-calling against a local model instead of the Gemini API. The seam is the existing `ModelApi` interface — a new `OllamaClient` implements it via the `ollama` browser-entry package, and `GeminiClientFactory.createFromPlugin` routes to either client based on a new plugin-wide `provider` setting. `RetryDecorator` is reused unchanged, and `ContextManager` falls back to a chars/4 token estimate (conservative 32k context window) when Ollama is active. Gemini-specific features (Google Search, URL Context, Deep Research, image generation, RAG indexing, PDF/audio/video attachments) are automatically hidden in settings and skipped at lifecycle init when Ollama is selected. Model discovery is live via `GET /api/tags` with a manual-refresh button. Closes the local-model ask in #576 (Phase 1).
+
+### [#700 feat: missed-run catch-up on startup](https://github.com/allenhutchison/obsidian-gemini/pull/700)
+
+Implements missed-run catch-up for scheduled tasks. Tasks with `runIfMissed: true` in their frontmatter are now detected on startup (within a 7-day window, excluding paused tasks) and surfaced in a "Missed Scheduled Runs" modal with per-row Run/Skip and global Run all/Skip all actions. A red `!` badge on the status bar persists if the modal is dismissed without acting, and clicking the badge reopens it. A new `autoRunCatchUp` setting (default `false`) skips the modal entirely and submits missed tasks silently as background tasks. Fixes #635.
+
+Contributed by @saheersk.
+
+### [#701 feat: scheduler management UI — create, edit, delete, toggle tasks](https://github.com/allenhutchison/obsidian-gemini/pull/701)
+
+Delivers the full CRUD interface for scheduled tasks — users no longer need to hand-edit markdown files to manage their tasks. A new `SchedulerManagementModal` provides a list view (with next/last run times, inline error state, and per-row Enable/Disable, Run now, Edit, Delete, Reset controls), a create form (slug, schedule dropdown, tool access checkboxes, prompt textarea, advanced options), an edit form pre-filled with existing values, and an inline confirm-delete screen. Errors auto-refresh live via `agentEventBus` so the modal reflects task failures without close/reopen. Two new command palette entries — `Open Scheduler` and `New Scheduled Task` — are registered in `src/main.ts`; the legacy `View Scheduled Tasks` command is kept for backwards compatibility. A "Scheduled Tasks" section with quick-access buttons is added to Settings → General. Fixes #636.
+
+Contributed by @saheersk.
+
+### [#721 docs: audit-docs sweep — fix drift across user-facing docs](https://github.com/allenhutchison/obsidian-gemini/pull/721)
+
+First run of the new `audit-docs` skill against the live code — eleven files patched in place, no new docs added (all gaps were thin coverage rather than completely missing sections). Conceptual drift fixed: a `README.md` reference to a "Gemini Scribe: Clear All Chat History" command that does not exist, stale version number (4.6.0 → 4.7.0), a "use GPT-4" recommendation in a Gemini-only plugin, six stale `selection-action` tag references (now `gemini-scribe/selection-prompt`), and missing documentation for the per-turn `AGENT_LOOP_ABORT_THRESHOLD = 3` abort behavior. Stale model names updated throughout `completions.md`, `advanced-settings.md`, `scheduled-tasks.md`, `settings.md`, `context-system.md`, and `agent-mode.md`. Six missing tools added to the `agent-mode.md` catalog: `create_folder`, `update_memory`, `read_memory`, `deep_research`, `generate_image`, `vault_semantic_search`.
+
+### [#720 feat(skills): daily-update orchestrator + per-day housekeeping skills](https://github.com/allenhutchison/obsidian-gemini/pull/720)
+
+Adds a `daily-update` orchestrator skill and three per-day sub-skills (`daily-changelog`, `audit-docs`, `triage-issues`) to automate the housekeeping the maintainer does by hand today. The intent is a single `/schedule` slot that runs every evening so a remote agent sweeps up PR-merge changelogs, doc drift, and issue triage without burning multiple slots. On quiet days (no working-tree changes, no triage activity) no PR is opened; triage-only days report inline; working-tree changes are packaged into one PR via the existing `create-pr` skill. Also includes the first real `daily-changelog` run: `planning/changelog/2026-04-25.md`. Closes #718.


### PR DESCRIPTION
## Summary

Automated daily housekeeping run for 2026-04-26.

## Changes

### daily-changelog
- Wrote `planning/changelog/2026-04-26.md` covering 8 PRs
- Feature-heavy day: Ollama provider (#694), scheduler management UI (#701), missed-run catch-up modal (#700), Vitest migration (#699), daily-update housekeeping skills (#720), docs audit sweep (#721), plus two bugfix/hotfix PRs (#696, #702)
- External contributions by @saheersk: #696 (scheduler dedup fix), #700 (catch-up modal), #701 (scheduler management UI)

### audit-docs
Two drift items found and patched:

- **`AGENTS.md`** — Comment on `npm test` still read `# Run Jest tests` after #699 migrated the runner to Vitest. The Testing Guidelines section (line 210) was updated in #699 but the development commands block comment was missed. Fixed to `# Run Vitest tests`.
- **`docs/reference/settings.md`** — `autoRunCatchUp` setting (added by #700, exposed in Settings → UI Settings as "Auto-run missed scheduled tasks on startup", default `false`) was not documented. Added entry under the UI Settings section.

No new doc files needed — all yesterday's features (Ollama, scheduler UI, catch-up modal) were already covered by their respective PRs' documentation updates.

### triage-issues
Issues processed: 0 — no unlabeled open issues found. Well-tended tracker.

## Screenshots / Screencast

N/A — documentation and changelog only; no UI changes.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: automated daily housekeeping run
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop — N/A: docs and changelog only
- [x] I have verified this change does not break Mobile — N/A: docs and changelog only
- [x] Documentation has been updated — this PR *is* the documentation update
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (claude-sonnet-4-6), via the `daily-update` skill
- [x] I have reviewed and understand all AI-generated code in this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fe9cEcTeVQAjX6PqwzXNhT)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for the new `autoRunCatchUp` UI setting, which controls automatic handling of missed scheduled tasks on startup—when enabled, tasks process silently in the background; when disabled, a modal appears for manual management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->