### PR TITLE
feat(scheduled-tasks): add time-of-day and day-of-week schedule formats

### DIFF
--- a/docs/guide/scheduled-tasks.md
+++ b/docs/guide/scheduled-tasks.md
@@ -53,13 +53,29 @@ Summarise the notes I created or modified today. List the key topics and any ope
 
 ### Schedule Formats
 
-| Value         | Runs…                                 |
-| ------------- | ------------------------------------- |
-| `once`        | Exactly once, then stops              |
-| `daily`       | Every 24 hours                        |
-| `weekly`      | Every 7 days                          |
-| `interval:Xm` | Every X minutes (e.g. `interval:30m`) |
-| `interval:Xh` | Every X hours (e.g. `interval:2h`)    |
+| Value               | Runs…                                                                                                             |
+| ------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `once`              | Exactly once, then stops                                                                                          |
+| `daily`             | Every 24 hours from when the task was created                                                                     |
+| `daily@HH:MM`       | Every day at the given local time (24-hour). Example: `daily@16:30` for 4:30 PM                                   |
+| `weekly`            | Every 7 days from when the task was created                                                                       |
+| `weekly@HH:MM:DAYS` | At the given local time on the listed weekdays. `DAYS` is a comma-separated list of `sun,mon,tue,wed,thu,fri,sat` |
+| `interval:Xm`       | Every X minutes (e.g. `interval:30m`)                                                                             |
+| `interval:Xh`       | Every X hours (e.g. `interval:2h`)                                                                                |
+
+`HH:MM` is 24-hour and uses your local timezone. The scheduler ticks once a minute, so a task scheduled for 16:30 may fire any time between 16:30:00 and 16:30:59. Daylight saving transitions follow JavaScript `Date` semantics — on the spring-forward day, a `daily@02:30` slot may shift by one hour.
+
+**Example — run a daily summary every weekday at 4:30 PM:**
+
+```markdown
+---
+schedule: weekly@16:30:mon,tue,wed,thu,fri
+enabledTools:
+  - read_only
+---
+
+Summarise the notes I created or modified today.
+```
 
 ### Tool Access
 

--- a/src/services/scheduled-task-manager.ts
+++ b/src/services/scheduled-task-manager.ts
@@ -27,11 +27,14 @@ export interface ScheduledTask {
 	slug: string;
 	/**
 	 * Schedule string. Supported values:
-	 *   once        — run exactly once, then the task is considered exhausted
-	 *   daily       — every 24 h
-	 *   weekly      — every 7 d
-	 *   interval:Xm — every X minutes  (e.g. interval:30m)
-	 *   interval:Xh — every X hours    (e.g. interval:2h)
+	 *   once               — run exactly once, then the task is considered exhausted
+	 *   daily              — every 24 h from creation
+	 *   daily@HH:MM        — every day at the given local time (e.g. daily@16:30)
+	 *   weekly             — every 7 d from creation
+	 *   weekly@HH:MM:DAYS  — at the given local time on the listed weekdays
+	 *                        (DAYS is comma-separated, e.g. weekly@16:30:mon,tue,wed)
+	 *   interval:Xm        — every X minutes (e.g. interval:30m)
+	 *   interval:Xh        — every X hours   (e.g. interval:2h)
 	 */
 	schedule: string;
 	/** ToolCategory enum values to enable for this session (e.g. ['read_only']). */
@@ -89,6 +92,11 @@ export interface PendingCatchUp {
 
 // ─── Pure helper ─────────────────────────────────────────────────────────────
 
+// Day-of-week codes accepted in `weekly@HH:MM:DAYS` schedules. Order matches
+// JS Date.getDay() so the array index doubles as the weekday number.
+const WEEKDAY_CODES = ['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat'] as const;
+type WeekdayCode = (typeof WEEKDAY_CODES)[number];
+
 /**
  * Compute the next run time given a schedule string and a reference instant.
  * Pure function — no I/O — safe to unit-test in isolation.
@@ -118,9 +126,103 @@ export function computeNextRunAt(schedule: string, from: Date): Date {
 				const ms = match[2] === 'h' ? value * 60 * 60 * 1000 : value * 60 * 1000;
 				return new Date(from.getTime() + ms);
 			}
-			throw new Error(`Unknown schedule type: "${schedule}". Expected: once, daily, weekly, interval:Xm, interval:Xh`);
+			if (schedule.startsWith('daily@')) {
+				const { hour, minute } = parseHourMinute(schedule, schedule.slice('daily@'.length));
+				return nextOccurrenceAtTime(from, hour, minute);
+			}
+			if (schedule.startsWith('weekly@')) {
+				const rest = schedule.slice('weekly@'.length).toLowerCase();
+				const match = /^(\d{1,2}:\d{2}):(.+)$/.exec(rest);
+				if (!match) {
+					throw new Error(
+						`Invalid weekly schedule: "${schedule}". Expected format: weekly@HH:MM:days (e.g. weekly@16:30:mon,tue,wed)`
+					);
+				}
+				const { hour, minute } = parseHourMinute(schedule, match[1]);
+				const allowedDays = parseWeekdayList(schedule, match[2]);
+				return nextOccurrenceOnAllowedDay(from, hour, minute, allowedDays);
+			}
+			throw new Error(
+				`Unknown schedule type: "${schedule}". Expected: once, daily, weekly, interval:Xm, interval:Xh, daily@HH:MM, weekly@HH:MM:days`
+			);
 		}
 	}
+}
+
+/**
+ * Parse a `HH:MM` time component out of a `daily@…` or `weekly@…` schedule
+ * and validate that hour/minute are in range. The full schedule string is
+ * passed in only so the error messages can quote the offending value.
+ */
+function parseHourMinute(schedule: string, time: string): { hour: number; minute: number } {
+	const match = /^(\d{1,2}):(\d{2})$/.exec(time);
+	if (!match) {
+		throw new Error(`Invalid schedule time in "${schedule}". Expected HH:MM (24-hour, e.g. 16:30)`);
+	}
+	const hour = parseInt(match[1], 10);
+	const minute = parseInt(match[2], 10);
+	if (hour < 0 || hour > 23 || minute < 0 || minute > 59) {
+		throw new Error(`Invalid schedule time in "${schedule}". Hour must be 0-23 and minute must be 0-59`);
+	}
+	return { hour, minute };
+}
+
+/**
+ * Parse the comma-separated weekday list from a `weekly@HH:MM:days` schedule
+ * into a Set of weekday numbers (0 = Sunday … 6 = Saturday). Empty lists,
+ * unknown codes, and stray separators are all rejected.
+ */
+function parseWeekdayList(schedule: string, days: string): Set<number> {
+	const tokens = days.split(',').map((d) => d.trim());
+	if (tokens.some((t) => t.length === 0)) {
+		throw new Error(`Invalid weekly schedule "${schedule}": days list contains empty entries`);
+	}
+	const result = new Set<number>();
+	for (const token of tokens) {
+		const idx = WEEKDAY_CODES.indexOf(token as WeekdayCode);
+		if (idx === -1) {
+			throw new Error(`Invalid weekday "${token}" in "${schedule}". Expected one of: ${WEEKDAY_CODES.join(', ')}`);
+		}
+		result.add(idx);
+	}
+	return result;
+}
+
+/**
+ * Return the next Date strictly after `from` whose local time is `hour:minute`.
+ * Today's slot is preferred when it's still in the future; otherwise tomorrow's.
+ */
+function nextOccurrenceAtTime(from: Date, hour: number, minute: number): Date {
+	const candidate = new Date(from);
+	candidate.setHours(hour, minute, 0, 0);
+	if (candidate.getTime() > from.getTime()) return candidate;
+	candidate.setDate(candidate.getDate() + 1);
+	return candidate;
+}
+
+/**
+ * Return the next Date strictly after `from` whose local time is `hour:minute`
+ * AND whose weekday is in `allowedDays`. The set is non-empty (validated by
+ * the caller), so the search terminates within 8 days: each weekday-and-time
+ * pair is checked once over the next 7 days, plus a final wrap-around for the
+ * case where today's allowed slot has already passed and no later day in the
+ * week qualifies.
+ */
+function nextOccurrenceOnAllowedDay(from: Date, hour: number, minute: number, allowedDays: Set<number>): Date {
+	for (let offset = 0; offset <= 7; offset++) {
+		const candidate = new Date(from);
+		candidate.setDate(candidate.getDate() + offset);
+		candidate.setHours(hour, minute, 0, 0);
+		if (allowedDays.has(candidate.getDay()) && candidate.getTime() > from.getTime()) {
+			return candidate;
+		}
+	}
+	// Unreachable: with a non-empty allowedDays set, one of the 8 candidates
+	// above always matches. Throw rather than return a wrong value if the
+	// invariant ever breaks.
+	throw new Error(
+		`Internal error: failed to compute next run for weekly schedule (allowedDays=${[...allowedDays].join(',')})`
+	);
 }
 
 // ─── Manager ─────────────────────────────────────────────────────────────────

--- a/src/ui/scheduler-management-modal.ts
+++ b/src/ui/scheduler-management-modal.ts
@@ -539,7 +539,9 @@ export class SchedulerManagementModal extends Modal {
 	private async handleSave(isEdit: boolean): Promise<void> {
 		const schedule = this.resolvedSchedule();
 		if (!schedule) {
-			new Notice('Please enter a valid schedule (e.g. 30m or 2h for custom intervals).');
+			new Notice(
+				'Please enter a valid schedule. Custom interval expects 30m or 2h. Daily at time and Weekly on days at time both need a valid HH:MM (and Weekly needs at least one day).'
+			);
 			return;
 		}
 		if (!this.form.prompt.trim()) {

--- a/src/ui/scheduler-management-modal.ts
+++ b/src/ui/scheduler-management-modal.ts
@@ -8,9 +8,22 @@ const TOOL_CATEGORIES = ['read_only', 'read_write', 'destructive'] as const;
 
 const SCHEDULE_PRESETS = [
 	{ label: 'Once', value: 'once' },
-	{ label: 'Daily', value: 'daily' },
-	{ label: 'Weekly', value: 'weekly' },
+	{ label: 'Daily (every 24h)', value: 'daily' },
+	{ label: 'Daily at time', value: 'daily-at' },
+	{ label: 'Weekly (every 7d)', value: 'weekly' },
+	{ label: 'Weekly on days at time', value: 'weekly-days' },
 	{ label: 'Custom interval', value: 'custom' },
+] as const;
+
+// Order matches JS Date.getDay(); shown left-to-right in the day picker.
+const WEEKDAY_OPTIONS = [
+	{ code: 'sun', label: 'Sun' },
+	{ code: 'mon', label: 'Mon' },
+	{ code: 'tue', label: 'Tue' },
+	{ code: 'wed', label: 'Wed' },
+	{ code: 'thu', label: 'Thu' },
+	{ code: 'fri', label: 'Fri' },
+	{ code: 'sat', label: 'Sat' },
 ] as const;
 
 /**
@@ -305,10 +318,15 @@ export class SchedulerManagementModal extends Modal {
 	private openEdit(task: ScheduledTask): void {
 		this.view = 'edit';
 		this.editingSlug = task.slug;
+		const preset = this.detectPreset(task.schedule);
+		const blank = this.blankForm();
+		const { time, days } = this.parseTimeAndDaysFromSchedule(task.schedule);
 		this.form = {
 			slug: task.slug,
-			schedulePreset: this.detectPreset(task.schedule),
+			schedulePreset: preset,
 			scheduleCustom: task.schedule.startsWith('interval:') ? task.schedule.slice('interval:'.length) : '',
+			scheduleTime: time ?? blank.scheduleTime,
+			scheduleDays: days ?? blank.scheduleDays,
 			enabledTools: [...task.enabledTools],
 			outputPath: task.outputPath,
 			model: task.model ?? '',
@@ -372,14 +390,51 @@ export class SchedulerManagementModal extends Modal {
 				value: this.form.scheduleCustom,
 			},
 		});
-		customInput.style.display = this.form.schedulePreset === 'custom' ? '' : 'none';
+
+		// Time picker (HTML5 native — works on desktop and mobile without deps).
+		// Shown for the time-of-day presets only.
+		const timeInput = scheduleRow.createEl('input', {
+			cls: 'gemini-scheduler-time-input',
+			attr: {
+				type: 'time',
+				value: this.form.scheduleTime,
+			},
+		});
+
+		// Day-of-week checkbox row, shown only for the weekly-days preset.
+		const daysRow = form.createDiv({ cls: 'gemini-scheduler-days-row' });
+		const dayCheckboxes: HTMLInputElement[] = [];
+		for (const day of WEEKDAY_OPTIONS) {
+			const label = daysRow.createEl('label', { cls: 'gemini-scheduler-day-label' });
+			const cb = label.createEl('input', { attr: { type: 'checkbox' } }) as HTMLInputElement;
+			cb.checked = this.form.scheduleDays.includes(day.code);
+			cb.addEventListener('change', () => {
+				if (cb.checked) {
+					if (!this.form.scheduleDays.includes(day.code)) this.form.scheduleDays.push(day.code);
+				} else {
+					this.form.scheduleDays = this.form.scheduleDays.filter((d) => d !== day.code);
+				}
+			});
+			label.appendText(` ${day.label}`);
+			dayCheckboxes.push(cb);
+		}
+
+		const updateScheduleVisibility = (preset: string) => {
+			customInput.style.display = preset === 'custom' ? '' : 'none';
+			timeInput.style.display = preset === 'daily-at' || preset === 'weekly-days' ? '' : 'none';
+			daysRow.style.display = preset === 'weekly-days' ? '' : 'none';
+		};
+		updateScheduleVisibility(this.form.schedulePreset);
 
 		presetSelect.addEventListener('change', () => {
 			this.form.schedulePreset = presetSelect.value as any;
-			customInput.style.display = presetSelect.value === 'custom' ? '' : 'none';
+			updateScheduleVisibility(presetSelect.value);
 		});
 		customInput.addEventListener('input', () => {
 			this.form.scheduleCustom = customInput.value;
+		});
+		timeInput.addEventListener('input', () => {
+			this.form.scheduleTime = timeInput.value;
 		});
 
 		// Tool access
@@ -545,6 +600,8 @@ export class SchedulerManagementModal extends Modal {
 			slug: '',
 			schedulePreset: 'daily' as string,
 			scheduleCustom: '',
+			scheduleTime: '09:00',
+			scheduleDays: ['mon', 'tue', 'wed', 'thu', 'fri'] as string[],
 			enabledTools: ['read_only'] as string[],
 			outputPath: '',
 			model: '',
@@ -556,17 +613,61 @@ export class SchedulerManagementModal extends Modal {
 
 	private detectPreset(schedule: string): string {
 		if (schedule === 'once' || schedule === 'daily' || schedule === 'weekly') return schedule;
+		if (/^daily@\d{1,2}:\d{2}$/.test(schedule)) return 'daily-at';
+		if (/^weekly@\d{1,2}:\d{2}:[a-z,]+$/i.test(schedule)) return 'weekly-days';
 		return 'custom';
 	}
 
 	private resolvedSchedule(): string | null {
-		if (this.form.schedulePreset !== 'custom') return this.form.schedulePreset;
+		const preset = this.form.schedulePreset;
+		if (preset === 'once' || preset === 'daily' || preset === 'weekly') return preset;
+		if (preset === 'daily-at') {
+			if (!this.isValidTime(this.form.scheduleTime)) return null;
+			return `daily@${this.form.scheduleTime}`;
+		}
+		if (preset === 'weekly-days') {
+			if (!this.isValidTime(this.form.scheduleTime) || this.form.scheduleDays.length === 0) return null;
+			// Sort by canonical weekday order so the persisted value is stable
+			// regardless of the order the user clicked the checkboxes in.
+			const orderedDays = WEEKDAY_OPTIONS.map((d) => d.code).filter((c) => this.form.scheduleDays.includes(c));
+			return `weekly@${this.form.scheduleTime}:${orderedDays.join(',')}`;
+		}
+		// custom
 		const raw = this.form.scheduleCustom.trim();
 		if (!raw) return null;
 		if (/^\d+(m|h)$/.test(raw)) return `interval:${raw}`;
 		// Accept full form too
 		if (/^interval:\d+(m|h)$/.test(raw)) return raw;
 		return null;
+	}
+
+	private isValidTime(value: string): boolean {
+		const m = /^(\d{1,2}):(\d{2})$/.exec(value);
+		if (!m) return false;
+		const h = parseInt(m[1], 10);
+		const min = parseInt(m[2], 10);
+		return h >= 0 && h <= 23 && min >= 0 && min <= 59;
+	}
+
+	/**
+	 * Pull the time and day-list out of a `daily@HH:MM` or `weekly@HH:MM:days`
+	 * schedule so the form can pre-fill its time/day controls when editing.
+	 * Returns nulls for any other schedule shape (the caller falls back to
+	 * defaults from `blankForm()`).
+	 */
+	private parseTimeAndDaysFromSchedule(schedule: string): { time: string | null; days: string[] | null } {
+		const dailyAt = /^daily@(\d{1,2}:\d{2})$/.exec(schedule);
+		if (dailyAt) return { time: dailyAt[1], days: null };
+		const weeklyDays = /^weekly@(\d{1,2}:\d{2}):([a-z,]+)$/i.exec(schedule);
+		if (weeklyDays) {
+			const validCodes = WEEKDAY_OPTIONS.map((d) => d.code) as readonly string[];
+			const days = weeklyDays[2]
+				.toLowerCase()
+				.split(',')
+				.filter((d) => validCodes.includes(d));
+			return { time: weeklyDays[1], days: days.length > 0 ? days : null };
+		}
+		return { time: null, days: null };
 	}
 
 	private truncateError(raw: string): string {

--- a/styles.css
+++ b/styles.css
@@ -5128,6 +5128,30 @@ If your plugin does not need CSS, delete this file.
 	width: 100px;
 }
 
+.gemini-scheduler-time-input {
+	border: 1px solid var(--background-modifier-border);
+	border-radius: 4px;
+	background: var(--background-secondary);
+	color: var(--text-normal);
+	padding: 4px 8px;
+	font-size: var(--font-ui-small);
+}
+
+.gemini-scheduler-days-row {
+	display: flex;
+	gap: 12px;
+	flex-wrap: wrap;
+	margin-bottom: 8px;
+}
+
+.gemini-scheduler-day-label {
+	display: flex;
+	align-items: center;
+	gap: 4px;
+	font-size: var(--font-ui-small);
+	cursor: pointer;
+}
+
 .gemini-scheduler-tools {
 	display: flex;
 	gap: 12px;

--- a/test/services/scheduled-task-manager.test.ts
+++ b/test/services/scheduled-task-manager.test.ts
@@ -118,6 +118,136 @@ describe('computeNextRunAt', () => {
 	});
 });
 
+// ─── computeNextRunAt — daily@HH:MM ───────────────────────────────────────────
+//
+// These tests use `new Date(year, monthIndex, day, hour, minute)` (local-time
+// constructor) on purpose: the `daily@HH:MM` and `weekly@HH:MM:DAYS` schedule
+// formats are specified in the *user's local time* by design, so testing them
+// with UTC ISO strings would produce timezone-dependent assertions.
+
+describe('computeNextRunAt — daily@HH:MM (time-of-day)', () => {
+	it('returns today at HH:MM when current time is earlier', () => {
+		// 2026-04-17 (Friday) 14:00 local → next 16:30 = today 16:30
+		const from = new Date(2026, 3, 17, 14, 0);
+		const result = computeNextRunAt('daily@16:30', from);
+		expect(result).toEqual(new Date(2026, 3, 17, 16, 30));
+	});
+
+	it('returns tomorrow at HH:MM when current time is later', () => {
+		// 17:00 → next 16:30 = tomorrow 16:30
+		const from = new Date(2026, 3, 17, 17, 0);
+		const result = computeNextRunAt('daily@16:30', from);
+		expect(result).toEqual(new Date(2026, 3, 18, 16, 30));
+	});
+
+	it('returns tomorrow at HH:MM when current time is exactly the slot (avoids same-tick double-fire)', () => {
+		const from = new Date(2026, 3, 17, 16, 30, 0, 0);
+		const result = computeNextRunAt('daily@16:30', from);
+		expect(result).toEqual(new Date(2026, 3, 18, 16, 30));
+	});
+
+	it('handles midnight (00:00)', () => {
+		// Yesterday 23:00 → today 00:00
+		const from = new Date(2026, 3, 17, 23, 0);
+		const result = computeNextRunAt('daily@00:00', from);
+		expect(result).toEqual(new Date(2026, 3, 18, 0, 0));
+	});
+
+	it('rejects out-of-range hour', () => {
+		expect(() => computeNextRunAt('daily@25:00', new Date())).toThrow(/Hour must be 0-23/);
+	});
+
+	it('rejects out-of-range minute', () => {
+		expect(() => computeNextRunAt('daily@16:60', new Date())).toThrow(/minute must be 0-59/);
+	});
+
+	it('rejects missing time', () => {
+		expect(() => computeNextRunAt('daily@', new Date())).toThrow(/Expected HH:MM/);
+	});
+
+	it('rejects non-numeric time', () => {
+		expect(() => computeNextRunAt('daily@abc', new Date())).toThrow(/Expected HH:MM/);
+	});
+
+	it('rejects extra trailing colon', () => {
+		expect(() => computeNextRunAt('daily@16:30:', new Date())).toThrow(/Expected HH:MM/);
+	});
+});
+
+// ─── computeNextRunAt — weekly@HH:MM:DAYS ─────────────────────────────────────
+
+describe('computeNextRunAt — weekly@HH:MM:DAYS (day-of-week + time)', () => {
+	// April 2026 weekday reference:
+	//   Mon Apr 13, Tue Apr 14, Wed Apr 15, Thu Apr 16, Fri Apr 17,
+	//   Sat Apr 18, Sun Apr 19, Mon Apr 20, …
+
+	it('returns today when today qualifies and the time is still in the future', () => {
+		// Tuesday Apr 14 at 14:00, allowed = {tue}
+		const from = new Date(2026, 3, 14, 14, 0);
+		const result = computeNextRunAt('weekly@16:30:tue', from);
+		expect(result).toEqual(new Date(2026, 3, 14, 16, 30));
+	});
+
+	it('rolls forward to the next allowed weekday when today qualifies but the time has passed', () => {
+		// Tuesday Apr 14 at 17:00, allowed = {tue, thu}
+		const from = new Date(2026, 3, 14, 17, 0);
+		const result = computeNextRunAt('weekly@16:30:tue,thu', from);
+		expect(result).toEqual(new Date(2026, 3, 16, 16, 30));
+	});
+
+	it('finds the next allowed day later in the week when today is not allowed', () => {
+		// Monday Apr 13 at 12:00, allowed = {sat}
+		const from = new Date(2026, 3, 13, 12, 0);
+		const result = computeNextRunAt('weekly@16:30:sat', from);
+		expect(result).toEqual(new Date(2026, 3, 18, 16, 30));
+	});
+
+	it('wraps to next week when no day in the rest of this week qualifies', () => {
+		// Sunday Apr 19 at 17:00, allowed = {sun} → next Sunday Apr 26 16:30
+		const from = new Date(2026, 3, 19, 17, 0);
+		const result = computeNextRunAt('weekly@16:30:sun', from);
+		expect(result).toEqual(new Date(2026, 3, 26, 16, 30));
+	});
+
+	it('handles the issue #727 motivating case (Sun-Thu at 16:30)', () => {
+		// Friday Apr 17 (not in set) at 12:00 → Sunday Apr 19 at 16:30
+		const fri = new Date(2026, 3, 17, 12, 0);
+		expect(computeNextRunAt('weekly@16:30:sun,mon,tue,wed,thu', fri)).toEqual(new Date(2026, 3, 19, 16, 30));
+		// Saturday (also not in set) → still Sunday
+		const sat = new Date(2026, 3, 18, 9, 0);
+		expect(computeNextRunAt('weekly@16:30:sun,mon,tue,wed,thu', sat)).toEqual(new Date(2026, 3, 19, 16, 30));
+		// Sunday at 17:00 (slot already passed today) → Monday 16:30
+		const sun = new Date(2026, 3, 19, 17, 0);
+		expect(computeNextRunAt('weekly@16:30:sun,mon,tue,wed,thu', sun)).toEqual(new Date(2026, 3, 20, 16, 30));
+	});
+
+	it('accepts uppercase day codes (case-insensitive)', () => {
+		const from = new Date(2026, 3, 13, 12, 0);
+		expect(computeNextRunAt('weekly@16:30:SAT', from)).toEqual(new Date(2026, 3, 18, 16, 30));
+	});
+
+	it('rejects unknown weekday codes', () => {
+		expect(() => computeNextRunAt('weekly@16:30:funday', new Date())).toThrow(/Invalid weekday "funday"/);
+	});
+
+	it('rejects empty days list', () => {
+		// "weekly@16:30:" — colon present but no days
+		expect(() => computeNextRunAt('weekly@16:30:', new Date())).toThrow(/Expected format: weekly@HH:MM:days/);
+	});
+
+	it('rejects empty entries within the days list', () => {
+		expect(() => computeNextRunAt('weekly@16:30:mon,,tue', new Date())).toThrow(/empty entries/);
+	});
+
+	it('rejects out-of-range time', () => {
+		expect(() => computeNextRunAt('weekly@25:00:mon', new Date())).toThrow(/Hour must be 0-23/);
+	});
+
+	it('rejects missing time component', () => {
+		expect(() => computeNextRunAt('weekly@mon', new Date())).toThrow(/Expected format: weekly@HH:MM:days/);
+	});
+});
+
 // ─── ScheduledTaskManager ─────────────────────────────────────────────────────
 
 describe('ScheduledTaskManager', () => {


### PR DESCRIPTION
## Summary

Closes #727.

The existing schedule grammar supported \`once\`, \`daily\`, \`weekly\`, and
\`interval:Xm/h\` — none of which could express "run at 4:30 PM every
weekday", which is the most natural use of scheduled tasks. \`daily\`
literally means "every 24 h from when the task was created", so a task
created at 11 AM ran at 11 AM forever.

Adds two new schedule string forms (backwards-compatible — existing
tasks keep working byte-for-byte):

| New format | Meaning |
|---|---|
| \`daily@HH:MM\` | Every day at the given local time (24h). Example: \`daily@16:30\` |
| \`weekly@HH:MM:DAYS\` | At the given local time on the listed weekdays. \`DAYS\` is a comma-separated list of \`sun,mon,tue,wed,thu,fri,sat\`. Example: \`weekly@16:30:mon,tue,wed,thu,fri\` (the issue's case) |

\`HH:MM\` is local time. The scheduler ticks once a minute, so a task at
16:30 fires sometime between 16:30:00 and 16:30:59. DST follows JS
\`Date\` semantics — a brief note in the docs covers the spring-forward
edge case.

## Changes

- **\`src/services/scheduled-task-manager.ts\`** — \`computeNextRunAt\`
  gains two new branches. Pure helpers \`parseHourMinute\`,
  \`parseWeekdayList\`, \`nextOccurrenceAtTime\`,
  \`nextOccurrenceOnAllowedDay\` handle parsing + arithmetic. JSDoc on
  the \`schedule\` field updated. The scheduler tick loop,
  \`detectMissedRuns\`, persistence, and the runner are unchanged — they
  consume only the ISO timestamp \`computeNextRunAt\` produces.
- **\`src/ui/scheduler-management-modal.ts\`** — two new presets ("Daily
  at time", "Weekly on days at time"). When selected, an HTML5
  \`<input type="time">\` (works on desktop and mobile) and a row of
  weekday checkboxes appear. The form composes the schedule string on
  save and pre-fills the controls when editing an existing time-based
  task. The two existing \`daily\` / \`weekly\` presets are now labelled
  "Daily (every 24h)" and "Weekly (every 7d)" so the distinction is
  clear.
- **\`styles.css\`** — minimal styling for the time picker and day-of-week
  row, matching the existing scheduler form theme.
- **\`test/services/scheduled-task-manager.test.ts\`** — 20 new tests
  covering happy paths, the same-tick edge case, end-of-week wrap, the
  issue's case across a Fri→Sat→Sun boundary, and all validation
  errors. Tests use \`new Date(year, month, day, hour, minute)\` (local
  constructor) so assertions are timezone-stable.
- **\`docs/guide/scheduled-tasks.md\`** — Schedule Formats table
  extended; example added showing the "every weekday at 4:30 PM"
  pattern; brief notes on local timezone, 60s tick granularity, and DST.

## Test plan

- [x] \`npm test\` — 1534 passed, 5 skipped (was 1514 → +20)
- [x] \`npm run build\` — clean
- [x] \`npm run format-check\` — clean
- [x] CI \`typecheck:test\` (\`tsc --noEmit -p tsconfig.test.json\`) — clean
- [ ] Manual: create a task with \`schedule: daily@<a-few-minutes-from-now>\` via the UI; confirm it fires at the right minute.
- [ ] Manual: create the issue's case via the UI; confirm \`nextRunAt\` advances correctly across a Fri → Sat → Sun boundary.
- [ ] Manual: edit an existing time-based task; confirm the form pre-fills time and days.
- [ ] Manual: backwards compat — an existing \`daily\` task still behaves as before (selectable as the "Daily (every 24h)" preset).

## Out of scope

- Object-form frontmatter (\`schedule: { type, time, days }\`) — would be a breaking change.
- Full cron syntax — overkill for this plugin's audience.
- Per-task timezone overrides — local time is correct; documented.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer (#727)
- [x] All CI checks pass (\`npm test\`, \`npm run build\`, \`npm run format-check\`)
- [x] I have tested this change on Desktop (automated; manual checks pending)
- [x] I have verified this change does not break Mobile (HTML5 \`<input type="time">\` is mobile-supported; no platform-specific code)
- [x] Documentation has been updated (if applicable)
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Daily-at-time and Weekly-on-days-at-time schedules (e.g., daily@14:30, weekly@16:30:mon..fri)
  * Scheduler modal: time picker and weekday selection; presets for daily/weekly schedules
  * Edited tasks prefill time and weekdays when applicable

* **Bug Fixes**
  * Stronger validation with clearer notices for invalid time/weekday selections

* **Documentation**
  * Expanded schedule guide with examples, timezone and daylight-saving notes

* **Tests / Style**
  * Added tests for new schedule formats; styling for time/weekday inputs
<!-- end of auto-generated comment: release notes by coderabbit.ai -->