### PR TITLE
fix: post-test housekeeping (orphan state, BG tab default, doc nit)

### DIFF
--- a/docs/guide/scheduled-tasks.md
+++ b/docs/guide/scheduled-tasks.md
@@ -42,14 +42,14 @@ Summarise the notes I created or modified today. List the key topics and any ope
 
 ### Frontmatter Fields
 
-| Field          | Required | Default                                                  | Description                                                                                                                 |
-| -------------- | -------- | -------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
-| `schedule`     | Yes      | —                                                        | When to run. See [Schedule Formats](#schedule-formats) below.                                                               |
-| `enabledTools` | No       | `[]` (read-only + skills)                                | List of tool categories the agent may use. See [Tool Access](#tool-access).                                                 |
-| `outputPath`   | No       | `<history-folder>/Scheduled-Tasks/Runs/<slug>/{date}.md` | Where to write results. Supports `{slug}` and `{date}` placeholders.                                                        |
-| `model`        | No       | Plugin chat model                                        | Override the model for this task (e.g. `gemini-flash-latest`).                                                              |
-| `enabled`      | No       | `true`                                                   | Set to `false` to disable the task without deleting it.                                                                     |
-| `runIfMissed`  | No       | `false`                                                  | When `true`, tasks missed while Obsidian was closed are caught up on the next startup. See [Catch-up Runs](#catch-up-runs). |
+| Field          | Required | Default                                                  | Description                                                                                                                              |
+| -------------- | -------- | -------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `schedule`     | Yes      | —                                                        | When to run. See [Schedule Formats](#schedule-formats) below.                                                                            |
+| `enabledTools` | No       | `['read_only', 'skills']`                                | List of tool categories the agent may use. See [Tool Access](#tool-access). Omitting the field or setting `[]` resolves to this default. |
+| `outputPath`   | No       | `<history-folder>/Scheduled-Tasks/Runs/<slug>/{date}.md` | Where to write results. Supports `{slug}` and `{date}` placeholders.                                                                     |
+| `model`        | No       | Plugin chat model                                        | Override the model for this task (e.g. `gemini-flash-latest`).                                                                           |
+| `enabled`      | No       | `true`                                                   | Set to `false` to disable the task without deleting it.                                                                                  |
+| `runIfMissed`  | No       | `false`                                                  | When `true`, tasks missed while Obsidian was closed are caught up on the next startup. See [Catch-up Runs](#catch-up-runs).              |
 
 ### Schedule Formats
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -347,7 +347,9 @@ export default class ObsidianGemini extends Plugin {
 			name: 'View Background Tasks',
 			callback: async () => {
 				const { BackgroundTasksModal } = await import('./ui/background-tasks-modal');
-				new BackgroundTasksModal(this.app, this).open();
+				// Command name is unambiguous, so always land on the Tasks tab.
+				// The status-bar entry uses its own context-aware default.
+				new BackgroundTasksModal(this.app, this, 'tasks').open();
 			},
 		});
 

--- a/src/services/scheduled-task-manager.ts
+++ b/src/services/scheduled-task-manager.ts
@@ -809,6 +809,18 @@ export class ScheduledTaskManager {
 			}
 		}
 
+		// Drop state entries for slugs whose definition file is gone. The tick
+		// already tolerates orphan state, but stripping it on init keeps the
+		// JSON tidy and prevents stale lastError messages from accumulating.
+		for (const slug of Object.keys(this.state)) {
+			if (!this.tasks.has(slug)) {
+				delete this.state[slug];
+				this.plugin.logger.log(
+					`[ScheduledTaskManager] Purged orphan state entry for "${slug}" (no matching task file)`
+				);
+			}
+		}
+
 		await this.saveState();
 	}
 

--- a/test/services/scheduled-task-manager.test.ts
+++ b/test/services/scheduled-task-manager.test.ts
@@ -310,6 +310,14 @@ describe('ScheduledTaskManager', () => {
 			const plugin = createMockPlugin();
 			plugin.app.vault.adapter.exists.mockResolvedValue(true);
 			plugin.app.vault.adapter.read.mockResolvedValue(JSON.stringify(existingState));
+			// Provide a matching task file so the orphan-state purge keeps the entry.
+			plugin.app.vault.getMarkdownFiles.mockReturnValue([
+				{ path: 'gemini-scribe/Scheduled-Tasks/my-task.md', basename: 'my-task' },
+			]);
+			plugin.app.metadataCache.getFileCache.mockReturnValue({
+				frontmatter: { schedule: 'daily' },
+			});
+			plugin.app.vault.read = vi.fn().mockResolvedValue('Prompt body.');
 			const manager = new ScheduledTaskManager(plugin);
 			await manager.initialize();
 			expect(manager.getState()['my-task'].nextRunAt).toBe('2026-04-18T08:00:00.000Z');
@@ -456,6 +464,61 @@ describe('ScheduledTaskManager', () => {
 			await manager.initialize();
 
 			expect(manager.getTasks()[0].enabledTools).toEqual([]);
+		});
+
+		it('purges state entries for slugs whose task file no longer exists', async () => {
+			// Pre-existing state contains an orphan ("deleted-task") plus an entry
+			// for a task whose file is still present. After init, only the live
+			// entry should remain.
+			const existingState = {
+				'deleted-task': {
+					nextRunAt: '2026-04-01T00:00:00.000Z',
+					lastError: 'old failure',
+					consecutiveFailures: 1,
+				},
+				'live-task': { nextRunAt: '2026-05-04T00:00:00.000Z' },
+			};
+			const plugin = createMockPlugin();
+			plugin.app.vault.adapter.exists.mockResolvedValue(true);
+			plugin.app.vault.adapter.read.mockResolvedValue(JSON.stringify(existingState));
+			plugin.app.vault.getMarkdownFiles.mockReturnValue([
+				{ path: 'gemini-scribe/Scheduled-Tasks/live-task.md', basename: 'live-task' },
+			]);
+			plugin.app.metadataCache.getFileCache.mockReturnValue({
+				frontmatter: { schedule: 'daily' },
+			});
+			plugin.app.vault.read = vi.fn().mockResolvedValue('Live prompt.');
+
+			const manager = new ScheduledTaskManager(plugin);
+			await manager.initialize();
+
+			const state = manager.getState();
+			expect(state['live-task']).toBeDefined();
+			// nextRunAt should be preserved verbatim from the loaded state, not
+			// reseeded to "now" — the entry pre-existed for this slug.
+			expect(state['live-task'].nextRunAt).toBe('2026-05-04T00:00:00.000Z');
+			expect(state['deleted-task']).toBeUndefined();
+		});
+
+		it('keeps state entries when the task file is present (no false positives)', async () => {
+			const existingState = {
+				'my-task': { nextRunAt: '2026-05-04T00:00:00.000Z', lastRunAt: '2026-05-03T00:00:00.000Z' },
+			};
+			const plugin = createMockPlugin();
+			plugin.app.vault.adapter.exists.mockResolvedValue(true);
+			plugin.app.vault.adapter.read.mockResolvedValue(JSON.stringify(existingState));
+			plugin.app.vault.getMarkdownFiles.mockReturnValue([
+				{ path: 'gemini-scribe/Scheduled-Tasks/my-task.md', basename: 'my-task' },
+			]);
+			plugin.app.metadataCache.getFileCache.mockReturnValue({
+				frontmatter: { schedule: 'daily' },
+			});
+			plugin.app.vault.read = vi.fn().mockResolvedValue('Prompt.');
+
+			const manager = new ScheduledTaskManager(plugin);
+			await manager.initialize();
+
+			expect(manager.getState()['my-task']).toEqual(existingState['my-task']);
 		});
 	});
 


### PR DESCRIPTION
## Summary

Three minor items the 2026-05-03 plugin-test report flagged but didn't fix at the time. None are release-blockers; bundling them so the next release ships with a clean baseline.

## Changes

### 1. Purge orphan scheduled-task state entries on init

`ScheduledTaskManager.discoverTasks()` now drops state entries whose task definition file no longer exists. The tick already tolerated orphan state (it just skipped them), but `scheduled-tasks-state.json` would accumulate stale `lastError`/`consecutiveFailures` from deleted tasks indefinitely. Surfaced during the plugin-test run when the test vault still had a `test-696` entry from a long-deleted task.

- Added two regression tests in `test/services/scheduled-task-manager.test.ts`:
  - `purges state entries for slugs whose task file no longer exists` — plants an orphan + a live entry, asserts only the live entry survives and its `nextRunAt` is preserved verbatim.
  - `keeps state entries when the task file is present (no false positives)` — defensive guard.
- Updated the existing `loads existing state from the sidecar file` test to provide a matching task file, since its previous setup relied on orphan-state being preserved (which is no longer the contract).

### 2. "View Background Tasks" command lands on the Tasks tab

`src/main.ts:350` now passes `'tasks'` as the modal's `defaultTab`. Previously the command fell through to the modal's heuristic (`hasRunningTasks || !ragEnabled ? 'tasks' : 'rag'`), which meant invoking the command literally named "View Background Tasks" with RAG enabled and nothing running would open on the RAG tab. The status-bar entry's context-aware heuristic is unchanged.

### 3. Doc fix in `docs/guide/scheduled-tasks.md`

The frontmatter-fields table now states the resolved `enabledTools` default (`['read_only', 'skills']`) directly, instead of saying `[]` and relying on the prose footnote to explain the empty-array case. Behaviorally unchanged; just clearer.

## Test plan

- [x] `npm run format-check` — clean
- [x] `npm run build` — clean (incl. `tsc --noEmit`)
- [x] `npx tsc --noEmit --skipLibCheck --project tsconfig.test.json` — clean
- [x] `npm test` — **1538 passed / 5 skipped** (+2 new state-purge tests; was 1536 / 5 before)
- [x] Live verification in Test Vault:
  - Planted `orphan-test-slug` in `scheduled-tasks-state.json`, reloaded the plugin, confirmed state file becomes `{}` (purge ran)
  - Triggered `Gemini Scribe: View Background Tasks` from the command palette, confirmed the active tab is "Background Tasks" (was "RAG" before the fix)
- [x] No console errors (`obsidian dev:errors` empty after both reloads)

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue — _follow-ups from a self-initiated acceptance test; small enough to land directly._
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop
- [x] I have verified this change does not break Mobile (no platform-specific code touched)
- [x] Documentation has been updated (the doc fix is part of this PR)
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude (Claude Code)
- [x] I have reviewed and understand all AI-generated code in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated scheduled tasks guide to clarify default tool enablement settings.

* **Bug Fixes**
  * Orphaned task state entries are now automatically removed during startup.
  * View Background Tasks command now opens with improved state initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->