### PR TITLE
chore(daily): 2026-05-10 daily update

### DIFF
--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -363,6 +363,35 @@ Prevents the AI agent from executing identical tools repeatedly, which can cause
 - **Description**: Time window for detecting repeated calls
 - **Example**: If threshold is 3 and window is 30s, calling the same tool 3+ times within 30 seconds triggers detection
 
+### Tool Permissions
+
+Controls which agent tools execute automatically, which require user confirmation before each run, and which are blocked entirely. Access via Settings → Gemini Scribe → Show Advanced Settings → Tool Permissions.
+
+#### Permission Preset
+
+- **Setting**: `toolPolicy.activePreset`
+- **Type**: String
+- **Default**: `cautious`
+- **Options**:
+
+| Preset      | Label              | Read tools         | Write tools        | Destructive tools  | External tools     |
+| ----------- | ------------------ | ------------------ | ------------------ | ------------------ | ------------------ |
+| `read_only` | Read Only          | Auto               | Blocked            | Blocked            | Blocked            |
+| `cautious`  | Cautious (Default) | Auto               | Ask                | Ask                | Ask                |
+| `edit_mode` | Edit Mode          | Auto               | Auto               | Ask                | Ask                |
+| `yolo`      | YOLO Mode          | Auto               | Auto               | Auto               | Auto               |
+| `custom`    | Custom             | Per-tool overrides | Per-tool overrides | Per-tool overrides | Per-tool overrides |
+
+- **YOLO Mode warning**: Selecting YOLO Mode requires explicit confirmation in a modal. All operations execute without prompts — use only in trusted, well-understood workflows.
+- **Custom preset**: Automatically activated when you override any individual tool's permission. Selecting a named preset resets all per-tool overrides.
+
+#### Per-Tool Overrides
+
+- **Setting**: `toolPolicy.toolPermissions`
+- **Type**: Object (tool name → permission)
+- **Default**: `{}` (empty — preset governs all tools)
+- **Description**: Each registered tool can be individually set to `deny` (blocked), `ask_user` (confirmation required), or `approve` (runs automatically). Overrides take precedence over the active preset. Setting an override causes the preset to switch to `custom`.
+
 ### MCP Servers
 
 MCP (Model Context Protocol) server support allows the agent to use tools from external MCP servers. Supports both local (stdio) and remote (HTTP) servers.

--- a/planning/changelog/2026-05-10.md
+++ b/planning/changelog/2026-05-10.md
@@ -1,0 +1,16 @@
+# Daily changelog — May 10, 2026
+
+**Date:** 2026-05-10
+**PRs merged:** 1
+
+---
+
+## Summary
+
+Quiet housekeeping day. The only merge was the automated daily update packaging the previous day's changelog, audit, and triage work.
+
+## What shipped
+
+### [#790 chore(daily): 2026-05-09 daily update](https://github.com/allenhutchison/obsidian-gemini/pull/790)
+
+Automated daily housekeeping for 2026-05-09. Bundled the previous day's changelog (9 PRs covering eval harness baselines, agent correctness fixes, and a security patch), a clean audit pass (no docs drift found), and one triage label applied to #785 (`enhancement` + `chat-ux` for hotkey-bindable agent view context menu commands).


### PR DESCRIPTION
## Summary

Automated daily housekeeping run for 2026-05-10 (Pacific time).

## Changes

### daily-changelog

- Wrote `planning/changelog/2026-05-10.md` covering 1 PR
- Quiet day — only the previous daily update PR (#790) merged

### audit-docs

- Added missing **Tool Permissions** section to `docs/reference/settings.md`
- The ToC referenced "Tool Permissions" under Developer Settings but the section had no content documenting the policy preset system
- Documented `toolPolicy.activePreset` (read_only / cautious / edit_mode / yolo / custom presets with their permission mappings) and `toolPolicy.toolPermissions` (per-tool deny/ask_user/approve overrides)
- All other claims checked: settings names/defaults, command palette IDs, schedule formats, tool categories, folder paths, loop detection thresholds, model defaults, and attachment limits all match source exactly

### triage-issues

- Issues processed: 0
- No unlabeled open issues — no-op

## Screenshots / Screencast

N/A — changelog and docs fix only; no UI changes.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: automated daily housekeeping run
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop — N/A: changelog and docs only
- [ ] I have verified this change does not break Mobile — N/A: changelog and docs only
- [x] Documentation has been updated — this PR *is* the documentation update
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (claude-sonnet-4-6), via the `daily-update` skill
- [x] I have reviewed and understand all AI-generated code in this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01N9QPGurzcCrRhMhYmRy2ZG)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Tool Permissions advanced settings documentation, covering permission preset models (read_only, cautious, edit_mode, yolo, custom) and per-tool override configurations for controlling tool execution behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/allenhutchison/obsidian-gemini/pull/792)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->