### PR TITLE
fix(agent): preserve perTurnContext across follow-up requests

### DIFF
--- a/evals/fixtures/context-from-shelf/places-i-want-to-visit.md
+++ b/evals/fixtures/context-from-shelf/places-i-want-to-visit.md
@@ -1,0 +1,26 @@
+# Places I Want to Visit
+
+A bucket-list of destinations I'd love to see in my lifetime.
+
+## Confirmed Top Three
+
+- The Great Wall of China
+- Machu Picchu in Peru
+- Petra in Jordan
+
+## Other Dream Destinations
+
+- The Northern Lights from Tromsø, Norway
+- Angkor Wat in Cambodia
+- Gorilla trekking in Rwanda
+
+## Domestic Trips Planned for 2027
+
+- Hike a section of the Appalachian Trail
+- Visit Glacier National Park in Montana
+
+## Notes
+
+I want to do the Great Wall before I turn 50. Petra needs to be combined with
+a side trip to Wadi Rum. Machu Picchu requires permits booked at least four
+months in advance.

--- a/evals/lib/obsidian-driver.mjs
+++ b/evals/lib/obsidian-driver.mjs
@@ -126,6 +126,45 @@ export async function createSession(title) {
 }
 
 /**
+ * Populate the current agent session's shelf with the given vault paths so
+ * subsequent turns receive the rendered file content via `perTurnContext`,
+ * mirroring the user-facing drag-and-drop / @-mention flow.
+ *
+ * Must be called AFTER createSession() so `agentView.currentSession` and
+ * `agentView.shelf` reference the session under test. Throws if a path
+ * doesn't resolve to a vault TFile — that's an eval-task authoring error,
+ * not something the harness should silently paper over.
+ *
+ * Used by tasks that test context-chip behavior (e.g. "context-from-shelf"):
+ * the file lives on disk via setupFixtures, then this routine threads it
+ * into the agent context the same way the user would.
+ */
+export async function addContextFiles(paths) {
+	if (!Array.isArray(paths) || paths.length === 0) return;
+	const pathsLiteral = JSON.stringify(paths);
+	await obsidianEval(
+		`(async () => {
+    const p = app.plugins.plugins['gemini-scribe'];
+    const session = p.agentView?.currentSession;
+    if (!session) throw new Error('addContextFiles: no current session — call createSession() first');
+    const paths = ${pathsLiteral};
+    const missing = [];
+    for (const path of paths) {
+      const file = app.vault.getAbstractFileByPath(path);
+      if (!file) { missing.push(path); continue; }
+      p.agentView.addContextFileToShelf(file);
+      // Also persist into the session context so loadSession round-trips
+      // would hydrate the shelf — same code path as the user's @ pick.
+      p.agentView.context?.addFileToContext(file, session);
+    }
+    if (missing.length) throw new Error('addContextFiles: not found in vault: ' + missing.join(', '));
+    return JSON.stringify({ shelf: p.agentView.shelf.getItems().map(i => i.path).filter(Boolean) });
+  })()`,
+		{ timeoutMs: 10_000 }
+	);
+}
+
+/**
  * Copy fixture files into the vault's eval-scratch folder.
  * fixtureFiles is an array of { name, content } objects.
  */

--- a/evals/run.mjs
+++ b/evals/run.mjs
@@ -24,6 +24,7 @@ import {
 	verifyPlugin,
 	createSession,
 	setupFixtures,
+	addContextFiles,
 	sendMessage,
 	cancelAgent,
 	cleanup,
@@ -232,6 +233,15 @@ async function runTask(task, keepArtifacts, provider, judgeFn) {
 		// Publish current task to module state so the SIGINT handler can find
 		// the historyPath / sessionId for cleanup.
 		if (currentTaskInfo) currentTaskInfo.sessionInfo = sessionInfo;
+
+		// 2b. Optional: populate the session's context shelf with vault files.
+		// Mirrors the user's drag-and-drop / @-mention flow so tasks can
+		// exercise the perTurnContext path. Paths must resolve in the vault
+		// (i.e. fixture files must already be present from step 1).
+		if (Array.isArray(task.contextFiles) && task.contextFiles.length > 0) {
+			console.log(`  Adding ${task.contextFiles.length} context file(s) to shelf...`);
+			await addContextFiles(task.contextFiles);
+		}
 
 		// 3. Install collector
 		await installCollector();

--- a/evals/tasks/context-from-shelf.json
+++ b/evals/tasks/context-from-shelf.json
@@ -1,0 +1,15 @@
+{
+	"id": "context-from-shelf",
+	"description": "A file dragged or @-mentioned into the chat is rendered into the system prompt; the model should answer from that context without re-reading via tools",
+	"userMessage": "Without using any tools, list the three confirmed top destinations from the file in my context. Just list them, one per line, no extra commentary.",
+	"fixture": "context-from-shelf",
+	"contextFiles": ["eval-scratch/places-i-want-to-visit.md"],
+	"forbiddenTools": ["read_file", "find_files_by_name", "find_files_by_content", "list_files"],
+	"outputMatchers": [
+		{ "type": "contains", "value": "Great Wall" },
+		{ "type": "contains", "value": "Machu Picchu" },
+		{ "type": "contains", "value": "Petra" }
+	],
+	"maxTurns": 5,
+	"timeoutMs": 60000
+}

--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -10,6 +10,7 @@ import {
 	buildFollowUpRequest,
 	buildRetryRequest,
 	buildEmptyResponseMessage,
+	type PerTurnContext,
 } from '../ui/agent-view/agent-view-tool-followup';
 
 /**
@@ -66,6 +67,15 @@ export interface AgentLoopOptions {
 	customPrompt?: CustomPrompt;
 	projectRootPath?: string;
 	projectPermissions?: Record<string, ToolPermission>;
+	/**
+	 * System-prompt fields that must stay byte-stable across the initial model
+	 * call and every follow-up/retry within this turn. Without these, follow-up
+	 * requests rebuild the system prompt without context-file content / project
+	 * scope, which both confuses the model after a tool call and forces a
+	 * Gemini implicit-cache miss on every follow-up. Caller (agent-view-send)
+	 * sets these once when the user submits the turn.
+	 */
+	perTurn?: PerTurnContext;
 	hooks?: AgentLoopHooks;
 	/**
 	 * Factory for the model API used for follow-up and retry requests.
@@ -138,7 +148,7 @@ export class AgentLoop {
 		options: AgentLoopOptions;
 	}): Promise<AgentLoopResult> {
 		const { initialResponse, initialUserMessage, initialHistory, options } = args;
-		const { plugin, session, isCancelled, hooks, customPrompt, projectRootPath, projectPermissions } = options;
+		const { plugin, session, isCancelled, hooks, customPrompt, projectRootPath, projectPermissions, perTurn } = options;
 		const maxIterations = options.maxIterations;
 
 		const toolContext: ToolExecutionContext = {
@@ -254,6 +264,7 @@ export class AgentLoop {
 				customPrompt,
 				projectRootPath,
 				projectPermissions,
+				...perTurn,
 			});
 
 			const modelApi = createModel();
@@ -303,6 +314,8 @@ export class AgentLoop {
 				plugin,
 				currentSession: session,
 				updatedHistory,
+				customPrompt,
+				...perTurn,
 			});
 
 			const retryModelApi = createModel();

--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -1,5 +1,5 @@
 import type ObsidianGemini from '../main';
-import type { ChatSession } from '../types/agent';
+import type { ChatSession, PerTurnContext } from '../types/agent';
 import type { ToolPermission } from '../types/tool-policy';
 import type { ToolCall, ModelResponse, ModelApi } from '../api/interfaces/model-api';
 import type { CustomPrompt } from '../prompts/types';
@@ -10,7 +10,6 @@ import {
 	buildFollowUpRequest,
 	buildRetryRequest,
 	buildEmptyResponseMessage,
-	type PerTurnContext,
 } from '../ui/agent-view/agent-view-tool-followup';
 
 /**

--- a/src/types/agent.ts
+++ b/src/types/agent.ts
@@ -219,3 +219,34 @@ export const DEFAULT_CONTEXTS = {
 		maxCharsPerFile: 15000,
 	} as AgentContext,
 } as const;
+
+/**
+ * Per-turn system-prompt fields that must stay byte-stable across the
+ * initial model call AND every follow-up/retry within the same user turn.
+ *
+ * These are set once when the user sends a message (in `agent-view-send.ts`)
+ * and threaded through `AgentLoopOptions` so the system prompt rebuilt on
+ * each model call inside the loop is byte-identical to the initial one.
+ *
+ * Two reasons this matters:
+ *  1. Correctness — `perTurnContext` carries the rendered content of files
+ *     dragged or @-mentioned into the chat. Dropping it on follow-ups means
+ *     the model can't reference that content after a tool call, so it tends
+ *     to re-read the same files via tools. `projectInstructions` /
+ *     `projectSkills` similarly disappear, so project-scoped behavior
+ *     degrades the moment a tool fires.
+ *  2. Cache stability — Gemini's implicit prefix cache keys on the exact
+ *     system-prompt bytes. Rebuilding without these fields between the
+ *     initial call and the follow-up changes the prefix and forces a
+ *     cache miss on every follow-up in a long tool chain.
+ *
+ * Lives in this shared types module (rather than the UI agent-view module)
+ * so the UI-agnostic `AgentLoop` can depend on the type without crossing
+ * the agent → UI boundary.
+ */
+export interface PerTurnContext {
+	perTurnContext?: string;
+	projectInstructions?: string;
+	projectSkills?: string[];
+	sessionStartedAt?: string;
+}

--- a/src/ui/agent-view/agent-view-send.ts
+++ b/src/ui/agent-view/agent-view-send.ts
@@ -327,6 +327,18 @@ To reference an attachment in your response, use the path shown above.`;
 					);
 				}
 
+				// Per-turn fields that must stay byte-stable across the initial
+				// model call AND every follow-up/retry inside the agent loop.
+				// Threaded through to handleToolCalls below so the system prompt
+				// rebuilt on each tool-loop iteration is identical to the one
+				// the model saw on the initial call (correctness + cache).
+				const perTurn = {
+					perTurnContext: additionalInstructions,
+					projectInstructions,
+					projectSkills: activeProject?.config.skills,
+					sessionStartedAt: formatLocalTimestamp(currentSession.created),
+				};
+
 				const request: ExtendedModelRequest = {
 					userMessage: message,
 					conversationHistory: compactionResult.compactedHistory,
@@ -334,16 +346,13 @@ To reference an attachment in your response, use the path shown above.`;
 					temperature: modelConfig.temperature ?? this.ctx.plugin.settings.temperature,
 					topP: modelConfig.topP ?? this.ctx.plugin.settings.topP,
 					prompt: '', // Unused in agent pipeline — perTurnContext carries context instead
-					perTurnContext: additionalInstructions, // Context files, attachments, rendered content
-					customPrompt: customPrompt, // Custom prompt template (if configured)
-					projectInstructions: projectInstructions, // Project-scoped instructions (if active)
-					projectSkills: activeProject?.config.skills, // Filter skills to project scope
+					perTurnContext: perTurn.perTurnContext,
+					customPrompt: customPrompt,
+					projectInstructions: perTurn.projectInstructions,
+					projectSkills: perTurn.projectSkills,
 					renderContent: false, // We already rendered content above
 					availableTools: availableTools,
-					// Session-start anchor for the system prompt. Derived from the
-					// session's immutable `created` date so it's stable across every
-					// tool-loop iteration within this turn.
-					sessionStartedAt: formatLocalTimestamp(currentSession.created),
+					sessionStartedAt: perTurn.sessionStartedAt,
 					inlineAttachments: attachments.map((a: InlineAttachment) => ({ base64: a.base64, mimeType: a.mimeType })),
 				};
 
@@ -438,7 +447,8 @@ To reference an attachment in your response, use the path shown above.`;
 								message,
 								compactionResult.compactedHistory,
 								userEntry,
-								customPrompt
+								customPrompt,
+								perTurn
 							);
 						} else {
 							// Normal response without tool calls
@@ -513,7 +523,8 @@ To reference an attachment in your response, use the path shown above.`;
 							message,
 							compactionResult.compactedHistory,
 							userEntry,
-							customPrompt
+							customPrompt,
+							perTurn
 						);
 					} else {
 						// Normal response without tool calls

--- a/src/ui/agent-view/agent-view-tool-followup.ts
+++ b/src/ui/agent-view/agent-view-tool-followup.ts
@@ -1,35 +1,14 @@
 import type ObsidianGemini from '../../main';
-import { ChatSession } from '../../types/agent';
+import { ChatSession, type PerTurnContext } from '../../types/agent';
 import { ToolExecutionContext } from '../../tools/types';
 import { ExtendedModelRequest } from '../../api/interfaces/model-api';
 import { CustomPrompt } from '../../prompts/types';
 
-/**
- * Per-turn system-prompt fields that must stay stable across the initial
- * model call AND every follow-up/retry within the same user turn.
- *
- * These are set once when the user sends a message (in `agent-view-send.ts`)
- * and threaded through `AgentLoopOptions` so the system prompt rebuilt on
- * each model call inside the loop is byte-identical to the initial one.
- *
- * Two reasons this matters:
- *  1. Correctness — `perTurnContext` carries the rendered content of files
- *     dragged or @-mentioned into the chat. Dropping it on follow-ups means
- *     the model can't reference that content after a tool call, so it tends
- *     to re-read the same files via tools. `projectInstructions` /
- *     `projectSkills` similarly disappear, so project-scoped behavior
- *     degrades the moment a tool fires.
- *  2. Cache stability — Gemini's implicit prefix cache keys on the exact
- *     system-prompt bytes. Rebuilding without these fields between the
- *     initial call and the follow-up changes the prefix and forces a
- *     cache miss on every follow-up in a long tool chain.
- */
-export interface PerTurnContext {
-	perTurnContext?: string;
-	projectInstructions?: string;
-	projectSkills?: string[];
-	sessionStartedAt?: string;
-}
+// Re-export so existing callers that import PerTurnContext from this module
+// keep working — the canonical home is now `src/types/agent.ts` so the
+// UI-agnostic `AgentLoop` can depend on the type without reaching into a
+// UI module.
+export type { PerTurnContext };
 
 export interface FollowUpRequestParams extends PerTurnContext {
 	plugin: ObsidianGemini;

--- a/src/ui/agent-view/agent-view-tool-followup.ts
+++ b/src/ui/agent-view/agent-view-tool-followup.ts
@@ -4,7 +4,34 @@ import { ToolExecutionContext } from '../../tools/types';
 import { ExtendedModelRequest } from '../../api/interfaces/model-api';
 import { CustomPrompt } from '../../prompts/types';
 
-export interface FollowUpRequestParams {
+/**
+ * Per-turn system-prompt fields that must stay stable across the initial
+ * model call AND every follow-up/retry within the same user turn.
+ *
+ * These are set once when the user sends a message (in `agent-view-send.ts`)
+ * and threaded through `AgentLoopOptions` so the system prompt rebuilt on
+ * each model call inside the loop is byte-identical to the initial one.
+ *
+ * Two reasons this matters:
+ *  1. Correctness — `perTurnContext` carries the rendered content of files
+ *     dragged or @-mentioned into the chat. Dropping it on follow-ups means
+ *     the model can't reference that content after a tool call, so it tends
+ *     to re-read the same files via tools. `projectInstructions` /
+ *     `projectSkills` similarly disappear, so project-scoped behavior
+ *     degrades the moment a tool fires.
+ *  2. Cache stability — Gemini's implicit prefix cache keys on the exact
+ *     system-prompt bytes. Rebuilding without these fields between the
+ *     initial call and the follow-up changes the prefix and forces a
+ *     cache miss on every follow-up in a long tool chain.
+ */
+export interface PerTurnContext {
+	perTurnContext?: string;
+	projectInstructions?: string;
+	projectSkills?: string[];
+	sessionStartedAt?: string;
+}
+
+export interface FollowUpRequestParams extends PerTurnContext {
 	plugin: ObsidianGemini;
 	currentSession: ChatSession;
 	updatedHistory: any[];
@@ -13,10 +40,11 @@ export interface FollowUpRequestParams {
 	projectPermissions?: Record<string, import('../../types/tool-policy').ToolPermission>;
 }
 
-export interface RetryRequestParams {
+export interface RetryRequestParams extends PerTurnContext {
 	plugin: ObsidianGemini;
 	currentSession: ChatSession;
 	updatedHistory: any[];
+	customPrompt?: CustomPrompt;
 }
 
 /**
@@ -24,7 +52,18 @@ export interface RetryRequestParams {
  * Includes available tools so the model can chain additional calls.
  */
 export function buildFollowUpRequest(params: FollowUpRequestParams): ExtendedModelRequest {
-	const { plugin, currentSession, updatedHistory, customPrompt, projectRootPath, projectPermissions } = params;
+	const {
+		plugin,
+		currentSession,
+		updatedHistory,
+		customPrompt,
+		projectRootPath,
+		projectPermissions,
+		perTurnContext,
+		projectInstructions,
+		projectSkills,
+		sessionStartedAt,
+	} = params;
 
 	const availableToolsContext: ToolExecutionContext = {
 		plugin,
@@ -42,8 +81,12 @@ export function buildFollowUpRequest(params: FollowUpRequestParams): ExtendedMod
 		model: modelConfig.model || plugin.settings.chatModelName,
 		temperature: modelConfig.temperature ?? plugin.settings.temperature,
 		topP: modelConfig.topP ?? plugin.settings.topP,
-		prompt: '', // Unused in agent pipeline
-		customPrompt, // Pass custom prompt through to follow-up requests
+		prompt: '', // Unused in agent pipeline — perTurnContext carries context instead
+		customPrompt,
+		projectInstructions,
+		projectSkills,
+		perTurnContext,
+		sessionStartedAt,
 		renderContent: false,
 		availableTools, // Include tools so model can chain calls
 	};
@@ -54,7 +97,16 @@ export function buildFollowUpRequest(params: FollowUpRequestParams): ExtendedMod
  * Does not include tools — just asks the model to summarize what it did.
  */
 export function buildRetryRequest(params: RetryRequestParams): ExtendedModelRequest {
-	const { plugin, currentSession, updatedHistory } = params;
+	const {
+		plugin,
+		currentSession,
+		updatedHistory,
+		customPrompt,
+		perTurnContext,
+		projectInstructions,
+		projectSkills,
+		sessionStartedAt,
+	} = params;
 	const modelConfig = currentSession?.modelConfig || {};
 
 	return {
@@ -63,7 +115,12 @@ export function buildRetryRequest(params: RetryRequestParams): ExtendedModelRequ
 		model: modelConfig.model || plugin.settings.chatModelName,
 		temperature: modelConfig.temperature ?? plugin.settings.temperature,
 		topP: modelConfig.topP ?? plugin.settings.topP,
-		prompt: '', // Unused in agent pipeline
+		prompt: '', // Unused in agent pipeline — perTurnContext carries context instead
+		customPrompt,
+		projectInstructions,
+		projectSkills,
+		perTurnContext,
+		sessionStartedAt,
 		renderContent: false,
 	};
 }

--- a/src/ui/agent-view/agent-view-tools.ts
+++ b/src/ui/agent-view/agent-view-tools.ts
@@ -5,6 +5,7 @@ import { IConfirmationProvider, ToolResult } from '../../tools/types';
 import { CustomPrompt } from '../../prompts/types';
 import { AgentLoop } from '../../agent/agent-loop';
 import { AgentViewToolDisplay } from './agent-view-tool-display';
+import type { PerTurnContext } from './agent-view-tool-followup';
 
 /**
  * Callbacks and state access that AgentViewTools needs from AgentView
@@ -54,7 +55,8 @@ export class AgentViewTools {
 		userMessage: string,
 		conversationHistory: any[],
 		_userEntry: GeminiConversationEntry,
-		customPrompt?: CustomPrompt
+		customPrompt?: CustomPrompt,
+		perTurn?: PerTurnContext
 	) {
 		const currentSession = this.context.getCurrentSession();
 		if (!currentSession) return;
@@ -77,6 +79,7 @@ export class AgentViewTools {
 					customPrompt,
 					projectRootPath: activeProject?.rootPath,
 					projectPermissions: activeProject?.config.permissions,
+					perTurn,
 					hooks: {
 						onToolBatchStart: (batch) => {
 							this.ensureGroupContainer(batch.length);

--- a/test/agent/agent-loop.test.ts
+++ b/test/agent/agent-loop.test.ts
@@ -737,6 +737,109 @@ describe('AgentLoop', () => {
 		});
 	});
 
+	describe('per-turn context propagation', () => {
+		// The system prompt is rebuilt on each model call inside the loop. Per-turn
+		// fields (perTurnContext, projectInstructions, projectSkills, sessionStartedAt)
+		// must be threaded onto every follow-up request so the system prompt stays
+		// byte-stable across initial + follow-ups. Without this:
+		//   1. Context-file content the user dragged in disappears once a tool fires,
+		//      forcing the model to re-read via tools.
+		//   2. Gemini implicit prefix cache misses on every follow-up because the
+		//      system-prompt prefix changes shape mid-turn.
+		test('follow-up request carries the same perTurn context the initial call had', async () => {
+			const plugin = buildPlugin();
+			const session = buildSession();
+			const api = makeScriptedModelApi([textResponse('done')]);
+
+			const loop = new AgentLoop();
+			await loop.run({
+				initialResponse: toolResponse([tc('read_file', { path: 'a.md' })]),
+				initialUserMessage: 'q',
+				initialHistory: [],
+				options: {
+					plugin,
+					session,
+					confirmationProvider,
+					isCancelled: () => false,
+					createModelApi: () => api,
+					perTurn: {
+						perTurnContext: 'CONTEXT FILES: foo.md\n<rendered contents>',
+						projectInstructions: 'be concise',
+						projectSkills: ['code-review'],
+						sessionStartedAt: '2026-05-09T10:00:00',
+					},
+				},
+			});
+
+			expect(api.generateModelResponse).toHaveBeenCalledTimes(1);
+			const followUpRequest = (api.generateModelResponse as Mock).mock.calls[0][0];
+			expect(followUpRequest.perTurnContext).toBe('CONTEXT FILES: foo.md\n<rendered contents>');
+			expect(followUpRequest.projectInstructions).toBe('be concise');
+			expect(followUpRequest.projectSkills).toEqual(['code-review']);
+			expect(followUpRequest.sessionStartedAt).toBe('2026-05-09T10:00:00');
+		});
+
+		test('retry request (empty-response path) also carries perTurn context', async () => {
+			const plugin = buildPlugin();
+			const session = buildSession();
+			// First follow-up returns empty → triggers retry path.
+			const api = makeScriptedModelApi([textResponse(''), textResponse('summary text')]);
+
+			const loop = new AgentLoop();
+			const result = await loop.run({
+				initialResponse: toolResponse([tc('read_file', { path: 'a.md' })]),
+				initialUserMessage: 'q',
+				initialHistory: [],
+				options: {
+					plugin,
+					session,
+					confirmationProvider,
+					isCancelled: () => false,
+					createModelApi: () => api,
+					perTurn: {
+						perTurnContext: 'CTX',
+						sessionStartedAt: '2026-05-09T10:00:00',
+					},
+				},
+			});
+
+			expect(result.retried).toBe(true);
+			expect(api.generateModelResponse).toHaveBeenCalledTimes(2);
+			const retryRequest = (api.generateModelResponse as Mock).mock.calls[1][0];
+			expect(retryRequest.perTurnContext).toBe('CTX');
+			expect(retryRequest.sessionStartedAt).toBe('2026-05-09T10:00:00');
+		});
+
+		test('multi-iteration: every follow-up carries perTurn context, not just the first', async () => {
+			const plugin = buildPlugin();
+			const session = buildSession();
+			const api = makeScriptedModelApi([
+				toolResponse([tc('write_file', { path: 'b.md', content: 'x' })]),
+				textResponse('after two batches'),
+			]);
+
+			const loop = new AgentLoop();
+			await loop.run({
+				initialResponse: toolResponse([tc('read_file', { path: 'a.md' })]),
+				initialUserMessage: 'q',
+				initialHistory: [],
+				options: {
+					plugin,
+					session,
+					confirmationProvider,
+					isCancelled: () => false,
+					createModelApi: () => api,
+					perTurn: { perTurnContext: 'CTX' },
+				},
+			});
+
+			const calls = (api.generateModelResponse as Mock).mock.calls;
+			expect(calls).toHaveLength(2);
+			expect(calls[0][0].perTurnContext).toBe('CTX');
+			expect(calls[1][0].perTurnContext).toBe('CTX');
+		});
+	});
+
 	describe('loop-detector escalation', () => {
 		test('aborts the turn once loopDetected fires accumulate past threshold', async () => {
 			const plugin = buildPlugin();

--- a/test/api/gemini-client.test.ts
+++ b/test/api/gemini-client.test.ts
@@ -1,11 +1,23 @@
+import type { Mock } from 'vitest';
 import { GeminiClient, GeminiClientConfig } from '../../src/api/gemini-client';
 import { GeminiPrompts } from '../../src/prompts';
+import type { ExtendedModelRequest } from '../../src/api/interfaces/model-api';
 
-// Mock @google/genai
+// Capture every call to `client.models.generateContent` so tests can assert on
+// the params (system instruction, contents, etc.) the SDK sees. vi.hoisted lets
+// us share the spy with the factory while keeping vitest's mock-hoisting safe.
+const { generateContentMock } = vi.hoisted(() => ({
+	generateContentMock: vi.fn(),
+}));
+
 vi.mock('@google/genai', () => ({
 	GoogleGenAI: vi.fn().mockImplementation(function () {
 		return {
 			getModel: vi.fn(),
+			models: {
+				generateContent: generateContentMock,
+				generateContentStream: vi.fn(),
+			},
 		};
 	}),
 }));
@@ -203,6 +215,67 @@ describe('GeminiClient', () => {
 				expect(testSupportsThinking('my-gemini-3-model')).toBe(true); // contains "gemini-3"
 				expect(testSupportsThinking('custom-thinking-exp-model')).toBe(true); // contains "thinking-exp"
 			});
+		});
+	});
+
+	// Regression coverage for the drag-and-drop / @-mention bug. perTurnContext
+	// carries the rendered content of context-chip files; the GeminiClient
+	// must paste it into the SDK request's `systemInstruction` so the model
+	// can read those files without a redundant tool call. See agent-loop
+	// tests for the follow-up propagation guarantee — this test confirms the
+	// initial-request wiring on the Gemini path.
+	describe('perTurnContext propagation to systemInstruction', () => {
+		beforeEach(() => {
+			generateContentMock.mockReset();
+			generateContentMock.mockResolvedValue({
+				candidates: [{ content: { parts: [{ text: 'ok' }] } }],
+				usageMetadata: { promptTokenCount: 1, candidatesTokenCount: 1, totalTokenCount: 2 },
+			});
+
+			// Stub agentsMemory + skillManager so buildSystemInstruction doesn't NPE.
+			(mockPlugin as any).agentsMemory = { read: vi.fn().mockResolvedValue('') };
+			(mockPlugin as any).skillManager = { getSkillSummaries: vi.fn().mockResolvedValue([]) };
+			(mockPlugin as any).settings = { userName: 'Tester', ragIndexing: { enabled: false } };
+		});
+
+		test('embeds perTurnContext under "## Turn Context" in systemInstruction', async () => {
+			const renderedContext =
+				'CONTEXT FILES: places.md\n\n==============================\nFile Label: Context File\nFile Name: places.md\n==============================\n\nMachu Picchu, Petra, the Great Wall.';
+
+			const request: ExtendedModelRequest = {
+				prompt: '',
+				userMessage: 'list the places',
+				conversationHistory: [],
+				perTurnContext: renderedContext,
+				projectInstructions: 'always cite paths',
+				sessionStartedAt: '2026-05-09T10:00:00',
+			};
+
+			await client.generateModelResponse(request);
+
+			expect(generateContentMock).toHaveBeenCalledTimes(1);
+			const params = (generateContentMock as Mock).mock.calls[0][0];
+			expect(params.config.systemInstruction).toBeTruthy();
+			expect(params.config.systemInstruction).toContain('## Turn Context');
+			expect(params.config.systemInstruction).toContain('Machu Picchu, Petra, the Great Wall.');
+			expect(params.config.systemInstruction).toContain('always cite paths');
+			expect(params.config.systemInstruction).toContain('2026-05-09T10:00:00');
+		});
+
+		test('omits "## Turn Context" section when perTurnContext is empty', async () => {
+			// Without a per-turn context (e.g. a chat with no chip files), the
+			// section should not appear in the system instruction. This guards
+			// against accidentally always-injecting an empty heading that would
+			// shift the prefix bytes Gemini's implicit cache keys on.
+			await client.generateModelResponse({
+				prompt: '',
+				userMessage: 'just chat',
+				conversationHistory: [],
+			});
+
+			expect(generateContentMock).toHaveBeenCalledTimes(1);
+			const params = (generateContentMock as Mock).mock.calls[0][0];
+			expect(params.config.systemInstruction).not.toContain('## Turn Context');
 		});
 	});
 });

--- a/test/api/ollama-client.test.ts
+++ b/test/api/ollama-client.test.ts
@@ -186,6 +186,42 @@ describe('OllamaClient', () => {
 			expect(userTurn.images).toEqual(['b64data']);
 		});
 
+		// Regression test for the drag-and-drop / @-mention bug fixed in
+		// the perTurnContext-on-followup PR. perTurnContext is the rendered
+		// content of context-chip files; the OllamaClient must paste it into
+		// the system message under "## Turn Context" so the model can read
+		// dropped/@-mentioned files without a redundant `read_file` tool call.
+		// This test asserts the wiring on the initial request — see
+		// agent-loop.test.ts for the follow-up propagation guarantee.
+		it('embeds perTurnContext into the system message under "## Turn Context"', async () => {
+			ollamaCalls.chat.mockResolvedValue({
+				message: { role: 'assistant', content: 'ok' },
+				prompt_eval_count: 1,
+				eval_count: 1,
+				done: true,
+			});
+
+			const renderedContext =
+				'CONTEXT FILES: foo.md\n\n==============================\nFile Label: Context File\nFile Name: foo.md\n==============================\n\nThe quick brown fox jumps over the lazy dog.';
+
+			await client.generateModelResponse({
+				prompt: '',
+				userMessage: 'what does the file say',
+				conversationHistory: [],
+				perTurnContext: renderedContext,
+				projectInstructions: 'always cite file paths',
+				sessionStartedAt: '2026-05-09T10:00:00',
+			});
+
+			const args = ollamaCalls.chat.mock.calls[0][0];
+			const systemMessage = args.messages.find((m: any) => m.role === 'system');
+			expect(systemMessage).toBeDefined();
+			expect(systemMessage.content).toContain('## Turn Context');
+			expect(systemMessage.content).toContain('The quick brown fox jumps over the lazy dog.');
+			expect(systemMessage.content).toContain('always cite file paths');
+			expect(systemMessage.content).toContain('2026-05-09T10:00:00');
+		});
+
 		it('rejects non-image attachments with a clear error', async () => {
 			await expect(
 				client.generateModelResponse({


### PR DESCRIPTION
## Summary

Drag-and-drop / @-mention context files were rendered into `perTurnContext` on the initial model call but disappeared from every follow-up after a tool fired, because `buildFollowUpRequest` only plumbed `customPrompt` and tool-permission fields through.

Two consequences for the user:

1. Once the model called any tool, its system prompt was rebuilt without the rendered context-file content (and without `projectInstructions` / `projectSkills`), so the model couldn't reference the dragged file anymore — it tended to re-read the same file via tools, which looked like the chip was being ignored.
2. Gemini's implicit prefix cache keys on the exact system-prompt bytes. Stripping these fields between the initial call and the follow-up changed the prefix shape mid-turn, forcing a cache miss on every follow-up in long tool chains.

This was provider-agnostic — same code path on both Gemini and Ollama. It just became visible on Ollama because gemma readily falls back to `read_file` and on Gemini it mostly cost cache hits silently.

## Verification

Live capture against `gemma4:latest`:

| | Before | After |
|---|---|---|
| Initial system-prompt size | 31635 | 31635 |
| Follow-up system-prompt size | 25020 (-6.6 KB) | 31635 |
| `## Turn Context` heading in follow-up | absent | present |
| Rendered context-file contents in follow-up | absent | present |
| Initial vs. follow-up byte-identical | no | **yes** |

End-to-end eval (`context-from-shelf`) on `gemma4:latest`: SOLVED in 1 turn / 0 tool calls.

## Changes

**Fix**

- New `PerTurnContext` interface in `agent-view-tool-followup.ts` — the four fields that must stay byte-stable across the turn.
- `buildFollowUpRequest` and `buildRetryRequest` now extend `PerTurnContext` and pass the fields through.
- `AgentLoopOptions` gains `perTurn?: PerTurnContext`; `AgentLoop.run` spreads it onto the helper params.
- `AgentViewTools.handleToolCalls` accepts and forwards `perTurn` to the loop.
- `agent-view-send.ts` builds the `perTurn` object once and passes it to both `handleToolCalls` call sites (streaming + non-streaming).

`inlineAttachments` deliberately not threaded through — they belong to the user's original turn and would create empty-content user messages on follow-ups.

**Regression coverage** (added in second commit)

Three layers so this can't silently regress again:

1. `test/agent/agent-loop.test.ts` — 3 tests covering follow-up propagation, empty-response retry propagation, and multi-iteration tool chains. All four perTurn fields verified.
2. `test/api/ollama-client.test.ts` — asserts `perTurnContext` lands in the system message under `## Turn Context` on the wire to the Ollama daemon.
3. `test/api/gemini-client.test.ts` — captures the SDK's `generateContent` params and asserts `perTurnContext` is in `config.systemInstruction`. Also pins the negative case so the section doesn't appear when no context is set (cache-prefix stability).
4. `evals/tasks/context-from-shelf.json` (new) — full end-to-end task. New `addContextFiles()` driver helper threads a vault file onto the agent shelf via the same `addContextFileToShelf` API drag-drop uses, then asks a question answerable only from that file. Forbids `read_file` / `find_files_*` / `list_files` so a model that ignores the in-context content has nowhere to fall back.

Together: user message → agent-view-send → AgentLoop → {Gemini|Ollama}Client → follow-up → retry, all instrumented.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer (interactively diagnosed)
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards) — pure agent-loop plumbing, no platform-gated code touched
- [x] Documentation has been updated (if applicable) — internal plumbing only, no user-facing doc surface
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

## Test plan

- [x] `npm test` — 1685 passing (3 agent-loop + 1 Ollama + 2 Gemini new)
- [x] `npm run build` — clean
- [x] `npm run format-check` — clean
- [x] Live verification: dragged file → asked question → captured Ollama payload shows initial + follow-up system prompts byte-identical (31635 == 31635)
- [x] `npm run eval -- --task=context-from-shelf` — SOLVED in 1 turn / 0 tool calls on `gemma4:latest`