### PR TITLE
chore(daily): 2026-05-01 daily update

### DIFF
--- a/docs/guide/scheduled-tasks.md
+++ b/docs/guide/scheduled-tasks.md
@@ -65,13 +65,14 @@ Summarise the notes I created or modified today. List the key topics and any ope
 
 The `enabledTools` list controls what the agent can do during a run:
 
-| Category      | Capabilities                         |
-| ------------- | ------------------------------------ |
-| `read_only`   | Read files, list files, search vault |
-| `read_write`  | Read + write, create, move files     |
-| `destructive` | Read + write + delete files          |
+| Category       | Capabilities                                           |
+| -------------- | ------------------------------------------------------ |
+| `read_only`    | Read files, list files, search vault, web search/fetch |
+| `vault_ops`    | Create, modify, move, and delete files in the vault    |
+| `external_mcp` | Tools provided by connected MCP servers                |
+| `skills`       | Load and activate agent skills                         |
 
-If `enabledTools` is empty the task defaults to `read_only`.
+Categories are additive — list as many as the task needs. If `enabledTools` is empty the task defaults to read-only tools only.
 
 ## Managing Tasks
 

--- a/planning/changelog/2026-04-30.md
+++ b/planning/changelog/2026-04-30.md
@@ -1,0 +1,18 @@
+# Daily changelog — April 30, 2026
+
+**Date:** 2026-04-30
+**PRs merged:** 1
+
+---
+
+## Summary
+
+Quiet day — one automated daily housekeeping PR landed, carrying AGENTS.md drift fixes (history path correction, Scheduled-Tasks folder entry) and issue triage from the 2026-04-30 morning run.
+
+## What shipped
+
+### [#732 chore(daily): 2026-04-30 daily update](https://github.com/allenhutchison/obsidian-gemini/pull/732)
+
+Automated daily housekeeping run for 2026-04-29. The changelog sub-skill wrote `planning/changelog/2026-04-29.md` covering one quiet day (only the prior daily-update PR #729 had merged). The audit-docs sub-skill found and patched two drift items in `AGENTS.md`: the Key Components section incorrectly listed `[state-folder]/History/` as the agent session storage path (it's `[state-folder]/Agent-Sessions/`), and the Folder Structure pattern was missing the `[state-folder]/Scheduled-Tasks/` entry that shipped with the scheduled tasks feature.
+
+The PR also surfaced a code bug — `TOOL_CATEGORIES` in `src/ui/scheduler-management-modal.ts` uses wrong `ToolCategory` values (`read_write`/`destructive` instead of `vault_ops`), causing tasks created via the Scheduler UI to silently receive no vault-write tool access. That fix was deferred to a separate PR. The triage sub-skill labeled issue #731 (`enhancement` + `chat-ux` + `quick-win`) — a request to make tool call parameters/results copyable in the agent view.


### PR DESCRIPTION
## Summary

Automated daily housekeeping run for 2026-04-30.

## Changes

### daily-changelog
- Wrote `planning/changelog/2026-04-30.md` covering 1 PR
- Quiet day: only the automated 2026-04-30 daily-update PR (#732) merged — AGENTS.md drift fixes and issue triage

### audit-docs
One drift fix applied in `docs/guide/scheduled-tasks.md`:

- **Tool Access table**: The `enabledTools` field was documented with `read_write` and `destructive` as valid category values — neither exists in the `ToolCategory` enum (`src/types/agent.ts`). The enum defines `read_only`, `vault_ops`, `external_mcp`, and `skills`. Tasks written with `read_write` or `destructive` silently received no vault-write tool access (the registry string-compares against the enum values). Fixed the table to show the four correct values with accurate capability descriptions.

  Note: `src/ui/scheduler-management-modal.ts` still exposes `TOOL_CATEGORIES = ['read_only', 'read_write', 'destructive']` in its checkbox UI — that's a matching code bug that needs a separate code + UI fix. The docs now reflect the values that actually work in frontmatter.

No new docs were warranted — all recently-shipped features (Ollama, Scheduler UI, catch-up runs, edit_skill) are already documented.

### triage-issues
- Issues processed: 0
- No unlabeled open issues found

## Screenshots / Screencast

N/A — documentation and changelog only; no UI changes.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: automated daily housekeeping run
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop — N/A: docs and changelog only
- [ ] I have verified this change does not break Mobile — N/A: docs and changelog only
- [x] Documentation has been updated — this PR *is* the documentation update
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (claude-sonnet-4-6), via the `daily-update` skill
- [x] I have reviewed and understand all AI-generated code in this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01UhkMTQvRLsbjsiurcRZsrM)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated scheduled tasks documentation with revised tool access categories and new capability model for enabling tools.
  * Added changelog entry documenting recent updates and routine maintenance activities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->