### PR TITLE
fix(scheduled-tasks): include skills in default tool allowlist

### DIFF
--- a/docs/guide/scheduled-tasks.md
+++ b/docs/guide/scheduled-tasks.md
@@ -45,7 +45,7 @@ Summarise the notes I created or modified today. List the key topics and any ope
 | Field          | Required | Default                                                  | Description                                                                                                                 |
 | -------------- | -------- | -------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
 | `schedule`     | Yes      | —                                                        | When to run. See [Schedule Formats](#schedule-formats) below.                                                               |
-| `enabledTools` | No       | `[]` (read-only)                                         | List of tool categories the agent may use. See [Tool Access](#tool-access).                                                 |
+| `enabledTools` | No       | `[]` (read-only + skills)                                | List of tool categories the agent may use. See [Tool Access](#tool-access).                                                 |
 | `outputPath`   | No       | `<history-folder>/Scheduled-Tasks/Runs/<slug>/{date}.md` | Where to write results. Supports `{slug}` and `{date}` placeholders.                                                        |
 | `model`        | No       | Plugin chat model                                        | Override the model for this task (e.g. `gemini-flash-latest`).                                                              |
 | `enabled`      | No       | `true`                                                   | Set to `false` to disable the task without deleting it.                                                                     |
@@ -72,7 +72,7 @@ The `enabledTools` list controls what the agent can do during a run:
 | `external_mcp` | Tools provided by connected MCP servers                |
 | `skills`       | Load and activate agent skills                         |
 
-Categories are additive — list as many as the task needs. If `enabledTools` is empty the task defaults to read-only tools only.
+Categories are additive — list as many as the task needs. If `enabledTools` is empty the task defaults to `read_only` + `skills`, so common patterns like "run skill X on a schedule" work without extra setup. Set `enabledTools: ['read_only']` explicitly if you want a stricter allowlist that omits skill tools.
 
 ## Managing Tasks
 

--- a/src/services/scheduled-task-runner.ts
+++ b/src/services/scheduled-task-runner.ts
@@ -61,10 +61,16 @@ export class ScheduledTaskRunner {
 			throw new Error('[ScheduledTaskRunner] Agent services not initialised');
 		}
 
-		// Map task's enabledTools strings to ToolCategory enum values,
-		// defaulting to read-only when the list is empty.
+		// Map task's enabledTools strings to ToolCategory enum values, defaulting
+		// to read-only + skills when the list is empty. SKILLS is included so the
+		// most natural scheduled-task pattern — "run skill X on a schedule" — works
+		// out of the box; this matches DEFAULT_CONTEXTS.AGENT_SESSION (which also
+		// includes SKILLS by default for live agent sessions). Users who want a
+		// stricter allowlist can set `enabledTools: ['read_only']` explicitly.
 		const enabledToolCategories =
-			this.task.enabledTools.length > 0 ? (this.task.enabledTools as ToolCategory[]) : [ToolCategory.READ_ONLY];
+			this.task.enabledTools.length > 0
+				? (this.task.enabledTools as ToolCategory[])
+				: [ToolCategory.READ_ONLY, ToolCategory.SKILLS];
 
 		// Create a headless session — no confirmation required.
 		const session = await this.plugin.sessionManager.createAgentSession(`Scheduled: ${this.task.slug}`, {

--- a/test/services/scheduled-task-runner.test.ts
+++ b/test/services/scheduled-task-runner.test.ts
@@ -285,4 +285,38 @@ describe('ScheduledTaskRunner', () => {
 		);
 		expect(plugin.app.vault.modify).not.toHaveBeenCalled();
 	});
+
+	describe('default enabledTools', () => {
+		// Pin the broadened default added to fix #728: scheduled tasks with empty
+		// enabledTools should get read_only + skills (not just read_only) so the
+		// "run skill X on a schedule" pattern works without extra setup.
+		it('defaults to read_only + skills when frontmatter enabledTools is empty', async () => {
+			const plugin = createMockPlugin();
+			const runner = new ScheduledTaskRunner(plugin, makeTask({ enabledTools: [] }));
+
+			await runner.run(() => false);
+
+			expect(plugin.sessionManager.createAgentSession).toHaveBeenCalledWith(
+				expect.any(String),
+				expect.objectContaining({
+					enabledTools: ['read_only', 'skills'],
+				})
+			);
+		});
+
+		it('honors an explicit enabledTools list and does not augment it', async () => {
+			const plugin = createMockPlugin();
+			const runner = new ScheduledTaskRunner(plugin, makeTask({ enabledTools: ['read_only'] }));
+
+			await runner.run(() => false);
+
+			// User explicitly chose read_only — must NOT silently add skills.
+			expect(plugin.sessionManager.createAgentSession).toHaveBeenCalledWith(
+				expect.any(String),
+				expect.objectContaining({
+					enabledTools: ['read_only'],
+				})
+			);
+		});
+	});
 });


### PR DESCRIPTION
## Summary

Closes #728.

Scheduled tasks with empty \`enabledTools\` frontmatter previously
defaulted to \`[READ_ONLY]\` only, so the agent could not call
\`activate_skill\` even though the regular agent session
(\`DEFAULT_CONTEXTS.AGENT_SESSION\`) already includes \`SKILLS\` in its
default. That divergence broke the most natural use case for scheduled
tasks — running a pre-defined skill on a schedule (daily-changelog,
audit-docs, etc.) — without any clear hint to the user.

Brings the scheduled-task default in line with the live-session default
by changing the empty-list fallback from \`[READ_ONLY]\` to
\`[READ_ONLY, SKILLS]\`. Users who want a stricter allowlist can still
set \`enabledTools: ['read_only']\` explicitly.

## Changes

- \`src/services/scheduled-task-runner.ts\` — broaden the empty-default to
  \`[READ_ONLY, SKILLS]\`; comment now points at the AGENT_SESSION parity
  rationale.
- \`docs/guide/scheduled-tasks.md\` — update the default-value column in
  the frontmatter table and the explanatory paragraph under "Tool Access"
  so users see the new default and the opt-out (\`['read_only']\`).
- \`test/services/scheduled-task-runner.test.ts\` — new \`describe\` block
  pinning both branches: empty list → broadened to \`[read_only, skills]\`,
  explicit \`['read_only']\` → respected as-is (no silent augmentation).

## Notes

- Including \`SKILLS\` also enables \`create_skill\` and \`edit_skill\` (both
  classified as WRITE within the SKILLS category). Users wanting to
  prevent skill mutation from scheduled tasks can either set the
  allowlist explicitly or use per-tool DENY in the global policy
  settings. Same trade-off the live agent session already makes.
- Test count: 1492 → 1494.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer (#728)
- [x] All CI checks pass (\`npm test\`, \`npm run build\`, \`npm run format-check\`)
- [x] I have tested this change on Desktop
- [x] I have verified this change does not break Mobile (no platform-specific code)
- [x] Documentation has been updated (if applicable)
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated scheduled task documentation to clarify default tool availability behavior and how tool categories interact.

* **Improvements**
  * Scheduled tasks now enable read-only and skills tools by default, instead of read-only only.

* **Tests**
  * Added test coverage for scheduled task tool configuration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->