### PR TITLE
chore(daily): 2026-05-08 daily update

### DIFF
--- a/planning/changelog/2026-05-07.md
+++ b/planning/changelog/2026-05-07.md
@@ -1,0 +1,20 @@
+# Daily changelog — May 07, 2026
+
+**Date:** 2026-05-07
+**PRs merged:** 2
+
+---
+
+## Summary
+
+A focused eval-tooling day: the main feature PR added per-task timeout budgets, live progress polling, and clean interrupt handling to the eval harness. The daily housekeeping PR closed out the day's docs-drift fixes from the previous session's settings reorganization.
+
+## What shipped
+
+### [#769 chore(daily): 2026-05-07 daily update](https://github.com/allenhutchison/obsidian-gemini/pull/769)
+
+Automated daily housekeeping covering 2026-05-06. Fixed five settings navigation paths across `docs/reference/advanced-settings.md`, `docs/reference/loop-detection.md`, `docs/guide/lifecycle-hooks.md`, `docs/guide/scheduled-tasks.md`, and `README.md` — all caused by PR #764 reorganizing the settings UI into collapsible sections (paths now point to the new Automation and Agent Config tabs). No unlabeled issues were found; triage was a no-op.
+
+### [#768 feat(evals): per-task timeout, progress polling, clean interrupt](https://github.com/allenhutchison/obsidian-gemini/pull/768)
+
+Closes #715. Addresses three eval harness reliability gaps that surfaced on slow Ollama runs. Each task now runs against a configurable `timeoutMs` budget (default 5 minutes); on timeout the in-flight agent loop is cancelled, the task is marked `TIMEOUT`, and the run continues. A 2-second async poll loop reads `window.__evalCollector` and prints `[turn N | M tool calls | Ts elapsed | ETA Ys]` lines, suppressing elapsed-only noise. SIGINT/SIGTERM now cancels the in-flight agent, cleans up scratch and session history for the interrupted task, and exits cleanly with a partial-progress summary. Fourteen new unit tests cover the progress formatter; live Obsidian-CLI integration deferred to the next actual eval run.


### PR DESCRIPTION
## Summary

Automated daily housekeeping run for 2026-05-07 (Pacific time).

## Changes

### daily-changelog

- Wrote `planning/changelog/2026-05-07.md` covering 2 PRs
- Eval harness day: per-task timeout/progress/clean-interrupt (#768) and yesterday's daily housekeeping (#769)

### audit-docs

No drift found — all settings names/defaults, command palette IDs, schedule formats, tool names, folder paths, loop detection thresholds, lifecycle hooks fields, and attachment limits match the source code exactly. No new docs warranted.

### triage-issues

- Issues processed: 0
- Issues labeled: 0
- No unlabeled open issues — tracker is clean.

## Screenshots / Screencast

N/A — changelog only; no UI changes.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: automated daily housekeeping run
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop — N/A: changelog only
- [ ] I have verified this change does not break Mobile — N/A: changelog only
- [x] Documentation has been updated — this PR *is* the documentation update
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (claude-sonnet-4-6), via the `daily-update` skill
- [x] I have reviewed and understand all AI-generated code in this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_014m31PMAEcjuoc7eednmYab)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed settings navigation links affected by UI reorganization.

* **New Features**
  * Added per-task timeout budgets for eval harness.
  * Added live progress polling for eval harness.
  * Improved interrupt handling with partial-progress reporting.

* **Tests**
  * Added unit tests for progress formatter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->