### PR TITLE
refactor(api): clean up follow-ups from PR #760

### DIFF
--- a/src/api/gemini-client.ts
+++ b/src/api/gemini-client.ts
@@ -60,7 +60,7 @@ export class GeminiClient implements ModelApi {
 		};
 		this.plugin = plugin;
 		this.prompts = prompts || new GeminiPrompts(plugin);
-		this.ai = this.plugin ? createGoogleGenAI(this.plugin) : new GoogleGenAI({ apiKey: config.apiKey });
+		this.ai = this.plugin ? createGoogleGenAI(this.plugin, config.apiKey) : new GoogleGenAI({ apiKey: config.apiKey });
 	}
 
 	/**

--- a/src/api/google-genai-factory.ts
+++ b/src/api/google-genai-factory.ts
@@ -5,9 +5,14 @@ import type ObsidianGemini from '../main';
  * Creates a GoogleGenAI instance using plugin settings.
  * Always use this helper instead of calling `new GoogleGenAI(...)` directly,
  * so that customBaseUrl is applied consistently across all call sites.
+ *
+ * `apiKeyOverride` lets callers (e.g. GeminiClient) pass an explicit key that
+ * wins over `plugin.apiKey`. Today every production caller passes the same
+ * value, but accepting an override keeps GeminiClientConfig.apiKey honest as
+ * the authoritative source when it is supplied.
  */
-export function createGoogleGenAI(plugin: ObsidianGemini): GoogleGenAI {
-	const apiKey = plugin.apiKey;
+export function createGoogleGenAI(plugin: ObsidianGemini, apiKeyOverride?: string): GoogleGenAI {
+	const apiKey = apiKeyOverride ?? plugin.apiKey;
 	const customBaseUrl = plugin.settings.customBaseUrl?.trim();
 	const httpOptions: HttpOptions | undefined = customBaseUrl ? { baseUrl: customBaseUrl } : undefined;
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -968,10 +968,6 @@ export default class ObsidianGemini extends Plugin {
 				if (needsInit && !apiKeyChanged && !providerChanged) {
 					new Notice('Gemini Scribe is now ready to use!');
 				}
-				// Invalidate cached DeepResearch manager so it rebuilds with the new base URL
-				if (customBaseUrlChanged && this.deepResearch) {
-					this.deepResearch.invalidateResearchManager();
-				}
 			} catch (error) {
 				this.logger.error('Failed to re-initialize after settings change:', error);
 				this.lastInitError = error instanceof Error ? error.message : String(error);

--- a/src/services/deep-research.ts
+++ b/src/services/deep-research.ts
@@ -48,19 +48,6 @@ export class DeepResearchService {
 		this.reportGenerator = new ReportGenerator();
 		this.retryConfig = DEFAULT_RETRY_CONFIG;
 	}
-	/**
-	 * Invalidate the cached ResearchManager so it is rebuilt with the
-	 * current plugin settings (e.g. after customBaseUrl changes).
-	 */
-	public invalidateResearchManager(): void {
-		// Do not invalidate while a research job is active — cancelResearch()
-		// still needs the manager to send the cancel request.
-		if (this.currentInteractionId !== null) {
-			this.plugin.logger.warn('[DeepResearch] Cannot invalidate manager while research is in progress');
-			return;
-		}
-		this.researchManager = null;
-	}
 
 	/**
 	 * Initialize the ResearchManager with a GoogleGenAI client

--- a/src/ui/settings-agent-config.ts
+++ b/src/ui/settings-agent-config.ts
@@ -72,33 +72,38 @@ export async function renderAgentConfigSettings(
 			})
 		);
 
-	new Setting(sectionEl)
-		.setName('Custom API endpoint')
-		.setDesc(
-			'Override the default Google API base URL (e.g. for a corporate proxy or local gateway). Leave blank to use the official endpoint.'
-		)
-		.addText((text) => {
-			text
-				.setPlaceholder('https://my-proxy.example.com')
-				.setValue(plugin.settings.customBaseUrl)
-				.onChange((value) => {
-					plugin.settings.customBaseUrl = value.trim();
-					debouncedSave();
+	// Only the Gemini provider honours customBaseUrl — the Ollama path has its
+	// own ollamaBaseUrl setting and ignores this value. Hide the row entirely
+	// on Ollama so users don't type a URL that silently does nothing.
+	if (plugin.settings.provider === 'gemini') {
+		new Setting(sectionEl)
+			.setName('Custom API endpoint')
+			.setDesc(
+				'Override the default Google API base URL (e.g. for a corporate proxy or local gateway). Leave blank to use the official endpoint.'
+			)
+			.addText((text) => {
+				text
+					.setPlaceholder('https://my-proxy.example.com')
+					.setValue(plugin.settings.customBaseUrl)
+					.onChange((value) => {
+						plugin.settings.customBaseUrl = value.trim();
+						debouncedSave();
+					});
+				text.inputEl.addEventListener('blur', () => {
+					const trimmed = plugin.settings.customBaseUrl.trim();
+					if (trimmed === '') return;
+					try {
+						new URL(trimmed);
+					} catch {
+						new Notice('Custom API endpoint is not a valid URL — clearing.');
+						plugin.settings.customBaseUrl = '';
+						text.setValue('');
+						debouncedSave();
+					}
 				});
-			text.inputEl.addEventListener('blur', () => {
-				const trimmed = plugin.settings.customBaseUrl.trim();
-				if (trimmed === '') return;
-				try {
-					new URL(trimmed);
-				} catch {
-					new Notice('Custom API endpoint is not a valid URL — clearing.');
-					plugin.settings.customBaseUrl = '';
-					text.setValue('');
-					debouncedSave();
-				}
+				return text;
 			});
-			return text;
-		});
+	}
 
 	new Setting(sectionEl)
 		.setName('Maximum Retries')

--- a/test/api/gemini-client.test.ts
+++ b/test/api/gemini-client.test.ts
@@ -1,4 +1,5 @@
 import type { Mock } from 'vitest';
+import { GoogleGenAI } from '@google/genai';
 import { GeminiClient, GeminiClientConfig } from '../../src/api/gemini-client';
 import { GeminiPrompts } from '../../src/prompts';
 import type { ExtendedModelRequest } from '../../src/api/interfaces/model-api';
@@ -21,6 +22,8 @@ vi.mock('@google/genai', () => ({
 		};
 	}),
 }));
+
+const MockedGoogleGenAI = GoogleGenAI as unknown as Mock;
 
 // Mock window.localStorage
 const mockLocalStorage = {
@@ -280,6 +283,55 @@ describe('GeminiClient', () => {
 			expect(generateContentMock).toHaveBeenCalledTimes(1);
 			const params = (generateContentMock as Mock).mock.calls[0][0];
 			expect(params.config.systemInstruction).not.toContain('## Turn Context');
+		});
+	});
+
+	// Wiring coverage: the constructor must route through createGoogleGenAI so a
+	// user-configured customBaseUrl reaches the SDK as httpOptions.baseUrl. The
+	// google-genai-factory tests cover the helper in isolation; these guard the
+	// integration so a future refactor that bypasses the helper would fail loudly.
+	describe('customBaseUrl wiring', () => {
+		beforeEach(() => {
+			MockedGoogleGenAI.mockClear();
+		});
+
+		test('forwards httpOptions.baseUrl when plugin.settings.customBaseUrl is set', () => {
+			const plugin: any = {
+				logger: mockLogger,
+				apiKey: 'test-api-key',
+				settings: { customBaseUrl: 'https://my-proxy.example.com' },
+			};
+			new GeminiClient({ apiKey: 'test-api-key', model: 'gemini-pro' }, new GeminiPrompts(plugin), plugin);
+
+			expect(MockedGoogleGenAI).toHaveBeenCalledWith(
+				expect.objectContaining({
+					apiKey: 'test-api-key',
+					httpOptions: { baseUrl: 'https://my-proxy.example.com' },
+				})
+			);
+		});
+
+		test('omits httpOptions when plugin.settings.customBaseUrl is empty', () => {
+			const plugin: any = {
+				logger: mockLogger,
+				apiKey: 'test-api-key',
+				settings: { customBaseUrl: '' },
+			};
+			new GeminiClient({ apiKey: 'test-api-key', model: 'gemini-pro' }, new GeminiPrompts(plugin), plugin);
+
+			const callArg = MockedGoogleGenAI.mock.calls[0][0];
+			expect(callArg.httpOptions).toBeUndefined();
+		});
+
+		test('no-plugin fallback constructs GoogleGenAI with config.apiKey only', () => {
+			// When GeminiClient is constructed without a plugin (e.g. via
+			// GeminiClientFactory.createCustom in code paths that don't have one
+			// handy), the helper isn't invoked — the constructor falls back to
+			// using config.apiKey directly and customBaseUrl is unreachable.
+			const promptsPlugin: any = { logger: mockLogger, settings: {} };
+			new GeminiClient({ apiKey: 'config-only-key', model: 'gemini-pro' }, new GeminiPrompts(promptsPlugin), undefined);
+
+			expect(MockedGoogleGenAI).toHaveBeenCalledWith({ apiKey: 'config-only-key' });
 		});
 	});
 });

--- a/test/api/google-genai-factory.test.ts
+++ b/test/api/google-genai-factory.test.ts
@@ -66,25 +66,24 @@ describe('createGoogleGenAI', () => {
 		expect(result).toBeDefined();
 	});
 
-	test('does not call createGoogleGenAI when plugin is absent (no-plugin fallback)', () => {
+	test('apiKeyOverride wins over plugin.apiKey when provided', () => {
+		mockPlugin.apiKey = 'plugin-key';
+
+		createGoogleGenAI(mockPlugin, 'override-key');
+
+		expect(MockedGoogleGenAI).toHaveBeenCalledWith(expect.objectContaining({ apiKey: 'override-key' }));
+	});
+
+	test('tolerates undefined apiKey without throwing', () => {
+		// Defensive: if the plugin is initialised before the user enters an API key,
+		// the helper still has to return something — it forwards apiKey: undefined
+		// to GoogleGenAI rather than throwing. The actual no-plugin fallback path
+		// (constructing GoogleGenAI without going through the helper at all) lives
+		// in GeminiClient and is covered in test/api/gemini-client.test.ts.
 		mockPlugin.apiKey = undefined;
 		mockPlugin.settings.customBaseUrl = '';
 
 		expect(() => createGoogleGenAI(mockPlugin)).not.toThrow();
 		expect(MockedGoogleGenAI).toHaveBeenCalledWith(expect.objectContaining({ apiKey: undefined }));
-	});
-
-	test('passes httpOptions.baseUrl when provider is gemini and customBaseUrl is set', () => {
-		mockPlugin.apiKey = 'test-api-key';
-		mockPlugin.settings.customBaseUrl = 'https://corporate-proxy.example.com';
-
-		createGoogleGenAI(mockPlugin);
-
-		expect(MockedGoogleGenAI).toHaveBeenCalledWith(
-			expect.objectContaining({
-				apiKey: 'test-api-key',
-				httpOptions: { baseUrl: 'https://corporate-proxy.example.com' },
-			})
-		);
 	});
 });

--- a/test/ui/settings-agent-config.test.ts
+++ b/test/ui/settings-agent-config.test.ts
@@ -130,6 +130,7 @@ function buildPlugin(): FakePlugin {
 			maxRetries: 3,
 			initialBackoffDelay: 1000,
 			modelDiscovery: { enabled: false, autoUpdateInterval: 24, fallbackToStatic: true },
+			provider: 'gemini',
 			customBaseUrl: '',
 		},
 		saveSettings: vi.fn().mockResolvedValue(undefined),


### PR DESCRIPTION
## Summary
Post-merge cleanup for the customBaseUrl feature that landed in #760 — items we decided not to push back on the contributor for a fourth review round.

## Changes

- **Tests** — `test/api/gemini-client.test.ts` now asserts that constructing a `GeminiClient` with a plugin whose `customBaseUrl` is set causes `GoogleGenAI` to be called with `httpOptions.baseUrl`. Also covers the no-plugin fallback path that the factory tests can't reach.
- **Tests** — Renamed the misnamed factory test (was titled "does not call createGoogleGenAI when plugin is absent" but actually *did* call it; really tested apiKey-undefined tolerance). Dropped the duplicate "provider is gemini" variant.
- **Dead code** — Removed `DeepResearchService.invalidateResearchManager()` and its call site in `main.ts`. `lifecycle.setup()` already reinstantiates `plugin.deepResearch` on a settings-change re-init, so the explicit invalidate ran against a freshly-constructed service with no cached manager — a no-op.
- **UI** — The "Custom API endpoint" setting is now hidden when `provider === 'ollama'`. Previously it rendered for everyone but only took effect on the Gemini path, so Ollama users could type a value that silently did nothing.
- **API contract** — `createGoogleGenAI(plugin, apiKeyOverride?)` now accepts an explicit override. `GeminiClient` passes `config.apiKey` through so the `GeminiClientConfig.apiKey` field is actually authoritative when supplied, matching what the type advertises. Today every production caller passes the same value via both paths, so behavior is unchanged in practice.

## Test plan
- [x] `npm test` — 1695 pass / 5 skipped
- [x] `npm run build` — clean
- [x] `npm run format-check` — clean
- [ ] Smoke test: toggle provider between Gemini and Ollama in settings and confirm the "Custom API endpoint" row appears only on Gemini

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI/UX Changes**
  * Custom API endpoint field now displays only when using Gemini provider.

* **Improvements**
  * Added "Gemini Scribe is now ready to use!" confirmation message after successful settings initialization.
  * Enhanced API key handling for custom endpoint configurations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/allenhutchison/obsidian-gemini/pull/795)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->