### PR TITLE
chore(daily): 2026-05-03 daily update

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,7 @@ The plugin uses a simplified factory pattern (`GeminiClientFactory`) to create G
    - `[state-folder]/Agent-Sessions/` - Agent mode session files
    - `[state-folder]/Skills/` - Agent skill packages (agentskills.io format)
    - `[state-folder]/Scheduled-Tasks/` - Scheduled task definitions and run output
+   - `[state-folder]/Background-Tasks/` - Output from background deep-research and image-gen tasks
    - Automatic migration for existing users from flat structure
 8. **System Folder Protection**: Always exclude system folders from file operations:
    - The plugin state folder (`settings.historyFolder`)

--- a/README.md
+++ b/README.md
@@ -270,16 +270,14 @@ Precisely rewrite any portion of your text with AI assistance. This feature prov
 
 ### Custom Prompts
 
-Create reusable AI instruction templates that customize how the AI behaves for specific notes.
+Create reusable AI instruction templates that customize how the AI behaves for specific sessions.
 
-1. **Enable Custom Prompts:** In plugin settings, ensure "Enable Custom Prompts" is toggled ON.
-
-2. **Create New Prompts:**
+1. **Create New Prompts:**
    - Use the command palette: "Gemini Scribe: Create New Custom Prompt"
    - Enter a name and edit the generated template
-   - Or manually create `.md` files in `[History Folder]/Prompts/`
+   - Or manually create `.md` files in `[Plugin State Folder]/Prompts/`
 
-3. **Apply to Sessions:**
+2. **Apply to Sessions:**
    - Open the agent panel and click the gear icon in the session header
    - Select your prompt from the "Prompt Template" dropdown
    - The prompt applies to all messages in that session

--- a/docs/guide/deep-research.md
+++ b/docs/guide/deep-research.md
@@ -113,7 +113,7 @@ The agent has both tools available and will choose the right one based on your r
 
 Because Deep Research takes several minutes, the agent can run it as a background task so it doesn't block your editing session. To trigger background mode, ask:
 
-```
+```text
 Run deep research on quantum error correction in the background and save it to Research/quantum.md
 ```
 

--- a/docs/guide/deep-research.md
+++ b/docs/guide/deep-research.md
@@ -109,6 +109,20 @@ When you specify an output file:
 
 The agent has both tools available and will choose the right one based on your request. A question like "what year was Python created?" gets a quick Google Search, while "research the evolution of Python's type system" triggers Deep Research.
 
+## Background Mode
+
+Because Deep Research takes several minutes, the agent can run it as a background task so it doesn't block your editing session. To trigger background mode, ask:
+
+```
+Run deep research on quantum error correction in the background and save it to Research/quantum.md
+```
+
+When the task starts, the agent returns immediately with a task ID. A notification appears in the bottom-right corner when the research completes, with an **Open result** link. You can track progress (or cancel) from the **Background Tasks** panel (Command Palette → **View Background Tasks**).
+
+If you don't specify an output file, results land in `[state-folder]/Background-Tasks/YYYY-MM-DD <topic>.md` by default.
+
+See [Background Tasks](/guide/background-tasks) for more on the status bar indicator, the task panel, and cancellation.
+
 ## Limitations
 
 - **Takes time** — Expect several minutes per research request. The API performs multiple rounds of searching and analysis.

--- a/docs/guide/scheduled-tasks.md
+++ b/docs/guide/scheduled-tasks.md
@@ -132,7 +132,7 @@ To resume a paused task:
 
 When Obsidian is closed, scheduled tasks cannot run. Set `runIfMissed: true` in a task's frontmatter to have it caught up automatically the next time Obsidian starts.
 
-On startup, the plugin compares each task's `nextRunAt` against the current time. Any task with `runIfMissed: true` that is overdue (and not paused) is treated as a missed run. By default, a red `!` badge appears on the background-tasks status bar item — click it to open the **Missed Scheduled Runs** modal, which lists each missed task with **Run** and **Skip** buttons:
+On startup, the plugin compares each task's `nextRunAt` against the current time. Any task with `runIfMissed: true` that is overdue (and not paused) is treated as a missed run. By default, a red `!` badge appears on the background-tasks status bar item — click it to open the **Missed Scheduled Runs** modal, which lists each missed task with **Run** and **Skip** buttons. On mobile (where the status bar is hidden), the modal opens automatically on startup instead of waiting for a badge click.
 
 - **Run** — submits the task immediately as a background task
 - **Skip** — advances the schedule without running

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -55,13 +55,14 @@ This document provides a comprehensive reference for all Obsidian Gemini Scribe 
 - **Structure**:
   ```
   gemini-scribe/
-  ├── History/         # Legacy chat history files (v3.x)
-  ├── Prompts/         # Custom prompt templates
-  ├── Skills/          # Custom agent skills (<skill-name>/SKILL.md)
-  ├── Agent-Sessions/  # Agent mode sessions with conversation history
-  ├── Scheduled-Tasks/ # Scheduled task definitions and run output
-  ├── debug.log        # Current log file (when file logging is enabled)
-  └── debug.log.old    # Previous rotated log file
+  ├── History/          # Legacy chat history files (v3.x)
+  ├── Prompts/          # Custom prompt templates
+  ├── Skills/           # Custom agent skills (<skill-name>/SKILL.md)
+  ├── Agent-Sessions/   # Agent mode sessions with conversation history
+  ├── Scheduled-Tasks/  # Scheduled task definitions and run output
+  ├── Background-Tasks/ # Output from background deep-research and image-gen tasks
+  ├── debug.log         # Current log file (when file logging is enabled)
+  └── debug.log.old     # Previous rotated log file
   ```
 
 ### Enable Session History

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -53,7 +53,7 @@ This document provides a comprehensive reference for all Obsidian Gemini Scribe 
 - **Default**: `gemini-scribe`
 - **Description**: Folder where plugin stores history, prompts, and sessions
 - **Structure**:
-  ```
+  ```text
   gemini-scribe/
   ├── History/          # Legacy chat history files (v3.x)
   ├── Prompts/          # Custom prompt templates

--- a/planning/changelog/2026-05-02.md
+++ b/planning/changelog/2026-05-02.md
@@ -1,0 +1,22 @@
+# Daily changelog — May 02, 2026
+
+**Date:** 2026-05-02
+**PRs merged:** 2
+
+---
+
+## Summary
+
+A quiet but meaningful day: a mobile bug fix landed alongside the routine daily-update housekeeping PR. The mobile fix — from contributor @saheersk — closes a longstanding gap where scheduled-task catch-up was silently unreachable on mobile because the status bar badge is hidden.
+
+## What shipped
+
+### [#734 chore(daily): 2026-05-02 daily update](https://github.com/allenhutchison/obsidian-gemini/pull/734)
+
+Automated daily housekeeping run for 2026-05-01. Wrote the `planning/changelog/2026-05-01.md` entry (1 PR), applied two drift fixes to docs (`docs/guide/background-tasks.md` corrected the Deep Research default output path; `docs/reference/settings.md` added the missing `imageModelName` setting), and confirmed no unlabeled open issues remained.
+
+### [#723 fix: open CatchUpModal directly on mobile when catch-up is pending](https://github.com/allenhutchison/obsidian-gemini/pull/723)
+
+On mobile, Obsidian suppresses the status bar entirely, which made the catch-up badge set by `BackgroundStatusBar.setPendingCatchUpCount()` unreachable. Missed scheduled tasks would sit indefinitely with no path for the user to discover or approve them. This fix detects `Platform.isMobile` inside `LifecycleService.handleCatchUp()` and opens `CatchUpModal` directly on startup when pending catch-up runs exist and `autoRunCatchUp` is off. The existing desktop flow (badge only) is unchanged. Two new tests cover the mobile path and verify the desktop path is unaffected. Fixes #719.
+
+Contributed by @saheersk.


### PR DESCRIPTION
## Summary

Automated daily housekeeping run for 2026-05-02.

## Changes

### daily-changelog
- Wrote `planning/changelog/2026-05-02.md` covering 2 PRs
- Mixed day: mobile catch-up fix (#723, contributed by @saheersk) and routine daily-update housekeeping (#734)

### audit-docs
Four drift fixes applied:

1. **`docs/reference/settings.md`** — `Background-Tasks/` subfolder was missing from the plugin state folder structure tree. Added alongside the other subfolders. (Introduced by feat #724 which consolidated background outputs there; the settings doc was not updated at the time.)

2. **`AGENTS.md`** — Same omission: `[state-folder]/Background-Tasks/` was absent from the folder structure list in the Folder Structure section of Important Patterns.

3. **`README.md`** — The Custom Prompts section included a step "Enable Custom Prompts: In plugin settings, ensure 'Enable Custom Prompts' is toggled ON." No such setting exists in `ObsidianGeminiSettings` or the settings UI. Removed the phantom step; also corrected `[History Folder]` → `[Plugin State Folder]` in the manual-file-creation instruction.

4. **`docs/guide/scheduled-tasks.md`** — The Catch-up Runs section described the `!` badge on the status bar as the only entry point for the missed-runs modal, but #723 (merged yesterday) added a mobile path where the modal opens automatically on startup because the status bar is hidden on mobile. Added a one-sentence note.

5. **`docs/guide/deep-research.md`** — The `deep_research` tool accepts a `background=true` parameter that submits the research as a non-blocking background task, returning control immediately. This is a user-visible behavior (no blocking, result in Background Tasks panel) with zero documentation in the guide. Added a "Background Mode" section.

No new docs were warranted beyond the fixes above.

### triage-issues
- Issues processed: 0
- No unlabeled open issues found

## Screenshots / Screencast

N/A — documentation and changelog only; no UI changes.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: automated daily housekeeping run
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop — N/A: docs and changelog only
- [ ] I have verified this change does not break Mobile — N/A: docs and changelog only
- [x] Documentation has been updated — this PR *is* the documentation update
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (claude-sonnet-4-6), via the `daily-update` skill
- [x] I have reviewed and understand all AI-generated code in this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01Etkb1r6EPpmvwyraHTEJ5Y)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Background Mode for Deep Research with non‑blocking runs, task tracking, completion notifications and Background Tasks guidance
  * Clarified mobile vs desktop Catch-up Runs startup behavior
  * Simplified Custom Prompts instructions and workflow
  * Updated plugin state folder layout display
  * Added daily changelog entry noting mobile catch‑up behavior and related tests
<!-- end of auto-generated comment: release notes by coderabbit.ai -->