### PR TITLE
chore(evals): bless ollama-gemma4-latest baseline

### DIFF
--- a/evals/baselines/ollama-gemma4-latest.NOTES.md
+++ b/evals/baselines/ollama-gemma4-latest.NOTES.md
@@ -1,0 +1,62 @@
+# Baseline: ollama-gemma4-latest
+
+This baseline was blessed against the **`:latest`** tag, which the
+eval-harness skill flags as an anti-pattern: the tag's digest can move
+under the baseline if the operator runs `ollama pull gemma4` later, and
+a future "regression" report could just be a model swap.
+
+We accepted that tradeoff for this baseline (no `gemma4:8b-q4` tag exists
+locally yet). The notes below let a future operator detect drift on
+inspection.
+
+## Snapshot at bless time
+
+| Field             | Value                                                                     |
+| ----------------- | ------------------------------------------------------------------------- |
+| Bless date (UTC)  | 2026-05-10T01:04:13Z                                                      |
+| Plugin git SHA    | `6eb4b2a`                                                                 |
+| Tag               | `gemma4:latest`                                                           |
+| Manifest digest   | `c6eb396dbd59`                                                            |
+| Weights blob      | `sha256-4c27e0f5b5adf02ac956c7322bd2ee7636fe3f45a8512c9aba5385242cb6e09a` |
+| Architecture      | gemma4                                                                    |
+| Parameters        | 8.0B                                                                      |
+| Quantization      | Q4_K_M                                                                    |
+| Context length    | 131072                                                                    |
+| Embedding length  | 2560                                                                      |
+| Required Ollama   | ≥ 0.20.0                                                                  |
+| Capabilities      | completion, vision, audio, tools, thinking                                |
+| Sampling defaults | `temperature=1`, `top_k=64`, `top_p=0.95`                                 |
+
+## How to verify before trusting a comparison
+
+```bash
+ollama show gemma4:latest | grep -E "parameters|quantization"
+# Expect: parameters 8.0B, quantization Q4_K_M
+
+# Confirm the manifest digest matches the snapshot above:
+curl -s http://localhost:11434/api/tags \
+  | jq '.models[] | select(.name=="gemma4:latest") | .digest'
+# Expect prefix: c6eb396dbd59
+```
+
+If either check disagrees with this file, the `:latest` tag has been
+re-pulled. Don't trust the comparison until you re-bless or re-pin the
+baseline filename to a stable tag.
+
+## Run summary at bless time
+
+```
+Tasks:    8 × 3 runs = 24 total
+pass^3:   100%   (mean 100%)
+solve^3:  62.5%  (mean 79.2%)
+Flaky:    2 (create-note-from-search, loop-trap-cyclic-refs)
+Failing:  multi-file-summary (0/3 solved — judge matcher rejects)
+Mean turns: 3.1 (p95: 7)
+Cost:     $0.00 (Ollama)
+```
+
+## Next baseline
+
+Pull a stable tag (`ollama cp gemma4:latest gemma4:8b-q4`), point the
+plugin's `chatModelName` at it, and bless under `ollama-gemma4-8b-q4.json`.
+That kills the anti-pattern and this NOTES file becomes redundant.

--- a/evals/baselines/ollama-gemma4-latest.json
+++ b/evals/baselines/ollama-gemma4-latest.json
@@ -1,0 +1,800 @@
+{
+	"run_id": "2026-05-10T01:03:37.777Z",
+	"git_sha": "6eb4b2a",
+	"model": "gemma4:latest",
+	"provider": "ollama",
+	"tasks": [
+		{
+			"id": "context-from-shelf",
+			"n_runs": 3,
+			"passed_count": 3,
+			"solved_count": 3,
+			"pass_k": true,
+			"solve_k": true,
+			"flaky": false,
+			"metrics": {
+				"turns": 1,
+				"tool_calls": 0,
+				"prompt_tokens": 9347,
+				"cached_tokens": 0,
+				"cache_ratio": null,
+				"output_tokens": 228.666667,
+				"cost_usd": 0,
+				"loop_fires": 0,
+				"duration_ms": 11408.666667
+			},
+			"runs": [
+				{
+					"id": "context-from-shelf",
+					"passed": true,
+					"solved": true,
+					"metrics": {
+						"turns": 1,
+						"tool_calls": 0,
+						"prompt_tokens": 9347,
+						"cached_tokens": null,
+						"cache_ratio": null,
+						"output_tokens": 191,
+						"cost_usd": 0,
+						"loop_fires": 0,
+						"duration_ms": 12081,
+						"tool_list": []
+					},
+					"errors": [],
+					"solve_details": {
+						"expected_tools_met": true,
+						"forbidden_tools_clean": true,
+						"matchers_pass": true,
+						"judge_attempted": false,
+						"judge_available": false
+					}
+				},
+				{
+					"id": "context-from-shelf",
+					"passed": true,
+					"solved": true,
+					"metrics": {
+						"turns": 1,
+						"tool_calls": 0,
+						"prompt_tokens": 9347,
+						"cached_tokens": null,
+						"cache_ratio": null,
+						"output_tokens": 327,
+						"cost_usd": 0,
+						"loop_fires": 0,
+						"duration_ms": 12077,
+						"tool_list": []
+					},
+					"errors": [],
+					"solve_details": {
+						"expected_tools_met": true,
+						"forbidden_tools_clean": true,
+						"matchers_pass": true,
+						"judge_attempted": false,
+						"judge_available": false
+					}
+				},
+				{
+					"id": "context-from-shelf",
+					"passed": true,
+					"solved": true,
+					"metrics": {
+						"turns": 1,
+						"tool_calls": 0,
+						"prompt_tokens": 9347,
+						"cached_tokens": null,
+						"cache_ratio": null,
+						"output_tokens": 168,
+						"cost_usd": 0,
+						"loop_fires": 0,
+						"duration_ms": 10068,
+						"tool_list": []
+					},
+					"errors": [],
+					"solve_details": {
+						"expected_tools_met": true,
+						"forbidden_tools_clean": true,
+						"matchers_pass": true,
+						"judge_attempted": false,
+						"judge_available": false
+					}
+				}
+			]
+		},
+		{
+			"id": "create-note-from-search",
+			"n_runs": 3,
+			"passed_count": 3,
+			"solved_count": 2,
+			"pass_k": true,
+			"solve_k": false,
+			"flaky": true,
+			"metrics": {
+				"turns": 4,
+				"tool_calls": 3.666667,
+				"prompt_tokens": 14626.666667,
+				"cached_tokens": 0,
+				"cache_ratio": null,
+				"output_tokens": 1068.666667,
+				"cost_usd": 0,
+				"loop_fires": 0,
+				"duration_ms": 28838.666667
+			},
+			"runs": [
+				{
+					"id": "create-note-from-search",
+					"passed": true,
+					"solved": true,
+					"metrics": {
+						"turns": 7,
+						"tool_calls": 6,
+						"prompt_tokens": 10285,
+						"cached_tokens": null,
+						"cache_ratio": null,
+						"output_tokens": 1090,
+						"cost_usd": 0,
+						"loop_fires": 0,
+						"duration_ms": 24129,
+						"tool_list": ["list_files", "read_file", "read_file", "read_file", "read_file", "write_file"]
+					},
+					"errors": [],
+					"solve_details": {
+						"expected_tools_met": true,
+						"forbidden_tools_clean": true,
+						"matchers_pass": true,
+						"judge_attempted": false,
+						"judge_available": false
+					}
+				},
+				{
+					"id": "create-note-from-search",
+					"passed": true,
+					"solved": false,
+					"metrics": {
+						"turns": 1,
+						"tool_calls": 0,
+						"prompt_tokens": 9064,
+						"cached_tokens": null,
+						"cache_ratio": null,
+						"output_tokens": 376,
+						"cost_usd": 0,
+						"loop_fires": 0,
+						"duration_ms": 12092,
+						"tool_list": []
+					},
+					"errors": [],
+					"solve_details": {
+						"expected_tools_met": false,
+						"forbidden_tools_clean": true,
+						"matchers_pass": false,
+						"judge_attempted": false,
+						"judge_available": false
+					}
+				},
+				{
+					"id": "create-note-from-search",
+					"passed": true,
+					"solved": true,
+					"metrics": {
+						"turns": 4,
+						"tool_calls": 5,
+						"prompt_tokens": 24531,
+						"cached_tokens": null,
+						"cache_ratio": null,
+						"output_tokens": 1740,
+						"cost_usd": 0,
+						"loop_fires": 0,
+						"duration_ms": 50295,
+						"tool_list": ["find_files_by_content", "read_file", "read_file", "read_file", "write_file"]
+					},
+					"errors": [],
+					"solve_details": {
+						"expected_tools_met": true,
+						"forbidden_tools_clean": true,
+						"matchers_pass": true,
+						"judge_attempted": false,
+						"judge_available": false
+					}
+				}
+			]
+		},
+		{
+			"id": "find-tagged-notes",
+			"n_runs": 3,
+			"passed_count": 3,
+			"solved_count": 3,
+			"pass_k": true,
+			"solve_k": true,
+			"flaky": false,
+			"metrics": {
+				"turns": 4.333333,
+				"tool_calls": 4.333333,
+				"prompt_tokens": 9796,
+				"cached_tokens": 0,
+				"cache_ratio": null,
+				"output_tokens": 1377,
+				"cost_usd": 0,
+				"loop_fires": 0,
+				"duration_ms": 28168.666667
+			},
+			"runs": [
+				{
+					"id": "find-tagged-notes",
+					"passed": true,
+					"solved": true,
+					"metrics": {
+						"turns": 3,
+						"tool_calls": 2,
+						"prompt_tokens": 9371,
+						"cached_tokens": null,
+						"cache_ratio": null,
+						"output_tokens": 1129,
+						"cost_usd": 0,
+						"loop_fires": 0,
+						"duration_ms": 24154,
+						"tool_list": ["find_files_by_content", "list_files"]
+					},
+					"errors": [],
+					"solve_details": {
+						"expected_tools_met": true,
+						"forbidden_tools_clean": true,
+						"matchers_pass": true,
+						"judge_attempted": false,
+						"judge_available": false
+					}
+				},
+				{
+					"id": "find-tagged-notes",
+					"passed": true,
+					"solved": true,
+					"metrics": {
+						"turns": 3,
+						"tool_calls": 5,
+						"prompt_tokens": 9969,
+						"cached_tokens": null,
+						"cache_ratio": null,
+						"output_tokens": 844,
+						"cost_usd": 0,
+						"loop_fires": 0,
+						"duration_ms": 22144,
+						"tool_list": ["list_files", "read_file", "read_file", "read_file", "read_file"]
+					},
+					"errors": [],
+					"solve_details": {
+						"expected_tools_met": true,
+						"forbidden_tools_clean": true,
+						"matchers_pass": true,
+						"judge_attempted": false,
+						"judge_available": false
+					}
+				},
+				{
+					"id": "find-tagged-notes",
+					"passed": true,
+					"solved": true,
+					"metrics": {
+						"turns": 7,
+						"tool_calls": 6,
+						"prompt_tokens": 10048,
+						"cached_tokens": null,
+						"cache_ratio": null,
+						"output_tokens": 2158,
+						"cost_usd": 0,
+						"loop_fires": 0,
+						"duration_ms": 38208,
+						"tool_list": ["find_files_by_content", "list_files", "read_file", "read_file", "read_file", "read_file"]
+					},
+					"errors": [],
+					"solve_details": {
+						"expected_tools_met": true,
+						"forbidden_tools_clean": true,
+						"matchers_pass": true,
+						"judge_attempted": false,
+						"judge_available": false
+					}
+				}
+			]
+		},
+		{
+			"id": "loop-trap-cyclic-refs",
+			"n_runs": 3,
+			"passed_count": 3,
+			"solved_count": 2,
+			"pass_k": true,
+			"solve_k": false,
+			"flaky": true,
+			"metrics": {
+				"turns": 4,
+				"tool_calls": 3,
+				"prompt_tokens": 10050.666667,
+				"cached_tokens": 0,
+				"cache_ratio": null,
+				"output_tokens": 863.666667,
+				"cost_usd": 0,
+				"loop_fires": 0,
+				"duration_ms": 28230.666667
+			},
+			"runs": [
+				{
+					"id": "loop-trap-cyclic-refs",
+					"passed": true,
+					"solved": true,
+					"metrics": {
+						"turns": 4,
+						"tool_calls": 3,
+						"prompt_tokens": 10048,
+						"cached_tokens": null,
+						"cache_ratio": null,
+						"output_tokens": 599,
+						"cost_usd": 0,
+						"loop_fires": 0,
+						"duration_ms": 20129,
+						"tool_list": ["list_files", "read_file", "read_file"]
+					},
+					"errors": [],
+					"solve_details": {
+						"expected_tools_met": true,
+						"forbidden_tools_clean": true,
+						"matchers_pass": true,
+						"judge_attempted": false,
+						"judge_available": false
+					}
+				},
+				{
+					"id": "loop-trap-cyclic-refs",
+					"passed": true,
+					"solved": false,
+					"metrics": {
+						"turns": 4,
+						"tool_calls": 3,
+						"prompt_tokens": 10052,
+						"cached_tokens": null,
+						"cache_ratio": null,
+						"output_tokens": 822,
+						"cost_usd": 0,
+						"loop_fires": 0,
+						"duration_ms": 30270,
+						"tool_list": ["list_files", "read_file", "read_file"]
+					},
+					"errors": [],
+					"solve_details": {
+						"expected_tools_met": true,
+						"forbidden_tools_clean": true,
+						"matchers_pass": false,
+						"judge_attempted": false,
+						"judge_available": false
+					}
+				},
+				{
+					"id": "loop-trap-cyclic-refs",
+					"passed": true,
+					"solved": true,
+					"metrics": {
+						"turns": 4,
+						"tool_calls": 3,
+						"prompt_tokens": 10052,
+						"cached_tokens": null,
+						"cache_ratio": null,
+						"output_tokens": 1170,
+						"cost_usd": 0,
+						"loop_fires": 0,
+						"duration_ms": 34293,
+						"tool_list": ["list_files", "read_file", "read_file"]
+					},
+					"errors": [],
+					"solve_details": {
+						"expected_tools_met": true,
+						"forbidden_tools_clean": true,
+						"matchers_pass": true,
+						"judge_attempted": false,
+						"judge_available": false
+					}
+				}
+			]
+		},
+		{
+			"id": "multi-file-summary",
+			"n_runs": 3,
+			"passed_count": 3,
+			"solved_count": 0,
+			"pass_k": true,
+			"solve_k": false,
+			"flaky": false,
+			"metrics": {
+				"turns": 3,
+				"tool_calls": 4,
+				"prompt_tokens": 9786,
+				"cached_tokens": 0,
+				"cache_ratio": null,
+				"output_tokens": 621,
+				"cost_usd": 0,
+				"loop_fires": 0,
+				"duration_ms": 22825.666667
+			},
+			"runs": [
+				{
+					"id": "multi-file-summary",
+					"passed": true,
+					"solved": false,
+					"metrics": {
+						"turns": 3,
+						"tool_calls": 4,
+						"prompt_tokens": 9786,
+						"cached_tokens": null,
+						"cache_ratio": null,
+						"output_tokens": 486,
+						"cost_usd": 0,
+						"loop_fires": 0,
+						"duration_ms": 18150,
+						"tool_list": ["list_files", "read_file", "read_file", "read_file"]
+					},
+					"errors": [],
+					"solve_details": {
+						"expected_tools_met": true,
+						"forbidden_tools_clean": true,
+						"matchers_pass": false,
+						"judge_attempted": true,
+						"judge_available": false
+					}
+				},
+				{
+					"id": "multi-file-summary",
+					"passed": true,
+					"solved": false,
+					"metrics": {
+						"turns": 3,
+						"tool_calls": 4,
+						"prompt_tokens": 9786,
+						"cached_tokens": null,
+						"cache_ratio": null,
+						"output_tokens": 700,
+						"cost_usd": 0,
+						"loop_fires": 0,
+						"duration_ms": 26169,
+						"tool_list": ["list_files", "read_file", "read_file", "read_file"]
+					},
+					"errors": [],
+					"solve_details": {
+						"expected_tools_met": true,
+						"forbidden_tools_clean": true,
+						"matchers_pass": false,
+						"judge_attempted": true,
+						"judge_available": false
+					}
+				},
+				{
+					"id": "multi-file-summary",
+					"passed": true,
+					"solved": false,
+					"metrics": {
+						"turns": 3,
+						"tool_calls": 4,
+						"prompt_tokens": 9786,
+						"cached_tokens": null,
+						"cache_ratio": null,
+						"output_tokens": 677,
+						"cost_usd": 0,
+						"loop_fires": 0,
+						"duration_ms": 24158,
+						"tool_list": ["list_files", "read_file", "read_file", "read_file"]
+					},
+					"errors": [],
+					"solve_details": {
+						"expected_tools_met": true,
+						"forbidden_tools_clean": true,
+						"matchers_pass": false,
+						"judge_attempted": true,
+						"judge_available": false
+					}
+				}
+			]
+		},
+		{
+			"id": "multi-hop-retrieval",
+			"n_runs": 3,
+			"passed_count": 3,
+			"solved_count": 3,
+			"pass_k": true,
+			"solve_k": true,
+			"flaky": false,
+			"metrics": {
+				"turns": 4.333333,
+				"tool_calls": 3.333333,
+				"prompt_tokens": 10317.333333,
+				"cached_tokens": 0,
+				"cache_ratio": null,
+				"output_tokens": 797,
+				"cost_usd": 0,
+				"loop_fires": 0,
+				"duration_ms": 25494.666667
+			},
+			"runs": [
+				{
+					"id": "multi-hop-retrieval",
+					"passed": true,
+					"solved": true,
+					"metrics": {
+						"turns": 4,
+						"tool_calls": 3,
+						"prompt_tokens": 10283,
+						"cached_tokens": null,
+						"cache_ratio": null,
+						"output_tokens": 909,
+						"cost_usd": 0,
+						"loop_fires": 0,
+						"duration_ms": 28173,
+						"tool_list": ["list_files", "read_file", "read_file"]
+					},
+					"errors": [],
+					"solve_details": {
+						"expected_tools_met": true,
+						"forbidden_tools_clean": true,
+						"matchers_pass": true,
+						"judge_attempted": false,
+						"judge_available": false
+					}
+				},
+				{
+					"id": "multi-hop-retrieval",
+					"passed": true,
+					"solved": true,
+					"metrics": {
+						"turns": 5,
+						"tool_calls": 4,
+						"prompt_tokens": 10386,
+						"cached_tokens": null,
+						"cache_ratio": null,
+						"output_tokens": 926,
+						"cost_usd": 0,
+						"loop_fires": 0,
+						"duration_ms": 26163,
+						"tool_list": ["find_files_by_content", "list_files", "read_file", "read_file"]
+					},
+					"errors": [],
+					"solve_details": {
+						"expected_tools_met": true,
+						"forbidden_tools_clean": true,
+						"matchers_pass": true,
+						"judge_attempted": false,
+						"judge_available": false
+					}
+				},
+				{
+					"id": "multi-hop-retrieval",
+					"passed": true,
+					"solved": true,
+					"metrics": {
+						"turns": 4,
+						"tool_calls": 3,
+						"prompt_tokens": 10283,
+						"cached_tokens": null,
+						"cache_ratio": null,
+						"output_tokens": 556,
+						"cost_usd": 0,
+						"loop_fires": 0,
+						"duration_ms": 22148,
+						"tool_list": ["list_files", "read_file", "read_file"]
+					},
+					"errors": [],
+					"solve_details": {
+						"expected_tools_met": true,
+						"forbidden_tools_clean": true,
+						"matchers_pass": true,
+						"judge_attempted": false,
+						"judge_available": false
+					}
+				}
+			]
+		},
+		{
+			"id": "read-and-answer",
+			"n_runs": 3,
+			"passed_count": 3,
+			"solved_count": 3,
+			"pass_k": true,
+			"solve_k": true,
+			"flaky": false,
+			"metrics": {
+				"turns": 2,
+				"tool_calls": 1,
+				"prompt_tokens": 9243,
+				"cached_tokens": 0,
+				"cache_ratio": null,
+				"output_tokens": 136.666667,
+				"cost_usd": 0,
+				"loop_fires": 0,
+				"duration_ms": 14814.666667
+			},
+			"runs": [
+				{
+					"id": "read-and-answer",
+					"passed": true,
+					"solved": true,
+					"metrics": {
+						"turns": 2,
+						"tool_calls": 1,
+						"prompt_tokens": 9243,
+						"cached_tokens": null,
+						"cache_ratio": null,
+						"output_tokens": 171,
+						"cost_usd": 0,
+						"loop_fires": 0,
+						"duration_ms": 16117,
+						"tool_list": ["read_file"]
+					},
+					"errors": [],
+					"solve_details": {
+						"expected_tools_met": true,
+						"forbidden_tools_clean": true,
+						"matchers_pass": true,
+						"judge_attempted": false,
+						"judge_available": false
+					}
+				},
+				{
+					"id": "read-and-answer",
+					"passed": true,
+					"solved": true,
+					"metrics": {
+						"turns": 2,
+						"tool_calls": 1,
+						"prompt_tokens": 9243,
+						"cached_tokens": null,
+						"cache_ratio": null,
+						"output_tokens": 187,
+						"cost_usd": 0,
+						"loop_fires": 0,
+						"duration_ms": 16222,
+						"tool_list": ["read_file"]
+					},
+					"errors": [],
+					"solve_details": {
+						"expected_tools_met": true,
+						"forbidden_tools_clean": true,
+						"matchers_pass": true,
+						"judge_attempted": false,
+						"judge_available": false
+					}
+				},
+				{
+					"id": "read-and-answer",
+					"passed": true,
+					"solved": true,
+					"metrics": {
+						"turns": 2,
+						"tool_calls": 1,
+						"prompt_tokens": 9243,
+						"cached_tokens": null,
+						"cache_ratio": null,
+						"output_tokens": 52,
+						"cost_usd": 0,
+						"loop_fires": 0,
+						"duration_ms": 12105,
+						"tool_list": ["read_file"]
+					},
+					"errors": [],
+					"solve_details": {
+						"expected_tools_met": true,
+						"forbidden_tools_clean": true,
+						"matchers_pass": true,
+						"judge_attempted": false,
+						"judge_available": false
+					}
+				}
+			]
+		},
+		{
+			"id": "smoke-list-files",
+			"n_runs": 3,
+			"passed_count": 3,
+			"solved_count": 3,
+			"pass_k": true,
+			"solve_k": true,
+			"flaky": false,
+			"metrics": {
+				"turns": 2,
+				"tool_calls": 1,
+				"prompt_tokens": 9195,
+				"cached_tokens": 0,
+				"cache_ratio": null,
+				"output_tokens": 166.333333,
+				"cost_usd": 0,
+				"loop_fires": 0,
+				"duration_ms": 14772.666667
+			},
+			"runs": [
+				{
+					"id": "smoke-list-files",
+					"passed": true,
+					"solved": true,
+					"metrics": {
+						"turns": 2,
+						"tool_calls": 1,
+						"prompt_tokens": 9195,
+						"cached_tokens": null,
+						"cache_ratio": null,
+						"output_tokens": 57,
+						"cost_usd": 0,
+						"loop_fires": 0,
+						"duration_ms": 14110,
+						"tool_list": ["find_files_by_name"]
+					},
+					"errors": [],
+					"solve_details": {
+						"expected_tools_met": true,
+						"forbidden_tools_clean": true,
+						"matchers_pass": true,
+						"judge_attempted": false,
+						"judge_available": false
+					}
+				},
+				{
+					"id": "smoke-list-files",
+					"passed": true,
+					"solved": true,
+					"metrics": {
+						"turns": 2,
+						"tool_calls": 1,
+						"prompt_tokens": 9195,
+						"cached_tokens": null,
+						"cache_ratio": null,
+						"output_tokens": 208,
+						"cost_usd": 0,
+						"loop_fires": 0,
+						"duration_ms": 14103,
+						"tool_list": ["find_files_by_name"]
+					},
+					"errors": [],
+					"solve_details": {
+						"expected_tools_met": true,
+						"forbidden_tools_clean": true,
+						"matchers_pass": true,
+						"judge_attempted": false,
+						"judge_available": false
+					}
+				},
+				{
+					"id": "smoke-list-files",
+					"passed": true,
+					"solved": true,
+					"metrics": {
+						"turns": 2,
+						"tool_calls": 1,
+						"prompt_tokens": 9195,
+						"cached_tokens": null,
+						"cache_ratio": null,
+						"output_tokens": 234,
+						"cost_usd": 0,
+						"loop_fires": 0,
+						"duration_ms": 16105,
+						"tool_list": ["find_files_by_name"]
+					},
+					"errors": [],
+					"solve_details": {
+						"expected_tools_met": true,
+						"forbidden_tools_clean": true,
+						"matchers_pass": true,
+						"judge_attempted": false,
+						"judge_available": false
+					}
+				}
+			]
+		}
+	],
+	"aggregate": {
+		"total_tasks": 8,
+		"n_runs": 3,
+		"total_runs": 24,
+		"pass_k_rate": 100,
+		"solve_k_rate": 62.5,
+		"mean_pass_rate": 100,
+		"mean_solve_rate": 79.2,
+		"flaky_task_count": 2,
+		"mean_turns": 3.1,
+		"p95_turns": 7,
+		"mean_cache_ratio": null,
+		"mean_cost_usd": 0,
+		"total_cost_usd": 0,
+		"total_loop_fires": 0
+	}
+}


### PR DESCRIPTION
## Summary

24-run sweep (8 tasks × 3 reps) against `gemma4:latest` at git `6eb4b2a`:

| Metric | Value |
| --- | --- |
| pass^3 | 100% (mean 100%) |
| solve^3 | 62.5% (mean 79.2%) |
| Flaky tasks | create-note-from-search, loop-trap-cyclic-refs (2/3 each) |
| Failing | multi-file-summary (0/3 — judge matcher rejection) |
| Mean turns | 3.1 (p95: 7) |
| Total cost | $0 (Ollama) |
| Wall-clock | ~17 min |

The new `context-from-shelf` task (regression coverage from #784) went **3/3 SOLVED in 1 turn / 0 tool calls** — the model answers from `perTurnContext` directly, exactly as the fix intends. That makes this the first baseline to lock in correct context-chip behavior on a local model.

## Per-task results

| Task | Pass | Solve | Mean turns |
| --- | --- | --- | --- |
| context-from-shelf | 3/3 | 3/3 | 1.0 |
| create-note-from-search | 3/3 | 2/3 ⚠ | 4.0 |
| find-tagged-notes | 3/3 | 3/3 | 4.3 |
| loop-trap-cyclic-refs | 3/3 | 2/3 ⚠ | 4.0 |
| multi-file-summary | 3/3 | 0/3 | 3.0 |
| multi-hop-retrieval | 3/3 | 3/3 | 4.3 |
| read-and-answer | 3/3 | 3/3 | 2.0 |
| smoke-list-files | 3/3 | 3/3 | 2.0 |

## `*-latest` anti-pattern, acknowledged

The eval-harness skill flags `*-latest` baselines as an anti-pattern: the digest under `gemma4:latest` can move if the operator runs `ollama pull gemma4` later, and a future "regression" report could just be a silent model swap.

We accepted that tradeoff for this baseline (no stable `gemma4:8b-q4` tag exists locally yet). The companion `ollama-gemma4-latest.NOTES.md` records today's:

- Manifest digest: `c6eb396dbd59`
- Weights blob: `sha256-4c27e0f5b5adf02ac956c7322bd2ee7636fe3f45a8512c9aba5385242cb6e09a`
- Quantization: Q4_K_M, 8.0B params, 131072 context

…with verification commands so a future operator can detect drift before trusting a comparison. Next baseline cycle should pin to a stable tag (`ollama cp gemma4:latest gemma4:8b-q4`) and bless under `ollama-gemma4-8b-q4.json`.

## Changes

- `evals/baselines/ollama-gemma4-latest.json` — blessed via `npm run eval:bless` from `evals/results/2026-05-10T01-03-37-777Z.json`
- `evals/baselines/ollama-gemma4-latest.NOTES.md` — digest + verification snapshot

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] All CI checks pass — N/A, no source/test changes
- [x] I have tested this change on Desktop — full live eval sweep was the test
- [ ] I have verified this change does not break Mobile — N/A, baseline data file only
- [x] Documentation has been updated (if applicable) — NOTES.md companion file

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

## Test plan

- [x] `npm run eval` ran cleanly (24/24 runs, no ERROR / TIMEOUT / manual-kill)
- [x] No collector leak post-run (`window.__evalCollector` undefined)
- [x] `npm run eval:bless` wrote to expected baseline path
- [x] Plugin's `chatModelName` was `gemma4:latest` throughout the sweep

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added baseline evaluation notes for Ollama Gemma4:latest, including model snapshot metadata and verification instructions.

* **Tests**
  * Added baseline evaluation results for Ollama Gemma4:latest with performance metrics across evaluation tasks.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/allenhutchison/obsidian-gemini/pull/787)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->