### PR TITLE
chore(daily): 2026-05-06 daily update

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,23 +7,25 @@ Gemini Scribe is an Obsidian plugin that integrates Google's Gemini AI models, p
 > - **Google Gemini (cloud)** — requires a Gemini API key (free tier available at [Google AI Studio](https://aistudio.google.com/apikey)).
 > - **Ollama (local)** — runs locally with no API key; install [Ollama](https://ollama.com), pull a model, and select it in settings. See [docs/guide/ollama-setup.md](docs/guide/ollama-setup.md) for the feature-parity table.
 
-## What's New in v4.7.0
+## What's New in v4.8.0
 
-**✨ Projects, Session Memory & File Shelf**
+**✨ Gemini Scribe 4.8 - Scheduled & Background Tasks, Ollama, Activity Modal**
+
+- **⏰ Scheduled tasks** - Run agent tasks on a cron, time-of-day, or day-of-week schedule with full management UI. See the [Scheduled Tasks guide](docs/guide/scheduled-tasks.md).
+- **🌙 Missed-run catch-up** - Tasks that should have run while Obsidian was closed surface on startup for review.
+- **🛰️ Background tasks** - Deep research and image generation now run in the background with output consolidated under `[state-folder]/Background-Tasks/`. See the [Background Tasks guide](docs/guide/background-tasks.md).
+- **📊 Unified activity modal** - Background Tasks and RAG status share a single tabbed view.
+- **🦙 Ollama provider** - Point the plugin at a local Ollama server for offline, local-model chat. See the [Ollama Setup guide](docs/guide/ollama-setup.md).
+- **🛑 Runaway-loop abort** - Repeated tool-loop detections within a turn now abort the turn with a clear notice instead of churning.
+- **🛠️ Headless agent loop** - AgentLoop extracted from the agent view so scheduled and background runners share the same execution engine.
+
+**Previous Updates (v4.7.0):**
 
 - **📂 Projects** - Scope agent sessions to a folder with custom instructions, permission overrides, and skill filters. See the [Projects guide](docs/guide/projects.md).
 - **🧠 Session recall** - The agent can search past conversations for relevant context via the `recall_sessions` tool.
 - **📦 Bundled skills** - Built-in help and Obsidian-knowledge skills, auto-generated from the docs site at build time.
 - **📄 Binary file awareness in tools** - `read_file` can return images, audio, video, and PDFs directly to the model when encountered during tool execution.
 - **🏗️ Layered prompt architecture** - System prompts refactored into composable Handlebars sections.
-
-**Previous Updates (v4.6.0):**
-
-- **📝 Diff review view** - Side-by-side diff for `write_file`, `append_content`, `create_skill`, and `edit_skill` with inline editing before approval
-- **✏️ edit_skill tool** - Update existing skill instructions through the agent
-- **🔧 get_workspace_state** - Comprehensive workspace snapshot replacing the old `get_active_file`
-- **📎 Binary files in @ mentions** - File picker supports images, PDFs, audio, and video alongside text
-- **🗂️ Folder re-expansion** - Folders in context auto-include newly created files on each turn
 
 ## Features
 

--- a/planning/changelog/2026-05-05.md
+++ b/planning/changelog/2026-05-05.md
@@ -1,0 +1,30 @@
+# Daily changelog — May 05, 2026
+
+**Date:** 2026-05-05
+**PRs merged:** 3
+
+---
+
+## Summary
+
+Lifecycle-hooks day: the epic's third PR landed in the morning rounding out the action vocabulary (`summarize`, `rewrite`, `command` alongside the existing `agent-task`), then a quick follow-up tightened the `command` action with an opt-in `focusFile` flag so editor-scoped commands target the right file. The automated daily housekeeping PR (covering 2026-05-04) also merged in the evening.
+
+## What shipped
+
+### [#758 feat(hooks): summarize, rewrite, and command actions (#749 PR 3)](https://github.com/allenhutchison/obsidian-gemini/pull/758)
+
+Phase 3 of the lifecycle-hooks epic (#749). Three new action types join `agent-task` in the hook runner:
+
+- **`summarize`** — runs the existing summary feature against the triggering file and writes the result to frontmatter. Non-markdown files are silently skipped.
+- **`rewrite`** — rewrites the full file using the hook's prompt body as instructions, via `vault.read`/`vault.modify` (no active editor required). Non-markdown files are silently skipped.
+- **`command`** — dispatches a registered command palette command by id (`commandId` frontmatter field). Unknown ids surface as hook failures rather than silent no-ops.
+
+Service-side, `GeminiSummary.summarizeFile(file)` and `SelectionRewriter.rewriteFile(file, instructions)` were extracted so non-interactive callers can invoke them without an active editor. A drive-by fix corrects a binary-encoding bug in `globToRegExp` introduced by prettier during PR 1's reformat; the logic is unchanged and all 40 existing glob tests pass. The management modal gains an action dropdown with per-action input sections. Suite at 1594 passing.
+
+### [#762 chore(daily): 2026-05-05 daily update](https://github.com/allenhutchison/obsidian-gemini/pull/762)
+
+Automated daily housekeeping covering 2026-05-04. Wrote `planning/changelog/2026-05-04.md` (4 PRs: lifecycle-hooks engine, management UI, post-test fixups, and the prior daily update). Fixed four doc-drift items in `README.md`, `docs/reference/settings.md`, and `AGENTS.md` — all triggered by the hooks PRs landing without corresponding top-level doc updates. Labeled issue #755 (`enhancement` + `agent-config`).
+
+### [#761 feat(hooks): focusFile flag for command action (closes #759)](https://github.com/allenhutchison/obsidian-gemini/pull/761)
+
+Follow-up to PR 3, deferred from review feedback. Adds an opt-in `focusFile: true` frontmatter field for `action: command` hooks. When set, the runner calls `app.workspace.openLinkText` to bring the triggering file into focus before dispatching the command — making editor-scoped commands like `editor:save-file` target the correct file rather than whatever is currently active. The flag is omitted from serialized hook files by default to keep frontmatter clean. With this PR the lifecycle-hooks epic (#749) is feature-complete; only the optional metadata-cache/workspace-events PR 4 remains. Suite at 1603 passing.


### PR DESCRIPTION
## Summary

Automated daily housekeeping run for 2026-05-05.

## Changes

### daily-changelog

- Wrote `planning/changelog/2026-05-05.md` covering 3 PRs
- Feature-heavy day: lifecycle-hooks action types (summarize, rewrite, command) in PR 3 (#758), the follow-up `focusFile` flag for command hooks (#761), and the automated daily-update (#762)

### audit-docs

One drift fix:

1. **`README.md`** — "What's New" section referenced v4.7.0 but `manifest.json` is at v4.8.0. Updated the section to show v4.8.0 highlights (Scheduled Tasks, Background Tasks, Ollama provider, unified activity modal, runaway-loop abort, headless agent loop) and demoted the v4.7.0 bullets to "Previous Updates (v4.7.0)". All other docs (lifecycle-hooks.md, settings.md, loop-detection.md, scheduled-tasks.md, agent-mode.md) are current — the lifecycle-hooks PRs that merged yesterday (#758, #761) already shipped with their own doc updates.

### triage-issues

- Issues processed: 0
- Issues labeled: 0
- No unlabeled open issues — tracker is clean.

## Screenshots / Screencast

N/A — changelog and documentation drift fix only; no UI changes.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: automated daily housekeeping run
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop — N/A: docs and changelog only
- [ ] I have verified this change does not break Mobile — N/A: docs and changelog only
- [x] Documentation has been updated — this PR *is* the documentation update
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (claude-sonnet-4-6), via the `daily-update` skill
- [x] I have reviewed and understand all AI-generated code in this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_014grVb7LW9oXhZvXc31a9He)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated changelog to document v4.8.0 release featuring scheduled tasks, missed-run catch-up, background tasks, unified activity modal, Ollama provider support, runaway-loop abort, and headless agent loop functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->