### PR TITLE
feat(hooks): focusFile flag for command action (closes #759)

### DIFF
--- a/docs/guide/lifecycle-hooks.md
+++ b/docs/guide/lifecycle-hooks.md
@@ -56,22 +56,23 @@ The user just saved {{filePath}}. Read it and write a one-paragraph summary high
 
 ### Frontmatter Fields
 
-| Field               | Required               | Default                   | Description                                                                                                        |
-| ------------------- | ---------------------- | ------------------------- | ------------------------------------------------------------------------------------------------------------------ |
-| `trigger`           | Yes                    | —                         | Vault event. One of: `file-created`, `file-modified`, `file-deleted`, `file-renamed`.                              |
-| `action`            | Yes                    | —                         | What to do on each fire. One of: `agent-task`, `summarize`, `rewrite`, `command`. See [Actions](#actions) below.   |
-| `commandId`         | When `action: command` | —                         | Command palette id to dispatch (e.g. `editor:save-file`).                                                          |
-| `pathGlob`          | No                     | (matches all paths)       | Glob pattern matched against the triggering file's vault path. Supports `*` and `**`.                              |
-| `frontmatterFilter` | No                     | —                         | Object of key/value pairs the note's frontmatter must match for the hook to fire.                                  |
-| `debounceMs`        | No                     | `5000`                    | Per-(hook, file) debounce window in milliseconds. Coalesces rapid saves into one fire.                             |
-| `maxRunsPerHour`    | No                     | unlimited                 | Sliding-window rate limit per hook (across all files).                                                             |
-| `cooldownMs`        | No                     | `30000`                   | After a fire completes, suppress further events on the same (hook, file) for this window. Prevents self-retrigger. |
-| `enabledTools`      | No                     | `['read_only', 'skills']` | Tool categories the agent may use during the run.                                                                  |
-| `enabledSkills`     | No                     | `[]`                      | Skill slugs to pre-activate in the headless session.                                                               |
-| `model`             | No                     | Plugin chat model         | Override the model for this hook (e.g. `gemini-2.5-flash-lite`).                                                   |
-| `outputPath`        | No                     | (no file written)         | Where to write the agent's final response. Supports `{slug}`, `{date}`, and `{fileName}` placeholders.             |
-| `enabled`           | No                     | `true`                    | Set to `false` to disable the hook without deleting it.                                                            |
-| `desktopOnly`       | No                     | `true`                    | When `true` the hook is skipped on mobile. Headless agent runs can be heavyweight on phones.                       |
+| Field               | Required               | Default                   | Description                                                                                                                                                                      |
+| ------------------- | ---------------------- | ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `trigger`           | Yes                    | —                         | Vault event. One of: `file-created`, `file-modified`, `file-deleted`, `file-renamed`.                                                                                            |
+| `action`            | Yes                    | —                         | What to do on each fire. One of: `agent-task`, `summarize`, `rewrite`, `command`. See [Actions](#actions) below.                                                                 |
+| `commandId`         | When `action: command` | —                         | Command palette id to dispatch (e.g. `editor:save-file`).                                                                                                                        |
+| `focusFile`         | No                     | `false`                   | When `action: command`, focus the triggering file in the workspace before dispatching so editor-scoped commands target it. Off by default — see [Actions → `command`](#command). |
+| `pathGlob`          | No                     | (matches all paths)       | Glob pattern matched against the triggering file's vault path. Supports `*` and `**`.                                                                                            |
+| `frontmatterFilter` | No                     | —                         | Object of key/value pairs the note's frontmatter must match for the hook to fire.                                                                                                |
+| `debounceMs`        | No                     | `5000`                    | Per-(hook, file) debounce window in milliseconds. Coalesces rapid saves into one fire.                                                                                           |
+| `maxRunsPerHour`    | No                     | unlimited                 | Sliding-window rate limit per hook (across all files).                                                                                                                           |
+| `cooldownMs`        | No                     | `30000`                   | After a fire completes, suppress further events on the same (hook, file) for this window. Prevents self-retrigger.                                                               |
+| `enabledTools`      | No                     | `['read_only', 'skills']` | Tool categories the agent may use during the run.                                                                                                                                |
+| `enabledSkills`     | No                     | `[]`                      | Skill slugs to pre-activate in the headless session.                                                                                                                             |
+| `model`             | No                     | Plugin chat model         | Override the model for this hook (e.g. `gemini-2.5-flash-lite`).                                                                                                                 |
+| `outputPath`        | No                     | (no file written)         | Where to write the agent's final response. Supports `{slug}`, `{date}`, and `{fileName}` placeholders.                                                                           |
+| `enabled`           | No                     | `true`                    | Set to `false` to disable the hook without deleting it.                                                                                                                          |
+| `desktopOnly`       | No                     | `true`                    | When `true` the hook is skipped on mobile. Headless agent runs can be heavyweight on phones.                                                                                     |
 
 ### Prompt Template Variables
 
@@ -102,7 +103,20 @@ Run a full-file rewrite using the prompt body as the rewrite instruction. The tr
 
 ### `command`
 
-Execute a registered command palette command by id. The hook frontmatter must include `commandId:` (e.g. `editor:save-file`, `gemini-scribe-summarize-active-file`); the prompt body is ignored. The command runs in whatever context Obsidian gives it — most commands depend on the active file/editor, so chaining a hook to a command that operates on the active file is best when paired with a trigger that means the file is already focused (e.g. `file-modified`). If the command id is unknown, the hook records a failure rather than silently no-op.
+Execute a registered command palette command by id. The hook frontmatter must include `commandId:` (e.g. `editor:save-file`, `gemini-scribe-summarize-active-file`); the prompt body is ignored. If the command id is unknown, the hook records a failure rather than silently no-op.
+
+**Active file vs. trigger file.** Obsidian's command API (`app.commands.executeCommandById`) always runs the command against whatever workspace state is currently active — there's no way to scope a single dispatch to a specific file. By default a hook just dispatches; if your trigger file is already focused (typical for `file-modified`), an editor-scoped command like `editor:save-file` will act on it. If you can't rely on that, opt in to `focusFile: true`:
+
+```yaml
+---
+trigger: file-modified
+action: command
+commandId: editor:save-file
+focusFile: true
+---
+```
+
+With `focusFile: true`, the runner calls `app.workspace.openLinkText(filePath, '', false)` before dispatching, so the trigger file is the active editor when the command runs. If the trigger file is gone (e.g. a `file-deleted` trigger), the dispatch is skipped with a log entry. The flag is opt-in because focusing the file changes the user's view — disruptive on every fire of a global command (`app:reload`, `theme:toggle`, etc.) where the active file is irrelevant.
 
 ## Safety Features
 
@@ -214,17 +228,19 @@ action: rewrite
 Tighten the prose in {{fileName}}: remove filler words, hedging, and passive voice. Preserve all headings, links, and code blocks.
 ```
 
-### Save the active file via a command
+### Run a command against the trigger file
 
 ```markdown
 ---
-trigger: file-modified
+trigger: file-created
+pathGlob: 'Inbox/**/*.md'
 action: command
-commandId: editor:save-file
+commandId: gemini-scribe-summarize-active-file
+focusFile: true
 ---
 ```
 
-A loop-trap example more than a useful one — but it shows how `command` dispatches a registered command by id.
+When a new file lands in `Inbox/`, focus it in the workspace and run the **Summarize Active File** command against it. `focusFile: true` is the bit that ensures the command targets the trigger file rather than whatever the user happens to be looking at.
 
 ## Limitations
 

--- a/src/services/hook-manager.ts
+++ b/src/services/hook-manager.ts
@@ -93,6 +93,15 @@ export interface Hook {
 	 * Ignored for every other action.
 	 */
 	commandId?: string;
+	/**
+	 * When `action: command` and this is true, focus the triggering file in
+	 * the workspace before dispatching the command. Lets editor-scoped
+	 * commands (`editor:save-file`, etc.) target the file that fired the
+	 * hook rather than whatever happens to be active. Defaults to false to
+	 * keep global-command hooks from jumping the user's view on every fire.
+	 * Ignored for every action other than `command`.
+	 */
+	focusFile?: boolean;
 	/** Vault path of the hook definition file. */
 	filePath: string;
 }
@@ -151,6 +160,7 @@ export interface HookCreateParams {
 	enabled?: boolean;
 	desktopOnly?: boolean;
 	commandId?: string;
+	focusFile?: boolean;
 }
 
 export type HookUpdateParams = Partial<Omit<HookCreateParams, 'slug'>>;
@@ -402,6 +412,7 @@ export class HookManager {
 			desktopOnly: params.desktopOnly ?? hook.desktopOnly,
 			prompt: params.prompt ?? hook.prompt,
 			commandId: params.commandId ?? hook.commandId ?? '',
+			focusFile: params.focusFile ?? hook.focusFile ?? false,
 		};
 
 		const content = this.serializeHook(merged);
@@ -458,6 +469,7 @@ export class HookManager {
 			desktopOnly: params.desktopOnly ?? true,
 			prompt: params.prompt,
 			commandId: params.commandId || undefined,
+			focusFile: params.focusFile === true ? true : undefined,
 			filePath,
 		};
 	}
@@ -506,10 +518,11 @@ export class HookManager {
 		if (params.outputPath) lines.push(`outputPath: ${JSON.stringify(params.outputPath)}`);
 		if (params.commandId) lines.push(`commandId: ${JSON.stringify(params.commandId)}`);
 
-		// Defaults are enabled=true, desktopOnly=true — only write when the
-		// user picked the non-default value.
+		// Defaults are enabled=true, desktopOnly=true, focusFile=false —
+		// only write when the user picked the non-default value.
 		if (params.enabled === false) lines.push('enabled: false');
 		if (params.desktopOnly === false) lines.push('desktopOnly: false');
+		if (params.focusFile === true) lines.push('focusFile: true');
 
 		// `summarize` and `command` actions don't use the prompt body, but
 		// `parseHookFile` rejects empty bodies for `agent-task` and `rewrite`.
@@ -898,6 +911,7 @@ export class HookManager {
 			model: typeof frontmatter.model === 'string' ? frontmatter.model : undefined,
 			outputPath: typeof frontmatter.outputPath === 'string' ? frontmatter.outputPath : undefined,
 			commandId,
+			focusFile: frontmatter.focusFile === true ? true : undefined,
 			enabled: frontmatter.enabled !== false,
 			desktopOnly: frontmatter.desktopOnly !== false,
 			prompt,

--- a/src/services/hook-runner.ts
+++ b/src/services/hook-runner.ts
@@ -209,6 +209,25 @@ export class HookRunner {
 		if (!commandId) {
 			throw new Error(`[HookRunner] Hook "${hook.slug}" has action=command but no commandId`);
 		}
+
+		// Optional focus step: editor-scoped commands like `editor:save-file`
+		// run against whatever workspace state is active when dispatched, not
+		// against ctx.filePath. When the hook opts in via `focusFile: true`,
+		// we open the trigger file first so the command targets it. If the
+		// file is gone (file-deleted, renamed away, etc.) we skip the
+		// dispatch with a log entry rather than fire on the wrong file.
+		if (hook.focusFile) {
+			const file = this.resolveTriggerFile();
+			if (!file) {
+				this.plugin.logger.log(
+					`[HookRunner] Hook "${hook.slug}" — command: focusFile is on but ${this.ctx.filePath} is not present; skipping dispatch`
+				);
+				return undefined;
+			}
+			await this.plugin.app.workspace.openLinkText(this.ctx.filePath, '', false);
+			if (isCancelled()) return undefined;
+		}
+
 		// `executeCommandById` is part of the Obsidian Commands API. It's not
 		// in the public types but it's a documented runtime surface every
 		// plugin uses (no other way to fire a registered command by id). It

--- a/src/services/hook-runner.ts
+++ b/src/services/hook-runner.ts
@@ -219,7 +219,10 @@ export class HookRunner {
 		if (hook.focusFile) {
 			const file = this.resolveTriggerFile();
 			if (!file) {
-				this.plugin.logger.log(
+				// Warn-level: the user explicitly opted into focusFile, so a
+				// silent skip would mask why the command didn't fire. Per
+				// AGENTS.md, logger.log only surfaces in debug mode.
+				this.plugin.logger.warn(
 					`[HookRunner] Hook "${hook.slug}" — command: focusFile is on but ${this.ctx.filePath} is not present; skipping dispatch`
 				);
 				return undefined;

--- a/src/ui/hook-management-modal.ts
+++ b/src/ui/hook-management-modal.ts
@@ -317,6 +317,7 @@ export class HookManagementModal extends Modal {
 			desktopOnly: hook.desktopOnly,
 			prompt: hook.prompt,
 			commandId: hook.commandId ?? '',
+			focusFile: hook.focusFile === true,
 		};
 		this.render();
 	}
@@ -411,6 +412,22 @@ export class HookManagementModal extends Modal {
 			);
 		const commandIdEl = commandIdSetting.settingEl;
 
+		// Focus file — only shown when action=command. Editor-scoped commands
+		// run against the active workspace state; this toggle lets the hook
+		// open the trigger file before dispatching so commands like
+		// `editor:save-file` target the right note.
+		const focusFileSetting = new Setting(form)
+			.setName('Focus trigger file before dispatch')
+			.setDesc(
+				'When on, the triggering file is opened in the workspace before the command runs — useful for editor-scoped commands. When off, the command runs against whatever file is currently active. Default off.'
+			)
+			.addToggle((toggle) =>
+				toggle.setValue(this.form.focusFile).onChange((v) => {
+					this.form.focusFile = v;
+				})
+			);
+		const focusFileEl = focusFileSetting.settingEl;
+
 		// Tool access — only meaningful for the agent-task action.
 		const toolsSetting = new Setting(form).setName('Tool access').setDesc('Which tool categories the agent may use.');
 		const toolsContainer = form.createDiv({ cls: 'gemini-scheduler-tools' });
@@ -450,6 +467,7 @@ export class HookManagementModal extends Modal {
 			const showPrompt = action === 'agent-task' || action === 'rewrite';
 
 			commandIdEl.style.display = showCommandId ? '' : 'none';
+			focusFileEl.style.display = showCommandId ? '' : 'none';
 			toolsSetting.settingEl.style.display = showTools ? '' : 'none';
 			toolsContainer.style.display = showTools ? '' : 'none';
 			promptSetting.settingEl.style.display = showPrompt ? '' : 'none';
@@ -618,6 +636,7 @@ export class HookManagementModal extends Modal {
 					desktopOnly: this.form.desktopOnly,
 					prompt: this.form.prompt,
 					commandId: this.form.commandId || undefined,
+					focusFile: this.form.focusFile === true ? true : undefined,
 				});
 				new Notice(`Hook "${this.editingSlug}" updated`);
 			} else {
@@ -637,6 +656,7 @@ export class HookManagementModal extends Modal {
 					enabled: this.form.enabled,
 					desktopOnly: this.form.desktopOnly,
 					commandId: this.form.commandId || undefined,
+					focusFile: this.form.focusFile === true ? true : undefined,
 				});
 				new Notice(`Hook "${this.form.slug}" created`);
 			}
@@ -668,6 +688,7 @@ export class HookManagementModal extends Modal {
 			desktopOnly: true,
 			prompt: '',
 			commandId: '',
+			focusFile: false,
 		};
 	}
 

--- a/test/services/hook-manager.test.ts
+++ b/test/services/hook-manager.test.ts
@@ -316,6 +316,37 @@ describe('HookManager CRUD', () => {
 		expect(content).toContain('desktopOnly: false');
 	});
 
+	it('serialises focusFile only when the user opts in (default false stays out of the file)', async () => {
+		const plugin = createPluginWithVaultStore();
+		const manager = newManager(plugin);
+
+		// Default: focusFile not provided → serialized file omits the line.
+		await manager.createHook({
+			...baseCreateParams,
+			slug: 'no-focus',
+			action: 'command',
+			commandId: 'editor:save-file',
+		});
+		const noFocusContent = plugin.__files.get('gemini-scribe/Hooks/no-focus.md');
+		expect(noFocusContent).not.toContain('focusFile');
+
+		// Opted in: file gains the line.
+		await manager.createHook({
+			...baseCreateParams,
+			slug: 'with-focus',
+			action: 'command',
+			commandId: 'editor:save-file',
+			focusFile: true,
+		});
+		const focusContent = plugin.__files.get('gemini-scribe/Hooks/with-focus.md');
+		expect(focusContent).toContain('focusFile: true');
+
+		// In-memory hook reflects the same.
+		const hooks = manager.getHooks();
+		expect(hooks.find((h) => h.slug === 'no-focus')?.focusFile).toBeUndefined();
+		expect(hooks.find((h) => h.slug === 'with-focus')?.focusFile).toBe(true);
+	});
+
 	it('updateHook rewrites the file with merged values', async () => {
 		const plugin = createPluginWithVaultStore();
 		const manager = newManager(plugin);

--- a/test/services/hook-runner.test.ts
+++ b/test/services/hook-runner.test.ts
@@ -169,6 +169,9 @@ function createMockPlugin(opts: { existingPaths?: string[]; createBehaviour?: Va
 					mutator({});
 				}),
 			},
+			workspace: {
+				openLinkText: vi.fn().mockResolvedValue(undefined),
+			},
 			commands: {
 				executeCommandById: vi.fn().mockReturnValue(true),
 			},
@@ -563,5 +566,68 @@ describe('HookRunner action: command', () => {
 		const runner = new HookRunner(plugin as any, makeContext(hook));
 
 		await expect(runner.run()).rejects.toThrow(/not found/);
+	});
+
+	it('does not call openLinkText when focusFile is unset (default)', async () => {
+		const plugin = createMockPlugin();
+		const hook = makeHook({ action: 'command', commandId: 'editor:save-file', prompt: '' });
+		const runner = new HookRunner(plugin as any, makeContext(hook));
+
+		await runner.run();
+
+		expect(plugin.app.workspace.openLinkText).not.toHaveBeenCalled();
+		expect(plugin.app.commands.executeCommandById).toHaveBeenCalledTimes(1);
+	});
+
+	it('focuses the trigger file before dispatching when focusFile is true', async () => {
+		const plugin = createMockPlugin();
+		plantFile(plugin, 'Notes/foo.md');
+		const order: string[] = [];
+		plugin.app.workspace.openLinkText.mockImplementation(async () => {
+			order.push('focus');
+		});
+		plugin.app.commands.executeCommandById.mockImplementation(() => {
+			order.push('dispatch');
+			return true;
+		});
+
+		const hook = makeHook({
+			action: 'command',
+			commandId: 'editor:save-file',
+			focusFile: true,
+			prompt: '',
+		});
+		const runner = new HookRunner(plugin as any, makeContext(hook));
+
+		await runner.run();
+
+		expect(plugin.app.workspace.openLinkText).toHaveBeenCalledTimes(1);
+		expect(plugin.app.workspace.openLinkText).toHaveBeenCalledWith('Notes/foo.md', '', false);
+		expect(plugin.app.commands.executeCommandById).toHaveBeenCalledTimes(1);
+		// Focus must precede dispatch — otherwise the command runs against
+		// the wrong file.
+		expect(order).toEqual(['focus', 'dispatch']);
+	});
+
+	it('skips dispatch (and logs) when focusFile is true but the file is missing', async () => {
+		const plugin = createMockPlugin();
+		// getAbstractFileByPath defaults to null lookup — file is gone.
+		const hook = makeHook({
+			action: 'command',
+			commandId: 'editor:save-file',
+			focusFile: true,
+			prompt: '',
+		});
+		const runner = new HookRunner(plugin as any, makeContext(hook));
+
+		await runner.run();
+
+		expect(plugin.app.workspace.openLinkText).not.toHaveBeenCalled();
+		expect(plugin.app.commands.executeCommandById).not.toHaveBeenCalled();
+		// The skip path logs at info level so the user can see why nothing
+		// happened — assert it landed.
+		expect(plugin.logger.log).toHaveBeenCalledWith(
+			expect.stringContaining('focusFile is on but Notes/foo.md is not present')
+		);
 	});
 });

--- a/test/services/hook-runner.test.ts
+++ b/test/services/hook-runner.test.ts
@@ -630,4 +630,34 @@ describe('HookRunner action: command', () => {
 			expect.stringContaining('focusFile is on but Notes/foo.md is not present')
 		);
 	});
+
+	it('skips dispatch when cancellation flips true between focus and command dispatch', async () => {
+		// Locks in the isCancelled re-check that sits between openLinkText
+		// and executeCommandById in runCommand. Without that guard a
+		// cancellation that lands during the focus await would still fire
+		// the command.
+		const plugin = createMockPlugin();
+		plantFile(plugin, 'Notes/foo.md');
+
+		let cancelled = false;
+		// Simulate cancellation arriving while the focus await is pending.
+		plugin.app.workspace.openLinkText.mockImplementation(async () => {
+			cancelled = true;
+		});
+
+		const hook = makeHook({
+			action: 'command',
+			commandId: 'editor:save-file',
+			focusFile: true,
+			prompt: '',
+		});
+		const runner = new HookRunner(plugin as any, makeContext(hook));
+
+		await runner.run(() => cancelled);
+
+		// Focus completed before cancellation flipped, so it should have
+		// been called once. Dispatch must NOT have happened.
+		expect(plugin.app.workspace.openLinkText).toHaveBeenCalledTimes(1);
+		expect(plugin.app.commands.executeCommandById).not.toHaveBeenCalled();
+	});
 });

--- a/test/services/hook-runner.test.ts
+++ b/test/services/hook-runner.test.ts
@@ -624,9 +624,9 @@ describe('HookRunner action: command', () => {
 
 		expect(plugin.app.workspace.openLinkText).not.toHaveBeenCalled();
 		expect(plugin.app.commands.executeCommandById).not.toHaveBeenCalled();
-		// The skip path logs at info level so the user can see why nothing
-		// happened — assert it landed.
-		expect(plugin.logger.log).toHaveBeenCalledWith(
+		// Skip path uses warn so the user sees why nothing happened even
+		// without debug mode enabled (logger.log is debug-gated per AGENTS.md).
+		expect(plugin.logger.warn).toHaveBeenCalledWith(
 			expect.stringContaining('focusFile is on but Notes/foo.md is not present')
 		);
 	});


### PR DESCRIPTION
## Summary

Closes #759. Adds an opt-in `focusFile: true` field for hooks with `action: command`. When set, the runner focuses the triggering file in the workspace before dispatching the command, so editor-scoped commands like `editor:save-file` target the file that fired the hook instead of whatever happens to be active.

This was deferred from PR 3 (#758) review feedback. The active-context limitation of `app.commands.executeCommandById` is real but auto-focusing on every fire would jump the user's view for global commands (`app:reload`, `theme:toggle`, etc.) where the active file is irrelevant — making it opt-in keeps both cases clean.

Refs #749. With this PR the lifecycle-hooks epic is feature-complete; only the optional PR 4 (workspace/metadata events) remains and isn't blocking anything.

## Changes

**Hook type / parser / serializer** — `src/services/hook-manager.ts`
- New optional `focusFile?: boolean` field on `Hook`, `HookCreateParams`, `HookUpdateParams`
- `parseHookFile`, `serializeHook`, `toHook`, and `updateHook` merge all updated
- Serializer only writes the line when the user opted in (default `false` keeps the file clean)

**Runner** — `src/services/hook-runner.ts`
- `runCommand` checks `hook.focusFile`. When true:
  1. Resolves the trigger file via the existing `resolveTriggerFile` helper
  2. If the file is gone (e.g. `file-deleted` trigger), skip the dispatch with a log entry — better than firing the command against the wrong file
  3. Otherwise calls `app.workspace.openLinkText(filePath, '', false)` to focus it
  4. Re-checks `isCancelled` between focus and dispatch
  5. Dispatches as before

**Modal** — `src/ui/hook-management-modal.ts`
- New "Focus trigger file before dispatch" toggle in the form, shown only when `action: command` (alongside the existing command-id field)
- Plumbed through `blankForm`, `openEdit`, and `handleSave`

**Docs** — `docs/guide/lifecycle-hooks.md`
- Frontmatter table gains the `focusFile` row
- Actions → `command` section rewritten to explain active-context vs trigger-file behaviour and when to use the flag, with a worked YAML example
- The "Save the active file via a command" example replaced with a more useful one (`gemini-scribe-summarize-active-file` against new files in `Inbox/`)

## Tests

Four new tests:

**Runner**
- `default focusFile (unset) doesn't call openLinkText`
- `focusFile: true focuses then dispatches in the correct order`
- `focusFile: true with missing file skips dispatch and logs`

**CRUD round-trip**
- Default `focusFile` (unset) omits the line from the serialized markdown
- `focusFile: true` writes the line; in-memory hook reflects the value

Suite at **1603 passing** (up from 1599).

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer (#759, design and open question filed; this PR resolves it)
- [x] All CI checks pass (`npm test` 1603 passing, `npm run build`, `npm run format-check`, test typecheck)
- [x] I have tested this change on Desktop
- [ ] I have verified this change does not break Mobile — the entire hooks engine defaults `desktopOnly: true`, so the new flag is gated off on mobile by the same opt-in path as everything else in #749
- [x] Documentation has been updated (`docs/guide/lifecycle-hooks.md`)
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional `focusFile` toggle for command-based hooks, which opens the trigger file in the workspace before executing the command
  * New setting available in the hook management UI for easy configuration

* **Documentation**
  * Updated lifecycle hooks documentation with `focusFile` field details, default behavior, and practical examples

* **Tests**
  * Added test coverage for `focusFile` serialization and command execution flow
<!-- end of auto-generated comment: release notes by coderabbit.ai -->