### PR TITLE
chore: clean up lifecycle-service nits from PR #723 review

### DIFF
--- a/src/services/lifecycle-service.ts
+++ b/src/services/lifecycle-service.ts
@@ -1,5 +1,4 @@
-import { TFile, Platform } from 'obsidian';
-import { Notice } from 'obsidian';
+import { TFile, Platform, Notice } from 'obsidian';
 import type ObsidianGemini from '../main';
 import { AgentEventBus } from '../agent/agent-event-bus';
 import { ContextTrackingSubscriber } from '../subscribers/context-tracking-subscriber';
@@ -538,7 +537,8 @@ export class LifecycleService {
 		} else {
 			// Reserve slugs so the tick loop skips them until user approves/skips
 			plugin.scheduledTaskManager.reserveForCatchUp(pending.map((e) => e.task.slug));
-			// Show the ! badge — clicking it opens the CatchUpModal
+			// Set the badge regardless of platform: it drives the desktop entry point,
+			// and on mobile the call is a harmless no-op that keeps internal state consistent.
 			plugin.backgroundStatusBar?.setPendingCatchUpCount(pending.length);
 
 			// On mobile the status bar is hidden, so the badge is unreachable.


### PR DESCRIPTION
## Summary

Two small follow-ups from the review of #723. Pure code/comment cleanup
in `src/services/lifecycle-service.ts` — no behavior change.

## Changes

- Consolidate the two consecutive `import ... from 'obsidian'` lines into
  one (`TFile`, `Platform`, `Notice`).
- Replace the `// Show the ! badge — clicking it opens the CatchUpModal`
  comment with a clearer note explaining that the badge is intentionally
  set on every platform: it drives the desktop entry point and is a
  harmless no-op on mobile (where the status bar is hidden) that keeps
  internal state consistent. Without the comment a future reader could
  reasonably think the call is dead code on mobile and remove it.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: trivial cleanup of comments + import grouping flagged in the review of #723
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop
- [x] I have verified this change does not break Mobile (no behavior change; mobile guard from #723 is untouched)
- [ ] Documentation has been updated (if applicable) — N/A: no user-facing change
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code organization and updated documentation for clearer platform behavior handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->