### PR TITLE
fix: Add support for SVG images (#641)

### DIFF
--- a/src/ui/agent-view/inline-attachment.ts
+++ b/src/ui/agent-view/inline-attachment.ts
@@ -60,7 +60,7 @@ export function getMimeType(file: File | Blob): string {
  * Check if a MIME type is a supported image type
  */
 export function isSupportedImageType(mimeType: string): boolean {
-	const supported = ['image/png', 'image/jpeg', 'image/gif', 'image/webp'];
+	const supported = ['image/png', 'image/jpeg', 'image/gif', 'image/webp', 'image/svg+xml'];
 	return supported.includes(mimeType);
 }
 
@@ -75,6 +75,7 @@ export function getExtensionFromMimeType(mimeType: string): string {
 		'image/webp': 'webp',
 		'image/heic': 'heic',
 		'image/heif': 'heif',
+		'image/svg+xml': 'svg',
 		'audio/wav': 'wav',
 		'audio/mp3': 'mp3',
 		'audio/aac': 'aac',

--- a/src/utils/file-classification.ts
+++ b/src/utils/file-classification.ts
@@ -23,6 +23,8 @@ export const GEMINI_INLINE_BINARY_MIMES: Record<string, string> = {
 	webp: 'image/webp',
 	heic: 'image/heic',
 	heif: 'image/heif',
+	svg: 'image/svg+xml',
+	svgz: 'image/svg+xml',
 
 	// Audio
 	wav: 'audio/wav',

--- a/test/api/ollama-client.test.ts
+++ b/test/api/ollama-client.test.ts
@@ -32,6 +32,18 @@ const mockLogger = {
 	error: vi.fn(),
 };
 
+// Mock window.localStorage
+const mockLocalStorage = {
+	getItem: vi.fn().mockReturnValue('en'),
+	setItem: vi.fn(),
+	removeItem: vi.fn(),
+	clear: vi.fn(),
+};
+Object.defineProperty(window, 'localStorage', {
+	value: mockLocalStorage,
+	writable: true,
+});
+
 const buildPlugin = () =>
 	({
 		logger: mockLogger,


### PR DESCRIPTION
## Summary

Fixes #641. This PR adds support for `.svg` and `.svgz` image attachments, allowing them to be correctly classified and passed to the Gemini API as inline attachments. It also includes a test fix to mock `window.localStorage` in `ollama-client.test.ts`.

## Changes

- Added `image/svg+xml` to the list of supported image types in `isSupportedImageType`
- Mapped `image/svg+xml` to `svg` in `getExtensionFromMimeType`
- Added `svg` and `svgz` to `GEMINI_INLINE_BINARY_MIMES` map in `file-classification.ts`
- Mocked `window.localStorage` in `test/api/ollama-client.test.ts` to fix CI issues.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards)
- [x] Documentation has been updated (if applicable) - N/A
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Antigravity
- [x] I have reviewed and understand all AI-generated code in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SVG files are now supported as inline attachments with proper file handling and MIME type recognition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->