### PR TITLE
chore(daily): 2026-04-27 daily update

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Gemini Scribe is an Obsidian plugin that integrates Google's Gemini AI models, p
     - **Summary Frontmatter Key:** Specify the key to use when storing summaries in the frontmatter (default: `summary`).
     - **Your Name:** Enter your name, which the AI will use when addressing you.
     - **Chat History:**
-      - **Enable Chat History:** Toggle whether to save agent session history.
+      - **Enable Session History:** Toggle whether to save agent session history.
       - **Plugin State Folder:** Choose the folder within your vault to store plugin data (agent sessions and custom prompts).
     - **Custom Prompts:**
       - **Allow System Prompt Override:** Allow custom prompts to completely replace the system prompt (use with caution).
@@ -106,7 +106,7 @@ Gemini Scribe is an Obsidian plugin that integrates Google's Gemini AI models, p
     - **Advanced Settings:** (Click "Show Advanced Settings" to reveal)
       - **Temperature:** Control AI creativity and randomness (0-2.0, automatically adjusted based on available models).
       - **Top P:** Control response diversity and focus (0-1.0).
-      - **Model Discovery:** Automatically fetch and update available Gemini models with their parameter limits.
+      - **Model Discovery:** Gemini models are automatically fetched on startup; Ollama users can click **Refresh model list** after pulling new models.
       - **API Configuration:** Configure retry behavior and backoff delays.
       - **Tool Execution:** Control whether to stop agent execution on tool errors.
       - **Tool Loop Detection:** Prevent infinite tool execution loops.
@@ -296,7 +296,7 @@ Create reusable AI instruction templates that customize how the AI behaves for s
   - Try typing a few words and pausing to trigger the suggestion
   - Check that you're in a Markdown file
   - Disable other completion plugins that might conflict
-- **Sessions Not Loading:** Ensure "Enable Chat History" is on and the "Plugin State Folder" path is correct. Sessions live under `[Plugin State Folder]/Agent-Sessions/`.
+- **Sessions Not Loading:** Ensure "Enable Session History" is on and the "Plugin State Folder" path is correct. Sessions live under `[Plugin State Folder]/Agent-Sessions/`.
 - **Custom Prompts Not Working:**
   - Ensure "Enable Custom Prompts" is toggled on in settings
   - Verify the prompt file exists in the Prompts folder
@@ -305,7 +305,7 @@ Create reusable AI instruction templates that customize how the AI behaves for s
 - **Parameter/Advanced Settings Issues:**
   - Check if your model supports the temperature range you're using
   - Reset temperature and Top P to defaults if getting unexpected responses
-  - Enable model discovery to get latest parameter limits
+  - Restart Obsidian to trigger a fresh model list fetch (for Gemini), or click **Refresh model list** (for Ollama)
   - See the [Advanced Settings Guide](docs/reference/advanced-settings.md) for detailed configuration help
 - **Agent Mode / Tool Issues:**
   - Verify your Gemini model supports function calling (all Gemini 2.0+ models do)

--- a/docs/reference/advanced-settings.md
+++ b/docs/reference/advanced-settings.md
@@ -33,7 +33,7 @@ Advanced settings are hidden by default to keep the interface clean. To access t
 **Top P** controls the diversity of word choices the AI considers:
 
 - **Range**: 0 to 1.0 (always fixed range for Gemini models)
-- **Default**: Varies by model (typically 0.95-1.0)
+- **Default**: `1.0`
 - **Lower values** (0.1-0.5): More focused, predictable responses
 - **Higher values** (0.8-1.0): More diverse, exploratory responses
 
@@ -82,43 +82,9 @@ Configure how the plugin handles API failures:
 
 ## Model Discovery
 
-### Dynamic Model Discovery
+Model discovery is fully automatic — there are no user-configurable settings for it. On startup, the plugin fetches the latest available Gemini models from Google's API and updates the model dropdowns. If the API fetch fails, the bundled static model list is used as a fallback.
 
-Automatically fetch available models from Google's API:
-
-**Enable Dynamic Model Discovery**
-
-- **Default**: Enabled
-- **Purpose**: Keeps model list current with Google's latest releases
-- **Updates**: Model parameter limits and availability
-
-**Auto-update Interval**
-
-- **Default**: 24 hours
-- **Range**: 0-168 hours (7 days)
-- **0 = Manual only**: Disable automatic updates
-
-**Fallback to Static Models**
-
-- **Default**: Enabled
-- **Purpose**: Use built-in model list when API discovery fails
-- **Recommended**: Keep enabled for reliability
-
-### Discovery Status
-
-Monitor and control model discovery:
-
-**Status Indicators:**
-
-- ✓ Working: Discovery successful, shows last update time
-- ✗ Not working: Shows error details
-- Model count: Number of models found
-
-**Manual Refresh:**
-
-- Click "Refresh models" to update immediately
-- Useful when new models are released
-- Shows success/failure status
+When using the **Ollama** provider, a **Refresh model list** button appears in Settings → General. Click it after pulling new models with `ollama pull <name>` to force a re-query of the Ollama daemon without restarting Obsidian.
 
 ## Performance Optimization
 
@@ -181,12 +147,11 @@ In v4.0+, context is manually managed through session-based file selection:
 3. **Adjust retry settings** - More retries for unreliable connections
 4. **Enable fallback models** - Ensures continued functionality
 
-### Model Discovery
+### Model List
 
-1. **Keep discovery enabled** - Stay current with new releases
-2. **Use manual refresh** - When you know new models are available
-3. **Monitor discovery status** - Check for API key or connection issues
-4. **Update regularly** - Enable auto-updates for convenience
+1. **Restart Obsidian** to pick up newly published Gemini models — discovery runs automatically on startup
+2. **Use Refresh model list** (Ollama provider) after pulling new models with `ollama pull`
+3. **Check your API key** if the model list looks empty or stale
 
 ## Troubleshooting
 
@@ -220,21 +185,13 @@ In v4.0+, context is manually managed through session-based file selection:
 - Start new session to clear conversation history
 - Lower retry count for quicker failures
 
-### Model Discovery Issues
+### Model List Issues
 
-**Discovery failing:**
+**Models not appearing or stale:**
 
-- Check API key validity
-- Verify network connectivity
-- Try manual refresh
-- Enable fallback to static models
-
-**Models not updating:**
-
-- Check auto-update interval
-- Force refresh manually
-- Clear plugin cache (restart Obsidian)
-- Verify API key permissions
+- For Gemini: check API key validity and network connectivity; restart Obsidian to trigger a fresh fetch
+- For Ollama: click **Refresh model list** in Settings → General after pulling new models
+- If the list still looks wrong, restart Obsidian to clear the cached model list
 
 ## Security Considerations
 

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -64,13 +64,13 @@ This document provides a comprehensive reference for all Obsidian Gemini Scribe 
   └── debug.log.old    # Previous rotated log file
   ```
 
-### Enable Chat History
+### Enable Session History
 
 - **Setting**: `chatHistory`
 - **Type**: Boolean
 - **Default**: `false`
-- **Description**: Save chat conversations to markdown files
-- **Note**: Chat history is stored in Agent Sessions folder in v4.0.0
+- **Description**: Store agent session history as markdown files in your vault
+- **Note**: Sessions are saved in the Agent-Sessions subfolder with auto-generated titles
 
 ### Summary Frontmatter Key
 
@@ -268,37 +268,7 @@ Advanced settings for developers and power users. Access by clicking "Show Advan
 
 ### Model Discovery
 
-Dynamic model discovery automatically fetches the latest available Gemini models and their capabilities from Google's API.
-
-#### Enable Model Discovery
-
-- **Setting**: `modelDiscovery.enabled`
-- **Type**: Boolean
-- **Default**: `true`
-- **Description**: Automatically discover and update available Gemini models
-
-#### Auto-Update Interval
-
-- **Setting**: `modelDiscovery.autoUpdateInterval`
-- **Type**: Number (hours)
-- **Default**: `24`
-- **Description**: How often to check for new models (0 to disable)
-- **Range**: 0-168 hours (0-7 days)
-
-#### Fallback to Static Models
-
-- **Setting**: `modelDiscovery.fallbackToStatic`
-- **Type**: Boolean
-- **Default**: `true`
-- **Description**: Use built-in model list when API discovery fails
-- **Recommendation**: Keep enabled for reliability
-
-#### Last Update
-
-- **Setting**: `modelDiscovery.lastUpdate`
-- **Type**: Number (timestamp)
-- **Description**: Timestamp of last successful model discovery
-- **Note**: Read-only, automatically updated
+Model discovery is automatic — no user-configurable settings are required. On startup, the plugin fetches the latest available Gemini models from Google's API and falls back to the bundled list if the fetch fails. When using the Ollama provider, a **Refresh model list** button appears in Settings → General to re-query the Ollama daemon for newly pulled models. The remote model list is cached in `data.json` under `remoteModelCache` (managed internally; do not edit by hand).
 
 ### Tool Execution
 

--- a/planning/changelog/2026-04-27.md
+++ b/planning/changelog/2026-04-27.md
@@ -1,0 +1,16 @@
+# Daily changelog — April 27, 2026
+
+**Date:** 2026-04-27
+**PRs merged:** 1
+
+---
+
+## Summary
+
+Quiet day — one automated daily-housekeeping PR landed, closing out the 2026-04-26 daily update cycle. The PR patched two doc drift items (Vitest comment in `AGENTS.md`, `autoRunCatchUp` entry in `docs/reference/settings.md`) and generated the April 26 internal changelog.
+
+## What shipped
+
+### [#722 chore(daily): 2026-04-26 daily update](https://github.com/allenhutchison/obsidian-gemini/pull/722)
+
+Automated daily-update run for 2026-04-26. Wrote `planning/changelog/2026-04-26.md` summarizing eight PRs (Ollama provider, scheduler management UI, missed-run catch-up modal, Vitest migration, daily-update housekeeping skills, docs audit sweep, plus two bugfixes). Two doc drift items were fixed: a stale "Run Jest tests" comment in `AGENTS.md` updated to reflect the Vitest migration, and the missing `autoRunCatchUp` setting documented in `docs/reference/settings.md`.


### PR DESCRIPTION
## Summary

Automated daily housekeeping run for 2026-04-27.

## Changes

### daily-changelog
- Wrote `planning/changelog/2026-04-27.md` covering 1 PR
- Quiet day: only the automated 2026-04-26 daily-update PR (#722) merged

### audit-docs
Five drift items found and patched across three files:

- **`docs/reference/settings.md`** — "Model Discovery" sub-section under Developer Settings claimed four user-configurable settings (`modelDiscovery.enabled`, `modelDiscovery.autoUpdateInterval`, `modelDiscovery.fallbackToStatic`, `modelDiscovery.lastUpdate`) that do not exist in `ObsidianGeminiSettings`. Model refresh is automatic; no user settings control it. Replaced the fabricated settings block with an accurate one-paragraph description.
- **`docs/reference/settings.md`** — "Enable Chat History" heading did not match the actual UI label "Enable Session History" (per `src/ui/settings-general.ts`). Fixed.
- **`docs/reference/advanced-settings.md`** — Same phantom `modelDiscovery.*` settings in "Model Discovery" / "Best Practices" / "Troubleshooting" sections. All three removed and replaced with accurate descriptions.
- **`docs/reference/advanced-settings.md`** — topP default claimed "Varies by model (typically 0.95–1.0)" but `DEFAULT_SETTINGS.topP = 1`. Fixed to `1.0`.
- **`README.md`** — "Enable Chat History" label (×2) and "Enable model discovery" troubleshooting tip updated to match actual UI labels and behavior.

### triage-issues
Issues processed: 0 — no unlabeled open issues found.

## Screenshots / Screencast

N/A — documentation and changelog only; no UI changes.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: automated daily housekeeping run
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop — N/A: docs and changelog only
- [x] I have verified this change does not break Mobile — N/A: docs and changelog only
- [x] Documentation has been updated — this PR *is* the documentation update
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (claude-sonnet-4-6), via the `daily-update` skill
- [x] I have reviewed and understand all AI-generated code in this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01RCiMLqjEfDaupR4FpwFeiV)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated terminology: The session history setting is now labeled "Enable Session History" instead of "Enable Chat History"
  * Simplified Model Discovery: Gemini models are now automatically discovered on startup, while Ollama models require manual refresh through the "Refresh model list" button after pulling new models
  * Improved troubleshooting guidance aligned with the new model discovery behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->