### PR TITLE
feat: consolidate background outputs into [state-folder]/Background-T…

### DIFF
--- a/src/services/deep-research.ts
+++ b/src/services/deep-research.ts
@@ -295,12 +295,18 @@ export class DeepResearchService {
 			}
 		}
 
-		// Check if path is inside the plugin's history folder (or is the folder itself)
+		// Check if path is inside the plugin's history folder (or is the folder itself).
+		// Background-Tasks/ is the one allowed subfolder — it is the canonical output
+		// location for background and scheduled-task outputs.
 		const historyFolder = this.plugin.settings.historyFolder;
 		if (historyFolder) {
-			// Normalize the history folder to ensure consistent comparison
 			const normalizedHistoryFolder = normalizePath(historyFolder);
-			if (normalizedPath === normalizedHistoryFolder || normalizedPath.startsWith(normalizedHistoryFolder + '/')) {
+			const backgroundTasksFolder = normalizePath(`${normalizedHistoryFolder}/Background-Tasks`);
+			const insideStateFolder =
+				normalizedPath === normalizedHistoryFolder || normalizedPath.startsWith(normalizedHistoryFolder + '/');
+			const insideBackgroundTasks =
+				normalizedPath === backgroundTasksFolder || normalizedPath.startsWith(backgroundTasksFolder + '/');
+			if (insideStateFolder && !insideBackgroundTasks) {
 				throw new Error(
 					`Cannot write report to plugin state folder: "${historyFolder}". Please choose a different output location.`
 				);

--- a/src/services/deep-research.ts
+++ b/src/services/deep-research.ts
@@ -304,8 +304,7 @@ export class DeepResearchService {
 			const backgroundTasksFolder = normalizePath(`${normalizedHistoryFolder}/Background-Tasks`);
 			const insideStateFolder =
 				normalizedPath === normalizedHistoryFolder || normalizedPath.startsWith(normalizedHistoryFolder + '/');
-			const insideBackgroundTasks =
-				normalizedPath === backgroundTasksFolder || normalizedPath.startsWith(backgroundTasksFolder + '/');
+			const insideBackgroundTasks = normalizedPath.startsWith(backgroundTasksFolder + '/');
 			if (insideStateFolder && !insideBackgroundTasks) {
 				throw new Error(
 					`Cannot write report to plugin state folder: "${historyFolder}". Please choose a different output location.`

--- a/src/services/folder-initializer.ts
+++ b/src/services/folder-initializer.ts
@@ -11,6 +11,7 @@ export class FolderInitializer {
 	// Subfolder names relative to the plugin state root
 	private static readonly SUBFOLDERS = [
 		'Agent-Sessions',
+		'Background-Tasks',
 		'Prompts',
 		'Skills',
 		'Scheduled-Tasks',

--- a/src/services/image-generation.ts
+++ b/src/services/image-generation.ts
@@ -188,6 +188,15 @@ export class ImageGeneration {
 			throw new Error(`Output path cannot be inside the Obsidian configuration folder: "${outputPath}"`);
 		}
 
+		// Always ensure the file ends with .png — the code always writes PNG bytes.
+		// Rewrite extension before the state-folder check so the validated path
+		// matches what will actually be written (e.g. "Background-Tasks" bare →
+		// "Background-Tasks.png", which is outside the allowed subfolder).
+		const dotIndex = normalized.lastIndexOf('.');
+		const slashIndex = normalized.lastIndexOf('/');
+		const hasExtension = dotIndex > slashIndex + 1;
+		const normalizedFilePath = hasExtension ? normalized.slice(0, dotIndex) + '.png' : normalized + '.png';
+
 		// Reject paths inside the plugin state folder, except for the canonical
 		// Background-Tasks/ subfolder which is the designated output location.
 		const historyFolder = this.plugin.settings.historyFolder;
@@ -195,20 +204,14 @@ export class ImageGeneration {
 			const normalizedHistoryFolder = normalizePath(historyFolder);
 			const backgroundTasksFolder = normalizePath(`${normalizedHistoryFolder}/Background-Tasks`);
 			const insideStateFolder =
-				normalized === normalizedHistoryFolder || normalized.startsWith(normalizedHistoryFolder + '/');
-			const insideBackgroundTasks =
-				normalized === backgroundTasksFolder || normalized.startsWith(backgroundTasksFolder + '/');
+				normalizedFilePath === normalizedHistoryFolder || normalizedFilePath.startsWith(normalizedHistoryFolder + '/');
+			const insideBackgroundTasks = normalizedFilePath.startsWith(backgroundTasksFolder + '/');
 			if (insideStateFolder && !insideBackgroundTasks) {
 				throw new Error(`Output path cannot be inside the plugin state folder: "${outputPath}"`);
 			}
 		}
 
-		// Always ensure the file ends with .png — the code always writes PNG bytes.
-		// Replace any existing extension (or append if none) so the vault file is readable.
-		const dotIndex = normalized.lastIndexOf('.');
-		const slashIndex = normalized.lastIndexOf('/');
-		const hasExtension = dotIndex > slashIndex + 1;
-		return hasExtension ? normalized.slice(0, dotIndex) + '.png' : normalized + '.png';
+		return normalizedFilePath;
 	}
 
 	/**

--- a/src/services/image-generation.ts
+++ b/src/services/image-generation.ts
@@ -114,8 +114,7 @@ export class ImageGeneration {
 	 * actual-write.
 	 *
 	 * Throws synchronously on an invalid explicit path (vault escape,
-	 * protected folder, etc.) or when the default branch has no active file
-	 * and no `targetNotePath` to anchor the attachment folder.
+	 * protected folder, etc.).
 	 */
 	async resolveOutputPath(prompt: string, targetNotePath?: string, outputPath?: string): Promise<string> {
 		if (outputPath) {
@@ -128,18 +127,17 @@ export class ImageGeneration {
 
 	/**
 	 * Resolve the path the image WOULD be saved at when no explicit `outputPath`
-	 * is given. Mirrors the no-`outputPath` branch of saveImageToVault.
+	 * is given. Writes to [state-folder]/Background-Tasks/ so all background
+	 * outputs share one predictable location alongside deep-research reports.
 	 *
 	 * Prefer `resolveOutputPath` for callers that may or may not have an
 	 * explicit path — it handles both branches consistently. This method is
 	 * kept public for callers that specifically want the default flow.
-	 *
-	 * Throws if no active file exists and no `targetNotePath` is provided.
 	 */
-	async resolveDefaultOutputPath(prompt: string, targetNotePath?: string): Promise<string> {
+	async resolveDefaultOutputPath(prompt: string, _targetNotePath?: string): Promise<string> {
 		const filename = this.buildDefaultFilename(prompt);
-		const referenceNotePath = this.resolveReferenceNotePath(targetNotePath);
-		return this.plugin.app.fileManager.getAvailablePathForAttachment(filename, referenceNotePath);
+		const backgroundTasksFolder = normalizePath(`${this.plugin.settings.historyFolder}/Background-Tasks`);
+		return normalizePath(`${backgroundTasksFolder}/${filename}`);
 	}
 
 	/**
@@ -163,20 +161,6 @@ export class ImageGeneration {
 			.replace(/^-|-$/g, '');
 		const randomSuffix = Math.random().toString(36).substring(2, 8);
 		return `generated-${sanitizedPrompt}-${Date.now()}-${randomSuffix}.png`;
-	}
-
-	/**
-	 * Resolve the note path used as the attachment-folder reference. Falls back
-	 * to the active file when no explicit target is given. Throws when neither
-	 * is available — Obsidian's getAvailablePathForAttachment requires a context.
-	 */
-	private resolveReferenceNotePath(targetNotePath?: string): string {
-		if (targetNotePath) return targetNotePath;
-		const activeFile = this.plugin.app.workspace.getActiveFile();
-		if (!activeFile) {
-			throw new Error('No active file and no target note path provided');
-		}
-		return activeFile.path;
 	}
 
 	/**
@@ -204,11 +188,17 @@ export class ImageGeneration {
 			throw new Error(`Output path cannot be inside the Obsidian configuration folder: "${outputPath}"`);
 		}
 
-		// Reject paths inside the plugin state folder
+		// Reject paths inside the plugin state folder, except for the canonical
+		// Background-Tasks/ subfolder which is the designated output location.
 		const historyFolder = this.plugin.settings.historyFolder;
 		if (historyFolder) {
 			const normalizedHistoryFolder = normalizePath(historyFolder);
-			if (normalized === normalizedHistoryFolder || normalized.startsWith(normalizedHistoryFolder + '/')) {
+			const backgroundTasksFolder = normalizePath(`${normalizedHistoryFolder}/Background-Tasks`);
+			const insideStateFolder =
+				normalized === normalizedHistoryFolder || normalized.startsWith(normalizedHistoryFolder + '/');
+			const insideBackgroundTasks =
+				normalized === backgroundTasksFolder || normalized.startsWith(backgroundTasksFolder + '/');
+			if (insideStateFolder && !insideBackgroundTasks) {
 				throw new Error(`Output path cannot be inside the plugin state folder: "${outputPath}"`);
 			}
 		}

--- a/src/tools/deep-research-tool.ts
+++ b/src/tools/deep-research-tool.ts
@@ -111,10 +111,12 @@ export class DeepResearchTool implements Tool {
 				}
 
 				// Resolve the output path upfront so the agent knows where to read results.
-				// Falls back to "Background Research/YYYY-MM-DD <topic>.md" at the vault root
-				// (outside the plugin state folder, which validators reject).
+				// Falls back to [state-folder]/Background-Tasks/YYYY-MM-DD <topic>.md,
+				// which the deep-research validator now explicitly allows.
+				const backgroundTasksFolder = normalizePath(`${plugin.settings.historyFolder}/Background-Tasks`);
 				const resolvedOutputFile =
-					outputFile ?? normalizePath(`Background Research/${formatLocalDate()} ${sanitizeFileName(params.topic)}.md`);
+					outputFile ??
+					normalizePath(`${backgroundTasksFolder}/${formatLocalDate()} ${sanitizeFileName(params.topic)}.md`);
 
 				const deepResearch = plugin.deepResearch;
 				const label = params.topic.length > 40 ? params.topic.slice(0, 37) + '…' : params.topic;

--- a/test/services/folder-initializer.test.ts
+++ b/test/services/folder-initializer.test.ts
@@ -51,8 +51,8 @@ describe('FolderInitializer', () => {
 	it('should create all plugin state folders in one pass', async () => {
 		await folderInitializer.initializeAll();
 
-		// root + 5 subfolders: Agent-Sessions, Prompts, Skills, Scheduled-Tasks, Scheduled-Tasks/Runs
-		expect(mockEnsureFolderExists).toHaveBeenCalledTimes(6);
+		// root + 6 subfolders: Agent-Sessions, Background-Tasks, Prompts, Skills, Scheduled-Tasks, Scheduled-Tasks/Runs
+		expect(mockEnsureFolderExists).toHaveBeenCalledTimes(7);
 		expect(mockEnsureFolderExists).toHaveBeenCalledWith(
 			mockPlugin.app.vault,
 			'gemini-scribe',
@@ -63,6 +63,12 @@ describe('FolderInitializer', () => {
 			mockPlugin.app.vault,
 			'gemini-scribe/Agent-Sessions',
 			'Agent-Sessions',
+			mockPlugin.logger
+		);
+		expect(mockEnsureFolderExists).toHaveBeenCalledWith(
+			mockPlugin.app.vault,
+			'gemini-scribe/Background-Tasks',
+			'Background-Tasks',
 			mockPlugin.logger
 		);
 		expect(mockEnsureFolderExists).toHaveBeenCalledWith(
@@ -104,6 +110,7 @@ describe('FolderInitializer', () => {
 		expect(callOrder.slice(1)).toEqual(
 			expect.arrayContaining([
 				'gemini-scribe/Agent-Sessions',
+				'gemini-scribe/Background-Tasks',
 				'gemini-scribe/Prompts',
 				'gemini-scribe/Skills',
 				'gemini-scribe/Scheduled-Tasks',

--- a/test/tools/deep-research-tool.test.ts
+++ b/test/tools/deep-research-tool.test.ts
@@ -386,11 +386,11 @@ describe('DeepResearchTool', () => {
 			);
 		});
 
-		it('auto-generates output_file under Background Research/ when none provided', async () => {
+		it('auto-generates output_file under [state-folder]/Background-Tasks/ when none provided', async () => {
 			const result = await tool.execute({ topic: 'Test Topic', background: true }, mockContext);
 
 			expect(result.success).toBe(true);
-			expect(result.data.output_file).toMatch(/^Background Research\/\d{4}-\d{2}-\d{2} Test Topic\.md$/);
+			expect(result.data.output_file).toMatch(/^gemini-scribe\/Background-Tasks\/\d{4}-\d{2}-\d{2} Test Topic\.md$/);
 		});
 
 		it('truncates long topic in the BackgroundTaskManager label', async () => {
@@ -419,7 +419,7 @@ describe('DeepResearchTool', () => {
 				topic: 'AI Ethics',
 				report: 'Report',
 				sourceCount: 5,
-				outputFile: { path: 'Background Research/2026-01-01 AI Ethics.md' },
+				outputFile: { path: 'gemini-scribe/Background-Tasks/2026-01-01 AI Ethics.md' },
 			});
 
 			await tool.execute({ topic: 'AI Ethics', background: true, outputFile: 'research/ai.md' }, mockContext);
@@ -431,7 +431,7 @@ describe('DeepResearchTool', () => {
 			expect(mockDeepResearch.conductResearch).toHaveBeenCalledWith(
 				expect.objectContaining({ topic: 'AI Ethics', outputFile: 'research/ai.md' })
 			);
-			expect(outputPath).toBe('Background Research/2026-01-01 AI Ethics.md');
+			expect(outputPath).toBe('gemini-scribe/Background-Tasks/2026-01-01 AI Ethics.md');
 		});
 
 		it('callback returns undefined when cancelled before research starts', async () => {


### PR DESCRIPTION
PR Description — fix/background-tasks-output-folder
=====================================================

Title: feat: consolidate background outputs into [state-folder]/Background-Tasks/

## Summary

Previously deep research fell back to a vault-root `Background Research/` folder
and image generation used the Obsidian attachment folder, giving users two
unpredictable locations for background task outputs. As the scheduled-tasks epic
progresses, users need one predictable place to browse all background outputs.

Provisions a `Background-Tasks/` subfolder under the plugin state folder and
routes both tools there by default, while relaxing the state-folder validators to
allow writes into that one subfolder only.

Fixes #657

## Changes

- `src/services/folder-initializer.ts`: add `Background-Tasks/` to `SUBFOLDERS`
  so it is provisioned alongside `Agent-Sessions/`, `Prompts/`, `Skills/`, etc.
- `src/services/deep-research.ts`: relax `validateAndNormalizeFilePath` to allow
  paths under `[state-folder]/Background-Tasks/` while still rejecting all other
  plugin-state subfolders
- `src/services/image-generation.ts`: same validator relaxation in
  `validateOutputPath`; update `resolveDefaultOutputPath` to write into
  `Background-Tasks/` instead of the Obsidian attachment folder; remove the
  now-unused `resolveReferenceNotePath` helper
- `src/tools/deep-research-tool.ts`: update default output path from vault-root
  `Background Research/<date> <topic>.md` to
  `[state-folder]/Background-Tasks/<date> <topic>.md`
- `test/services/folder-initializer.test.ts`: update call-count and
  `arrayContaining` assertions to include the new subfolder
- `test/tools/deep-research-tool.test.ts`: update path regex and mock path to
  match the new `Background-Tasks/` location

## Screenshots / Screencast

No UI changes — this is a backend output-path consolidation. Users will find
both deep research reports and generated images under
`[state-folder]/Background-Tasks/` instead of vault root / attachment folder.

## Checklist

### Required

- [x] I have read and agree to the Contributing Guidelines
- [x] I have read and agree to the AI Policy
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer
- [x] All CI checks pass (npm test, npm run build, npm run format-check)
- [x] I have tested this change on Desktop
- [x] I have verified this change does not break Mobile (no platform-specific code;
      FolderInitializer runs identically on mobile)
- [x] Documentation has been updated (if applicable) — no user-facing docs reference
      the old output paths
- [x] I understand that I must address all review comments from CodeRabbit and
      maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude
- [x] I have reviewed and understand all AI-generated code in this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a dedicated "Background-Tasks" folder for storing background reports and generated images.
* **Bug Fixes**
  * Refined path validation so outputs are allowed in the Background-Tasks subtree while still blocking other restricted locations.
* **Tests**
  * Updated tests to expect and validate the new Background-Tasks folder location.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->