### PR TITLE
chore(daily): 2026-05-11 daily update

### DIFF
--- a/docs/guide/agent-mode.md
+++ b/docs/guide/agent-mode.md
@@ -553,7 +553,7 @@ By default, these operations require confirmation:
 - **create_skill**: Creating new skill packages
 - **edit_skill**: Updating existing skill instructions
 
-You can configure which operations require confirmation in **Settings → Gemini Scribe → Agent Permissions**.
+You can configure which operations require confirmation in **Settings → Gemini Scribe → Tool Permissions** (under Advanced Settings).
 
 ### Session-Level Permissions
 

--- a/docs/guide/projects.md
+++ b/docs/guide/projects.md
@@ -39,7 +39,7 @@ skills:
   - writing-coach
   - continuity-tracker
 permissions:
-  edit_file: allow
+  write_file: allow
   delete_file: deny
 ---
 ```

--- a/planning/changelog/2026-05-11.md
+++ b/planning/changelog/2026-05-11.md
@@ -1,0 +1,26 @@
+# Daily changelog — May 11, 2026
+
+**Date:** 2026-05-11
+**PRs merged:** 3
+
+---
+
+## Summary
+
+The headliner on May 11 is an external contribution from @doherty registering the agent sidebar's session-management menu items as proper Obsidian commands, making them available in the command palette and assignable as hotkeys. An automated model-list refresh also landed, along with the previous day's daily housekeeping PR.
+
+## What shipped
+
+### [#791 chore: Update available Gemini models](https://github.com/allenhutchison/obsidian-gemini/pull/791)
+
+Automated update of `src/data/models.json` with new models detected from Google's API. The bot flags any additions for maintainer review — verifying labels, default-role assignments, image-generation flags, and whether a model should be surfaced to users at all. Merged after manual review confirmed the list was sane.
+
+### [#789 Fix #785: Register new agent sidebar actions as Obsidian commands](https://github.com/allenhutchison/obsidian-gemini/pull/789)
+
+The four items in the Gemini Scribe sidebar's hamburger menu — New Session, Browse Sessions, Link Project, and Session Settings — are now registered as Obsidian commands. They appear in the command palette and can be bound to hotkeys, which is particularly useful for quickly starting a new session without reaching for the mouse. Implementation exposed the existing handler functions as `public` methods on `AgentView` and wired them up in `main.ts`. README and the agent-mode guide were updated to document the new commands.
+
+Contributed by @doherty.
+
+### [#792 chore(daily): 2026-05-10 daily update](https://github.com/allenhutchison/obsidian-gemini/pull/792)
+
+Automated daily housekeeping for May 10. Wrote the 2026-05-10 changelog (one PR, the prior daily update) and patched `docs/reference/settings.md` to add the missing Tool Permissions section — the table of contents referenced it but the section body was absent. No issues were triaged that day.


### PR DESCRIPTION
## Summary

Automated daily housekeeping for May 11, 2026. Writes the changelog for the day and fixes two doc drift issues found during audit.

## Changes

- **Add `planning/changelog/2026-05-11.md`**: Documents 3 PRs merged on May 11 — #791 (model list update), #789 (register sidebar actions as Obsidian commands, contributed by @doherty), and #792 (prior daily update).
- **Fix `docs/guide/agent-mode.md` line 556**: Correct the settings navigation path from "Agent Permissions" → "Tool Permissions (under Advanced Settings)" to match the actual UI label in `src/ui/settings-tools.ts`.
- **Fix `docs/guide/projects.md` line 42**: Correct the permission key example from `edit_file: allow` → `write_file: allow` to match the actual registered tool name in `src/tools/vault/write-file-tool.ts` (an `edit_file` key would silently have no effect).

## Triage report — 2026-05-11

Issues processed: 0
Issues labeled: 0
No unlabeled open issues found.

## Screenshots / Screencast

N/A — no UI changes.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [ ] I have tested this change on Desktop
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards)
- [x] Documentation has been updated (if applicable)
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01F3FgSHGciWZAE3fFbDmFJu)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* **Updated settings guidance**: Corrected the navigation path for configuring tool confirmation permissions, now accurately directing users to the proper settings location.
* **Fixed permission examples**: Updated documentation example to reflect the correct permission configuration, ensuring consistency with current system behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/allenhutchison/obsidian-gemini/pull/796)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->