### PR TITLE
refactor: remove unused exports from dom-context

### DIFF
--- a/src/utils/dom-context.ts
+++ b/src/utils/dom-context.ts
@@ -39,25 +39,6 @@ export function createContextRange(element: HTMLElement): Range {
 }
 
 /**
- * Create a new DOM element in the correct document context.
- */
-export function createContextElement<K extends keyof HTMLElementTagNameMap>(
-	contextElement: HTMLElement,
-	tagName: K
-): HTMLElementTagNameMap[K] {
-	const { doc } = getDOMContext(contextElement);
-	return doc.createElement(tagName);
-}
-
-/**
- * Create a text node in the correct document context.
- */
-export function createContextTextNode(contextElement: HTMLElement, text: string): Text {
-	const { doc } = getDOMContext(contextElement);
-	return doc.createTextNode(text);
-}
-
-/**
  * Insert text at the current cursor position within an element.
  * Handles both main window and popout window contexts.
  */
@@ -105,54 +86,6 @@ export function insertTextAtCursor(element: HTMLElement, text: string): void {
 		range.collapse(false);
 		selection.removeAllRanges();
 		selection.addRange(range);
-	}
-}
-
-/**
- * Insert a node at the current cursor position within an element.
- * Handles both main window and popout window contexts.
- */
-export function insertNodeAtCursor(element: HTMLElement, node: Node): void {
-	const { doc, win } = getDOMContext(element);
-	const selection = win.getSelection();
-
-	if (!selection || selection.rangeCount === 0) {
-		// No selection, append to end
-		element.appendChild(node);
-
-		// Move cursor after the inserted node
-		if (selection && node.parentNode) {
-			const range = doc.createRange();
-			range.setStartAfter(node);
-			range.collapse(true);
-			selection.removeAllRanges();
-			selection.addRange(range);
-		}
-	} else {
-		const range = selection.getRangeAt(0);
-
-		// Ensure the range is within our element
-		if (element.contains(range.commonAncestorContainer)) {
-			range.insertNode(node);
-
-			// Move cursor after the node
-			range.setStartAfter(node);
-			range.collapse(true);
-			selection.removeAllRanges();
-			selection.addRange(range);
-		} else {
-			// Selection is outside our element, append to end
-			element.appendChild(node);
-
-			// Move cursor after the inserted node
-			if (node.parentNode) {
-				const range = doc.createRange();
-				range.setStartAfter(node);
-				range.collapse(true);
-				selection.removeAllRanges();
-				selection.addRange(range);
-			}
-		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Architecture-audit nightly sweep flagged: **dead code** in `src/utils/dom-context.ts`.

Three exported helper functions had zero callers anywhere in the codebase:

- \`createContextElement\` — no references in \`src/\` or \`test/\`
- \`createContextTextNode\` — no references in \`src/\` or \`test/\`
- \`insertNodeAtCursor\` — no references in \`src/\` or \`test/\`

The other six exports from this module (\`getDOMContext\`, \`getContextSelection\`, \`createContextRange\`, \`insertTextAtCursor\`, \`moveCursorToEnd\`, \`execContextCommand\`) remain in active use and are unaffected.

## Changes

- \`src/utils/dom-context.ts\`: remove three unused exported helpers and their JSDoc (67 lines removed, file shrinks from 183 → 115 lines)

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A; pure dead-code removal flagged by automated audit
- [x] All CI checks pass (\`npm test\`, \`npm run build\`, \`npm run format-check\`)
- [x] I have tested this change on Desktop — build + 1699 unit tests pass after deletion
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — no platform-specific code touched
- [ ] Documentation has been updated — N/A; internal utility surface
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (`architecture-audit` skill)
- [x] I have reviewed and understand all AI-generated code in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal text insertion utilities for improved cursor-based text handling within the editing context.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/allenhutchison/obsidian-gemini/pull/800)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->