### PR TITLE
feat(image-gen): route command-palette Generate Image through background tasks

### DIFF
--- a/docs/guide/background-tasks.md
+++ b/docs/guide/background-tasks.md
@@ -29,7 +29,7 @@ Completed tasks with output files show an **Open result** link that opens the fi
 Background tasks are created automatically when you trigger long-running operations:
 
 - **Deep Research** — starts a research task; result saved to `[state-folder]/Background-Tasks/YYYY-MM-DD <topic>.md` by default (you can specify a custom path via the `outputFile` parameter)
-- **Image Generation** — generates and saves an image; result path shown in the completion notice
+- **Image Generation** — generates and saves an image; result path shown in the completion notice. The **Generate Image** command palette entry also routes through the background system: it returns control immediately and inserts the wikilink at your captured cursor position when the task completes (or shows a Notice with the wikilink to copy if you've moved on from the source note).
 
 Both operations fire a completion notice with a clickable vault link when done. If a task fails, a notice explains the error.
 

--- a/src/services/image-generation.ts
+++ b/src/services/image-generation.ts
@@ -1,5 +1,5 @@
 import type ObsidianGemini from '../main';
-import { Notice, App, Modal, Setting, TextAreaComponent, normalizePath } from 'obsidian';
+import { Notice, App, MarkdownView, Modal, Setting, TextAreaComponent, TFile, normalizePath } from 'obsidian';
 import { BaseModelRequest, GeminiClient, GeminiClientFactory } from '../api';
 import { GeminiPrompts } from '../prompts';
 import { getErrorMessage } from '../utils/error-utils';
@@ -26,34 +26,123 @@ export class ImageGeneration {
 	}
 
 	/**
-	 * Generate an image and insert it at the cursor position
+	 * Generate an image as a background task and insert the wikilink at the
+	 * cursor position when the task completes.
+	 *
+	 * Captures the target file path and cursor coordinates at submit time so
+	 * the insertion lands in the right place even if the user navigates to
+	 * another note while waiting (typical: image generation takes 30–90s).
+	 *
+	 * Behavior on completion:
+	 *  - If the captured file is still open in a MarkdownView and the captured
+	 *    cursor is still in-bounds → insert there.
+	 *  - Otherwise → show a Notice containing the wikilink so the user can
+	 *    paste it manually. The image file itself is always saved either way.
+	 *
+	 * Falls back to the original synchronous flow if `backgroundTaskManager`
+	 * is unavailable, so the command keeps working during plugin startup or
+	 * if the manager fails to initialise.
 	 */
 	async generateAndInsertImage(prompt: string): Promise<void> {
-		const editor = this.plugin.app.workspace.activeEditor?.editor;
-		if (!editor) {
-			new Notice('No active editor. Please open a note first.');
+		const activeView = this.plugin.app.workspace.getActiveViewOfType(MarkdownView);
+		if (!activeView || !activeView.file) {
+			new Notice('No active note. Please open a note first.');
 			return;
 		}
 
+		const targetPath = activeView.file.path;
+		const cursor = activeView.editor.getCursor();
+		const taskManager = this.plugin.backgroundTaskManager;
+
+		if (!taskManager) {
+			await this.generateAndInsertSynchronously(prompt, activeView, cursor);
+			return;
+		}
+
+		const label = prompt.length > 40 ? prompt.slice(0, 37) + '…' : prompt;
+		taskManager.submit('image-generation', label, async (isCancelled) => {
+			if (isCancelled()) return undefined;
+
+			const base64Data = await this.client.generateImage(prompt, this.plugin.settings.imageModelName);
+			if (isCancelled()) return undefined;
+
+			const imagePath = await this.saveImageToVault(base64Data, prompt);
+			if (isCancelled()) return imagePath;
+
+			this.insertWikilinkAtCapturedPosition(targetPath, cursor, imagePath);
+			return imagePath;
+		});
+
+		new Notice('Image generation submitted — you can keep working.', 3000);
+	}
+
+	/**
+	 * Synchronous flow used as a fallback when BackgroundTaskManager is not
+	 * initialised (e.g. early plugin startup).
+	 */
+	private async generateAndInsertSynchronously(
+		prompt: string,
+		activeView: MarkdownView,
+		cursor: { line: number; ch: number }
+	): Promise<void> {
 		try {
 			new Notice('Generating image...');
-
-			// Generate the image
 			const base64Data = await this.client.generateImage(prompt, this.plugin.settings.imageModelName);
-
-			// Save the image to vault
 			const imagePath = await this.saveImageToVault(base64Data, prompt);
-
-			// Insert markdown link at cursor
-			const cursor = editor.getCursor();
-			editor.replaceRange(`![[${imagePath}]]`, cursor);
-
+			activeView.editor.replaceRange(`![[${imagePath}]]`, cursor);
 			new Notice('Image generated and inserted successfully!');
 		} catch (error) {
 			const errorMsg = `Failed to generate image: ${getErrorMessage(error)}`;
 			this.plugin.logger.error(errorMsg, error);
 			new Notice(errorMsg);
 		}
+	}
+
+	/**
+	 * Insert a wikilink at the captured (file, cursor) coordinates if the
+	 * file is still open in a MarkdownView and the cursor is in-bounds;
+	 * otherwise show a Notice with the wikilink so the user can paste it
+	 * manually. We don't silently modify a file the user isn't editing.
+	 */
+	private insertWikilinkAtCapturedPosition(
+		targetPath: string,
+		cursor: { line: number; ch: number },
+		imagePath: string
+	): void {
+		const wikilink = `![[${imagePath}]]`;
+		const file = this.plugin.app.vault.getAbstractFileByPath(targetPath);
+
+		if (!(file instanceof TFile)) {
+			this.notifyManualInsertion(wikilink, 'target note no longer exists');
+			return;
+		}
+
+		let editorView: MarkdownView | null = null;
+		this.plugin.app.workspace.iterateAllLeaves((leaf) => {
+			if (editorView) return;
+			const view = leaf.view;
+			if (view instanceof MarkdownView && view.file?.path === targetPath) {
+				editorView = view;
+			}
+		});
+
+		if (!editorView) {
+			this.notifyManualInsertion(wikilink, 'note is no longer open');
+			return;
+		}
+
+		const editor = (editorView as MarkdownView).editor;
+		if (cursor.line >= editor.lineCount()) {
+			this.notifyManualInsertion(wikilink, 'cursor position is no longer valid');
+			return;
+		}
+		const lineLength = editor.getLine(cursor.line).length;
+		const safeCh = Math.min(cursor.ch, lineLength);
+		editor.replaceRange(wikilink, { line: cursor.line, ch: safeCh });
+	}
+
+	private notifyManualInsertion(wikilink: string, reason: string): void {
+		new Notice(`Image saved (${reason}). Wikilink: ${wikilink}`, 10000);
 	}
 
 	/**

--- a/test/services/image-generation.test.ts
+++ b/test/services/image-generation.test.ts
@@ -101,7 +101,7 @@ describe('ImageGeneration.validateOutputPath (output-path validator)', () => {
 
 describe('ImageGeneration.generateAndInsertImage (palette flow)', () => {
 	let service: ImageGeneration;
-	let activeView: MockMarkdownView;
+	let activeView: InstanceType<typeof MockMarkdownView>;
 	let mockEditor: { getCursor: any; replaceRange: any; lineCount: any; getLine: any };
 	let mockSubmit: ReturnType<typeof vi.fn>;
 	let mockPlugin: any;

--- a/test/services/image-generation.test.ts
+++ b/test/services/image-generation.test.ts
@@ -1,14 +1,32 @@
 import { ImageGeneration } from '../../src/services/image-generation';
 
+// Hoist test doubles so they exist before vi.mock factories are evaluated.
+const { MockTFile, MockMarkdownView, mockGenerateImageBytes } = vi.hoisted(() => {
+	class MockTFile {
+		path: string = '';
+	}
+	class MockMarkdownView {
+		file: { path: string } | null = null;
+		editor: any = null;
+	}
+	return {
+		MockTFile,
+		MockMarkdownView,
+		mockGenerateImageBytes: vi.fn(),
+	};
+});
+
+// Real obsidian mock provides Notice, Modal, normalizePath etc.
+// Augment it with MarkdownView + TFile classes the production code uses.
 vi.mock('obsidian', async () => ({
 	...(await vi.importActual<any>('../../__mocks__/obsidian.js')),
+	TFile: MockTFile,
+	MarkdownView: MockMarkdownView,
 }));
 
-// The validator does not touch the network; mock the API factory so the
-// constructor can run without real credentials.
 vi.mock('../../src/api', () => ({
 	GeminiClient: vi.fn().mockImplementation(function () {
-		return {};
+		return { generateImage: mockGenerateImageBytes };
 	}),
 	GeminiClientFactory: { createSummaryModel: vi.fn() },
 }));
@@ -18,6 +36,12 @@ vi.mock('../../src/prompts', () => ({
 		return {};
 	}),
 }));
+
+vi.mock('../../src/utils/file-utils', () => ({
+	ensureFolderExists: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { Notice } from 'obsidian';
 
 describe('ImageGeneration.validateOutputPath (output-path validator)', () => {
 	let service: ImageGeneration;
@@ -72,5 +96,183 @@ describe('ImageGeneration.validateOutputPath (output-path validator)', () => {
 		expect(validate('attachments/foo.png')).toBe('attachments/foo.png');
 		expect(validate('attachments/foo.jpg')).toBe('attachments/foo.png');
 		expect(validate('attachments/foo')).toBe('attachments/foo.png');
+	});
+});
+
+describe('ImageGeneration.generateAndInsertImage (palette flow)', () => {
+	let service: ImageGeneration;
+	let activeView: MockMarkdownView;
+	let mockEditor: { getCursor: any; replaceRange: any; lineCount: any; getLine: any };
+	let mockSubmit: ReturnType<typeof vi.fn>;
+	let mockPlugin: any;
+	let leaves: Array<{ view: any }>;
+
+	const createBinaryMock = vi.fn();
+	const validBase64 = btoa('fake-png-bytes');
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockGenerateImageBytes.mockResolvedValue(validBase64);
+
+		mockEditor = {
+			getCursor: vi.fn().mockReturnValue({ line: 5, ch: 3 }),
+			replaceRange: vi.fn(),
+			lineCount: vi.fn().mockReturnValue(20),
+			getLine: vi.fn().mockReturnValue('some line content here'),
+		};
+
+		activeView = new MockMarkdownView();
+		activeView.file = { path: 'notes/today.md' };
+		activeView.editor = mockEditor;
+
+		// Default: the captured note is still open in a leaf.
+		leaves = [{ view: activeView }];
+
+		mockSubmit = vi.fn().mockReturnValue('task-1');
+
+		mockPlugin = {
+			apiKey: 'test-key',
+			settings: { historyFolder: 'gemini-scribe', temperature: 0, topP: 0, imageModelName: 'image-model' },
+			logger: { log: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+			backgroundTaskManager: { submit: mockSubmit },
+			app: {
+				vault: {
+					createBinary: createBinaryMock,
+					getAbstractFileByPath: vi.fn((path: string) => {
+						const f = new MockTFile();
+						f.path = path;
+						return f;
+					}),
+				},
+				workspace: {
+					getActiveViewOfType: vi.fn().mockReturnValue(activeView),
+					iterateAllLeaves: vi.fn((cb: (l: any) => void) => leaves.forEach(cb)),
+				},
+				fileManager: {},
+			},
+		} as any;
+
+		service = new ImageGeneration(mockPlugin);
+	});
+
+	it('submits work to BackgroundTaskManager and returns immediately', async () => {
+		await service.generateAndInsertImage('a sunset');
+
+		expect(mockSubmit).toHaveBeenCalledWith('image-generation', 'a sunset', expect.any(Function));
+		// Notice is fired synchronously to acknowledge submission.
+		expect(Notice).toHaveBeenCalledWith('Image generation submitted — you can keep working.', 3000);
+	});
+
+	it('truncates long prompts in the BackgroundTaskManager label', async () => {
+		const longPrompt = 'P'.repeat(60);
+		await service.generateAndInsertImage(longPrompt);
+
+		const label = mockSubmit.mock.calls[0][1] as string;
+		expect(label.length).toBeLessThanOrEqual(40);
+		expect(label.endsWith('…')).toBe(true);
+	});
+
+	it('inserts the wikilink at the captured cursor when the note is still open', async () => {
+		await service.generateAndInsertImage('a cat');
+
+		const work = mockSubmit.mock.calls[0][2] as (isCancelled: () => boolean) => Promise<string | undefined>;
+		const result = await work(() => false);
+
+		// Vault write happened (saveImageToVault path).
+		expect(createBinaryMock).toHaveBeenCalled();
+		// Wikilink inserted at the captured cursor.
+		expect(mockEditor.replaceRange).toHaveBeenCalledWith(expect.stringMatching(/^!\[\[.+\.png\]\]$/), {
+			line: 5,
+			ch: 3,
+		});
+		// Returns the saved image path so the BackgroundTaskManager Notice gets
+		// an "Open result" link.
+		expect(result).toBeDefined();
+	});
+
+	it('falls back to a Notice with the wikilink when the captured note is no longer open', async () => {
+		// User navigated away — no leaves still hold the captured file path.
+		leaves = [];
+
+		await service.generateAndInsertImage('a fox');
+		const work = mockSubmit.mock.calls[0][2];
+		await work(() => false);
+
+		expect(mockEditor.replaceRange).not.toHaveBeenCalled();
+		expect(Notice).toHaveBeenCalledWith(expect.stringMatching(/Image saved.*Wikilink: !\[\[/), 10000);
+	});
+
+	it('falls back to a Notice when the captured file no longer exists', async () => {
+		mockPlugin.app.vault.getAbstractFileByPath = vi.fn().mockReturnValue(null);
+
+		await service.generateAndInsertImage('a dog');
+		const work = mockSubmit.mock.calls[0][2];
+		await work(() => false);
+
+		expect(mockEditor.replaceRange).not.toHaveBeenCalled();
+		expect(Notice).toHaveBeenCalledWith(expect.stringContaining('target note no longer exists'), 10000);
+	});
+
+	it('clamps the captured cursor to the current line length when the line shrank', async () => {
+		mockEditor.getLine.mockReturnValue('short'); // 5 chars; captured ch=3 fits
+		mockEditor.getCursor.mockReturnValue({ line: 5, ch: 99 }); // way past EOL
+
+		await service.generateAndInsertImage('clamp test');
+		const work = mockSubmit.mock.calls[0][2];
+		await work(() => false);
+
+		expect(mockEditor.replaceRange).toHaveBeenCalledWith(expect.any(String), { line: 5, ch: 5 });
+	});
+
+	it('falls back to the Notice path when the captured cursor line is past EOF', async () => {
+		mockEditor.lineCount.mockReturnValue(3);
+		mockEditor.getCursor.mockReturnValue({ line: 10, ch: 0 });
+
+		await service.generateAndInsertImage('past EOF');
+		const work = mockSubmit.mock.calls[0][2];
+		await work(() => false);
+
+		expect(mockEditor.replaceRange).not.toHaveBeenCalled();
+		expect(Notice).toHaveBeenCalledWith(expect.stringContaining('cursor position is no longer valid'), 10000);
+	});
+
+	it('errors early when no markdown view is active', async () => {
+		mockPlugin.app.workspace.getActiveViewOfType = vi.fn().mockReturnValue(null);
+
+		await service.generateAndInsertImage('test');
+
+		expect(mockSubmit).not.toHaveBeenCalled();
+		expect(Notice).toHaveBeenCalledWith('No active note. Please open a note first.');
+	});
+
+	it('skips insertion (but keeps the file) when cancelled after the image is saved', async () => {
+		await service.generateAndInsertImage('cancelled mid-flight');
+		const work = mockSubmit.mock.calls[0][2];
+
+		// Cancel after the image is saved but before insertion.
+		let calls = 0;
+		const isCancelled = () => {
+			calls++;
+			// First two checks (start, post-generate) → not cancelled.
+			// Third check (post-save) → cancelled.
+			return calls >= 3;
+		};
+		const result = await work(isCancelled);
+
+		expect(createBinaryMock).toHaveBeenCalled();
+		expect(mockEditor.replaceRange).not.toHaveBeenCalled();
+		// Returns the path so the user can still find the file.
+		expect(result).toBeDefined();
+	});
+
+	it('falls back to the synchronous flow when BackgroundTaskManager is unavailable', async () => {
+		mockPlugin.backgroundTaskManager = null;
+
+		await service.generateAndInsertImage('startup race');
+
+		// No background submit — work runs inline.
+		expect(mockSubmit).not.toHaveBeenCalled();
+		expect(createBinaryMock).toHaveBeenCalled();
+		expect(mockEditor.replaceRange).toHaveBeenCalled();
 	});
 });


### PR DESCRIPTION
## Summary

Closes #652.

The agent's \`generate_image\` tool already routes through
\`BackgroundTaskManager\` (via the \`background: true\` parameter from
#651), but the command-palette **Generate Image** entry still ran
synchronously — blocking the user for 30–90 seconds while the model
generated, with no status-bar visibility, no cancellation, and no
completion Notice with a vault link.

Routes \`generateAndInsertImage\` through \`BackgroundTaskManager.submit\`.
To preserve the "image lands at my cursor" UX even when the user
navigates away during the wait, the cursor coordinates are captured at
submit time and looked up again when the task completes.

## Behavior

On submit:
- Capture the active note path and cursor coordinates.
- Submit work to \`BackgroundTaskManager\`; show "Image generation
  submitted — you can keep working." Notice and return immediately.

On completion:
- Find a \`MarkdownView\` leaf still holding the captured file.
- If found and the cursor's line is in-bounds, insert the wikilink at
  that position. The captured column is clamped to the current line
  length so a now-shorter line doesn't cause a write past EOL.
- If the file has been deleted, is no longer open, or the cursor's line
  is past EOF, show a Notice with the wikilink so the user can paste it
  manually.

The image file itself is always saved either way — the worst case is
the user copy/pastes a wikilink instead of getting it auto-inserted.

A synchronous fallback path is kept for the case where
\`backgroundTaskManager\` is null (e.g. early plugin startup), so the
command never breaks even if initialisation hasn't finished.

## Changes

- \`src/services/image-generation.ts\` — rewrite \`generateAndInsertImage\`
  to capture cursor + path, submit through \`BackgroundTaskManager\`,
  and insert (or fall back to Notice) on completion. Add
  \`generateAndInsertSynchronously\` (the old flow, kept as fallback) and
  \`insertWikilinkAtCapturedPosition\` / \`notifyManualInsertion\` helpers.
- \`test/services/image-generation.test.ts\` — new file. 10 tests cover:
  submission flow, the truncated-label format, the happy path
  (insertion at captured cursor), three Notice fallbacks (file gone,
  leaf gone, cursor past EOF), cursor-clamping when the line shrank,
  the no-active-note guard, mid-flight cancellation, and the
  synchronous-fallback path when \`backgroundTaskManager\` is null.
- \`docs/guide/background-tasks.md\` — updated the Image Generation entry
  in **How Tasks Are Created** to mention the palette command also
  routes through the background system, including the captured-cursor +
  Notice fallback semantics.

## Test plan

- [x] \`npm test\` — all 1502 tests pass (10 new).
- [x] \`npm run build\` — type-check clean.
- [x] \`npm run format-check\` — clean.
- [ ] Manual: trigger Generate Image from the palette, navigate to a
      different note while it's running, confirm the wikilink lands as a
      Notice (not silently in the wrong note).
- [ ] Manual: trigger Generate Image, stay in the same note, confirm
      the wikilink inserts at the captured cursor.
- [ ] Manual: trigger Generate Image, cancel from the Background Tasks
      panel, confirm no insertion happens.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer (#652)
- [x] All CI checks pass (\`npm test\`, \`npm run build\`, \`npm run format-check\`)
- [x] I have tested this change on Desktop (automated tests; manual checks pending)
- [x] I have verified this change does not break Mobile (no platform-specific code)
- [x] Documentation has been updated (if applicable)
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Generate Image now runs as a background task and returns immediately; when complete the image is saved and a wikilink is inserted at your captured cursor if that note is still open, otherwise a long notice shows the wikilink to copy. Synchronous fallback remains when background tasks aren’t available.

* **Documentation**
  * Expanded guide explaining background image generation and completion behavior.

* **Tests**
  * Added tests for background flow, insert vs. notice outcomes, cursor edge cases, and synchronous fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->