### PR TITLE
feat: add custom API endpoint configuration

### DIFF
--- a/src/api/gemini-client.ts
+++ b/src/api/gemini-client.ts
@@ -60,11 +60,9 @@ export class GeminiClient implements ModelApi {
 		};
 		this.plugin = plugin;
 		this.prompts = prompts || new GeminiPrompts(plugin);
-		//this.ai = new GoogleGenAI({ apiKey: config.apiKey });
 		const customUrl = this.plugin?.settings?.customBaseUrl;
 		this.ai = new GoogleGenAI({
 			apiKey: config.apiKey,
-			// 将 baseUrl 嵌套在 httpOptions 中
 			httpOptions: customUrl ? { baseUrl: customUrl } : undefined,
 		});
 	}

--- a/src/api/gemini-client.ts
+++ b/src/api/gemini-client.ts
@@ -60,9 +60,14 @@ export class GeminiClient implements ModelApi {
 		};
 		this.plugin = plugin;
 		this.prompts = prompts || new GeminiPrompts(plugin);
-		this.ai = new GoogleGenAI({ apiKey: config.apiKey });
+		//this.ai = new GoogleGenAI({ apiKey: config.apiKey });
+		const customUrl = this.plugin?.settings?.customBaseUrl;
+		this.ai = new GoogleGenAI({
+			apiKey: config.apiKey,
+			// 将 baseUrl 嵌套在 httpOptions 中
+			httpOptions: customUrl ? { baseUrl: customUrl } : undefined,
+		});
 	}
-
 	/**
 	 * Generate a non-streaming response
 	 */

--- a/src/main.ts
+++ b/src/main.ts
@@ -69,6 +69,7 @@ export interface ObsidianGeminiSettings {
 	initialBackoffDelay: number;
 	streamingEnabled: boolean;
 	allowSystemPromptOverride: boolean;
+	customBaseUrl: string;
 	temperature: number;
 	topP: number;
 	stopOnToolError: boolean;
@@ -118,6 +119,7 @@ const DEFAULT_SETTINGS: ObsidianGeminiSettings = {
 	initialBackoffDelay: 1000,
 	streamingEnabled: true,
 	allowSystemPromptOverride: false,
+	customBaseUrl: '',
 	temperature: 0.7,
 	topP: 1,
 	stopOnToolError: true,

--- a/src/ui/settings-api.ts
+++ b/src/ui/settings-api.ts
@@ -62,6 +62,20 @@ export async function renderApiSettings(
 
 	// API Configuration
 	new Setting(containerEl).setName('API Configuration').setHeading();
+	// === 【新增的代理设置面板区 开始】 ===
+	new Setting(containerEl)
+		.setName('Custom API Endpoint (自定义代理地址)')
+		.setDesc('可选。用于覆盖默认的 Google API 地址，例如本地反向代理服务器。留空则使用官方默认地址。')
+		.addText((text) =>
+			text
+				.setPlaceholder('例如：https://c.baicai.qzz.io')
+				.setValue(plugin.settings.customBaseUrl)
+				.onChange((value) => {
+					plugin.settings.customBaseUrl = value.trim();
+					debouncedSave();
+				})
+		);
+	// === 【新增的代理设置面板区 结束】 ===
 
 	new Setting(containerEl)
 		.setName('Maximum Retries')

--- a/src/ui/settings-api.ts
+++ b/src/ui/settings-api.ts
@@ -65,10 +65,10 @@ export async function renderApiSettings(
 	// === 【新增的代理设置面板区 开始】 ===
 	new Setting(containerEl)
 		.setName('Custom API Endpoint (自定义代理地址)')
-		.setDesc('可选。用于覆盖默认的 Google API 地址，例如本地反向代理服务器。留空则使用官方默认地址。')
+		.setDesc('option。用于覆盖默认的 Google API 地址，例如本地反向代理服务器。留空则使用官方默认地址。')
 		.addText((text) =>
 			text
-				.setPlaceholder('例如：https://c.baicai.qzz.io')
+				.setPlaceholder('example：https://ip:port')
 				.setValue(plugin.settings.customBaseUrl)
 				.onChange((value) => {
 					plugin.settings.customBaseUrl = value.trim();


### PR DESCRIPTION
**What does this PR do?**
This PR adds a "Custom API Endpoint" text field in the Advanced Settings under API Configuration. This allows users to pass a custom `baseUrl` to the `@google/genai` SDK, which is extremely useful for users utilizing local proxies or API gateways.

**Changes made:**
- Modified `src/main.ts`: Added `customBaseUrl` to `ObsidianGeminiSettings` interface and default settings.
- Modified `src/ui/settings-api.ts`: Added a text input field for the custom endpoint under the Advanced API settings.
- Modified `src/api/gemini-client.ts`: Updated `GoogleGenAI` initialization to utilize `httpOptions.baseUrl` if provided by the user.

**Testing:**
Tested locally in Obsidian. The setting correctly saves, and requests are successfully proxied through the configured base URL without affecting the default behavior when the field is left blank.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable "Custom Base URL" in plugin settings so users can route requests through a proxy or alternate API endpoint.
  * New settings field trims input and persists changes automatically.
  * When set, the plugin sends requests using the configured base URL; default behavior remains unchanged if left empty.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->