### PR TITLE
fix(agent): truncate old tool-result payloads in conversation history

### DIFF
--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -209,6 +209,10 @@ Context management automatically monitors and controls conversation size to prev
 - **How it works**: When conversation tokens exceed this percentage, older turns are summarized and replaced with a compact summary while preserving recent messages
 - **Hard ceiling**: Aggressive compaction triggers at 80% of the input limit to prevent API errors
 
+### Tool-result truncation in history
+
+In addition to compaction, the plugin sheds bloat from older tool-result turns before each request. When a tool (typically `read_file`) returns a payload larger than ~4 KB, the response in conversation history is replaced with a small `{ truncated: true, truncatedFrom: N, note: "..." }` marker once it falls outside the most recent two tool-result turns. This keeps the agent's reasoning intact for the current and immediately previous tool call while preventing the long tail of past tool responses from dominating every subsequent prompt. Re-issuing the original tool call brings the full output back when needed. The behavior is always-on and not currently exposed as a setting.
+
 ### Show Token Usage
 
 - **Setting**: `showTokenUsage`

--- a/src/agent/agent-loop-helpers.ts
+++ b/src/agent/agent-loop-helpers.ts
@@ -177,3 +177,96 @@ export function buildToolHistoryTurns(args: {
 
 	return updated;
 }
+
+/**
+ * Default per-tool-result size cap before we treat a stored response as
+ * bloat worth shedding from history. 4 KB comfortably covers prose answers,
+ * structured JSON, and short file fragments; anything larger is usually a
+ * `read_file` of source code that the model has already digested and won't
+ * need verbatim again.
+ */
+export const DEFAULT_TOOL_RESPONSE_TRUNCATE_BYTES = 4096;
+
+/**
+ * Default number of most-recent tool-result turns to leave intact. Two
+ * gives the agent the just-executed turn plus the previous one (so a model
+ * that's reasoning across a small batch of recent tool calls still has the
+ * full text), while older results — the long tail that drives quadratic
+ * input growth (#763) — get shed.
+ */
+export const DEFAULT_TOOL_RESPONSE_KEEP_RECENT = 2;
+
+/**
+ * Build the elision marker that replaces a `functionResponse.response`
+ * payload when it's truncated. Preserves whatever the original `success`
+ * flag was so loop-detection / scoring code that switches on success keeps
+ * working, and tells the model to re-call the tool if it actually needs
+ * the full content again.
+ */
+function buildTruncatedResponse(originalResponse: any, originalBytes: number): any {
+	return {
+		success: originalResponse?.success ?? false,
+		truncated: true,
+		truncatedFrom: originalBytes,
+		note: `Tool result truncated to save context (${originalBytes} bytes elided). Re-call the tool if you need the full output.`,
+	};
+}
+
+/**
+ * Shed bloat from older tool-result turns in a conversation history.
+ *
+ * The agent loop appends tool results to history as user-role turns
+ * containing `functionResponse` parts; on a long coding session those
+ * results (especially `read_file` returning hundreds of KB of source)
+ * are replayed on every subsequent send and drive input-token growth
+ * roughly quadratically in turns. This pass walks history, identifies
+ * tool-result turns, and replaces oversized response payloads in older
+ * turns with a small elision marker (preserving `success` and noting
+ * the original size).
+ *
+ * Defaults:
+ *   - `maxBytes`: only responses whose JSON exceeds this size get
+ *     truncated (4 KB by default). Smaller responses pass through.
+ *   - `keepRecent`: the latest N tool-result turns are left intact (2
+ *     by default), so an agent reasoning across a small batch of recent
+ *     tool calls still has full text.
+ *
+ * Returns a new array; the input is not mutated. Non-tool-result turns
+ * (user messages, model text, etc.) and the actual `functionCall`
+ * parts are passed through unchanged.
+ *
+ * Tracked under #763.
+ */
+export function truncateOldToolResults(history: any[], opts?: { maxBytes?: number; keepRecent?: number }): any[] {
+	const list = history || [];
+	const maxBytes = opts?.maxBytes ?? DEFAULT_TOOL_RESPONSE_TRUNCATE_BYTES;
+	const keepRecent = Math.max(0, opts?.keepRecent ?? DEFAULT_TOOL_RESPONSE_KEEP_RECENT);
+
+	const isToolResultTurn = (turn: any) =>
+		turn?.role === 'user' && Array.isArray(turn.parts) && turn.parts.some((p: any) => p?.functionResponse);
+
+	const toolTurnIndices = list.reduce<number[]>((acc, turn, i) => {
+		if (isToolResultTurn(turn)) acc.push(i);
+		return acc;
+	}, []);
+	if (toolTurnIndices.length <= keepRecent) return list;
+
+	const cutoff = toolTurnIndices[toolTurnIndices.length - keepRecent] ?? Infinity;
+
+	return list.map((turn, i) => {
+		if (i >= cutoff || !isToolResultTurn(turn)) return turn;
+		const newParts = turn.parts.map((p: any) => {
+			if (!p?.functionResponse?.response) return p;
+			const serialized = JSON.stringify(p.functionResponse.response);
+			if (serialized.length <= maxBytes) return p;
+			return {
+				...p,
+				functionResponse: {
+					...p.functionResponse,
+					response: buildTruncatedResponse(p.functionResponse.response, serialized.length),
+				},
+			};
+		});
+		return { ...turn, parts: newParts };
+	});
+}

--- a/src/services/context-manager.ts
+++ b/src/services/context-manager.ts
@@ -291,7 +291,7 @@ export class ContextManager {
 	 * compaction to measure the result size.
 	 */
 	async prepareHistory(conversationHistory: any[], modelName: string): Promise<CompactionResult> {
-		const estimatedTokens = this.lastUsageMetadata?.promptTokenCount ?? 0;
+		let estimatedTokens = this.lastUsageMetadata?.promptTokenCount ?? 0;
 
 		// Shed bloat from old tool-result turns (e.g., big `read_file` payloads)
 		// before any threshold check. This is cheap, deterministic, always-helpful,
@@ -309,6 +309,17 @@ export class ContextManager {
 			const truncationDelta = JSON.stringify(conversationHistory).length - JSON.stringify(truncatedHistory).length;
 			if (truncationDelta > 0) {
 				this.logger.log(`[ContextManager] Truncated old tool results: shed ~${truncationDelta} bytes from history`);
+				// `estimatedTokens` came from the *previous* response, when the
+				// now-shed bytes were still in history. Without correcting it
+				// here, the threshold check below would fire compaction the
+				// turn truncation kicks in even though the actual outgoing
+				// prompt is smaller. Using the standard 4-chars-per-token
+				// heuristic — the same one used elsewhere in this file for
+				// Ollama — avoids an extra countTokens API roundtrip while
+				// staying accurate enough to skip the spurious compaction.
+				if (estimatedTokens > 0) {
+					estimatedTokens = Math.max(0, estimatedTokens - Math.ceil(truncationDelta / 4));
+				}
 			}
 		}
 

--- a/src/services/context-manager.ts
+++ b/src/services/context-manager.ts
@@ -14,6 +14,7 @@ import { GoogleGenAI } from '@google/genai';
 import { Logger } from '../utils/logger';
 import type ObsidianGemini from '../main';
 import { GeminiClientFactory, ModelUseCase } from '../api/simple-factory';
+import { truncateOldToolResults } from '../agent/agent-loop-helpers';
 
 // @ts-ignore
 import contextSummaryPromptContent from '../../prompts/contextSummaryPrompt.hbs';
@@ -292,10 +293,22 @@ export class ContextManager {
 	async prepareHistory(conversationHistory: any[], modelName: string): Promise<CompactionResult> {
 		const estimatedTokens = this.lastUsageMetadata?.promptTokenCount ?? 0;
 
+		// Shed bloat from old tool-result turns (e.g., big `read_file` payloads)
+		// before any threshold check. This is cheap, deterministic, always-helpful,
+		// and often keeps a session below the compaction threshold long enough
+		// that the (more expensive) summarization pass never runs. The most
+		// recent few tool-result turns are left intact — see truncateOldToolResults
+		// for defaults. Tracked under #763.
+		const truncatedHistory = truncateOldToolResults(conversationHistory);
+		const truncationDelta = JSON.stringify(conversationHistory).length - JSON.stringify(truncatedHistory).length;
+		if (truncationDelta > 0) {
+			this.logger.log(`[ContextManager] Truncated old tool results: shed ~${truncationDelta} bytes from history`);
+		}
+
 		// Short-circuit for very short conversations
-		if (conversationHistory.length <= MIN_RECENT_TURNS_TO_KEEP) {
+		if (truncatedHistory.length <= MIN_RECENT_TURNS_TO_KEEP) {
 			return {
-				compactedHistory: conversationHistory,
+				compactedHistory: truncatedHistory,
 				wasCompacted: false,
 				estimatedTokens,
 			};
@@ -305,7 +318,7 @@ export class ContextManager {
 		if (estimatedTokens === 0) {
 			this.logger.log('[ContextManager] No cached token usage, skipping compaction');
 			return {
-				compactedHistory: conversationHistory,
+				compactedHistory: truncatedHistory,
 				wasCompacted: false,
 				estimatedTokens: 0,
 			};
@@ -318,7 +331,7 @@ export class ContextManager {
 				`[ContextManager] Under threshold (${estimatedTokens} < ${compactionThreshold}), skipping compaction`
 			);
 			return {
-				compactedHistory: conversationHistory,
+				compactedHistory: truncatedHistory,
 				wasCompacted: false,
 				estimatedTokens,
 			};
@@ -329,7 +342,7 @@ export class ContextManager {
 
 		const aggressiveThreshold = await this.getAggressiveThreshold(modelName);
 		const isAggressive = estimatedTokens >= aggressiveThreshold;
-		const result = await this.compactHistory(conversationHistory, modelName, isAggressive);
+		const result = await this.compactHistory(truncatedHistory, modelName, isAggressive);
 
 		// Verify the compacted history is smaller
 		const compactedTokens = await this.countTokens(modelName, result.compactedHistory);

--- a/src/services/context-manager.ts
+++ b/src/services/context-manager.ts
@@ -299,10 +299,17 @@ export class ContextManager {
 		// that the (more expensive) summarization pass never runs. The most
 		// recent few tool-result turns are left intact — see truncateOldToolResults
 		// for defaults. Tracked under #763.
+		//
+		// `truncateOldToolResults` returns the input array reference when nothing
+		// gets truncated, so the identity check is a free fast-path that avoids
+		// the double JSON.stringify on every prepareHistory call (which fires on
+		// every send — keeping the no-truncation path O(1) matters).
 		const truncatedHistory = truncateOldToolResults(conversationHistory);
-		const truncationDelta = JSON.stringify(conversationHistory).length - JSON.stringify(truncatedHistory).length;
-		if (truncationDelta > 0) {
-			this.logger.log(`[ContextManager] Truncated old tool results: shed ~${truncationDelta} bytes from history`);
+		if (truncatedHistory !== conversationHistory) {
+			const truncationDelta = JSON.stringify(conversationHistory).length - JSON.stringify(truncatedHistory).length;
+			if (truncationDelta > 0) {
+				this.logger.log(`[ContextManager] Truncated old tool results: shed ~${truncationDelta} bytes from history`);
+			}
 		}
 
 		// Short-circuit for very short conversations

--- a/test/agent/agent-loop-helpers.test.ts
+++ b/test/agent/agent-loop-helpers.test.ts
@@ -462,9 +462,18 @@ describe('truncateOldToolResults', () => {
 		content: 'x'.repeat(size),
 	});
 
-	test('returns history unchanged when there are no tool-result turns', () => {
+	test('returns the exact input reference when there are no tool-result turns', () => {
+		// Identity (not just deep equality) matters — ContextManager uses
+		// `truncated !== history` as a fast-path to skip the double
+		// JSON.stringify when no truncation occurred.
 		const history = [userText('hi'), modelText('hello')];
-		expect(truncateOldToolResults(history)).toEqual(history);
+		expect(truncateOldToolResults(history)).toBe(history);
+	});
+
+	test('returns the exact input reference when fewer tool-result turns exist than keepRecent', () => {
+		const history = [fnCallTurn('read_file'), fnResponseTurn('read_file', { success: true, content: 'tiny' })];
+		// Only 1 tool-result turn, keepRecent=2 — nothing to truncate.
+		expect(truncateOldToolResults(history, { keepRecent: 2 })).toBe(history);
 	});
 
 	test('keeps the most recent N tool-result turns intact', () => {

--- a/test/agent/agent-loop-helpers.test.ts
+++ b/test/agent/agent-loop-helpers.test.ts
@@ -3,6 +3,8 @@ import {
 	buildFunctionCallParts,
 	buildFunctionResponseParts,
 	buildToolHistoryTurns,
+	truncateOldToolResults,
+	DEFAULT_TOOL_RESPONSE_TRUNCATE_BYTES,
 	ToolCallResultPair,
 } from '../../src/agent/agent-loop-helpers';
 import type { ToolCall } from '../../src/api/interfaces/model-api';
@@ -440,5 +442,118 @@ describe('buildToolHistoryTurns', () => {
 		expect(userResponseTurn.parts).toHaveLength(2);
 		expect(userResponseTurn.parts[0].functionResponse).toBeDefined();
 		expect(userResponseTurn.parts[1].inlineData).toEqual({ mimeType: 'image/png', data: 'imgbytes' });
+	});
+});
+
+describe('truncateOldToolResults', () => {
+	const fnResponseTurn = (name: string, response: any) => ({
+		role: 'user',
+		parts: [{ functionResponse: { name, response } }],
+	});
+	const fnCallTurn = (name: string) => ({
+		role: 'model',
+		parts: [{ functionCall: { name, args: {} } }],
+	});
+	const userText = (text: string) => ({ role: 'user', parts: [{ text }] });
+	const modelText = (text: string) => ({ role: 'model', parts: [{ text }] });
+
+	const big = (size = DEFAULT_TOOL_RESPONSE_TRUNCATE_BYTES + 1000) => ({
+		success: true,
+		content: 'x'.repeat(size),
+	});
+
+	test('returns history unchanged when there are no tool-result turns', () => {
+		const history = [userText('hi'), modelText('hello')];
+		expect(truncateOldToolResults(history)).toEqual(history);
+	});
+
+	test('keeps the most recent N tool-result turns intact', () => {
+		const history = [
+			fnCallTurn('read_file'),
+			fnResponseTurn('read_file', big()), // index 1 — old
+			modelText('thinking'),
+			fnCallTurn('read_file'),
+			fnResponseTurn('read_file', big()), // index 4 — recent
+			modelText('more'),
+			fnCallTurn('read_file'),
+			fnResponseTurn('read_file', big()), // index 7 — most recent
+		];
+		const out = truncateOldToolResults(history, { keepRecent: 2 });
+		// First (oldest) tool-result turn should be truncated.
+		expect(out[1].parts[0].functionResponse.response.truncated).toBe(true);
+		expect(out[1].parts[0].functionResponse.response.success).toBe(true);
+		// The two most recent tool-result turns should be untouched.
+		expect(out[4]).toBe(history[4]);
+		expect(out[7]).toBe(history[7]);
+	});
+
+	test('does not truncate small responses regardless of age', () => {
+		const small = { success: true, content: 'short' };
+		const history = [
+			fnResponseTurn('read_file', small),
+			fnResponseTurn('read_file', small),
+			fnResponseTurn('read_file', small),
+		];
+		const out = truncateOldToolResults(history, { keepRecent: 1 });
+		// All three responses are well under the threshold — none should be marked truncated.
+		for (const turn of out) {
+			expect(turn.parts[0].functionResponse.response.truncated).toBeUndefined();
+		}
+	});
+
+	test('preserves the original success flag when truncating', () => {
+		const history = [
+			fnResponseTurn('read_file', { success: false, error: 'x'.repeat(5000) }),
+			fnResponseTurn('read_file', big()),
+		];
+		const out = truncateOldToolResults(history, { keepRecent: 1 });
+		expect(out[0].parts[0].functionResponse.response.success).toBe(false);
+		expect(out[0].parts[0].functionResponse.response.truncated).toBe(true);
+		// truncatedFrom should be the serialized JSON length, which exceeds maxBytes.
+		expect(out[0].parts[0].functionResponse.response.truncatedFrom).toBeGreaterThan(
+			DEFAULT_TOOL_RESPONSE_TRUNCATE_BYTES
+		);
+	});
+
+	test('does not mutate the input history array', () => {
+		const original = fnResponseTurn('read_file', big());
+		const history = [original, fnResponseTurn('read_file', big())];
+		truncateOldToolResults(history, { keepRecent: 1 });
+		// The first turn was a candidate for truncation; the original object should be unchanged.
+		expect(original.parts[0].functionResponse.response.truncated).toBeUndefined();
+	});
+
+	test('passes through inlineData and other non-functionResponse parts', () => {
+		const history = [
+			{
+				role: 'user',
+				parts: [
+					{ functionResponse: { name: 'read_file', response: big() } },
+					{ inlineData: { mimeType: 'image/png', data: 'abc' } },
+				],
+			},
+			fnResponseTurn('read_file', big()), // recent — kept intact
+		];
+		const out = truncateOldToolResults(history, { keepRecent: 1 });
+		// The functionResponse in the older turn was truncated...
+		expect(out[0].parts[0].functionResponse.response.truncated).toBe(true);
+		// ...but the inlineData sibling is preserved.
+		expect(out[0].parts[1].inlineData).toEqual({ mimeType: 'image/png', data: 'abc' });
+	});
+
+	test('respects custom maxBytes / keepRecent options', () => {
+		const history = [
+			fnResponseTurn('read_file', { success: true, content: 'x'.repeat(20) }),
+			fnResponseTurn('read_file', { success: true, content: 'x'.repeat(20) }),
+		];
+		const out = truncateOldToolResults(history, { maxBytes: 10, keepRecent: 1 });
+		expect(out[0].parts[0].functionResponse.response.truncated).toBe(true);
+		// keepRecent=1 → most recent is intact.
+		expect(out[1]).toBe(history[1]);
+	});
+
+	test('handles empty / undefined input', () => {
+		expect(truncateOldToolResults([])).toEqual([]);
+		expect(truncateOldToolResults(undefined as any)).toEqual([]);
 	});
 });

--- a/test/services/context-manager.test.ts
+++ b/test/services/context-manager.test.ts
@@ -399,6 +399,49 @@ describe('ContextManager', () => {
 			// So compacted history = summary + ack + ~5 recent = ~7
 			expect(result.compactedHistory.length).toBeLessThanOrEqual(8);
 		});
+
+		test('skips compaction when post-truncation estimate falls under threshold', async () => {
+			// Cached estimate is *just* over the 200K threshold (20% of 1M),
+			// reflecting the previous turn when a 600 KB tool result was still
+			// in history. Truncating that result sheds ~150K tokens by the
+			// chars-per-token heuristic — enough to push us back under the
+			// threshold and skip compaction entirely.
+			contextManager.updateUsageMetadata({
+				promptTokenCount: 220_000,
+				totalTokenCount: 230_000,
+			});
+
+			// Three tool-result turns: the oldest carries the fat payload; the
+			// two newer ones are kept intact by `keepRecent: 2` (the helper's
+			// default). We need MIN_RECENT_TURNS_TO_KEEP (6) total turns so we
+			// don't take the short-conversation early return — pad with text
+			// turns between tool exchanges.
+			const fatResponse = { success: true, content: 'x'.repeat(600_000) };
+			const smallResponse = { success: true, files: ['a'] };
+			const history = [
+				{ role: 'user', parts: [{ text: 'go' }] },
+				{ role: 'model', parts: [{ functionCall: { name: 'read_file', args: { path: 'big.md' } } }] },
+				{ role: 'user', parts: [{ functionResponse: { name: 'read_file', response: fatResponse } }] }, // OLDEST tool result — truncate
+				{ role: 'model', parts: [{ text: 'reasoning…' }] },
+				{ role: 'user', parts: [{ text: 'now list' }] },
+				{ role: 'model', parts: [{ functionCall: { name: 'list_files', args: {} } }] },
+				{ role: 'user', parts: [{ functionResponse: { name: 'list_files', response: smallResponse } }] }, // recent — kept
+				{ role: 'model', parts: [{ text: 'thinking' }] },
+				{ role: 'user', parts: [{ text: 'and one more' }] },
+				{ role: 'model', parts: [{ functionCall: { name: 'list_files', args: {} } }] },
+				{ role: 'user', parts: [{ functionResponse: { name: 'list_files', response: smallResponse } }] }, // most recent — kept
+			];
+
+			const result = await contextManager.prepareHistory(history, 'gemini-2.5-flash');
+
+			expect(result.wasCompacted).toBe(false);
+			// The big tool-result payload (oldest of 3) should be replaced with the elision marker.
+			const oldToolResult = result.compactedHistory[2].parts[0].functionResponse.response;
+			expect(oldToolResult.truncated).toBe(true);
+			// No countTokens API call should have fired — we relied on the
+			// byte-delta heuristic to update the estimate, not a roundtrip.
+			expect(mockCountTokens).not.toHaveBeenCalled();
+		});
 	});
 
 	describe('reset', () => {


### PR DESCRIPTION
## Summary

Tracked under #763. Long agent sessions (especially coding sessions full of `read_file` calls) show input tokens climbing roughly quadratically while output stays flat. The biggest single accumulator is `read_file` returning hundreds of KB of file contents that get appended to history as a `functionResponse` payload, then replayed verbatim on every subsequent send.

This change adds a deterministic, always-on truncation pass: when history is prepared for a request, older tool-result turns whose serialized response exceeds 4 KB get their `response` payload replaced with a small elision marker:

```js
{ success: <original.success>, truncated: true, truncatedFrom: 132489, note: 'Tool result truncated… Re-call the tool if you need the full output.' }
```

The most recent two tool-result turns are left intact so the agent reasoning across a small batch of recent tool calls still has the full text. Smaller responses (≤ 4 KB) pass through unchanged. The pass runs from `ContextManager.prepareHistory`, *before* the token-threshold check, so a session that would have crossed the compaction threshold often stays under it and skips the more expensive summarization round-trip entirely.

Now that #717 (auto-compare baseline), #713 (judge matchers), and #715 (runtime reliability) are landed, the eval harness can measure the impact of this change on solve rate / cost / cache ratio across runs — exactly the signal we built that runway for.

## Changes

- `src/agent/agent-loop-helpers.ts` — new `truncateOldToolResults(history, opts?)`. Pure, side-effect-free, returns a new array. Defaults: 4 KB cap, keep most recent 2 tool-result turns.
- `src/services/context-manager.ts` — `prepareHistory` runs the truncation pass before the threshold check. Logs the byte delta so the operator can see what was shed.
- `docs/reference/settings.md` — new "Tool-result truncation in history" subsection under Context Management.
- `test/agent/agent-loop-helpers.test.ts` — 8 cases covering empty input, no-tool-result histories, keep-recent boundary, mixed sizes, inlineData passthrough (sibling parts must survive), success-flag preservation, custom maxBytes/keepRecent options, and immutability of the input array.

## What this does NOT do

- Doesn't change `buildFunctionResponseParts` — the *fresh* tool result the agent uses on the current turn is still full text. Truncation only affects how that result appears in history on subsequent requests.
- Doesn't deduplicate identical reads (separate idea, deferred).
- Doesn't replace #536 (Files API for binary attachments). That's the cleaner architectural fix for the same class of problem; this PR is the immediate stopgap that needs no API surface changes.
- Doesn't expose a setting yet. Always-on with sensible defaults; we'll add a setting if there's demand.

## Verification

- `npm test` — 1667 tests passing (+8 in `agent-loop-helpers.test.ts`).
- `npm run typecheck:test` — clean.
- `npm run format-check` — clean.
- `npm run build` — clean.
- Live measurement against the eval harness will happen post-merge with `npm run eval` + `eval:bless` — that's the protocol we wired in #717. Expect lower mean prompt tokens on the multi-turn tasks (`multi-hop-retrieval`, `loop-trap-cyclic-refs`, `create-note-from-search`) without solve-rate regression.

## Screenshots / Screencast

N/A — internal change to history-prep logic.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer (#763)
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop — pure-helper logic has unit coverage; live integration impact will be measured via the eval harness as planned.
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A, `agent-loop-helpers.ts` is platform-neutral and runs on both.
- [x] Documentation has been updated — new subsection in `docs/reference/settings.md`.
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic truncation of large tool outputs in conversation history (~4 KB threshold) while preserving the most recent results and allowing full output to be restored by re-running the tool.
  * History preprocessing reduces estimated token counts and can prevent unnecessary compaction.

* **Documentation**
  * Added guidance on tool-result truncation and its interaction with context management.

* **Tests**
  * Added tests validating truncation behavior, recent-result preservation, non-destructive handling, and compaction-skip scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->