### PR TITLE
chore(daily): 2026-05-09 daily update

### DIFF
--- a/planning/changelog/2026-05-09.md
+++ b/planning/changelog/2026-05-09.md
@@ -1,0 +1,48 @@
+# Daily changelog — May 9, 2026
+
+**Date:** 2026-05-09
+**PRs merged:** 9
+
+---
+
+## Summary
+
+A productive day anchored by two substantial agent-loop correctness fixes: context chips now survive into follow-up requests after tool calls (#784), and session history finally records which model produced each response (#786). Alongside those, the eval harness got its first blessed baselines and a trio of reliability fixes (collector cleanup on interrupt, SIGKILL escalation for hung CLI children, and an Ollama/gemma4 baseline). A security dependency bump and docs links rounded out the day.
+
+## What shipped
+
+### [#775 chore(deps): bump fast-uri from 3.1.0 to 3.1.2](https://github.com/allenhutchison/obsidian-gemini/pull/775)
+
+Security patch from Dependabot: fast-uri 3.1.2 addresses two advisories (GHSA-v39h-62p7-jpjc and GHSA-q3j6-qgpj-74h6) covering malformed fragment decoding. No behavior change for the plugin.
+
+### [#779 chore(daily): 2026-05-09 daily update](https://github.com/allenhutchison/obsidian-gemini/pull/779)
+
+Automated daily housekeeping run covering 2026-05-08: changelog for that day (context-management heavy — tool-result truncation and two-phase compaction), plus an audit-docs fix for an invalid `read_write` tool category in the lifecycle-hooks example (correct value: `vault_ops`).
+
+### [#774 chore(evals): bless first baselines + add eval-harness skill](https://github.com/allenhutchison/obsidian-gemini/pull/774)
+
+First eval baselines since the auto-compare workflow landed in #717. Two pinned-version Gemini models captured against the post-truncation state of the agent loop: `gemini-3-flash-preview` (71.4% solve^3, 66% cache hit rate) and `gemini-2.5-flash` (57.1% solve^3, 35% cache hit). Also introduces `.agents/skills/eval-harness/SKILL.md`, which codifies the hard-won runtime lessons from the baselining session: single-tenant rule, preflight cleanup, SIGTERM workarounds, bless gate criteria, and the anti-pattern of blessing against `*-latest` tags. `evals/README.md` gains a new "Operational gotchas" section.
+
+### [#780 fix(evals): remove collector when interrupted (#777)](https://github.com/allenhutchison/obsidian-gemini/pull/780)
+
+Closes #777. When the eval harness exits via `process.exit()` from `handleInterrupt`, the `finally` block that calls `removeCollector()` does not run, leaving `window.__evalCollector` and ~6 event subscribers alive until the plugin reloads. The fix calls `removeCollector()` inside `handleInterrupt` before `process.exit`, matching the existing pattern for `cleanup` and `cancelAgent`. The helper is idempotent, so calling it early is safe.
+
+### [#781 fix(evals): hard-timeout obsidian CLI calls via SIGKILL escalation](https://github.com/allenhutchison/obsidian-gemini/pull/781)
+
+Closes #776, likely also mitigates #778 (lite model hangs). `execFile`'s built-in `timeout` sends SIGTERM and waits — but obsidian CLI children sometimes ignore SIGTERM, stalling entire sweeps. The new `evals/lib/spawn-with-timeout.mjs` helper escalates to SIGKILL after a 1s grace period, guaranteeing the parent's promise settles within `timeoutMs + grace`. `obsidianEval` now uses this helper instead of `execFile`. Six new unit tests cover the happy path, multi-line output, clean SIGTERM, the SIGTERM-ignored/#776 case (would hang indefinitely under old code), missing binary, and non-zero exit.
+
+### [#783 docs: link external coverage and 4.8.0 release post](https://github.com/allenhutchison/obsidian-gemini/pull/783)
+
+Two "Further Reading" additions: a MakeUseOf walkthrough on using Deep Research with Obsidian added to `docs/guide/deep-research.md`, and the 4.8.0 release post ("Automation and Measurement: Inside Gemini Scribe 4.8.0") appended to the chronological author-blog list in `docs/guide/getting-started.md`.
+
+### [#784 fix(agent): preserve perTurnContext across follow-up requests](https://github.com/allenhutchison/obsidian-gemini/pull/784)
+
+Significant correctness fix. Context chips (drag-and-drop files, @-mentions) were rendered into `perTurnContext` on the initial model call but stripped from every follow-up after a tool fired — `buildFollowUpRequest` only forwarded `customPrompt` and tool-permission fields. Two consequences: the model couldn't reference dropped files after the first tool call (and would re-fetch them via tools instead), and the missing context bytes changed the system-prompt prefix mid-turn, breaking Gemini's implicit prefix cache on every tool-using conversation. The fix introduces a `PerTurnContext` interface holding the four fields that must stay byte-stable (`perTurnContext`, `projectInstructions`, `projectSkills`, `customPrompt`), threads it through `AgentLoop`, `AgentViewTools`, and `agent-view-send.ts`, and locks it in with three test layers: agent-loop unit tests, Ollama wire-format assertion, Gemini SDK params assertion, plus the new `context-from-shelf` eval task that forbids all read tools (so the model must answer from context).
+
+### [#787 chore(evals): bless ollama-gemma4-latest baseline](https://github.com/allenhutchison/obsidian-gemini/pull/787)
+
+First Ollama baseline: 24-run sweep against `gemma4:latest` (8 tasks × 3 reps). 100% pass^3, 62.5% solve^3. The new `context-from-shelf` task (from #784) went 3/3 SOLVED in 1 turn / 0 tool calls — the first baseline to lock in correct context-chip behavior. A companion `ollama-gemma4-latest.NOTES.md` records the manifest digest and weights blob SHA so future operators can detect silent model drift before trusting comparisons. Acknowledged `*-latest` anti-pattern; notes that next cycle should pin to a stable tag.
+
+### [#786 feat(agent): record model name in session-history entries](https://github.com/allenhutchison/obsidian-gemini/pull/786)
+
+Session history files now record which model produced each AI response. The Handlebars template and the round-trip parser already supported the `entry.model` field; this PR populates it at all five AI-entry construction sites in `agent-view-send.ts` and `agent-view-tools.ts`, using `session.modelConfig?.model || settings.chatModelName`. User entries are unchanged — the `| Model |` metadata row only appears for assistant turns.


### PR DESCRIPTION
## Summary

Automated daily housekeeping run for 2026-05-09 (Pacific time).

## Changes

### daily-changelog

- Wrote `planning/changelog/2026-05-09.md` covering 9 PRs
- Eval harness infrastructure day: first blessed baselines (#774), collector cleanup on interrupt (#780), SIGKILL escalation for hung CLI children (#781), Ollama/gemma4 baseline (#787)
- Two agent correctness fixes: perTurnContext preserved across follow-up requests (#784), model name now recorded in session history (#786)
- Supporting: fast-uri security bump (#775), daily housekeeping (#779), external docs links (#783)

### audit-docs

- No drift found — settings names/defaults, command palette IDs, tool categories (`read_only`, `vault_ops`, `external_mcp`, `system`, `skills`), folder paths, loop detection thresholds, and schedule formats all match source exactly.
- No new user-visible features lacking docs coverage.

### triage-issues

- Issues processed: 1
- Issues labeled: 1
  - #785 `enhancement` + `chat-ux` — "New Session" and other context menu items aren't Obsidian Commands (user requests hotkey-bindable commands for agent view context menu actions)
- Issues abstained: 0

## Screenshots / Screencast

N/A — changelog and triage only; no UI changes.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: automated daily housekeeping run
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop — N/A: changelog and triage only
- [ ] I have verified this change does not break Mobile — N/A: changelog and triage only
- [x] Documentation has been updated — this PR *is* the documentation update
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (claude-sonnet-4-6), via the `daily-update` skill
- [x] I have reviewed and understand all AI-generated code in this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01DFipkNAhMVjBorK4A8Qpgq)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Session history now records the model name for each assistant response.

* **Bug Fixes**
  * Improved agent behavior to correctly preserve context in multi-turn conversations with tool usage.
  * Enhanced evaluation reliability with better process management.

* **Chores**
  * Security patch for dependency updates.
  * Updated documentation and daily changelog.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/allenhutchison/obsidian-gemini/pull/790)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->