### PR TITLE
chore(daily): 2026-04-29 daily update

### DIFF
--- a/docs/guide/ollama-setup.md
+++ b/docs/guide/ollama-setup.md
@@ -12,7 +12,7 @@ Gemini Scribe can route chat, summary, completions, rewrite, and agent tool-call
    ollama pull llava:13b      # for vision (image input)
    ```
 3. **Switch the provider in Gemini Scribe** — Open Settings → Gemini Scribe → Provider and choose **Ollama (local)**.
-4. **Pick a model** — The Chat / Summary / Completion dropdowns now list whatever you have pulled. Click **Refresh model list** if a new pull doesn't show up.
+4. **Pick a model** — The Chat / Summary / Completion dropdowns now list whatever you have pulled. In Settings → General, click **Refresh** in the **Refresh model list** row if a new pull doesn't show up.
 
 If the daemon runs on a different host or port, edit the **Ollama Base URL** field (e.g. `http://10.0.0.5:11434`).
 

--- a/docs/guide/ollama-setup.md
+++ b/docs/guide/ollama-setup.md
@@ -12,7 +12,7 @@ Gemini Scribe can route chat, summary, completions, rewrite, and agent tool-call
    ollama pull llava:13b      # for vision (image input)
    ```
 3. **Switch the provider in Gemini Scribe** — Open Settings → Gemini Scribe → Provider and choose **Ollama (local)**.
-4. **Pick a model** — The Chat / Summary / Completion dropdowns now list whatever you have pulled. Click **Refresh** if a new pull doesn't show up.
+4. **Pick a model** — The Chat / Summary / Completion dropdowns now list whatever you have pulled. Click **Refresh model list** if a new pull doesn't show up.
 
 If the daemon runs on a different host or port, edit the **Ollama Base URL** field (e.g. `http://10.0.0.5:11434`).
 

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -392,8 +392,8 @@ Available permission bypasses:
 ### Models not appearing
 
 1. Check API key is valid
-2. Enable Model Discovery in Developer Settings
-3. Click "Refresh models" button
+2. For Gemini: restart Obsidian — model discovery runs automatically on startup
+3. For Ollama: click **Refresh model list** in Settings → General after pulling new models
 4. Check console for errors (with Debug Mode enabled)
 
 ### Tool execution issues
@@ -405,7 +405,7 @@ Available permission bypasses:
 
 ### Chat history not saving
 
-1. Verify "Enable Chat History" is toggled on
+1. Verify "Enable Session History" is toggled on
 2. Check Plugin State Folder path is valid
 3. Ensure you have write permissions to vault
 

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -393,7 +393,7 @@ Available permission bypasses:
 
 1. Check API key is valid
 2. For Gemini: restart Obsidian — model discovery runs automatically on startup
-3. For Ollama: click **Refresh model list** in Settings → General after pulling new models
+3. For Ollama: go to Settings → General and click **Refresh** in the **Refresh model list** row after pulling new models
 4. Check console for errors (with Debug Mode enabled)
 
 ### Tool execution issues

--- a/planning/changelog/2026-04-28.md
+++ b/planning/changelog/2026-04-28.md
@@ -1,0 +1,22 @@
+# Daily changelog — April 28, 2026
+
+**Date:** 2026-04-28
+**PRs merged:** 1
+
+---
+
+## Summary
+
+Quiet day dominated by documentation housekeeping. The automated daily-update PR caught and corrected five documentation drift items — most notably, references to fabricated `modelDiscovery.*` settings that no longer match the codebase, and a stale UI label ("Enable Chat History" → "Enable Session History").
+
+## What shipped
+
+### [#726 chore(daily): 2026-04-27 daily update](https://github.com/allenhutchison/obsidian-gemini/pull/726)
+
+Automated daily housekeeping run for 2026-04-27. The `daily-changelog` sub-skill wrote `planning/changelog/2026-04-27.md`, noting a quiet day (only the prior automated daily-update PR had merged). The `audit-docs` sub-skill found and patched five drift items across three files:
+
+- `docs/reference/settings.md`: Removed a block of four fabricated `modelDiscovery.*` settings (`modelDiscovery.enabled`, `.autoUpdateInterval`, `.fallbackToStatic`, `.lastUpdate`) that do not exist in `ObsidianGeminiSettings`; model refresh is automatic and has no user-configurable knobs. Also corrected the "Enable Chat History" heading to "Enable Session History" to match the actual UI label.
+- `docs/reference/advanced-settings.md`: Same phantom `modelDiscovery.*` entries removed from three sections (Model Discovery, Best Practices, Troubleshooting). Fixed the documented `topP` default from "Varies by model (typically 0.95–1.0)" to the actual value of `1.0`.
+- `README.md`: Updated two occurrences of "Enable Chat History" and the "Enable model discovery" troubleshooting tip to reflect current labels and behavior.
+
+The `triage-issues` sub-skill found no unlabeled open issues.


### PR DESCRIPTION
## Summary

Automated daily housekeeping run for 2026-04-28.

## Changes

### daily-changelog
- Wrote `planning/changelog/2026-04-28.md` covering 1 PR
- Quiet day: only the automated 2026-04-27 daily-update PR (#726) merged — documentation drift corrections

### audit-docs
Three drift items found and patched across two files:

- **`docs/reference/settings.md`** — Troubleshooting → "Models not appearing": Steps 2–3 still referenced a non-existent "Enable Model Discovery in Developer Settings" toggle and a mis-labelled "Refresh models" button. Both were removed and replaced with accurate provider-specific instructions (Gemini: restart to trigger auto-discovery; Ollama: click "Refresh model list" in Settings → General).
- **`docs/reference/settings.md`** — Troubleshooting → "Chat history not saving": Step 1 still said "Enable Chat History" instead of the actual UI label "Enable Session History".
- **`docs/guide/ollama-setup.md`** — Setup step 4 said "Click **Refresh**" instead of the actual button name "Click **Refresh model list**".

### triage-issues
- Issues processed: 2
- Issues labeled: 2

Labeled:
- #728 `enhancement` + `tool-execution` — "We need to be able to run activate_skill from background tasks" (proposes making activate_skill available in background task tool policy)
- #727 `enhancement` — "Scheduled tasks need the ability to set time as well as day" (time-of-day/day-of-week scheduling feature request)

## Screenshots / Screencast

N/A — documentation and changelog only; no UI changes.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: automated daily housekeeping run
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop — N/A: docs and changelog only
- [x] I have verified this change does not break Mobile — N/A: docs and changelog only
- [x] Documentation has been updated — this PR *is* the documentation update
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (claude-sonnet-4-6), via the `daily-update` skill
- [x] I have reviewed and understand all AI-generated code in this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01JvJrXPN9FzD4WuXJ2TBRHt)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified UI steps for refreshing model lists (Settings → General → Refresh model list) and fixed model-selection labels.
  * Updated troubleshooting with provider-specific model-discovery steps for Gemini and Ollama.
  * Corrected settings terminology (“Enable Session History”) and default topP documentation.
* **Chores**
  * Added daily changelog entry documenting documentation housekeeping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->