### PR TITLE
fix: open CatchUpModal directly on mobile when catch-up is pending

### DIFF
--- a/src/services/lifecycle-service.ts
+++ b/src/services/lifecycle-service.ts
@@ -1,4 +1,4 @@
-import { TFile } from 'obsidian';
+import { TFile, Platform } from 'obsidian';
 import { Notice } from 'obsidian';
 import type ObsidianGemini from '../main';
 import { AgentEventBus } from '../agent/agent-event-bus';
@@ -540,6 +540,13 @@ export class LifecycleService {
 			plugin.scheduledTaskManager.reserveForCatchUp(pending.map((e) => e.task.slug));
 			// Show the ! badge — clicking it opens the CatchUpModal
 			plugin.backgroundStatusBar?.setPendingCatchUpCount(pending.length);
+
+			// On mobile the status bar is hidden, so the badge is unreachable.
+			// Open the approval modal directly so the user can act on missed runs.
+			if (Platform.isMobile) {
+				const { CatchUpModal } = await import('../ui/catch-up-modal');
+				new CatchUpModal(plugin.app, plugin, pending).open();
+			}
 		}
 	}
 

--- a/test/services/lifecycle-service.test.ts
+++ b/test/services/lifecycle-service.test.ts
@@ -1,10 +1,26 @@
 import type { Mock } from 'vitest';
 
+const { mockPlatform, mockCatchUpModal, MockCatchUpModalClass } = vi.hoisted(() => {
+	const mockCatchUpModal = { open: vi.fn() };
+	// Must use a regular function (not arrow) so it can be called with `new`
+	function MockCatchUpModalClass() {
+		return mockCatchUpModal;
+	}
+	return {
+		mockPlatform: { isMobile: false },
+		mockCatchUpModal,
+		MockCatchUpModalClass: vi.fn().mockImplementation(MockCatchUpModalClass),
+	};
+});
+
 vi.mock('obsidian', () => ({
 	TFile: class TFile {},
 	Notice: vi.fn(),
 	normalizePath: (p: string) => p,
+	Platform: mockPlatform,
 }));
+
+vi.mock('../../src/ui/catch-up-modal', () => ({ CatchUpModal: MockCatchUpModalClass }));
 
 vi.mock('../../src/services/tool-registrar', () => ({
 	ToolRegistrar: vi.fn().mockImplementation(function () {
@@ -382,6 +398,12 @@ describe('LifecycleService', () => {
 	describe('catch-up handling on layout ready', () => {
 		const missedTask = (slug: string) => ({ task: { slug }, missedAt: new Date(Date.now() - 60_000) });
 
+		beforeEach(() => {
+			mockPlatform.isMobile = false;
+			MockCatchUpModalClass.mockClear();
+			mockCatchUpModal.open.mockClear();
+		});
+
 		// Wires the ScheduledTaskManager mock so `detectMissedRuns` returns the
 		// supplied entries on the next instantiation. Returns the live mock
 		// instance once setup() has run, so tests can assert on its methods.
@@ -445,6 +467,36 @@ describe('LifecycleService', () => {
 				expect.stringContaining('Auto catch-up failed for "boom"'),
 				expect.any(Error)
 			);
+		});
+
+		it('opens CatchUpModal directly on mobile when autoRunCatchUp is false', async () => {
+			mockPlatform.isMobile = true;
+			await withMissedRuns([missedTask('task-a'), missedTask('task-b')], { autoRunCatchUp: false });
+
+			await lifecycle.onLayoutReady();
+
+			expect(MockCatchUpModalClass).toHaveBeenCalledTimes(1);
+			expect(MockCatchUpModalClass).toHaveBeenCalledWith(
+				mockPlugin.app,
+				mockPlugin,
+				expect.arrayContaining([
+					expect.objectContaining({ task: { slug: 'task-a' } }),
+					expect.objectContaining({ task: { slug: 'task-b' } }),
+				])
+			);
+			expect(mockCatchUpModal.open).toHaveBeenCalledTimes(1);
+		});
+
+		it('does not open CatchUpModal on desktop when autoRunCatchUp is false', async () => {
+			mockPlatform.isMobile = false;
+			await withMissedRuns([missedTask('task-a')], { autoRunCatchUp: false });
+
+			await lifecycle.onLayoutReady();
+
+			expect(MockCatchUpModalClass).not.toHaveBeenCalled();
+			expect(mockCatchUpModal.open).not.toHaveBeenCalled();
+			// Badge is still set so the desktop status-bar entry point works
+			expect(mockPlugin.backgroundStatusBar.setPendingCatchUpCount).toHaveBeenCalledWith(1);
 		});
 	});
 


### PR DESCRIPTION
PR Description — fix/mobile-catchup-modal
==========================================

Title: fix: open CatchUpModal directly on mobile when catch-up is pending

## Summary

On mobile, Obsidian hides the status bar entirely, making the `!` badge added by
`BackgroundStatusBar.setPendingCatchUpCount()` unreachable. Tasks reserved for
catch-up via `reserveForCatchUp()` sit indefinitely — the user has no way to
discover or act on them.

Detects `Platform.isMobile` inside `LifecycleService.handleCatchUp()` and opens
`CatchUpModal` directly on startup when missed scheduled runs are pending, instead
of relying solely on the badge. The badge is still set so the existing desktop
flow is completely unchanged.

Fixes #719

## Changes

- `src/services/lifecycle-service.ts`: import `Platform` from obsidian; add mobile
  guard in `handleCatchUp()` — when `Platform.isMobile` is true and
  `autoRunCatchUp` is false, open `CatchUpModal` directly in addition to setting
  the badge
- `test/services/lifecycle-service.test.ts`: add `vi.hoisted()` block for
  `mockPlatform` and `MockCatchUpModalClass`; add `Platform` to the obsidian mock;
  mock `../../src/ui/catch-up-modal`; add two new tests:
    - "opens CatchUpModal directly on mobile when autoRunCatchUp is false"
    - "does not open CatchUpModal on desktop when autoRunCatchUp is false"

## Screenshots / Screencast

No UI changes on desktop. On mobile: `CatchUpModal` now appears automatically on
startup when missed scheduled runs are pending. Previously nothing appeared and
tasks were stuck indefinitely.

<img width="609" height="336" alt="Screenshot 2026-04-27 at 10 28 16 PM" src="https://github.com/user-attachments/assets/8d19017b-3225-42f4-994e-891c37c2da23" />

## Checklist

### Required

- [x] I have read and agree to the Contributing Guidelines
- [x] I have read and agree to the AI Policy
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer
- [x] All CI checks pass (npm test, npm run build, npm run format-check)
- [x] I have tested this change on Desktop
- [x] I have verified this change does not break Mobile (fix is gated behind
      Platform.isMobile; desktop path is unaffected)
- [x] Documentation has been updated (if applicable) — no user-facing docs affected
      by this internal platform guard
- [x] I understand that I must address all review comments from CodeRabbit and
      maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude
- [x] I have reviewed and understand all AI-generated code in this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of missed scheduled tasks on mobile devices. Users now see an interactive approval modal for pending catch-ups when auto-catch-up is disabled, ensuring they can take action even when status bar indicators aren't visible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->