### PR TITLE
chore: follow-up cleanups from PR #724 review

### DIFF
--- a/docs/guide/background-tasks.md
+++ b/docs/guide/background-tasks.md
@@ -28,7 +28,7 @@ Completed tasks with output files show an **Open result** link that opens the fi
 
 Background tasks are created automatically when you trigger long-running operations:
 
-- **Deep Research** — starts a research task; result saved to `Background Research/YYYY-MM-DD <topic>.md` by default (you can specify a custom path via the `outputFile` parameter)
+- **Deep Research** — starts a research task; result saved to `[state-folder]/Background-Tasks/YYYY-MM-DD <topic>.md` by default (you can specify a custom path via the `outputFile` parameter)
 - **Image Generation** — generates and saves an image; result path shown in the completion notice
 
 Both operations fire a completion notice with a clickable vault link when done. If a task fails, a notice explains the error.
@@ -42,7 +42,7 @@ Click **Cancel** next to a running task in the panel. The task stops at the next
 When a task completes you'll see a notice in the bottom-right corner with an **Open result** link. You can also find the result by:
 
 1. Clicking the status bar indicator → **Open result** in the Recent section
-2. Navigating directly to `Background Research/` in the file explorer (unless you set a custom `outputFile` path)
+2. Navigating directly to `[state-folder]/Background-Tasks/` in the file explorer (unless you set a custom `outputFile` path)
 
 ## Troubleshooting
 

--- a/src/services/image-generation.ts
+++ b/src/services/image-generation.ts
@@ -60,18 +60,17 @@ export class ImageGeneration {
 	 * Generate an image and return the file path.
 	 * Used by the agent tool.
 	 *
-	 * @param prompt         - Text description of the image to generate
-	 * @param targetNotePath - Optional: note path used to resolve the attachment folder
-	 * @param outputPath     - Optional: explicit vault path for the output file.
-	 *                         When provided it takes priority over targetNotePath-based resolution.
+	 * @param prompt     - Text description of the image to generate
+	 * @param outputPath - Optional: explicit vault path for the output file.
+	 *                     When omitted, the image lands in [state-folder]/Background-Tasks/.
 	 */
-	async generateImage(prompt: string, targetNotePath?: string, outputPath?: string): Promise<string> {
+	async generateImage(prompt: string, outputPath?: string): Promise<string> {
 		try {
 			// Generate the image
 			const base64Data = await this.client.generateImage(prompt, this.plugin.settings.imageModelName);
 
 			// Save the image to vault
-			return await this.saveImageToVault(base64Data, prompt, targetNotePath, outputPath);
+			return await this.saveImageToVault(base64Data, prompt, outputPath);
 		} catch (error) {
 			this.plugin.logger.error('Failed to generate image:', error);
 			throw error;
@@ -101,11 +100,11 @@ export class ImageGeneration {
 
 	/**
 	 * Resolve the exact vault path an image will be saved at, for either an
-	 * explicit caller-supplied path or the default attachment-folder flow.
+	 * explicit caller-supplied path or the Background-Tasks default.
 	 *
 	 * When `outputPath` is provided, validates it and rewrites the extension
 	 * to `.png` (saveImageToVault writes PNG bytes unconditionally). When it
-	 * isn't, falls back to the default attachment-folder resolution.
+	 * isn't, falls back to [state-folder]/Background-Tasks/<generated-filename>.
 	 *
 	 * Used by background mode of GenerateImageTool to pre-compute the path at
 	 * submit time and return it synchronously — the agent relies on this path
@@ -116,13 +115,13 @@ export class ImageGeneration {
 	 * Throws synchronously on an invalid explicit path (vault escape,
 	 * protected folder, etc.).
 	 */
-	async resolveOutputPath(prompt: string, targetNotePath?: string, outputPath?: string): Promise<string> {
+	async resolveOutputPath(prompt: string, outputPath?: string): Promise<string> {
 		if (outputPath) {
 			// Runs the same validation/normalisation saveImageToVault uses,
 			// including rewriting any non-.png extension to .png.
 			return this.validateOutputPath(outputPath);
 		}
-		return this.resolveDefaultOutputPath(prompt, targetNotePath);
+		return this.resolveDefaultOutputPath(prompt);
 	}
 
 	/**
@@ -134,7 +133,7 @@ export class ImageGeneration {
 	 * explicit path — it handles both branches consistently. This method is
 	 * kept public for callers that specifically want the default flow.
 	 */
-	async resolveDefaultOutputPath(prompt: string, _targetNotePath?: string): Promise<string> {
+	async resolveDefaultOutputPath(prompt: string): Promise<string> {
 		const filename = this.buildDefaultFilename(prompt);
 		const backgroundTasksFolder = normalizePath(`${this.plugin.settings.historyFolder}/Background-Tasks`);
 		return normalizePath(`${backgroundTasksFolder}/${filename}`);
@@ -145,13 +144,11 @@ export class ImageGeneration {
 	 * Centralised so resolveDefaultOutputPath and saveImageToVault can't drift.
 	 *
 	 * Includes a timestamp AND a short random suffix so two concurrent
-	 * background tasks can't propose the same path. `getAvailablePathForAttachment`
-	 * is a non-atomic availability check — if it returned the same "free" path
-	 * to two callers, the second write would throw when `vault.createBinary`
-	 * encountered the file the first task wrote. The random suffix drops
-	 * collision probability to ~1-in-2-billion per same-millisecond submission
-	 * with the same prompt slice, from the ~100% it would be otherwise in
-	 * that (rare) case.
+	 * background tasks can't propose the same path. `vault.createBinary`
+	 * throws if the target exists, so two tasks landing on the same name
+	 * within the same millisecond would otherwise collide; the random suffix
+	 * drops collision probability to ~1-in-2-billion per same-millisecond
+	 * submission with the same prompt slice.
 	 */
 	private buildDefaultFilename(prompt: string): string {
 		const sanitizedPrompt = prompt
@@ -217,17 +214,11 @@ export class ImageGeneration {
 	/**
 	 * Save base64 image data to the vault.
 	 *
-	 * @param base64Data     - Base64 encoded image data
-	 * @param prompt         - The prompt used to generate the image (used for filename generation)
-	 * @param targetNotePath - Optional note path used to resolve the Obsidian attachment folder
-	 * @param outputPath     - Optional explicit vault path for the file; skips attachment-folder resolution
+	 * @param base64Data - Base64 encoded image data
+	 * @param prompt     - The prompt used to generate the image (used for filename generation)
+	 * @param outputPath - Optional explicit vault path for the file; falls back to the Background-Tasks default
 	 */
-	private async saveImageToVault(
-		base64Data: string,
-		prompt: string,
-		targetNotePath?: string,
-		outputPath?: string
-	): Promise<string> {
+	private async saveImageToVault(base64Data: string, prompt: string, outputPath?: string): Promise<string> {
 		// Convert base64 to binary with validation
 		let binaryData: string;
 		try {
@@ -256,7 +247,7 @@ export class ImageGeneration {
 				await ensureFolderExists(this.plugin.app.vault, parentPath, 'image output folder', this.plugin.logger);
 			}
 		} else {
-			resolvedPath = await this.resolveDefaultOutputPath(prompt, targetNotePath);
+			resolvedPath = await this.resolveDefaultOutputPath(prompt);
 		}
 
 		// Save to vault

--- a/src/tools/image-tools.ts
+++ b/src/tools/image-tools.ts
@@ -22,15 +22,10 @@ export class GenerateImageTool implements Tool {
 				type: 'string' as const,
 				description: 'Detailed description of the image to generate',
 			},
-			target_note: {
-				type: 'string' as const,
-				description:
-					'Optional: The path of the note to use for determining the attachment folder location where the image file will be saved. This does NOT insert the image into the note - it only affects where the image file is stored. If not provided, uses the currently active note to determine the attachment folder.',
-			},
 			output_path: {
 				type: 'string' as const,
 				description:
-					'Optional: Explicit vault path where the generated image file should be saved (e.g. "attachments/my-image.png"). When provided, the image is saved at exactly this path regardless of target_note. Useful when the caller needs a predictable location to retrieve the result later.',
+					'Optional: Explicit vault path where the generated image file should be saved (e.g. "attachments/my-image.png"). When omitted, the image is saved under the plugin\'s Background-Tasks folder.',
 			},
 			background: {
 				type: 'boolean' as const,
@@ -48,8 +43,6 @@ export class GenerateImageTool implements Tool {
 		let message = `Generate an image with prompt: "${params.prompt}"?\n\nThis will create a new image file in your vault.`;
 		if (params.output_path) {
 			message += `\n\nDestination: ${params.output_path}`;
-		} else if (params.target_note) {
-			message += `\n\nAttachment folder resolved from: ${params.target_note}`;
 		}
 		return message;
 	};
@@ -88,23 +81,14 @@ export class GenerateImageTool implements Tool {
 					return { success: false, error: 'Background task manager not available' };
 				}
 
-				// Capture the active file now — it may change while the task is in flight.
-				// Used as the attachment-folder reference when no explicit output_path is given.
-				const activeFilePath = plugin.app.workspace.getActiveFile()?.path ?? undefined;
-				const referenceNotePath = params.target_note ?? activeFilePath;
-
 				// Pre-resolve the output path at submit time so the agent has a concrete
 				// vault path to read_file later. resolveOutputPath handles both the
 				// explicit-path case (validation + .png extension rewrite) and the
-				// default attachment-folder case — so the path we return here always
+				// default Background-Tasks fallback — so the path we return here always
 				// matches where the task will actually write.
 				let resolvedOutputPath: string;
 				try {
-					resolvedOutputPath = await plugin.imageGeneration.resolveOutputPath(
-						params.prompt,
-						referenceNotePath,
-						params.output_path
-					);
+					resolvedOutputPath = await plugin.imageGeneration.resolveOutputPath(params.prompt, params.output_path);
 				} catch (error) {
 					return {
 						success: false,
@@ -118,7 +102,7 @@ export class GenerateImageTool implements Tool {
 					if (isCancelled()) return undefined;
 					// Always pass the pre-resolved path as the explicit outputPath so the
 					// task writes exactly where we told the agent it would land.
-					return imageGeneration.generateImage(params.prompt, referenceNotePath, resolvedOutputPath);
+					return imageGeneration.generateImage(params.prompt, resolvedOutputPath);
 				});
 
 				return {
@@ -128,11 +112,7 @@ export class GenerateImageTool implements Tool {
 			}
 
 			// ── Foreground mode (default) ────────────────────────────────────────
-			const imagePath = await plugin.imageGeneration.generateImage(
-				params.prompt,
-				params.target_note,
-				params.output_path
-			);
+			const imagePath = await plugin.imageGeneration.generateImage(params.prompt, params.output_path);
 
 			return {
 				success: true,

--- a/test/services/deep-research.test.ts
+++ b/test/services/deep-research.test.ts
@@ -426,4 +426,44 @@ describe('DeepResearchService', () => {
 			expect(result.sourceCount).toBe(0);
 		});
 	});
+
+	describe('validateAndNormalizeFilePath (output-path validator)', () => {
+		// Pin the state-folder allowlist behavior added in #724: Background-Tasks/
+		// is the one allowed subtree under the plugin state folder; everything
+		// else under it must still be rejected.
+		const validate = (path: string): string => (service as any).validateAndNormalizeFilePath(path);
+
+		beforeEach(() => {
+			mockPlugin.settings.historyFolder = 'gemini-scribe';
+		});
+
+		it('allows a file under [state-folder]/Background-Tasks/', () => {
+			expect(validate('gemini-scribe/Background-Tasks/2026-01-01 topic.md')).toBe(
+				'gemini-scribe/Background-Tasks/2026-01-01 topic.md'
+			);
+		});
+
+		it('rejects other subfolders under the state folder', () => {
+			expect(() => validate('gemini-scribe/Skills/foo.md')).toThrow(/plugin state folder/);
+			expect(() => validate('gemini-scribe/Agent-Sessions/foo.md')).toThrow(/plugin state folder/);
+		});
+
+		it('rejects the bare state folder', () => {
+			expect(() => validate('gemini-scribe')).toThrow(/plugin state folder/);
+		});
+
+		it('rejects sibling-prefix paths that start with Background-Tasks but are not the subfolder', () => {
+			// Without the trailing-slash check, "Background-Tasks-Other/foo" would
+			// sneak past startsWith('Background-Tasks') — guard that.
+			expect(() => validate('gemini-scribe/Background-Tasks-Other/foo.md')).toThrow(/plugin state folder/);
+		});
+
+		it('rejects paths inside .obsidian/', () => {
+			expect(() => validate('.obsidian/snippets/foo.md')).toThrow(/protected system folder/);
+		});
+
+		it('allows arbitrary paths outside the state folder', () => {
+			expect(validate('Notes/foo.md')).toBe('Notes/foo.md');
+		});
+	});
 });

--- a/test/services/image-generation.test.ts
+++ b/test/services/image-generation.test.ts
@@ -1,0 +1,76 @@
+import { ImageGeneration } from '../../src/services/image-generation';
+
+vi.mock('obsidian', async () => ({
+	...(await vi.importActual<any>('../../__mocks__/obsidian.js')),
+}));
+
+// The validator does not touch the network; mock the API factory so the
+// constructor can run without real credentials.
+vi.mock('../../src/api', () => ({
+	GeminiClient: vi.fn().mockImplementation(function () {
+		return {};
+	}),
+	GeminiClientFactory: { createSummaryModel: vi.fn() },
+}));
+
+vi.mock('../../src/prompts', () => ({
+	GeminiPrompts: vi.fn().mockImplementation(function () {
+		return {};
+	}),
+}));
+
+describe('ImageGeneration.validateOutputPath (output-path validator)', () => {
+	let service: ImageGeneration;
+
+	// Pin the state-folder allowlist behavior added in #724: Background-Tasks/
+	// is the one allowed subtree under the plugin state folder. Reach into the
+	// private method directly — its contract is what callers depend on.
+	const validate = (path: string): string => (service as any).validateOutputPath(path);
+
+	beforeEach(() => {
+		const mockPlugin = {
+			apiKey: 'test-key',
+			settings: { historyFolder: 'gemini-scribe', temperature: 0, topP: 0 },
+			logger: { log: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+		} as any;
+		service = new ImageGeneration(mockPlugin);
+	});
+
+	it('allows a file under [state-folder]/Background-Tasks/ and rewrites the extension to .png', () => {
+		expect(validate('gemini-scribe/Background-Tasks/foo.png')).toBe('gemini-scribe/Background-Tasks/foo.png');
+		expect(validate('gemini-scribe/Background-Tasks/foo.jpg')).toBe('gemini-scribe/Background-Tasks/foo.png');
+		expect(validate('gemini-scribe/Background-Tasks/foo')).toBe('gemini-scribe/Background-Tasks/foo.png');
+	});
+
+	it('rejects other subfolders under the state folder', () => {
+		expect(() => validate('gemini-scribe/Skills/foo.png')).toThrow(/plugin state folder/);
+		expect(() => validate('gemini-scribe/Agent-Sessions/foo.png')).toThrow(/plugin state folder/);
+	});
+
+	it('rejects sibling-prefix paths that start with Background-Tasks but are not the subfolder', () => {
+		// Without the trailing-slash check, "Background-Tasks-Other/foo" would
+		// sneak past startsWith('Background-Tasks') — guard that.
+		expect(() => validate('gemini-scribe/Background-Tasks-Other/foo.png')).toThrow(/plugin state folder/);
+	});
+
+	it('rejects bare "Background-Tasks" because the .png rewrite leaves it outside the allowed subfolder', () => {
+		// The extension rewrite happens before the state-folder check, so a bare
+		// "gemini-scribe/Background-Tasks" path becomes "gemini-scribe/Background-Tasks.png"
+		// which does not start with "gemini-scribe/Background-Tasks/" and is therefore rejected.
+		expect(() => validate('gemini-scribe/Background-Tasks')).toThrow(/plugin state folder/);
+	});
+
+	it('rejects paths inside .obsidian/', () => {
+		expect(() => validate('.obsidian/snippets/foo.png')).toThrow(/Obsidian configuration folder/);
+	});
+
+	it('rejects vault-escaping paths', () => {
+		expect(() => validate('../outside.png')).toThrow(/escapes the vault/);
+	});
+
+	it('allows arbitrary paths outside the state folder and forces a .png extension', () => {
+		expect(validate('attachments/foo.png')).toBe('attachments/foo.png');
+		expect(validate('attachments/foo.jpg')).toBe('attachments/foo.png');
+		expect(validate('attachments/foo')).toBe('attachments/foo.png');
+	});
+});

--- a/test/tools/image-tools.test.ts
+++ b/test/tools/image-tools.test.ts
@@ -51,7 +51,7 @@ describe('ImageTools', () => {
 		});
 
 		it('should generate image and return wikilink', async () => {
-			const imagePath = 'attachments/generated-image-123.png';
+			const imagePath = 'gemini-scribe/Background-Tasks/generated-image-123.png';
 			mockImageGeneration.generateImage.mockResolvedValue(imagePath);
 
 			const result = await tool.execute({ prompt: 'a loaf of bread' }, mockContext);
@@ -62,23 +62,7 @@ describe('ImageTools', () => {
 				prompt: 'a loaf of bread',
 				wikilink: `![[${imagePath}]]`,
 			});
-			expect(mockImageGeneration.generateImage).toHaveBeenCalledWith('a loaf of bread', undefined, undefined);
-		});
-
-		it('should pass target_note parameter when provided', async () => {
-			const imagePath = 'attachments/generated-image-456.png';
-			mockImageGeneration.generateImage.mockResolvedValue(imagePath);
-
-			const result = await tool.execute(
-				{
-					prompt: 'a sunset',
-					target_note: 'my-note.md',
-				},
-				mockContext
-			);
-
-			expect(result.success).toBe(true);
-			expect(mockImageGeneration.generateImage).toHaveBeenCalledWith('a sunset', 'my-note.md', undefined);
+			expect(mockImageGeneration.generateImage).toHaveBeenCalledWith('a loaf of bread', undefined);
 		});
 
 		it('should pass output_path parameter when provided', async () => {
@@ -99,28 +83,7 @@ describe('ImageTools', () => {
 				prompt: 'a mountain',
 				wikilink: `![[${imagePath}]]`,
 			});
-			expect(mockImageGeneration.generateImage).toHaveBeenCalledWith(
-				'a mountain',
-				undefined,
-				'attachments/my-custom-image.png'
-			);
-		});
-
-		it('should prefer output_path over target_note when both are provided', async () => {
-			const imagePath = 'custom/path/image.png';
-			mockImageGeneration.generateImage.mockResolvedValue(imagePath);
-
-			await tool.execute(
-				{
-					prompt: 'test',
-					target_note: 'some-note.md',
-					output_path: 'custom/path/image.png',
-				},
-				mockContext
-			);
-
-			// output_path and target_note are both forwarded; resolution priority is in the service
-			expect(mockImageGeneration.generateImage).toHaveBeenCalledWith('test', 'some-note.md', 'custom/path/image.png');
+			expect(mockImageGeneration.generateImage).toHaveBeenCalledWith('a mountain', 'attachments/my-custom-image.png');
 		});
 
 		it('should return error when image generation service is not available', async () => {
@@ -186,9 +149,9 @@ describe('ImageTools', () => {
 			tool = new GenerateImageTool();
 			vi.clearAllMocks();
 			// Default: the resolver echoes back the explicit output_path (or a generic
-			// default if not provided). Individual tests override as needed.
+			// Background-Tasks default if not provided). Individual tests override as needed.
 			mockImageGeneration.resolveOutputPath.mockImplementation(
-				async (_prompt: string, _target: string | undefined, explicit?: string) => explicit ?? 'attachments/default.png'
+				async (_prompt: string, explicit?: string) => explicit ?? 'gemini-scribe/Background-Tasks/default.png'
 			);
 		});
 
@@ -223,15 +186,16 @@ describe('ImageTools', () => {
 			expect(label.endsWith('…')).toBe(true);
 		});
 
-		it('pre-resolves output_path via attachment folder when none provided', async () => {
-			mockImageGeneration.resolveOutputPath.mockResolvedValue('attachments/generated-a-dog-12345.png');
+		it('pre-resolves output_path via the Background-Tasks default when none provided', async () => {
+			mockImageGeneration.resolveOutputPath.mockResolvedValue(
+				'gemini-scribe/Background-Tasks/generated-a-dog-12345.png'
+			);
 
 			const result = await tool.execute({ prompt: 'a dog', background: true }, mockContext);
 
 			expect(result.success).toBe(true);
-			expect(result.data.output_path).toBe('attachments/generated-a-dog-12345.png');
-			// Resolver is called with the prompt, active file as reference, and no explicit path
-			expect(mockImageGeneration.resolveOutputPath).toHaveBeenCalledWith('a dog', 'active-note.md', undefined);
+			expect(result.data.output_path).toBe('gemini-scribe/Background-Tasks/generated-a-dog-12345.png');
+			expect(mockImageGeneration.resolveOutputPath).toHaveBeenCalledWith('a dog', undefined);
 		});
 
 		it('routes explicit output_path through the service resolver so validation applies', async () => {
@@ -246,7 +210,7 @@ describe('ImageTools', () => {
 
 			expect(result.success).toBe(true);
 			expect(result.data.output_path).toBe('pictures/dog.png');
-			expect(mockImageGeneration.resolveOutputPath).toHaveBeenCalledWith('a dog', 'active-note.md', 'pictures/dog.jpg');
+			expect(mockImageGeneration.resolveOutputPath).toHaveBeenCalledWith('a dog', 'pictures/dog.jpg');
 		});
 
 		it('returns a tool error synchronously when the resolver throws (invalid path or no reference)', async () => {
@@ -278,8 +242,8 @@ describe('ImageTools', () => {
 		});
 
 		it('callback invokes generateImage with the pre-resolved output_path', async () => {
-			mockImageGeneration.resolveOutputPath.mockResolvedValue('attachments/result.png');
-			mockImageGeneration.generateImage.mockResolvedValue('attachments/result.png');
+			mockImageGeneration.resolveOutputPath.mockResolvedValue('gemini-scribe/Background-Tasks/result.png');
+			mockImageGeneration.generateImage.mockResolvedValue('gemini-scribe/Background-Tasks/result.png');
 
 			await tool.execute({ prompt: 'a sunset', background: true }, mockContext);
 
@@ -290,23 +254,9 @@ describe('ImageTools', () => {
 			// task writes exactly where we told the agent it would land.
 			expect(mockImageGeneration.generateImage).toHaveBeenCalledWith(
 				'a sunset',
-				'active-note.md',
-				'attachments/result.png'
+				'gemini-scribe/Background-Tasks/result.png'
 			);
-			expect(returnedPath).toBe('attachments/result.png');
-		});
-
-		it('callback uses explicit target_note over captured active file', async () => {
-			mockImageGeneration.resolveOutputPath.mockResolvedValue('my-folder/result.png');
-			mockImageGeneration.generateImage.mockResolvedValue('my-folder/result.png');
-
-			await tool.execute({ prompt: 'a fox', background: true, target_note: 'my-note.md' }, mockContext);
-
-			const callback = mockBackgroundTaskManager.submit.mock.calls[0][2];
-			await callback(() => false);
-
-			expect(mockImageGeneration.resolveOutputPath).toHaveBeenCalledWith('a fox', 'my-note.md', undefined);
-			expect(mockImageGeneration.generateImage).toHaveBeenCalledWith('a fox', 'my-note.md', 'my-folder/result.png');
+			expect(returnedPath).toBe('gemini-scribe/Background-Tasks/result.png');
 		});
 
 		it('callback returns undefined when cancelled', async () => {


### PR DESCRIPTION
## Summary

Follow-ups from the review of #724 (consolidating background outputs into
\`[state-folder]/Background-Tasks/\`). Three small, independent commits:

1. **docs**: \`docs/guide/background-tasks.md\` still pointed users at the
   old vault-root \`Background Research/\` location.
2. **refactor**: removes the now-dead \`targetNotePath\` parameter that
   #724 left behind on \`ImageGeneration.generateImage\` /
   \`resolveOutputPath\` / \`resolveDefaultOutputPath\` /
   \`saveImageToVault\`, plus the \`target_note\` parameter on the
   \`generate_image\` tool. After #724 the default output goes to
   \`Background-Tasks/\` regardless of the active note, so callers were
   passing arguments that got silently dropped.
3. **test**: adds direct unit tests on both validators
   (\`DeepResearchService.validateAndNormalizeFilePath\` and
   \`ImageGeneration.validateOutputPath\`) covering the four cases the new
   allowlist most easily breaks: Background-Tasks file allowed, sibling
   subfolder rejected, sibling-prefix rejected, bare state folder
   rejected. Image-generation also gets a test for the
   extension-rewrite-before-state-check ordering.

## Changes

- \`docs/guide/background-tasks.md\` — two path references updated to
  \`[state-folder]/Background-Tasks/\`.
- \`src/services/image-generation.ts\` — drop \`targetNotePath\` parameter
  from public \`generateImage\` / \`resolveOutputPath\` /
  \`resolveDefaultOutputPath\` and private \`saveImageToVault\`. Refresh
  JSDoc on each. Update the \`buildDefaultFilename\` comment, which still
  referenced the old \`getAvailablePathForAttachment\` collision rationale.
- \`src/tools/image-tools.ts\` — drop \`target_note\` from the tool schema
  and confirmation message; remove the \`referenceNotePath\` plumbing
  that fed it.
- \`test/tools/image-tools.test.ts\` — drop the \`target_note\`-specific
  test, update remaining call expectations to the new two-arg signature,
  switch default-path mocks to a Background-Tasks path.
- \`test/services/deep-research.test.ts\` — new
  \`validateAndNormalizeFilePath\` describe block.
- \`test/services/image-generation.test.ts\` — new file (no prior coverage
  of this service); 7 tests on \`validateOutputPath\`.

Test count: 1492 → 1502 (+10).

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: trivial follow-ups identified during review of #724
- [x] All CI checks pass (\`npm test\`, \`npm run build\`, \`npm run format-check\`)
- [x] I have tested this change on Desktop
- [x] I have verified this change does not break Mobile (no platform-specific code; the dead-parameter cleanup is internal API only)
- [x] Documentation has been updated (this PR is partly the documentation update #724 should have included)
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated default output location for generated images to the Background-Tasks folder within your vault.

* **Changes**
  * Removed `target_note` parameter from image generation.
  * Clarified `output_path` parameter behavior: when omitted, images are stored in Background-Tasks by default; explicit paths override this behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->