### PR TITLE
chore(deps): bump @allenhutchison/gemini-utils to 0.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "4.7.0",
 			"license": "MIT",
 			"dependencies": {
-				"@allenhutchison/gemini-utils": "^0.5.0",
+				"@allenhutchison/gemini-utils": "^0.6.0",
 				"@codemirror/merge": "^6.12.1",
 				"@types/turndown": "^5.0.6",
 				"ollama": "^0.6.3",
@@ -29,7 +29,7 @@
 				"husky": "^9.1.7",
 				"jsdom": "^29.1.1",
 				"lint-staged": "^16.4.0",
-				"obsidian": "*",
+				"obsidian": "latest",
 				"prettier": "^3.8.3",
 				"tslib": "2.8.1",
 				"typescript": "^6.0.3",
@@ -296,9 +296,9 @@
 			}
 		},
 		"node_modules/@allenhutchison/gemini-utils": {
-			"version": "0.5.0",
-			"resolved": "https://registry.npmjs.org/@allenhutchison/gemini-utils/-/gemini-utils-0.5.0.tgz",
-			"integrity": "sha512-xhKXmuFeDTv/MNh+qsXeQidysdUEXg5f7+AVy7JmvVazx6Gyp8XS0/3rYArK7J8OcD9fbw2iqN5qVFh2WO/OCg==",
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/@allenhutchison/gemini-utils/-/gemini-utils-0.6.0.tgz",
+			"integrity": "sha512-Fbllxagk9lfpOn7eF9e90CF0xsgNlopd0Cl/gve7NqT5m+iwuWhx7+YE6NkvZ3cE8HYxNaRRiu1ha35FTro9Tg==",
 			"license": "MIT",
 			"dependencies": {
 				"commander": "^14.0.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
 		"vitest": "^4.1.5"
 	},
 	"dependencies": {
-		"@allenhutchison/gemini-utils": "^0.5.0",
+		"@allenhutchison/gemini-utils": "^0.6.0",
 		"@codemirror/merge": "^6.12.1",
 		"@types/turndown": "^5.0.6",
 		"ollama": "^0.6.3",


### PR DESCRIPTION
## Summary

Bump `@allenhutchison/gemini-utils` from `^0.5.0` → `^0.6.0`. Released [a few hours ago](https://github.com/allenhutchison/gemini-utils/releases/tag/v0.6.0).

## What's in 0.6.0

- **New**: queryable MIME type support registry (`support-registry` subpath export)
- **New**: next-generation Gemini Deep Research agents support
- **Fix**: explicit Vertex AI routing disable in the GoogleGenAI client used by the interactions API
- A few CLI / build cleanups

The surface this plugin actually consumes — `EXTENSION_TO_MIME`, `TEXT_FALLBACK_EXTENSIONS`, `FileUploader`, `ResearchManager`, `ReportGenerator`, `Interaction`, the `FileSystemAdapter` interface — is unchanged. No source edits needed.

## Changes

- `package.json` and `package-lock.json` updated to 0.6.0.

## Test plan

- [x] `npm run format-check` — clean
- [x] `npm run build` — clean (incl. `tsc --noEmit`)
- [x] `npx tsc --noEmit --skipLibCheck --project tsconfig.test.json` — clean
- [x] `npm test` — **1536 passed / 5 skipped** (same count as the prior run; no regressions)
- [x] Live plugin reload in the test vault — no console errors after `obsidian plugin:reload id=gemini-scribe`
- [ ] Live deep-research / file-classification round-trip — _not run; would spend API. Test suite covers the integration points. Happy to run if a maintainer asks._

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue — _routine minor-bump dep update; the package author and the plugin author are the same person._
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop
- [x] I have verified this change does not break Mobile (no platform-specific code touched)
- [ ] Documentation has been updated — _no user-visible changes; nothing to document._
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude (Claude Code)
- [x] I have reviewed and understand all AI-generated code in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependencies to the latest compatible versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->