### PR TITLE
fix(models): gate remote model fetch by provider and online state

### DIFF
--- a/src/services/model-list-provider.ts
+++ b/src/services/model-list-provider.ts
@@ -40,8 +40,32 @@ export class ModelListProvider {
 	/**
 	 * Fire-and-forget fetch of the latest models.json from GitHub.
 	 * Uses a 24h cache to avoid unnecessary fetches.
+	 *
+	 * Skipped when:
+	 *   1. The active provider is not Gemini — the remote list only describes
+	 *      Gemini models, so fetching it would be wasted work for Ollama users
+	 *      who run fully offline (and risks a slow GitHub round-trip on every
+	 *      reload). Defense-in-depth: the caller in ModelManager.initialize()
+	 *      also gates this branch by provider, but enforcing it here keeps the
+	 *      contract local to the fetch.
+	 *   2. The host reports offline (`navigator.onLine === false`). Skipping
+	 *      avoids piling up doomed requestUrl calls when WiFi is down — Obsidian's
+	 *      requestUrl has no built-in timeout, so a hung connection (versus a
+	 *      clean refusal) could leave the promise pending. Caught Gemini users
+	 *      on airplane mode too, not just Ollama.
 	 */
 	startRemoteFetch(): void {
+		const provider = this.plugin.settings?.provider ?? 'gemini';
+		if (provider !== 'gemini') {
+			this.plugin.logger.debug(`[ModelListProvider] Skipping remote fetch (provider=${provider})`);
+			return;
+		}
+
+		if (typeof navigator !== 'undefined' && navigator.onLine === false) {
+			this.plugin.logger.debug('[ModelListProvider] Skipping remote fetch (navigator reports offline)');
+			return;
+		}
+
 		const now = Date.now();
 		if (now - this.cacheTimestamp < CACHE_DURATION) {
 			this.plugin.logger.debug('[ModelListProvider] Remote cache still fresh, skipping fetch');

--- a/test/services/model-list-provider.test.ts
+++ b/test/services/model-list-provider.test.ts
@@ -1,0 +1,100 @@
+import type { Mock } from 'vitest';
+import { requestUrl } from 'obsidian';
+import { ModelListProvider } from '../../src/services/model-list-provider';
+
+const mockedRequestUrl = requestUrl as unknown as Mock;
+
+const buildPlugin = (overrides: Partial<{ provider: string }> = {}) =>
+	({
+		logger: { log: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() },
+		settings: {
+			provider: 'gemini',
+			...overrides,
+		},
+		saveData: vi.fn().mockResolvedValue(undefined),
+	}) as any;
+
+describe('ModelListProvider.startRemoteFetch', () => {
+	let originalDescriptor: PropertyDescriptor | undefined;
+
+	beforeEach(() => {
+		mockedRequestUrl.mockReset();
+		// Capture the existing onLine descriptor so we can restore it between tests.
+		originalDescriptor = Object.getOwnPropertyDescriptor(globalThis.navigator, 'onLine');
+	});
+
+	afterEach(() => {
+		if (originalDescriptor) {
+			Object.defineProperty(globalThis.navigator, 'onLine', originalDescriptor);
+		}
+	});
+
+	const setOnline = (value: boolean) => {
+		Object.defineProperty(globalThis.navigator, 'onLine', {
+			configurable: true,
+			get: () => value,
+		});
+	};
+
+	it('skips the remote fetch when the active provider is not gemini', () => {
+		const plugin = buildPlugin({ provider: 'ollama' });
+		setOnline(true);
+
+		const provider = new ModelListProvider(plugin);
+		provider.startRemoteFetch();
+
+		expect(mockedRequestUrl).not.toHaveBeenCalled();
+		expect(plugin.logger.debug).toHaveBeenCalledWith(
+			expect.stringContaining('Skipping remote fetch (provider=ollama)')
+		);
+	});
+
+	it('skips the remote fetch when navigator reports offline', () => {
+		const plugin = buildPlugin();
+		setOnline(false);
+
+		const provider = new ModelListProvider(plugin);
+		provider.startRemoteFetch();
+
+		expect(mockedRequestUrl).not.toHaveBeenCalled();
+		expect(plugin.logger.debug).toHaveBeenCalledWith(expect.stringContaining('navigator reports offline'));
+	});
+
+	it('issues the remote fetch when provider is gemini and the host is online', async () => {
+		const plugin = buildPlugin();
+		setOnline(true);
+		mockedRequestUrl.mockResolvedValue({
+			status: 200,
+			json: { version: 1, lastUpdated: '2026-05-11', models: [{ value: 'gemini-flash-latest', label: 'Flash' }] },
+		});
+
+		const provider = new ModelListProvider(plugin);
+		provider.startRemoteFetch();
+
+		// fetch is fire-and-forget — give the microtask queue a tick to flush
+		await new Promise((resolve) => setImmediate(resolve));
+
+		expect(mockedRequestUrl).toHaveBeenCalledTimes(1);
+		expect(mockedRequestUrl.mock.calls[0][0].url).toContain('models.json');
+	});
+
+	it('treats a missing provider setting as gemini (legacy installs)', async () => {
+		const plugin = {
+			logger: { log: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() },
+			settings: {}, // no provider field at all
+			saveData: vi.fn().mockResolvedValue(undefined),
+		} as any;
+		setOnline(true);
+		mockedRequestUrl.mockResolvedValue({
+			status: 200,
+			json: { version: 1, lastUpdated: '2026-05-11', models: [{ value: 'gemini-flash-latest', label: 'Flash' }] },
+		});
+
+		const provider = new ModelListProvider(plugin);
+		provider.startRemoteFetch();
+
+		await new Promise((resolve) => setImmediate(resolve));
+
+		expect(mockedRequestUrl).toHaveBeenCalledTimes(1);
+	});
+});

--- a/test/services/model-list-provider.test.ts
+++ b/test/services/model-list-provider.test.ts
@@ -26,6 +26,11 @@ describe('ModelListProvider.startRemoteFetch', () => {
 	afterEach(() => {
 		if (originalDescriptor) {
 			Object.defineProperty(globalThis.navigator, 'onLine', originalDescriptor);
+		} else {
+			// In jsdom, navigator.onLine is inherited from Navigator.prototype, so
+			// getOwnPropertyDescriptor returns undefined. setOnline() then installs an
+			// own property that would leak across tests if we didn't delete it here.
+			delete (globalThis.navigator as { onLine?: boolean }).onLine;
 		}
 	});
 


### PR DESCRIPTION
## Summary

Defense-in-depth for the offline-startup hang reported in [discussion #576](https://github.com/allenhutchison/obsidian-gemini/discussions/576). `ModelManager.initialize()` already skips `startRemoteFetch()` when the active provider is Ollama (landed in #694), but pushing the guard into the fetch itself keeps the contract local and makes it impossible to bypass from a future caller. Also bails when `navigator.onLine === false` so Gemini users on airplane mode don't queue a doomed `requestUrl` that has no built-in timeout.

Investigation of the user's hang shows the model fetch was likely not the actual blocker — see the [follow-up comment](https://github.com/allenhutchison/obsidian-gemini/discussions/576#discussioncomment-16884685) for the more probable culprits (MCP HTTP servers, non-localhost Ollama base URL). A broader `requestUrlWithTimeout` fix will follow once we confirm which path was blocking.

Fixes #<!-- no issue, tracked via discussion #576 -->

## Changes

- `src/services/model-list-provider.ts` — `startRemoteFetch()` now short-circuits when `settings.provider !== 'gemini'` or when `navigator.onLine === false`, before the existing 24h cache check. Both new branches log at debug level only.
- `test/services/model-list-provider.test.ts` — new test file covering the four paths: non-Gemini provider skip, offline skip, online + Gemini fetches, and missing-provider fallback for legacy installs.

## Screenshots / Screencast

N/A — backend/internal change. No user-visible UI.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards)
- [x] Documentation has been updated (if applicable) — no user-facing docs touch this fetch behaviour
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Remote model fetching now skips when offline (browser) or when the configured provider isn’t Gemini, preventing unnecessary requests and errors.

* **Tests**
  * Added tests covering remote fetch behavior across provider settings (including legacy default) and online/offline connectivity, verifying correct request issuance and mocks are reset.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/allenhutchison/obsidian-gemini/pull/793)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->