### PR TITLE
refactor(tools): unify tool-policy across Sessions/Projects/Scheduled Tasks/Hooks

### DIFF
--- a/docs/contributing/tool-development.md
+++ b/docs/contributing/tool-development.md
@@ -160,18 +160,16 @@ if (shouldExcludePath(params.path, plugin)) {
 
 ### 4. **Permissions**
 
-Respect the context permissions:
+Tool gating is permission-driven. The `ToolRegistry` calls `resolveEffectivePermission()` for every registered tool when a session asks for its available tools, layering the optional `context.featureToolPolicy` on top of the global plugin policy:
 
-```typescript
-// Check if tool category is enabled
-const session = context.session;
-if (!session.context.enabledTools.includes(this.category)) {
-	return {
-		success: false,
-		error: 'Tool category not enabled for this session',
-	};
-}
-```
+1. Feature `overrides[toolName]`
+2. Global `toolPermissions[toolName]`
+3. Feature preset's `classification → permission` mapping
+4. Global active preset's `classification → permission` mapping
+
+Tools whose effective permission is `DENY` never reach `executeTool`. Tools mapped to `ASK_USER` are prompted for confirmation through the active `IConfirmationProvider`. You don't need to re-check categories or session enablement inside a tool's `execute` method — `ToolExecutionEngine.executeTool` already filters and confirms before calling you.
+
+The legacy `session.context.enabledTools` category array is gone; declare your tool's `classification` (READ / WRITE / DESTRUCTIVE / EXTERNAL) and let the policy system handle the rest.
 
 ### 5. **Return Meaningful Data**
 

--- a/docs/guide/lifecycle-hooks.md
+++ b/docs/guide/lifecycle-hooks.md
@@ -46,8 +46,8 @@ pathGlob: 'Daily/**/*.md'
 debounceMs: 5000
 maxRunsPerHour: 12
 action: agent-task
-enabledTools:
-  - read_only
+toolPolicy:
+  preset: read_only
 outputPath: 'Hooks/Runs/summarise-on-save/{date}.md'
 ---
 
@@ -56,23 +56,23 @@ The user just saved {{filePath}}. Read it and write a one-paragraph summary high
 
 ### Frontmatter Fields
 
-| Field               | Required               | Default                   | Description                                                                                                                                                                      |
-| ------------------- | ---------------------- | ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `trigger`           | Yes                    | —                         | Vault event. One of: `file-created`, `file-modified`, `file-deleted`, `file-renamed`.                                                                                            |
-| `action`            | Yes                    | —                         | What to do on each fire. One of: `agent-task`, `summarize`, `rewrite`, `command`. See [Actions](#actions) below.                                                                 |
-| `commandId`         | When `action: command` | —                         | Command palette id to dispatch (e.g. `editor:save-file`).                                                                                                                        |
-| `focusFile`         | No                     | `false`                   | When `action: command`, focus the triggering file in the workspace before dispatching so editor-scoped commands target it. Off by default — see [Actions → `command`](#command). |
-| `pathGlob`          | No                     | (matches all paths)       | Glob pattern matched against the triggering file's vault path. Supports `*` and `**`.                                                                                            |
-| `frontmatterFilter` | No                     | —                         | Object of key/value pairs the note's frontmatter must match for the hook to fire.                                                                                                |
-| `debounceMs`        | No                     | `5000`                    | Per-(hook, file) debounce window in milliseconds. Coalesces rapid saves into one fire.                                                                                           |
-| `maxRunsPerHour`    | No                     | unlimited                 | Sliding-window rate limit per hook (across all files).                                                                                                                           |
-| `cooldownMs`        | No                     | `30000`                   | After a fire completes, suppress further events on the same (hook, file) for this window. Prevents self-retrigger.                                                               |
-| `enabledTools`      | No                     | `['read_only', 'skills']` | Tool categories the agent may use during the run.                                                                                                                                |
-| `enabledSkills`     | No                     | `[]`                      | Skill slugs to pre-activate in the headless session.                                                                                                                             |
-| `model`             | No                     | Plugin chat model         | Override the model for this hook (e.g. `gemini-2.5-flash-lite`).                                                                                                                 |
-| `outputPath`        | No                     | (no file written)         | Where to write the agent's final response. Supports `{slug}`, `{date}`, and `{fileName}` placeholders.                                                                           |
-| `enabled`           | No                     | `true`                    | Set to `false` to disable the hook without deleting it.                                                                                                                          |
-| `desktopOnly`       | No                     | `true`                    | When `true` the hook is skipped on mobile. Headless agent runs can be heavyweight on phones.                                                                                     |
+| Field               | Required               | Default                        | Description                                                                                                                                                                      |
+| ------------------- | ---------------------- | ------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `trigger`           | Yes                    | —                              | Vault event. One of: `file-created`, `file-modified`, `file-deleted`, `file-renamed`.                                                                                            |
+| `action`            | Yes                    | —                              | What to do on each fire. One of: `agent-task`, `summarize`, `rewrite`, `command`. See [Actions](#actions) below.                                                                 |
+| `commandId`         | When `action: command` | —                              | Command palette id to dispatch (e.g. `editor:save-file`).                                                                                                                        |
+| `focusFile`         | No                     | `false`                        | When `action: command`, focus the triggering file in the workspace before dispatching so editor-scoped commands target it. Off by default — see [Actions → `command`](#command). |
+| `pathGlob`          | No                     | (matches all paths)            | Glob pattern matched against the triggering file's vault path. Supports `*` and `**`.                                                                                            |
+| `frontmatterFilter` | No                     | —                              | Object of key/value pairs the note's frontmatter must match for the hook to fire.                                                                                                |
+| `debounceMs`        | No                     | `5000`                         | Per-(hook, file) debounce window in milliseconds. Coalesces rapid saves into one fire.                                                                                           |
+| `maxRunsPerHour`    | No                     | unlimited                      | Sliding-window rate limit per hook (across all files).                                                                                                                           |
+| `cooldownMs`        | No                     | `30000`                        | After a fire completes, suppress further events on the same (hook, file) for this window. Prevents self-retrigger.                                                               |
+| `toolPolicy`        | No                     | _inherit global plugin policy_ | Per-fire tool policy (preset + per-tool overrides). Same shape used by projects and scheduled tasks — see [Tool Access](#tool-access) below.                                     |
+| `enabledSkills`     | No                     | `[]`                           | Skill slugs to pre-activate in the headless session.                                                                                                                             |
+| `model`             | No                     | Plugin chat model              | Override the model for this hook (e.g. `gemini-2.5-flash-lite`).                                                                                                                 |
+| `outputPath`        | No                     | (no file written)              | Where to write the agent's final response. Supports `{slug}`, `{date}`, and `{fileName}` placeholders.                                                                           |
+| `enabled`           | No                     | `true`                         | Set to `false` to disable the hook without deleting it.                                                                                                                          |
+| `desktopOnly`       | No                     | `true`                         | When `true` the hook is skipped on mobile. Headless agent runs can be heavyweight on phones.                                                                                     |
 
 ### Prompt Template Variables
 
@@ -91,7 +91,24 @@ Each hook does one of four things on fire. The form's **Action** dropdown switch
 
 ### `agent-task` (default)
 
-Run a headless agent session with the prompt body as the instruction. Honours `enabledTools`, `enabledSkills`, `model`, and writes the model's final response to `outputPath` if configured. This is the most flexible action — the agent can call tools, read other files, run skills, etc.
+Run a headless agent session with the prompt body as the instruction. Honours `toolPolicy`, `enabledSkills`, `model`, and writes the model's final response to `outputPath` if configured. This is the most flexible action — the agent can call tools, read other files, run skills, etc.
+
+### Tool Access
+
+The `toolPolicy` block uses the same shape every other policy-bearing feature uses:
+
+```yaml
+toolPolicy:
+  preset: read_only # one of: read_only, cautious, edit_mode, yolo
+  overrides:
+    web_fetch: deny
+```
+
+- `preset` chooses the baseline permission for every tool by classification. Omit to inherit the global plugin preset.
+- `overrides` maps individual tool names to a permission and beats both the hook preset and the global per-tool overrides.
+- An omitted `toolPolicy` block means "inherit the global plugin tool policy entirely."
+
+> **Legacy note** — older hook files used `enabledTools: ['read_only', …]` instead of `toolPolicy`. They still load: the plugin maps the old category list onto the closest preset and rewrites the file to the new shape the first time it is read.
 
 ### `summarize`
 
@@ -162,8 +179,8 @@ pathGlob: 'Daily/**/*.md'
 debounceMs: 10000
 maxRunsPerHour: 6
 action: agent-task
-enabledTools:
-  - read_only
+toolPolicy:
+  preset: read_only
 outputPath: 'Hooks/Runs/daily-summary/{fileName}'
 ---
 
@@ -177,9 +194,8 @@ Read the daily note at {{filePath}}. Append a brief summary of the day's main to
 trigger: file-created
 pathGlob: 'Attachments/**'
 action: agent-task
-enabledTools:
-  - read_only
-  - vault_ops
+toolPolicy:
+  preset: edit_mode
 ---
 
 A new file was just added at {{filePath}}. Read it (if it's text-based), generate a short description, and append a row to `Attachments/index.md` with the file path and description.

--- a/docs/guide/projects.md
+++ b/docs/guide/projects.md
@@ -38,9 +38,10 @@ name: My Project
 skills:
   - writing-coach
   - continuity-tracker
-permissions:
-  write_file: allow
-  delete_file: deny
+toolPolicy:
+  preset: edit_mode
+  overrides:
+    delete_file: deny
 ---
 ```
 
@@ -48,20 +49,38 @@ permissions:
 
 ### Frontmatter
 
-| Field         | Type     | Description                                              |
-| ------------- | -------- | -------------------------------------------------------- |
-| `tags`        | string[] | Must include `gemini-scribe/project`                     |
-| `name`        | string   | Display name (defaults to file basename)                 |
-| `skills`      | string[] | Skills to activate for this project (empty = all skills) |
-| `permissions` | object   | Per-tool permission overrides                            |
+| Field        | Type     | Description                                                                           |
+| ------------ | -------- | ------------------------------------------------------------------------------------- |
+| `tags`       | string[] | Must include `gemini-scribe/project`                                                  |
+| `name`       | string   | Display name (defaults to file basename)                                              |
+| `skills`     | string[] | Skills to activate for this project (empty = all skills)                              |
+| `toolPolicy` | object   | Project-scoped tool policy. Omit to inherit the global plugin tool policy. See below. |
 
-### Permission Values
+### Tool Policy
+
+The `toolPolicy` block lets a project narrow or open the agent's tool surface for any session linked to the project. It has the same shape every other policy-bearing feature uses (scheduled tasks, hooks, sessions):
+
+```yaml
+toolPolicy:
+  preset: read_only # one of: read_only, cautious, edit_mode, yolo
+  overrides: # optional per-tool overrides (most specific wins)
+    write_file: allow
+    delete_file: deny
+```
+
+- `preset` chooses the baseline permission for every tool by classification (READ / WRITE / DESTRUCTIVE / EXTERNAL). Omit to inherit the global plugin preset.
+- `overrides` maps individual tool names to a permission; entries here win over both the project preset and the global policy's per-tool overrides.
+- An omitted `toolPolicy` block means "inherit the global plugin tool policy entirely."
+
+#### Permission Values
 
 | Value   | Effect                             |
 | ------- | ---------------------------------- |
 | `allow` | Tool executes without confirmation |
 | `deny`  | Tool is blocked entirely           |
 | `ask`   | Tool requires user confirmation    |
+
+> **Legacy note** — the older `permissions: { tool: 'allow' }` frontmatter map still loads. The first time the plugin reads such a file it rewrites the frontmatter into the new `toolPolicy.overrides` shape.
 
 ### Body Text
 

--- a/docs/guide/projects.md
+++ b/docs/guide/projects.md
@@ -133,13 +133,14 @@ When you create a **new** agent session, the plugin inspects the session's initi
 | **Tool discovery**    | `list_files`, `find_files_by_name`, and `find_files_by_content` scope to the project root   |
 | **Read/write access** | Unrestricted — the agent can still access files outside the project when you reference them |
 | **Skills**            | Only skills listed in the project's `skills` array are available (empty = all)              |
-| **Permissions**       | Project permissions take priority over global presets and per-tool overrides                |
+| **Tool policy**       | The project's `toolPolicy` is layered on top of the global plugin tool policy               |
 
-### Permission Resolution Order
+### Tool Policy Resolution Order
 
-1. Project-level permission (`permissions` in project frontmatter)
-2. Per-tool global override (`Settings → Tool Policy → Custom`)
-3. Global preset default (Cautious, Edit Mode, etc.)
+1. Project `toolPolicy.overrides[toolName]`
+2. Global per-tool override (`Settings → Tool Policy → Custom`)
+3. Project `toolPolicy.preset` (if set)
+4. Global preset default (Cautious, Edit Mode, etc.)
 
 ## Managing Projects
 
@@ -166,5 +167,5 @@ Open the project file and use the **"Remove Project"** command to strip the `gem
 - **Keep project files at the root of the relevant folder** — the parent directory becomes the scope boundary
 - **Use wikilinks in the body** to reference files outside the project that the agent should know about
 - **Start with an empty `skills` array** to allow all skills, then narrow down as needed
-- **Set `delete_file: deny`** in permissions for projects where you want to prevent accidental deletions
+- **Set `delete_file: deny`** under `toolPolicy.overrides` for projects where you want to prevent accidental deletions
 - **Project instructions stack with custom prompts** — use projects for persistent context and custom prompts for per-session behavior

--- a/docs/guide/scheduled-tasks.md
+++ b/docs/guide/scheduled-tasks.md
@@ -33,8 +33,8 @@ Create a markdown file inside `<history-folder>/Scheduled-Tasks/`. The filename 
 ```markdown
 ---
 schedule: daily
-enabledTools:
-  - read_only
+toolPolicy:
+  preset: read_only
 ---
 
 Summarise the notes I created or modified today. List the key topics and any open questions.
@@ -42,14 +42,14 @@ Summarise the notes I created or modified today. List the key topics and any ope
 
 ### Frontmatter Fields
 
-| Field          | Required | Default                                                  | Description                                                                                                                              |
-| -------------- | -------- | -------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| `schedule`     | Yes      | —                                                        | When to run. See [Schedule Formats](#schedule-formats) below.                                                                            |
-| `enabledTools` | No       | `['read_only', 'skills']`                                | List of tool categories the agent may use. See [Tool Access](#tool-access). Omitting the field or setting `[]` resolves to this default. |
-| `outputPath`   | No       | `<history-folder>/Scheduled-Tasks/Runs/<slug>/{date}.md` | Where to write results. Supports `{slug}` and `{date}` placeholders.                                                                     |
-| `model`        | No       | Plugin chat model                                        | Override the model for this task (e.g. `gemini-flash-latest`).                                                                           |
-| `enabled`      | No       | `true`                                                   | Set to `false` to disable the task without deleting it.                                                                                  |
-| `runIfMissed`  | No       | `false`                                                  | When `true`, tasks missed while Obsidian was closed are caught up on the next startup. See [Catch-up Runs](#catch-up-runs).              |
+| Field         | Required | Default                                                  | Description                                                                                                                 |
+| ------------- | -------- | -------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `schedule`    | Yes      | —                                                        | When to run. See [Schedule Formats](#schedule-formats) below.                                                               |
+| `toolPolicy`  | No       | _inherit global plugin policy_                           | Per-run tool policy (preset + per-tool overrides). See [Tool Access](#tool-access).                                         |
+| `outputPath`  | No       | `<history-folder>/Scheduled-Tasks/Runs/<slug>/{date}.md` | Where to write results. Supports `{slug}` and `{date}` placeholders.                                                        |
+| `model`       | No       | Plugin chat model                                        | Override the model for this task (e.g. `gemini-flash-latest`).                                                              |
+| `enabled`     | No       | `true`                                                   | Set to `false` to disable the task without deleting it.                                                                     |
+| `runIfMissed` | No       | `false`                                                  | When `true`, tasks missed while Obsidian was closed are caught up on the next startup. See [Catch-up Runs](#catch-up-runs). |
 
 ### Schedule Formats
 
@@ -70,8 +70,8 @@ Summarise the notes I created or modified today. List the key topics and any ope
 ```markdown
 ---
 schedule: weekly@16:30:mon,tue,wed,thu,fri
-enabledTools:
-  - read_only
+toolPolicy:
+  preset: read_only
 ---
 
 Summarise the notes I created or modified today.
@@ -79,16 +79,26 @@ Summarise the notes I created or modified today.
 
 ### Tool Access
 
-The `enabledTools` list controls what the agent can do during a run:
+The `toolPolicy` block controls what the agent can do during a run. It uses the same shape as the global plugin tool policy and as project / hook / session policies — a preset baseline plus optional per-tool overrides:
 
-| Category       | Capabilities                                           |
-| -------------- | ------------------------------------------------------ |
-| `read_only`    | Read files, list files, search vault, web search/fetch |
-| `vault_ops`    | Create, modify, move, and delete files in the vault    |
-| `external_mcp` | Tools provided by connected MCP servers                |
-| `skills`       | Load and activate agent skills                         |
+```yaml
+toolPolicy:
+  preset: read_only # one of: read_only, cautious, edit_mode, yolo
+  overrides: # optional per-tool overrides
+    web_fetch: deny
+    write_file: allow
+```
 
-Categories are additive — list as many as the task needs. If `enabledTools` is empty the task defaults to `read_only` + `skills`, so common patterns like "run skill X on a schedule" work without extra setup. Set `enabledTools: ['read_only']` explicitly if you want a stricter allowlist that omits skill tools.
+| Preset      | Effect                                                                                    |
+| ----------- | ----------------------------------------------------------------------------------------- |
+| `read_only` | Read tools only — write / destructive / external tools are removed from the registry.     |
+| `cautious`  | Reads allowed; writes/destructive/external ask for confirmation. (Default global preset.) |
+| `edit_mode` | Reads + writes execute; destructive/external still ask.                                   |
+| `yolo`      | Everything executes without confirmation. Use with care.                                  |
+
+Omitting `toolPolicy` (or setting it to an empty object) means **inherit the global plugin tool policy**. The Scheduler UI exposes the same controls — picking a preset and adjusting per-tool overrides — so you usually don't need to author the YAML by hand.
+
+> **Legacy note** — older task files used `enabledTools: ['read_only', …]` instead of `toolPolicy`. They still load: the plugin maps the old category list onto the closest preset and rewrites the file to the new shape the first time it is read.
 
 ## Managing Tasks
 

--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -72,6 +72,14 @@ export interface AgentLoopOptions {
 	 */
 	featureToolPolicy?: FeatureToolPolicy;
 	/**
+	 * True when running unattended (scheduled task, hook fire). Headless runs
+	 * auto-approve confirmations, so we must hide ASK_USER tools from the
+	 * model — otherwise the user's "ask first" intent gets silently bypassed.
+	 * UI callers leave this false; the interactive confirmation provider
+	 * handles ASK_USER tools at execution time.
+	 */
+	headless?: boolean;
+	/**
 	 * System-prompt fields that must stay byte-stable across the initial model
 	 * call and every follow-up/retry within this turn. Without these, follow-up
 	 * requests rebuild the system prompt without context-file content / project
@@ -152,7 +160,8 @@ export class AgentLoop {
 		options: AgentLoopOptions;
 	}): Promise<AgentLoopResult> {
 		const { initialResponse, initialUserMessage, initialHistory, options } = args;
-		const { plugin, session, isCancelled, hooks, customPrompt, projectRootPath, featureToolPolicy, perTurn } = options;
+		const { plugin, session, isCancelled, hooks, customPrompt, projectRootPath, featureToolPolicy, perTurn, headless } =
+			options;
 		const maxIterations = options.maxIterations;
 
 		const toolContext: ToolExecutionContext = {
@@ -268,6 +277,7 @@ export class AgentLoop {
 				customPrompt,
 				projectRootPath,
 				featureToolPolicy,
+				headless,
 				...perTurn,
 			});
 

--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -1,6 +1,6 @@
 import type ObsidianGemini from '../main';
 import type { ChatSession, PerTurnContext } from '../types/agent';
-import type { ToolPermission } from '../types/tool-policy';
+import type { FeatureToolPolicy } from '../types/tool-policy';
 import type { ToolCall, ModelResponse, ModelApi } from '../api/interfaces/model-api';
 import type { CustomPrompt } from '../prompts/types';
 import type { IConfirmationProvider, ToolExecutionContext, ToolResult } from '../tools/types';
@@ -65,7 +65,12 @@ export interface AgentLoopOptions {
 	maxIterations?: number;
 	customPrompt?: CustomPrompt;
 	projectRootPath?: string;
-	projectPermissions?: Record<string, ToolPermission>;
+	/**
+	 * Feature-level tool policy (project / scheduled-task / hook scope) applied
+	 * on top of the global plugin policy for the duration of the turn. When
+	 * unset, only the global policy applies.
+	 */
+	featureToolPolicy?: FeatureToolPolicy;
 	/**
 	 * System-prompt fields that must stay byte-stable across the initial model
 	 * call and every follow-up/retry within this turn. Without these, follow-up
@@ -147,14 +152,14 @@ export class AgentLoop {
 		options: AgentLoopOptions;
 	}): Promise<AgentLoopResult> {
 		const { initialResponse, initialUserMessage, initialHistory, options } = args;
-		const { plugin, session, isCancelled, hooks, customPrompt, projectRootPath, projectPermissions, perTurn } = options;
+		const { plugin, session, isCancelled, hooks, customPrompt, projectRootPath, featureToolPolicy, perTurn } = options;
 		const maxIterations = options.maxIterations;
 
 		const toolContext: ToolExecutionContext = {
 			plugin,
 			session,
 			projectRootPath,
-			projectPermissions,
+			featureToolPolicy,
 		};
 
 		// `currentToolCalls` is what we execute on the next iteration. Seed it
@@ -262,7 +267,7 @@ export class AgentLoop {
 				updatedHistory,
 				customPrompt,
 				projectRootPath,
-				projectPermissions,
+				featureToolPolicy,
 				...perTurn,
 			});
 

--- a/src/agent/session-history.ts
+++ b/src/agent/session-history.ts
@@ -4,6 +4,7 @@ import { GeminiConversationEntry } from '../types/conversation';
 import type ObsidianGemini from '../main';
 import { pathToWikilink } from '../utils/accessed-files';
 import { formatLocalTimestamp } from '../utils/format-utils';
+import { serializeToolPolicy } from '../types/tool-policy';
 import * as Handlebars from 'handlebars';
 // @ts-ignore
 import historyEntryTemplate from '../history/templates/historyEntry.hbs';
@@ -338,11 +339,16 @@ export class SessionHistory {
 				delete frontmatter.accessed_files;
 			}
 
-			if (session.context?.enabledTools?.length) {
-				frontmatter.enabled_tools = session.context.enabledTools;
+			const serializedPolicy = serializeToolPolicy(session.context?.toolPolicy);
+			if (serializedPolicy) {
+				frontmatter.tool_policy = serializedPolicy;
 			} else {
-				delete frontmatter.enabled_tools;
+				delete frontmatter.tool_policy;
 			}
+			// Drop the legacy field whenever we rewrite this session — readers
+			// already migrate it in-memory; clearing here finishes the on-disk
+			// transition the first time we save the session.
+			delete frontmatter.enabled_tools;
 
 			if (session.context?.requireConfirmation !== undefined) {
 				frontmatter.require_confirmation = session.context.requireConfirmation;

--- a/src/agent/session-manager.ts
+++ b/src/agent/session-manager.ts
@@ -10,6 +10,54 @@ import {
 import type ObsidianGemini from '../main';
 import { sanitizeFileName } from '../utils/file-utils';
 import { formatLocalDate } from '../utils/format-utils';
+import { PolicyPreset, FeatureToolPolicy, parseToolPolicyFrontmatter, clonePolicy } from '../types/tool-policy';
+
+/**
+ * Map a legacy `enabled_tools` array (category-level allowlist from the
+ * pre-unified-policy era) to a FeatureToolPolicy. The mapping is best-effort:
+ *
+ * - `read_only` only ⇒ READ_ONLY preset
+ * - `read_only` + `vault_ops` ⇒ EDIT_MODE preset (writes execute, destructive asks)
+ * - any list containing `external_mcp` or `system` ⇒ undefined (inherit global)
+ *
+ * Broken legacy values (`read_write`, `destructive`) — written by the bugged
+ * scheduler/hook modals before this refactor — are folded into the closest
+ * preset.
+ */
+function migrateLegacyEnabledTools(value: unknown): FeatureToolPolicy | undefined {
+	if (!Array.isArray(value)) return undefined;
+	const set = new Set(value.filter((v): v is string => typeof v === 'string').map((v) => v.toLowerCase()));
+	if (set.size === 0) return undefined;
+
+	const hasReadOnly = set.has('read_only');
+	const hasVaultOps = set.has('vault_ops') || set.has('read_write');
+	const hasDestructive = set.has('destructive');
+	const hasExternal = set.has('external_mcp') || set.has('system');
+
+	if (hasExternal || (hasReadOnly && hasVaultOps && hasDestructive)) {
+		return undefined; // Inherit global — broadest legacy intent.
+	}
+	if (hasDestructive) return { preset: PolicyPreset.YOLO };
+	if (hasVaultOps) return { preset: PolicyPreset.EDIT_MODE };
+	if (hasReadOnly) return { preset: PolicyPreset.READ_ONLY };
+	return undefined;
+}
+
+/**
+ * Parse a session's tool policy from frontmatter. Prefers the new
+ * `tool_policy:` block; falls back to the legacy `enabled_tools` array;
+ * falls back to the supplied default.
+ */
+function parseSessionToolPolicy(
+	frontmatter: any,
+	fallback: FeatureToolPolicy | undefined
+): FeatureToolPolicy | undefined {
+	const fromNewShape = parseToolPolicyFrontmatter(frontmatter?.tool_policy);
+	if (fromNewShape) return fromNewShape;
+	const fromLegacy = migrateLegacyEnabledTools(frontmatter?.enabled_tools);
+	if (fromLegacy !== undefined) return fromLegacy;
+	return clonePolicy(fallback);
+}
 
 /**
  * Manages chat sessions for both note-centric and agent modes
@@ -33,8 +81,9 @@ export class SessionManager {
 		const context: AgentContext = {
 			...DEFAULT_CONTEXTS.NOTE_CHAT,
 			contextFiles: [sourceFile],
-			// Create new arrays to avoid sharing references between sessions
-			enabledTools: [...DEFAULT_CONTEXTS.NOTE_CHAT.enabledTools],
+			// Clone the policy so per-session mutations (e.g. overrides) don't bleed
+			// into the shared default. requireConfirmation is similarly cloned below.
+			toolPolicy: clonePolicy(DEFAULT_CONTEXTS.NOTE_CHAT.toolPolicy),
 			requireConfirmation: [...DEFAULT_CONTEXTS.NOTE_CHAT.requireConfirmation],
 		};
 
@@ -64,7 +113,10 @@ export class SessionManager {
 			...initialContext,
 			// Create new arrays to avoid sharing references between sessions
 			contextFiles: [...(initialContext?.contextFiles ?? [])],
-			enabledTools: [...(initialContext?.enabledTools ?? DEFAULT_CONTEXTS.AGENT_SESSION.enabledTools)],
+			toolPolicy:
+				'toolPolicy' in (initialContext ?? {})
+					? clonePolicy(initialContext?.toolPolicy)
+					: clonePolicy(DEFAULT_CONTEXTS.AGENT_SESSION.toolPolicy),
 			requireConfirmation: [
 				...(initialContext?.requireConfirmation ?? DEFAULT_CONTEXTS.AGENT_SESSION.requireConfirmation),
 			],
@@ -380,7 +432,7 @@ export class SessionManager {
 
 		return {
 			contextFiles,
-			enabledTools: frontmatter.enabled_tools || DEFAULT_CONTEXTS.NOTE_CHAT.enabledTools,
+			toolPolicy: parseSessionToolPolicy(frontmatter, DEFAULT_CONTEXTS.NOTE_CHAT.toolPolicy),
 			requireConfirmation: frontmatter.require_confirmation || [],
 			maxContextChars: frontmatter.max_context_chars,
 			maxCharsPerFile: frontmatter.max_chars_per_file,

--- a/src/services/feature-policy-yaml.ts
+++ b/src/services/feature-policy-yaml.ts
@@ -1,0 +1,62 @@
+import { FeatureToolPolicy, PolicyPreset, serializeToolPolicy } from '../types/tool-policy';
+
+/**
+ * Translate a legacy `enabledTools` category array (the pre-unified-policy
+ * shape used by scheduled tasks and hooks) into a FeatureToolPolicy.
+ *
+ * The legacy modal also wrote two values that never matched a real
+ * ToolCategory — `read_write` and `destructive` — so those are folded into
+ * the closest preset rather than discarded silently.
+ *
+ * Returns `undefined` for an empty / unrecognisable input, which the loader
+ * treats as "inherit the global policy".
+ */
+export function migrateLegacyToolCategoryArray(raw: unknown): FeatureToolPolicy | undefined {
+	if (!Array.isArray(raw)) return undefined;
+	const set = new Set(raw.filter((v): v is string => typeof v === 'string').map((v) => v.toLowerCase()));
+	if (set.size === 0) return undefined;
+
+	const hasReadOnly = set.has('read_only');
+	const hasVaultOps = set.has('vault_ops') || set.has('read_write');
+	const hasDestructive = set.has('destructive');
+	const hasExternal = set.has('external_mcp') || set.has('system');
+
+	// If the legacy list essentially asked for everything, inherit the global
+	// policy instead of locking the user into a specific preset.
+	if (hasExternal || (hasReadOnly && hasVaultOps && hasDestructive)) {
+		return undefined;
+	}
+	if (hasDestructive) return { preset: PolicyPreset.YOLO };
+	if (hasVaultOps) return { preset: PolicyPreset.EDIT_MODE };
+	if (hasReadOnly) return { preset: PolicyPreset.READ_ONLY };
+	return undefined;
+}
+
+/**
+ * Render a FeatureToolPolicy as YAML block lines suitable for hand-rolled
+ * frontmatter writers (scheduled tasks, hooks). Returns `null` when the
+ * policy is empty so the caller can omit the field entirely.
+ *
+ * Output shape:
+ *   toolPolicy:
+ *     preset: read_only
+ *     overrides:
+ *       write_file: deny
+ */
+export function formatToolPolicyYaml(policy: FeatureToolPolicy | undefined): string[] | null {
+	const serialized = serializeToolPolicy(policy);
+	if (!serialized) return null;
+
+	const lines: string[] = ['toolPolicy:'];
+	if (typeof serialized.preset === 'string') {
+		lines.push(`  preset: ${serialized.preset}`);
+	}
+	const overrides = serialized.overrides as Record<string, string> | undefined;
+	if (overrides && Object.keys(overrides).length > 0) {
+		lines.push('  overrides:');
+		for (const [tool, perm] of Object.entries(overrides)) {
+			lines.push(`    ${tool}: ${perm}`);
+		}
+	}
+	return lines;
+}

--- a/src/services/hook-manager.ts
+++ b/src/services/hook-manager.ts
@@ -2,6 +2,8 @@ import { Platform, TAbstractFile, TFile, normalizePath } from 'obsidian';
 import type ObsidianGemini from '../main';
 import { ensureFolderExists } from '../utils/file-utils';
 import { findFrontmatterEndOffset } from './skill-manager';
+import { FeatureToolPolicy, parseToolPolicyFrontmatter } from '../types/tool-policy';
+import { formatToolPolicyYaml, migrateLegacyToolCategoryArray } from './feature-policy-yaml';
 
 // ─── Folder / file layout ─────────────────────────────────────────────────────
 
@@ -62,8 +64,12 @@ export interface Hook {
 	 */
 	cooldownMs: number;
 	action: HookAction;
-	/** ToolCategory enum values to enable for the headless session. */
-	enabledTools: string[];
+	/**
+	 * Tool policy applied for the duration of each headless fire. Layered on
+	 * top of the global plugin policy via FeatureToolPolicy. Undefined means
+	 * inherit the global policy.
+	 */
+	toolPolicy?: FeatureToolPolicy;
 	/** Slugs of skills to pre-activate in the headless session. */
 	enabledSkills: string[];
 	/** Optional model override; defaults to plugin chat model. */
@@ -153,7 +159,7 @@ export interface HookCreateParams {
 	debounceMs?: number;
 	maxRunsPerHour?: number;
 	cooldownMs?: number;
-	enabledTools?: string[];
+	toolPolicy?: FeatureToolPolicy;
 	enabledSkills?: string[];
 	model?: string;
 	outputPath?: string;
@@ -395,7 +401,10 @@ export class HookManager {
 		const file = this.plugin.app.vault.getAbstractFileByPath(hook.filePath);
 		if (!file) throw new Error(`Hook file not found: ${hook.filePath}`);
 
-		const merged: Required<HookCreateParams> = {
+		// `toolPolicy` is genuinely optional (undefined == inherit global), so
+		// the merged shape can't use `Required<HookCreateParams>` like it used
+		// to. The other fields keep their default-coercion behavior below.
+		const merged: HookCreateParams & { slug: string } = {
 			slug,
 			trigger: params.trigger ?? hook.trigger,
 			pathGlob: params.pathGlob ?? hook.pathGlob ?? '',
@@ -404,7 +413,7 @@ export class HookManager {
 			maxRunsPerHour: params.maxRunsPerHour ?? hook.maxRunsPerHour ?? 0,
 			cooldownMs: params.cooldownMs ?? hook.cooldownMs,
 			action: params.action ?? hook.action,
-			enabledTools: params.enabledTools ?? hook.enabledTools,
+			toolPolicy: 'toolPolicy' in params ? params.toolPolicy : hook.toolPolicy,
 			enabledSkills: params.enabledSkills ?? hook.enabledSkills,
 			model: params.model ?? hook.model ?? '',
 			outputPath: params.outputPath ?? hook.outputPath ?? '',
@@ -461,7 +470,7 @@ export class HookManager {
 			maxRunsPerHour: params.maxRunsPerHour && params.maxRunsPerHour > 0 ? params.maxRunsPerHour : undefined,
 			cooldownMs: params.cooldownMs ?? DEFAULT_COOLDOWN_MS,
 			action: params.action,
-			enabledTools: params.enabledTools ?? [],
+			toolPolicy: params.toolPolicy,
 			enabledSkills: params.enabledSkills ?? [],
 			model: params.model || undefined,
 			outputPath: params.outputPath || undefined,
@@ -502,10 +511,9 @@ export class HookManager {
 			lines.push(`cooldownMs: ${params.cooldownMs}`);
 		}
 
-		const tools = params.enabledTools ?? [];
-		if (tools.length > 0) {
-			lines.push('enabledTools:');
-			for (const t of tools) lines.push(`  - ${t}`);
+		const policyLines = formatToolPolicyYaml(params.toolPolicy);
+		if (policyLines) {
+			lines.push(...policyLines);
 		}
 
 		const skills = params.enabledSkills ?? [];
@@ -894,7 +902,10 @@ export class HookManager {
 		const commandId = typeof frontmatter.commandId === 'string' ? frontmatter.commandId : undefined;
 		if (action === 'command' && !commandId) return null;
 
-		return {
+		const toolPolicy =
+			parseToolPolicyFrontmatter(frontmatter.toolPolicy) ?? migrateLegacyToolCategoryArray(frontmatter.enabledTools);
+
+		const hook: Hook = {
 			slug: file.basename,
 			trigger,
 			pathGlob: typeof frontmatter.pathGlob === 'string' ? frontmatter.pathGlob : undefined,
@@ -906,7 +917,7 @@ export class HookManager {
 			maxRunsPerHour: typeof frontmatter.maxRunsPerHour === 'number' ? frontmatter.maxRunsPerHour : undefined,
 			cooldownMs: typeof frontmatter.cooldownMs === 'number' ? frontmatter.cooldownMs : DEFAULT_COOLDOWN_MS,
 			action,
-			enabledTools: Array.isArray(frontmatter.enabledTools) ? (frontmatter.enabledTools as string[]) : [],
+			toolPolicy,
 			enabledSkills: Array.isArray(frontmatter.enabledSkills) ? (frontmatter.enabledSkills as string[]) : [],
 			model: typeof frontmatter.model === 'string' ? frontmatter.model : undefined,
 			outputPath: typeof frontmatter.outputPath === 'string' ? frontmatter.outputPath : undefined,
@@ -916,6 +927,45 @@ export class HookManager {
 			desktopOnly: frontmatter.desktopOnly !== false,
 			prompt,
 			filePath: file.path,
+		};
+
+		// Auto-migrate the legacy on-disk shape so the next load reads the new
+		// canonical key without re-running the migration. Failures are non-fatal.
+		if (frontmatter.enabledTools !== undefined && frontmatter.toolPolicy === undefined) {
+			try {
+				await this.plugin.app.vault.modify(file, this.serializeHook(this.hookToParams(hook)));
+			} catch (err) {
+				this.plugin.logger.warn(`[HookManager] legacy enabledTools migration failed for ${file.path}:`, err);
+			}
+		}
+
+		return hook;
+	}
+
+	/**
+	 * Convert a Hook back into the params shape expected by serializeHook —
+	 * used by the legacy-frontmatter migration path so the rewritten file
+	 * matches what a fresh create/update would produce.
+	 */
+	private hookToParams(hook: Hook): HookCreateParams & { slug: string } {
+		return {
+			slug: hook.slug,
+			trigger: hook.trigger,
+			action: hook.action,
+			prompt: hook.prompt,
+			pathGlob: hook.pathGlob,
+			frontmatterFilter: hook.frontmatterFilter,
+			debounceMs: hook.debounceMs,
+			maxRunsPerHour: hook.maxRunsPerHour,
+			cooldownMs: hook.cooldownMs,
+			toolPolicy: hook.toolPolicy,
+			enabledSkills: hook.enabledSkills,
+			model: hook.model,
+			outputPath: hook.outputPath,
+			enabled: hook.enabled,
+			desktopOnly: hook.desktopOnly,
+			commandId: hook.commandId,
+			focusFile: hook.focusFile,
 		};
 	}
 

--- a/src/services/hook-runner.ts
+++ b/src/services/hook-runner.ts
@@ -1,6 +1,6 @@
 import { App, TFile, normalizePath } from 'obsidian';
 import type ObsidianGemini from '../main';
-import { ToolCategory, DestructiveAction } from '../types/agent';
+import { DestructiveAction } from '../types/agent';
 import type { ConfirmationResult, DiffContext, IConfirmationProvider, Tool } from '../tools/types';
 import { ToolExecutionContext } from '../tools/types';
 import { ModelClientFactory } from '../api';
@@ -80,13 +80,8 @@ export class HookRunner {
 
 		const { hook } = this.ctx;
 
-		const enabledToolCategories =
-			hook.enabledTools.length > 0
-				? (hook.enabledTools as ToolCategory[])
-				: [ToolCategory.READ_ONLY, ToolCategory.SKILLS];
-
 		const session = await this.plugin.sessionManager.createAgentSession(`Hook: ${hook.slug}`, {
-			enabledTools: enabledToolCategories,
+			toolPolicy: hook.toolPolicy,
 			requireConfirmation: [] as DestructiveAction[],
 		});
 
@@ -94,7 +89,11 @@ export class HookRunner {
 			session.modelConfig = { model: hook.model };
 		}
 
-		const toolContext: ToolExecutionContext = { plugin: this.plugin, session };
+		const toolContext: ToolExecutionContext = {
+			plugin: this.plugin,
+			session,
+			featureToolPolicy: hook.toolPolicy,
+		};
 		const modelApi = ModelClientFactory.createChatModel(this.plugin);
 		const availableTools = this.plugin.toolRegistry.getEnabledTools(toolContext);
 
@@ -137,6 +136,7 @@ export class HookRunner {
 					isCancelled,
 					confirmationProvider: new HeadlessConfirmationProvider(),
 					maxIterations: 20,
+					featureToolPolicy: hook.toolPolicy,
 				},
 			});
 			if (result.cancelled) return undefined;

--- a/src/services/hook-runner.ts
+++ b/src/services/hook-runner.ts
@@ -95,7 +95,11 @@ export class HookRunner {
 			featureToolPolicy: hook.toolPolicy,
 		};
 		const modelApi = ModelClientFactory.createChatModel(this.plugin);
-		const availableTools = this.plugin.toolRegistry.getEnabledTools(toolContext);
+		// Headless hook fires auto-approve confirmations, so only expose
+		// APPROVE tools — ASK_USER tools would otherwise execute unattended.
+		// To allow an ASK_USER tool in a hook, the hook's toolPolicy must
+		// explicitly upgrade it (preset or per-tool override).
+		const availableTools = this.plugin.toolRegistry.getAutoApprovedTools(toolContext);
 
 		const renderedPrompt = renderPrompt(hook.prompt, this.promptVars());
 		const startedAt = formatLocalTimestamp(session.created);
@@ -137,6 +141,7 @@ export class HookRunner {
 					confirmationProvider: new HeadlessConfirmationProvider(),
 					maxIterations: 20,
 					featureToolPolicy: hook.toolPolicy,
+					headless: true,
 				},
 			});
 			if (result.cancelled) return undefined;

--- a/src/services/project-manager.ts
+++ b/src/services/project-manager.ts
@@ -363,10 +363,16 @@ Add your project instructions here. This text will be injected into the agent's 
 	 * Parse the project's tool policy from frontmatter. Prefers the new
 	 * `toolPolicy:` block; falls back to the legacy `permissions:` map and
 	 * lifts it into `toolPolicy.overrides`.
+	 *
+	 * If `toolPolicy:` is present (even as an empty block), it's authoritative
+	 * — explicit "inherit global" intent must not silently fall through to
+	 * stale `permissions:` overrides that the user thought they migrated away
+	 * from.
 	 */
 	private parseToolPolicy(frontmatter: any): FeatureToolPolicy | undefined {
-		const fromNewShape = parseToolPolicyFrontmatter(frontmatter.toolPolicy);
-		if (fromNewShape) return fromNewShape;
+		if (Object.prototype.hasOwnProperty.call(frontmatter, 'toolPolicy')) {
+			return parseToolPolicyFrontmatter(frontmatter.toolPolicy);
+		}
 
 		const legacy = frontmatter.permissions;
 		if (!legacy || typeof legacy !== 'object') return undefined;

--- a/src/services/project-manager.ts
+++ b/src/services/project-manager.ts
@@ -1,26 +1,16 @@
 import { TFile, normalizePath } from 'obsidian';
 import type ObsidianGemini from '../main';
 import { Project, ProjectConfig, ProjectSummary, PROJECT_TAG } from '../types/project';
-import { ToolPermission } from '../types/tool-policy';
+import {
+	FeatureToolPolicy,
+	ToolPermission,
+	PERMISSION_STRING_MAP,
+	parseToolPolicyFrontmatter,
+	serializeToolPolicy,
+} from '../types/tool-policy';
 
 /** Regex to strip dataview/dataviewjs/bases fenced code blocks from body text */
 const UNSUPPORTED_CODE_BLOCK_RE = /```(?:dataview|dataviewjs|bases?)[\s\S]*?```/g;
-
-/** Map user-facing permission strings to ToolPermission enum values */
-const PERMISSION_MAP: Record<string, ToolPermission> = {
-	allow: ToolPermission.APPROVE,
-	approve: ToolPermission.APPROVE,
-	deny: ToolPermission.DENY,
-	ask: ToolPermission.ASK_USER,
-	ask_user: ToolPermission.ASK_USER,
-};
-
-/** Reverse map: ToolPermission enum values back to preferred user-friendly strings */
-const PERMISSION_REVERSE_MAP: Record<ToolPermission, string> = {
-	[ToolPermission.APPROVE]: 'allow',
-	[ToolPermission.DENY]: 'deny',
-	[ToolPermission.ASK_USER]: 'ask',
-};
 
 /**
  * Discovers, parses, and caches project definitions from the vault.
@@ -129,13 +119,15 @@ export class ProjectManager {
 		await this.plugin.app.fileManager.processFrontMatter(file, (frontmatter: any) => {
 			if (updates.name !== undefined) frontmatter.name = updates.name;
 			if (updates.skills !== undefined) frontmatter.skills = updates.skills;
-			if (updates.permissions !== undefined) {
-				// Convert ToolPermission enum values back to user-friendly strings
-				const permObj: Record<string, string> = {};
-				for (const [tool, perm] of Object.entries(updates.permissions)) {
-					permObj[tool] = PERMISSION_REVERSE_MAP[perm] ?? perm;
+			if ('toolPolicy' in updates) {
+				const serialized = serializeToolPolicy(updates.toolPolicy);
+				if (serialized) {
+					frontmatter.toolPolicy = serialized;
+				} else {
+					delete frontmatter.toolPolicy;
 				}
-				frontmatter.permissions = permObj;
+				// Drop the legacy field whenever we write the new shape.
+				delete frontmatter.permissions;
 			}
 		});
 
@@ -154,7 +146,7 @@ tags:
   - ${PROJECT_TAG}
 name: "${name}"
 skills: []
-permissions: {}
+toolPolicy: {}
 ---
 
 Add your project instructions here. This text will be injected into the agent's system prompt when a session is linked to this project.
@@ -279,6 +271,25 @@ Add your project instructions here. This text will be injected into the agent's 
 		// Parse config from frontmatter
 		const config = this.parseConfig(frontmatter, file.basename);
 
+		// Auto-migrate legacy `permissions:` shape → `toolPolicy.overrides`.
+		// Project frontmatter from before the unified-policy refactor wrote a
+		// flat `permissions: { tool: 'allow' }` map; the new shape nests it under
+		// toolPolicy. Rewrite once so future reads use the canonical shape.
+		// Failures here are non-fatal — the in-memory shape is correct either way.
+		if (frontmatter.permissions !== undefined && frontmatter.toolPolicy === undefined) {
+			try {
+				await this.plugin.app.fileManager.processFrontMatter(file, (fm: any) => {
+					const serialized = serializeToolPolicy(config.toolPolicy);
+					if (serialized) {
+						fm.toolPolicy = serialized;
+					}
+					delete fm.permissions;
+				});
+			} catch (err) {
+				this.plugin.logger.warn(`ProjectManager: legacy permissions migration failed for ${file.path}:`, err);
+			}
+		}
+
 		// Extract body text (strip frontmatter)
 		const fullContent = await this.plugin.app.vault.read(file);
 		let body = fullContent;
@@ -343,28 +354,37 @@ Add your project instructions here. This text will be injected into the agent's 
 		const skills = Array.isArray(frontmatter.skills)
 			? frontmatter.skills.filter((s: any) => typeof s === 'string')
 			: [];
-		const permissions = this.parsePermissions(frontmatter.permissions);
+		const toolPolicy = this.parseToolPolicy(frontmatter);
 
-		return { name, skills, permissions };
+		return { name, skills, toolPolicy };
 	}
 
-	private parsePermissions(raw: unknown): Record<string, ToolPermission> {
-		if (!raw || typeof raw !== 'object') return {};
+	/**
+	 * Parse the project's tool policy from frontmatter. Prefers the new
+	 * `toolPolicy:` block; falls back to the legacy `permissions:` map and
+	 * lifts it into `toolPolicy.overrides`.
+	 */
+	private parseToolPolicy(frontmatter: any): FeatureToolPolicy | undefined {
+		const fromNewShape = parseToolPolicyFrontmatter(frontmatter.toolPolicy);
+		if (fromNewShape) return fromNewShape;
 
-		const result: Record<string, ToolPermission> = {};
-		for (const [tool, value] of Object.entries(raw as Record<string, unknown>)) {
+		const legacy = frontmatter.permissions;
+		if (!legacy || typeof legacy !== 'object') return undefined;
+
+		const overrides: Record<string, ToolPermission> = {};
+		for (const [tool, value] of Object.entries(legacy as Record<string, unknown>)) {
 			if (typeof value !== 'string') continue;
-			const mapped = PERMISSION_MAP[value.toLowerCase()];
-			if (mapped) {
-				result[tool] = mapped;
+			const mapped = PERMISSION_STRING_MAP[value.toLowerCase()];
+			if (mapped !== undefined) {
+				overrides[tool] = mapped;
 			} else {
 				this.plugin.logger.warn(
 					`ProjectManager: Unknown permission value '${value}' for tool '${tool}', defaulting to ask_user`
 				);
-				result[tool] = ToolPermission.ASK_USER;
+				overrides[tool] = ToolPermission.ASK_USER;
 			}
 		}
-		return result;
+		return Object.keys(overrides).length > 0 ? { overrides } : undefined;
 	}
 
 	private resolveLinks(links: Array<{ link: string }> | undefined, sourcePath: string): TFile[] {

--- a/src/services/scheduled-task-manager.ts
+++ b/src/services/scheduled-task-manager.ts
@@ -2,6 +2,8 @@ import { TFile, normalizePath } from 'obsidian';
 import type ObsidianGemini from '../main';
 import { ensureFolderExists } from '../utils/file-utils';
 import { findFrontmatterEndOffset } from './skill-manager';
+import { FeatureToolPolicy, parseToolPolicyFrontmatter } from '../types/tool-policy';
+import { migrateLegacyToolCategoryArray, formatToolPolicyYaml } from './feature-policy-yaml';
 
 // ─── Folder / file layout ─────────────────────────────────────────────────────
 
@@ -37,8 +39,12 @@ export interface ScheduledTask {
 	 *   interval:Xh        — every X hours   (e.g. interval:2h)
 	 */
 	schedule: string;
-	/** ToolCategory enum values to enable for this session (e.g. ['read_only']). */
-	enabledTools: string[];
+	/**
+	 * Tool policy applied for the duration of each run. Layered on top of the
+	 * global plugin policy via FeatureToolPolicy. Undefined means inherit the
+	 * global policy.
+	 */
+	toolPolicy?: FeatureToolPolicy;
 	/**
 	 * Output path template. Supports {slug} and {date} placeholders.
 	 * Default: Scheduled-Tasks/Runs/{slug}/{date}.md
@@ -479,7 +485,7 @@ export class ScheduledTaskManager {
 	async createTask(params: {
 		slug: string;
 		schedule: string;
-		enabledTools?: string[];
+		toolPolicy?: FeatureToolPolicy;
 		outputPath?: string;
 		model?: string;
 		enabled?: boolean;
@@ -505,7 +511,7 @@ export class ScheduledTaskManager {
 		const task: ScheduledTask = {
 			slug,
 			schedule: params.schedule,
-			enabledTools: params.enabledTools ?? [],
+			toolPolicy: params.toolPolicy,
 			outputPath: params.outputPath ?? defaultOutputPath,
 			model: params.model,
 			enabled: params.enabled ?? true,
@@ -547,7 +553,7 @@ export class ScheduledTaskManager {
 		slug: string,
 		params: {
 			schedule?: string;
-			enabledTools?: string[];
+			toolPolicy?: FeatureToolPolicy;
 			outputPath?: string;
 			model?: string;
 			enabled?: boolean;
@@ -569,7 +575,7 @@ export class ScheduledTaskManager {
 		const merged = {
 			slug,
 			schedule: params.schedule ?? task.schedule,
-			enabledTools: params.enabledTools ?? task.enabledTools,
+			toolPolicy: 'toolPolicy' in params ? params.toolPolicy : task.toolPolicy,
 			outputPath: params.outputPath ?? task.outputPath,
 			model: params.model ?? task.model,
 			enabled: params.enabled ?? task.enabled,
@@ -836,10 +842,16 @@ export class ScheduledTaskManager {
 		const slug = file.basename;
 		const defaultOutputPath = `${this.scheduledTasksFolder}/${RUNS_SUBFOLDER}/${slug}/{date}.md`;
 
-		return {
+		// Prefer the new `toolPolicy:` block; fall back to the legacy
+		// `enabledTools:` array (which the bugged modal also populated with
+		// `read_write` / `destructive`, both handled here).
+		const toolPolicy =
+			parseToolPolicyFrontmatter(frontmatter.toolPolicy) ?? migrateLegacyToolCategoryArray(frontmatter.enabledTools);
+
+		const task: ScheduledTask = {
 			slug,
 			schedule: String(frontmatter.schedule),
-			enabledTools: Array.isArray(frontmatter.enabledTools) ? (frontmatter.enabledTools as string[]) : [],
+			toolPolicy,
 			outputPath: typeof frontmatter.outputPath === 'string' ? frontmatter.outputPath : defaultOutputPath,
 			model: typeof frontmatter.model === 'string' ? frontmatter.model : undefined,
 			enabled: frontmatter.enabled !== false,
@@ -847,6 +859,18 @@ export class ScheduledTaskManager {
 			prompt,
 			filePath: file.path,
 		};
+
+		// Auto-migrate the file in place when we read the legacy shape so the
+		// next read uses the canonical key. Failures are non-fatal.
+		if (frontmatter.enabledTools !== undefined && frontmatter.toolPolicy === undefined) {
+			try {
+				await this.plugin.app.vault.modify(file, this.serializeTask(task));
+			} catch (err) {
+				this.plugin.logger.warn(`[ScheduledTaskManager] legacy enabledTools migration failed for ${file.path}:`, err);
+			}
+		}
+
+		return task;
 	}
 
 	/**
@@ -856,7 +880,7 @@ export class ScheduledTaskManager {
 	private serializeTask(params: {
 		slug?: string;
 		schedule: string;
-		enabledTools?: string[];
+		toolPolicy?: FeatureToolPolicy;
 		outputPath?: string;
 		model?: string;
 		enabled?: boolean;
@@ -866,12 +890,9 @@ export class ScheduledTaskManager {
 		const lines: string[] = ['---'];
 		lines.push(`schedule: '${params.schedule}'`);
 
-		const tools = params.enabledTools ?? [];
-		if (tools.length > 0) {
-			lines.push('enabledTools:');
-			for (const t of tools) {
-				lines.push(`  - ${t}`);
-			}
+		const policyLines = formatToolPolicyYaml(params.toolPolicy);
+		if (policyLines) {
+			lines.push(...policyLines);
 		}
 
 		const defaultOutputPath =

--- a/src/services/scheduled-task-runner.ts
+++ b/src/services/scheduled-task-runner.ts
@@ -82,7 +82,11 @@ export class ScheduledTaskRunner {
 			featureToolPolicy: this.task.toolPolicy,
 		};
 		const modelApi = ModelClientFactory.createChatModel(this.plugin);
-		const availableTools = this.plugin.toolRegistry.getEnabledTools(toolContext);
+		// Headless runs auto-approve confirmations, so only expose tools the
+		// user explicitly opted into (APPROVE under the layered policy).
+		// ASK_USER tools are excluded — exposing them would silently bypass
+		// the user's "ask first" intent because there's no UI to ask on.
+		const availableTools = this.plugin.toolRegistry.getAutoApprovedTools(toolContext);
 
 		// Prepend a turn preamble so the model has accurate "now" awareness.
 		const startedAt = formatLocalTimestamp(session.created);
@@ -123,6 +127,7 @@ export class ScheduledTaskRunner {
 					confirmationProvider: new HeadlessConfirmationProvider(),
 					maxIterations: 20,
 					featureToolPolicy: this.task.toolPolicy,
+					headless: true,
 				},
 			});
 

--- a/src/services/scheduled-task-runner.ts
+++ b/src/services/scheduled-task-runner.ts
@@ -1,7 +1,7 @@
 import { normalizePath } from 'obsidian';
 import type ObsidianGemini from '../main';
 import type { ScheduledTask } from './scheduled-task-manager';
-import { ToolCategory, DestructiveAction } from '../types/agent';
+import { DestructiveAction } from '../types/agent';
 import type { ConfirmationResult, DiffContext, IConfirmationProvider, Tool } from '../tools/types';
 import { ToolExecutionContext } from '../tools/types';
 import { ModelClientFactory } from '../api';
@@ -61,20 +61,12 @@ export class ScheduledTaskRunner {
 			throw new Error('[ScheduledTaskRunner] Agent services not initialised');
 		}
 
-		// Map task's enabledTools strings to ToolCategory enum values, defaulting
-		// to read-only + skills when the list is empty. SKILLS is included so the
-		// most natural scheduled-task pattern — "run skill X on a schedule" — works
-		// out of the box; this matches DEFAULT_CONTEXTS.AGENT_SESSION (which also
-		// includes SKILLS by default for live agent sessions). Users who want a
-		// stricter allowlist can set `enabledTools: ['read_only']` explicitly.
-		const enabledToolCategories =
-			this.task.enabledTools.length > 0
-				? (this.task.enabledTools as ToolCategory[])
-				: [ToolCategory.READ_ONLY, ToolCategory.SKILLS];
-
-		// Create a headless session — no confirmation required.
+		// Create a headless session bound to this task's tool policy. When the
+		// task has no toolPolicy, the session inherits the global plugin policy
+		// — the registry filter is permission-driven so a task without a policy
+		// sees the same tools as an interactive agent session.
 		const session = await this.plugin.sessionManager.createAgentSession(`Scheduled: ${this.task.slug}`, {
-			enabledTools: enabledToolCategories,
+			toolPolicy: this.task.toolPolicy,
 			requireConfirmation: [] as DestructiveAction[],
 		});
 
@@ -84,7 +76,11 @@ export class ScheduledTaskRunner {
 			session.modelConfig = { model: this.task.model };
 		}
 
-		const toolContext: ToolExecutionContext = { plugin: this.plugin, session };
+		const toolContext: ToolExecutionContext = {
+			plugin: this.plugin,
+			session,
+			featureToolPolicy: this.task.toolPolicy,
+		};
 		const modelApi = ModelClientFactory.createChatModel(this.plugin);
 		const availableTools = this.plugin.toolRegistry.getEnabledTools(toolContext);
 
@@ -126,6 +122,7 @@ export class ScheduledTaskRunner {
 					isCancelled,
 					confirmationProvider: new HeadlessConfirmationProvider(),
 					maxIterations: 20,
+					featureToolPolicy: this.task.toolPolicy,
 				},
 			});
 

--- a/src/tools/execution-engine.ts
+++ b/src/tools/execution-engine.ts
@@ -104,8 +104,8 @@ export class ToolExecutionEngine {
 			};
 		}
 
-		// Check if confirmation is required (project overrides → global policy)
-		const requiresConfirmation = this.registry.requiresConfirmation(toolCall.name, context.projectPermissions);
+		// Check if confirmation is required (feature policy overlay → global policy)
+		const requiresConfirmation = this.registry.requiresConfirmation(toolCall.name, context.featureToolPolicy);
 
 		if (requiresConfirmation) {
 			// Check if this tool is allowed without confirmation for this session

--- a/src/tools/tool-registry.ts
+++ b/src/tools/tool-registry.ts
@@ -97,6 +97,22 @@ export class ToolRegistry {
 	}
 
 	/**
+	 * Subset of `getEnabledTools` for headless callers (scheduled tasks, hooks).
+	 *
+	 * Returns only tools whose effective permission is APPROVE — i.e. tools the
+	 * user has explicitly opted into. Tools mapped to ASK_USER are excluded
+	 * because headless runs auto-approve every confirmation prompt, which would
+	 * silently bypass the user's ASK_USER intent. To allow a tool in a headless
+	 * flow, the task / hook policy must explicitly mark it APPROVE (via preset
+	 * or `overrides`).
+	 */
+	getAutoApprovedTools(context: ToolExecutionContext): Tool[] {
+		return this.getAllTools().filter(
+			(tool) => this.getEffectivePermission(tool.name, context.featureToolPolicy) === ToolPermission.APPROVE
+		);
+	}
+
+	/**
 	 * Check if a tool requires confirmation based on the effective policy.
 	 *
 	 * - APPROVE → no confirmation needed

--- a/src/tools/tool-registry.ts
+++ b/src/tools/tool-registry.ts
@@ -1,6 +1,11 @@
 import { Tool, ToolExecutionContext } from './types';
-import { ToolCategory } from '../types/agent';
-import { ToolPermission, resolvePermission, ToolPolicySettings, DEFAULT_TOOL_POLICY } from '../types/tool-policy';
+import {
+	ToolPermission,
+	FeatureToolPolicy,
+	resolveEffectivePermission,
+	ToolPolicySettings,
+	DEFAULT_TOOL_POLICY,
+} from '../types/tool-policy';
 import type ObsidianGemini from '../main';
 
 /**
@@ -61,55 +66,45 @@ export class ToolRegistry {
 	}
 
 	/**
-	 * Resolve the effective permission for a tool based on the current policy settings.
+	 * Resolve the effective permission for a tool, layering the optional
+	 * feature-level policy on top of the global plugin policy.
 	 *
-	 * Resolution order:
-	 * 1. Explicit per-tool override in `toolPolicy.toolPermissions`
-	 * 2. Preset-defined permission based on tool classification
+	 * Resolution order (most specific wins):
+	 *   1. Feature `overrides[toolName]`
+	 *   2. Global `toolPermissions[toolName]`
+	 *   3. Feature `preset[classification]`
+	 *   4. Global `activePreset[classification]`
 	 */
-	getEffectivePermission(toolName: string, projectPermissions?: Record<string, ToolPermission>): ToolPermission {
+	getEffectivePermission(toolName: string, featurePolicy?: FeatureToolPolicy): ToolPermission {
 		const tool = this.getTool(toolName);
 		if (!tool) return ToolPermission.DENY;
 
-		// Project-level override takes priority
-		if (projectPermissions?.[toolName] !== undefined) {
-			return projectPermissions[toolName];
-		}
-
-		return resolvePermission(toolName, tool.classification, this.getToolPolicy());
+		return resolveEffectivePermission(toolName, tool.classification, this.getToolPolicy(), featurePolicy);
 	}
 
 	/**
-	 * Get tools that are enabled for the current session.
+	 * Get tools that are enabled for the current execution context.
 	 *
-	 * A tool is enabled if:
-	 * 1. Its category is in the session's `enabledTools` list (session-level filtering)
-	 * 2. Its effective permission is NOT `DENY` (global policy filtering)
-	 *
-	 * Session contexts never escalate beyond global policy — a DENY tool
-	 * cannot be enabled by a session.
+	 * A tool is enabled iff its effective permission is not DENY. Filtering is
+	 * permission-driven only — there is no category filter. To narrow the tool
+	 * surface for a feature run, set a `featureToolPolicy` whose preset (or
+	 * per-tool overrides) maps the unwanted tools to DENY.
 	 */
 	getEnabledTools(context: ToolExecutionContext): Tool[] {
-		const enabledCategories = context.session.context.enabledTools;
-		return this.getAllTools().filter((tool) => {
-			// Session-level category filter
-			if (!enabledCategories.includes(tool.category as ToolCategory)) {
-				return false;
-			}
-			// Policy filter — exclude DENY tools (project overrides → global policy)
-			return this.getEffectivePermission(tool.name, context.projectPermissions) !== ToolPermission.DENY;
-		});
+		return this.getAllTools().filter(
+			(tool) => this.getEffectivePermission(tool.name, context.featureToolPolicy) !== ToolPermission.DENY
+		);
 	}
 
 	/**
-	 * Check if a tool requires confirmation based on global policy.
+	 * Check if a tool requires confirmation based on the effective policy.
 	 *
 	 * - APPROVE → no confirmation needed
 	 * - ASK_USER → confirmation required
 	 * - DENY → tool should not be present (but returns false as a safe default)
 	 */
-	requiresConfirmation(toolName: string, projectPermissions?: Record<string, ToolPermission>): boolean {
-		return this.getEffectivePermission(toolName, projectPermissions) === ToolPermission.ASK_USER;
+	requiresConfirmation(toolName: string, featurePolicy?: FeatureToolPolicy): boolean {
+		return this.getEffectivePermission(toolName, featurePolicy) === ToolPermission.ASK_USER;
 	}
 
 	/**

--- a/src/tools/types.ts
+++ b/src/tools/types.ts
@@ -30,8 +30,13 @@ export interface ToolExecutionContext {
 	plugin: any; // Will be typed to ObsidianGemini
 	/** When set, discovery tools default their search scope to this directory */
 	projectRootPath?: string;
-	/** When set, project-level permission overrides are applied to tool resolution */
-	projectPermissions?: Record<string, import('../types/tool-policy').ToolPermission>;
+	/**
+	 * Feature-level tool policy applied on top of the global plugin policy.
+	 * Used by Projects, Scheduled Tasks, Hooks, and Sessions to narrow or open
+	 * the tool surface for a single run. When unset, only the global policy
+	 * applies.
+	 */
+	featureToolPolicy?: import('../types/tool-policy').FeatureToolPolicy;
 }
 
 /**

--- a/src/types/agent.ts
+++ b/src/types/agent.ts
@@ -1,7 +1,13 @@
 import { TFile } from 'obsidian';
+import { FeatureToolPolicy, PolicyPreset } from './tool-policy';
 
 /**
- * Tool categories that can be enabled/disabled for an agent
+ * UI-only grouping label for tools (e.g. for "read-only tools" pickers).
+ *
+ * NOTE: As of the unified-tool-policy refactor this is no longer a security
+ * boundary — runtime tool filtering is permission-driven and goes through
+ * `ToolPolicySettings` / `FeatureToolPolicy`. The enum stays so existing tool
+ * declarations and grouped UIs keep working.
  */
 export enum ToolCategory {
 	READ_ONLY = 'read_only', // Search, read files, analyze
@@ -28,8 +34,12 @@ export interface AgentContext {
 	/** Files to include in the conversation context */
 	contextFiles: TFile[];
 
-	/** Tool categories enabled for this agent session */
-	enabledTools: ToolCategory[];
+	/**
+	 * Session-scoped tool policy. When unset, the session inherits the global
+	 * plugin tool policy. When set, the policy is layered on top of the global
+	 * policy at every tool resolution.
+	 */
+	toolPolicy?: FeatureToolPolicy;
 
 	/** Actions that require user confirmation */
 	requireConfirmation: DestructiveAction[];
@@ -195,7 +205,10 @@ export interface ToolExecution {
 export const DEFAULT_CONTEXTS = {
 	NOTE_CHAT: {
 		contextFiles: [], // Will be set to current file
-		enabledTools: [ToolCategory.READ_ONLY],
+		// Note-chat sessions are read-only by default; the policy maps every
+		// non-read classification to DENY, so write/destructive/external tools
+		// are filtered out of the registry.
+		toolPolicy: { preset: PolicyPreset.READ_ONLY },
 		requireConfirmation: [],
 		maxContextChars: 50000,
 		maxCharsPerFile: 10000,
@@ -203,12 +216,10 @@ export const DEFAULT_CONTEXTS = {
 
 	AGENT_SESSION: {
 		contextFiles: [],
-		enabledTools: [
-			ToolCategory.READ_ONLY,
-			ToolCategory.VAULT_OPERATIONS,
-			ToolCategory.EXTERNAL_MCP,
-			ToolCategory.SKILLS,
-		],
+		// Inherit the global tool policy — full agent sessions see the full
+		// tool surface unless the user narrows it via the plugin settings or
+		// a project / scheduled-task / hook policy.
+		toolPolicy: undefined,
 		requireConfirmation: [
 			DestructiveAction.MODIFY_FILES,
 			DestructiveAction.CREATE_FILES,

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -1,5 +1,5 @@
 import { TFile } from 'obsidian';
-import { ToolPermission } from './tool-policy';
+import { FeatureToolPolicy } from './tool-policy';
 
 /**
  * Tag that identifies a markdown file as a project definition.
@@ -16,8 +16,11 @@ export interface ProjectConfig {
 	/** Skill names to auto-activate for this project */
 	skills: string[];
 
-	/** Per-tool permission overrides */
-	permissions: Record<string, ToolPermission>;
+	/**
+	 * Project-scoped tool policy (preset + per-tool overrides).
+	 * When unset, the project inherits the global plugin tool policy.
+	 */
+	toolPolicy?: FeatureToolPolicy;
 }
 
 /**

--- a/src/types/tool-policy.ts
+++ b/src/types/tool-policy.ts
@@ -179,3 +179,148 @@ export function resolvePermission(
 	// Fall back to preset-defined permission
 	return PRESET_PERMISSIONS[settings.activePreset][classification];
 }
+
+/**
+ * Per-feature tool policy. Lets a Project, Scheduled Task, Hook, or Session
+ * narrow (or open up) the global tool policy for the duration of one run.
+ *
+ * When `preset` is unset the feature inherits the global active preset; when
+ * `overrides` is unset (or missing a tool entry) the feature inherits the
+ * global per-tool overrides.
+ */
+export interface FeatureToolPolicy {
+	preset?: PolicyPreset;
+	overrides?: Record<string, ToolPermission>;
+}
+
+/**
+ * Resolve the effective permission for a tool, layering a feature-level
+ * policy on top of the global policy.
+ *
+ * Resolution order (most specific wins):
+ *   1. Feature `overrides[toolName]`
+ *   2. Global `toolPermissions[toolName]`
+ *   3. Feature `preset[classification]`
+ *   4. Global `activePreset[classification]`
+ */
+export function resolveEffectivePermission(
+	toolName: string,
+	classification: ToolClassification,
+	global: ToolPolicySettings,
+	feature?: FeatureToolPolicy
+): ToolPermission {
+	if (feature?.overrides && feature.overrides[toolName] !== undefined) {
+		return feature.overrides[toolName];
+	}
+	const globalOverride = global.toolPermissions[toolName];
+	if (globalOverride !== undefined) {
+		return globalOverride;
+	}
+	if (feature?.preset !== undefined && feature.preset !== PolicyPreset.CUSTOM) {
+		return PRESET_PERMISSIONS[feature.preset][classification];
+	}
+	return PRESET_PERMISSIONS[global.activePreset][classification];
+}
+
+/**
+ * Map of user-facing permission strings to ToolPermission enum values.
+ * Used by YAML frontmatter parsers in project / scheduled-task / hook configs.
+ *
+ * - `allow` and `approve` both map to APPROVE (project frontmatter has historically used `allow`)
+ * - `ask` and `ask_user` both map to ASK_USER
+ * - `deny` maps to DENY
+ */
+export const PERMISSION_STRING_MAP: Record<string, ToolPermission> = {
+	allow: ToolPermission.APPROVE,
+	approve: ToolPermission.APPROVE,
+	deny: ToolPermission.DENY,
+	ask: ToolPermission.ASK_USER,
+	ask_user: ToolPermission.ASK_USER,
+};
+
+/**
+ * Reverse map: ToolPermission enum values back to preferred YAML strings.
+ * APPROVE serializes as `allow` (shorter, matches the legacy project format).
+ */
+export const PERMISSION_TO_STRING: Record<ToolPermission, string> = {
+	[ToolPermission.APPROVE]: 'allow',
+	[ToolPermission.DENY]: 'deny',
+	[ToolPermission.ASK_USER]: 'ask',
+};
+
+/**
+ * Parse a raw frontmatter value into a FeatureToolPolicy, or return undefined
+ * when the input doesn't look like a policy block (inherit-global semantics).
+ *
+ * Accepts shapes like:
+ *   { preset: 'read_only' }
+ *   { overrides: { read_file: 'allow', delete_file: 'deny' } }
+ *   { preset: 'cautious', overrides: { web_fetch: 'deny' } }
+ *
+ * Returns undefined for null/undefined input.
+ */
+export function parseToolPolicyFrontmatter(raw: unknown): FeatureToolPolicy | undefined {
+	if (raw === null || raw === undefined) return undefined;
+	if (typeof raw !== 'object') return undefined;
+
+	const obj = raw as Record<string, unknown>;
+	const policy: FeatureToolPolicy = {};
+
+	if (typeof obj.preset === 'string') {
+		const presetCandidate = obj.preset.toLowerCase();
+		if ((Object.values(PolicyPreset) as string[]).includes(presetCandidate)) {
+			policy.preset = presetCandidate as PolicyPreset;
+		}
+	}
+
+	if (obj.overrides && typeof obj.overrides === 'object') {
+		const overrides: Record<string, ToolPermission> = {};
+		for (const [tool, value] of Object.entries(obj.overrides as Record<string, unknown>)) {
+			if (typeof value !== 'string') continue;
+			const mapped = PERMISSION_STRING_MAP[value.toLowerCase()];
+			if (mapped !== undefined) {
+				overrides[tool] = mapped;
+			}
+		}
+		if (Object.keys(overrides).length > 0) {
+			policy.overrides = overrides;
+		}
+	}
+
+	if (policy.preset === undefined && policy.overrides === undefined) {
+		return undefined;
+	}
+	return policy;
+}
+
+/**
+ * Deep-clone a FeatureToolPolicy. Used by SessionManager and friends to avoid
+ * sharing nested `overrides` references with the static DEFAULT_CONTEXTS.
+ */
+export function clonePolicy(policy: FeatureToolPolicy | undefined): FeatureToolPolicy | undefined {
+	if (!policy) return undefined;
+	return {
+		...(policy.preset !== undefined ? { preset: policy.preset } : {}),
+		...(policy.overrides ? { overrides: { ...policy.overrides } } : {}),
+	};
+}
+
+/**
+ * Serialize a FeatureToolPolicy back to a plain frontmatter-friendly object.
+ * Returns undefined when the policy is effectively empty.
+ */
+export function serializeToolPolicy(policy: FeatureToolPolicy | undefined): Record<string, unknown> | undefined {
+	if (!policy) return undefined;
+	const out: Record<string, unknown> = {};
+	if (policy.preset !== undefined) {
+		out.preset = policy.preset;
+	}
+	if (policy.overrides && Object.keys(policy.overrides).length > 0) {
+		const overrides: Record<string, string> = {};
+		for (const [tool, perm] of Object.entries(policy.overrides)) {
+			overrides[tool] = PERMISSION_TO_STRING[perm];
+		}
+		out.overrides = overrides;
+	}
+	return Object.keys(out).length > 0 ? out : undefined;
+}

--- a/src/ui/agent-view/agent-view-send.ts
+++ b/src/ui/agent-view/agent-view-send.ts
@@ -285,7 +285,7 @@ To reference an attachment in your response, use the path shown above.`;
 				plugin: this.ctx.plugin,
 				session: currentSession,
 				projectRootPath: activeProject?.rootPath,
-				projectPermissions: activeProject?.config.permissions,
+				featureToolPolicy: activeProject?.config.toolPolicy,
 			};
 			const availableTools = this.ctx.plugin.toolRegistry.getEnabledTools(toolContext);
 			this.ctx.plugin.logger.log('Available tools from registry:', availableTools);

--- a/src/ui/agent-view/agent-view-tool-followup.ts
+++ b/src/ui/agent-view/agent-view-tool-followup.ts
@@ -17,6 +17,13 @@ export interface FollowUpRequestParams extends PerTurnContext {
 	customPrompt?: CustomPrompt;
 	projectRootPath?: string;
 	featureToolPolicy?: import('../../types/tool-policy').FeatureToolPolicy;
+	/**
+	 * When true, restrict follow-up tools to those auto-approved by the
+	 * effective policy. Scheduled-task and hook runners set this so the
+	 * model never sees an ASK_USER tool that would auto-approve through
+	 * the headless confirmation provider.
+	 */
+	headless?: boolean;
 }
 
 export interface RetryRequestParams extends PerTurnContext {
@@ -38,6 +45,7 @@ export function buildFollowUpRequest(params: FollowUpRequestParams): ExtendedMod
 		customPrompt,
 		projectRootPath,
 		featureToolPolicy,
+		headless,
 		perTurnContext,
 		projectInstructions,
 		projectSkills,
@@ -50,7 +58,12 @@ export function buildFollowUpRequest(params: FollowUpRequestParams): ExtendedMod
 		projectRootPath,
 		featureToolPolicy,
 	};
-	const availableTools = plugin.toolRegistry.getEnabledTools(availableToolsContext);
+	// Headless callers can't surface a confirmation prompt mid-run, so they
+	// must only see APPROVE tools. UI callers see the full enabled set and
+	// confirm ASK_USER tools through the in-chat prompt.
+	const availableTools = headless
+		? plugin.toolRegistry.getAutoApprovedTools(availableToolsContext)
+		: plugin.toolRegistry.getEnabledTools(availableToolsContext);
 
 	const modelConfig = currentSession?.modelConfig || {};
 

--- a/src/ui/agent-view/agent-view-tool-followup.ts
+++ b/src/ui/agent-view/agent-view-tool-followup.ts
@@ -16,7 +16,7 @@ export interface FollowUpRequestParams extends PerTurnContext {
 	updatedHistory: any[];
 	customPrompt?: CustomPrompt;
 	projectRootPath?: string;
-	projectPermissions?: Record<string, import('../../types/tool-policy').ToolPermission>;
+	featureToolPolicy?: import('../../types/tool-policy').FeatureToolPolicy;
 }
 
 export interface RetryRequestParams extends PerTurnContext {
@@ -37,7 +37,7 @@ export function buildFollowUpRequest(params: FollowUpRequestParams): ExtendedMod
 		updatedHistory,
 		customPrompt,
 		projectRootPath,
-		projectPermissions,
+		featureToolPolicy,
 		perTurnContext,
 		projectInstructions,
 		projectSkills,
@@ -48,7 +48,7 @@ export function buildFollowUpRequest(params: FollowUpRequestParams): ExtendedMod
 		plugin,
 		session: currentSession,
 		projectRootPath,
-		projectPermissions,
+		featureToolPolicy,
 	};
 	const availableTools = plugin.toolRegistry.getEnabledTools(availableToolsContext);
 

--- a/src/ui/agent-view/agent-view-tools.ts
+++ b/src/ui/agent-view/agent-view-tools.ts
@@ -78,7 +78,7 @@ export class AgentViewTools {
 					confirmationProvider: this.context.confirmationProvider,
 					customPrompt,
 					projectRootPath: activeProject?.rootPath,
-					projectPermissions: activeProject?.config.permissions,
+					featureToolPolicy: activeProject?.config.toolPolicy,
 					perTurn,
 					hooks: {
 						onToolBatchStart: (batch) => {

--- a/src/ui/components/tool-policy-editor.ts
+++ b/src/ui/components/tool-policy-editor.ts
@@ -56,6 +56,9 @@ export interface ToolPolicyEditorOptions {
  *   editor.destroy();
  */
 export class ToolPolicyEditor {
+	/** Monotonic counter for generating unique DOM ids per editor instance. */
+	private static nextInheritId = 0;
+
 	private state: FeatureToolPolicy | undefined;
 	private container: HTMLElement;
 	private bodyEl!: HTMLElement;
@@ -120,9 +123,19 @@ export class ToolPolicyEditor {
 
 		// Inherit toggle — when on, hides the rest of the editor.
 		const inheritRow = this.container.createDiv({ cls: 'gemini-tool-policy-editor-inherit' });
-		const inheritCb = inheritRow.createEl('input', { attr: { type: 'checkbox' } }) as HTMLInputElement;
+		// Bind the label to the checkbox via for/id so click-through and
+		// assistive tech work correctly. The id needs to be unique across the
+		// page, not just within this component, since multiple editors could
+		// briefly coexist during a modal re-render.
+		const inheritId = `gemini-tool-policy-inherit-${++ToolPolicyEditor.nextInheritId}`;
+		const inheritCb = inheritRow.createEl('input', {
+			attr: { type: 'checkbox', id: inheritId },
+		}) as HTMLInputElement;
 		inheritCb.checked = this.state === undefined;
-		inheritRow.createEl('label', { text: ' Inherit global plugin tool policy' });
+		inheritRow.createEl('label', {
+			text: ' Inherit global plugin tool policy',
+			attr: { for: inheritId },
+		});
 		inheritCb.addEventListener('change', () => {
 			if (inheritCb.checked) {
 				this.state = undefined;

--- a/src/ui/components/tool-policy-editor.ts
+++ b/src/ui/components/tool-policy-editor.ts
@@ -1,0 +1,229 @@
+import type ObsidianGemini from '../../main';
+import type { Tool } from '../../tools/types';
+import {
+	FeatureToolPolicy,
+	PolicyPreset,
+	PRESET_LABELS,
+	PERMISSION_LABELS,
+	CLASSIFICATION_LABELS,
+	ToolClassification,
+	ToolPermission,
+	clonePolicy,
+} from '../../types/tool-policy';
+
+/**
+ * Sentinel used in the preset dropdown to mean "no preset set on this feature
+ * — inherit whatever the global plugin policy currently uses." Stored as a
+ * sentinel string rather than `undefined` because <select> values are strings.
+ */
+const INHERIT_PRESET = '__inherit__';
+/** Same idea for per-tool overrides: "leave this tool to the preset / global". */
+const INHERIT_OVERRIDE = '__inherit__';
+
+export interface ToolPolicyEditorOptions {
+	/** Initial value. `undefined` means "inherit global policy". */
+	value: FeatureToolPolicy | undefined;
+	/** Fired whenever the user changes a field. */
+	onChange(next: FeatureToolPolicy | undefined): void;
+	/**
+	 * Optional title for the editor block. Defaults to "Tool access". Pass an
+	 * empty string to suppress the heading entirely when the editor is embedded
+	 * in a larger form that already has its own labels.
+	 */
+	title?: string;
+	/**
+	 * Optional description text rendered below the heading. Useful for telling
+	 * the user what "inherit" means in their feature's context (e.g. "When off,
+	 * inherits the global plugin tool policy.").
+	 */
+	description?: string;
+}
+
+/**
+ * Shared UI for picking a FeatureToolPolicy: an "Inherit global policy" toggle,
+ * a preset dropdown, and a per-tool overrides table grouped by classification.
+ *
+ * The editor mutates an internal clone of the supplied value so caller state is
+ * never accidentally aliased; every change is surfaced via `onChange` with the
+ * full new value (or `undefined` when the user chose to inherit).
+ *
+ * Usage:
+ *   const editor = new ToolPolicyEditor(plugin, container, {
+ *     value: task.toolPolicy,
+ *     onChange: (next) => { form.toolPolicy = next; },
+ *   });
+ *   // ... later, when destroying the modal:
+ *   editor.destroy();
+ */
+export class ToolPolicyEditor {
+	private state: FeatureToolPolicy | undefined;
+	private container: HTMLElement;
+	private bodyEl!: HTMLElement;
+
+	constructor(
+		private plugin: ObsidianGemini,
+		mount: HTMLElement,
+		private options: ToolPolicyEditorOptions
+	) {
+		this.state = clonePolicy(options.value);
+		this.container = mount.createDiv({ cls: 'gemini-tool-policy-editor' });
+		this.render();
+	}
+
+	/**
+	 * Replace the editor contents (e.g. after a re-render in the host modal).
+	 * No-op if the new value is structurally equal to the current state.
+	 */
+	setValue(next: FeatureToolPolicy | undefined): void {
+		this.state = clonePolicy(next);
+		this.render();
+	}
+
+	/** Remove the editor's DOM nodes. */
+	destroy(): void {
+		this.container.empty();
+		this.container.remove();
+	}
+
+	private emit(): void {
+		// Normalize: an empty overrides map is the same as no overrides; an
+		// empty policy object is the same as undefined.
+		let normalized: FeatureToolPolicy | undefined;
+		if (this.state) {
+			const { preset, overrides } = this.state;
+			const overridesNonEmpty = overrides && Object.keys(overrides).length > 0 ? overrides : undefined;
+			if (preset === undefined && !overridesNonEmpty) {
+				normalized = undefined;
+			} else {
+				normalized = {
+					...(preset !== undefined ? { preset } : {}),
+					...(overridesNonEmpty ? { overrides: { ...overridesNonEmpty } } : {}),
+				};
+			}
+		}
+		this.options.onChange(normalized);
+	}
+
+	private render(): void {
+		this.container.empty();
+
+		const title = this.options.title ?? 'Tool access';
+		if (title) {
+			this.container.createEl('h4', { text: title, cls: 'gemini-tool-policy-editor-title' });
+		}
+		if (this.options.description) {
+			this.container.createEl('p', {
+				text: this.options.description,
+				cls: 'gemini-tool-policy-editor-desc',
+			});
+		}
+
+		// Inherit toggle — when on, hides the rest of the editor.
+		const inheritRow = this.container.createDiv({ cls: 'gemini-tool-policy-editor-inherit' });
+		const inheritCb = inheritRow.createEl('input', { attr: { type: 'checkbox' } }) as HTMLInputElement;
+		inheritCb.checked = this.state === undefined;
+		inheritRow.createEl('label', { text: ' Inherit global plugin tool policy' });
+		inheritCb.addEventListener('change', () => {
+			if (inheritCb.checked) {
+				this.state = undefined;
+			} else {
+				// Initialise to an empty (custom) policy so the user can pick fields.
+				this.state = {};
+			}
+			this.emit();
+			this.render();
+		});
+
+		this.bodyEl = this.container.createDiv({ cls: 'gemini-tool-policy-editor-body' });
+		if (this.state === undefined) {
+			return;
+		}
+
+		this.renderPresetRow();
+		this.renderOverridesTable();
+	}
+
+	private renderPresetRow(): void {
+		const row = this.bodyEl.createDiv({ cls: 'gemini-tool-policy-editor-preset-row' });
+		row.createEl('label', { text: 'Preset:' });
+		const select = row.createEl('select') as HTMLSelectElement;
+
+		// "(no preset)" means: use the preset from the global policy, only
+		// honour any explicit overrides on this feature. Distinct from
+		// "inherit global policy" — that hides this entire body.
+		select.add(new Option('(no preset — use global preset)', INHERIT_PRESET));
+
+		// Skip CUSTOM in the picker — it's the implicit value when the user
+		// has only set overrides and no preset; the resolver treats CUSTOM as
+		// "no preset-driven contribution" already.
+		for (const preset of Object.values(PolicyPreset)) {
+			if (preset === PolicyPreset.CUSTOM) continue;
+			select.add(new Option(PRESET_LABELS[preset], preset));
+		}
+
+		select.value = this.state?.preset ?? INHERIT_PRESET;
+		select.addEventListener('change', () => {
+			if (!this.state) this.state = {};
+			if (select.value === INHERIT_PRESET) {
+				delete this.state.preset;
+			} else {
+				this.state.preset = select.value as PolicyPreset;
+			}
+			this.emit();
+		});
+	}
+
+	private renderOverridesTable(): void {
+		const wrapper = this.bodyEl.createDiv({ cls: 'gemini-tool-policy-editor-overrides' });
+		wrapper.createEl('h5', { text: 'Per-tool overrides' });
+
+		const tools = this.plugin.toolRegistry?.getAllTools() ?? [];
+		if (tools.length === 0) {
+			wrapper.createEl('p', { text: 'No tools registered.' });
+			return;
+		}
+
+		// Group tools by classification so the table mirrors the global-policy UI.
+		const byClass = new Map<ToolClassification, Tool[]>();
+		for (const tool of tools) {
+			const list = byClass.get(tool.classification) ?? [];
+			list.push(tool);
+			byClass.set(tool.classification, list);
+		}
+
+		for (const classification of Object.values(ToolClassification)) {
+			const list = byClass.get(classification);
+			if (!list || list.length === 0) continue;
+
+			wrapper.createEl('h6', {
+				text: CLASSIFICATION_LABELS[classification],
+				cls: 'gemini-tool-policy-editor-class-heading',
+			});
+
+			for (const tool of list) {
+				const row = wrapper.createDiv({ cls: 'gemini-tool-policy-editor-tool-row' });
+				row.createEl('span', {
+					text: tool.displayName || tool.name,
+					cls: 'gemini-tool-policy-editor-tool-name',
+				});
+
+				const select = row.createEl('select') as HTMLSelectElement;
+				select.add(new Option('(inherit)', INHERIT_OVERRIDE));
+				for (const perm of Object.values(ToolPermission)) {
+					select.add(new Option(PERMISSION_LABELS[perm], perm));
+				}
+				select.value = this.state?.overrides?.[tool.name] ?? INHERIT_OVERRIDE;
+				select.addEventListener('change', () => {
+					if (!this.state) this.state = {};
+					if (!this.state.overrides) this.state.overrides = {};
+					if (select.value === INHERIT_OVERRIDE) {
+						delete this.state.overrides[tool.name];
+					} else {
+						this.state.overrides[tool.name] = select.value as ToolPermission;
+					}
+					this.emit();
+				});
+			}
+		}
+	}
+}

--- a/src/ui/hook-management-modal.ts
+++ b/src/ui/hook-management-modal.ts
@@ -1,10 +1,10 @@
 import { App, Modal, Notice, Setting, setIcon } from 'obsidian';
 import type ObsidianGemini from '../main';
 import type { Hook, HookAction, HookState, HookTrigger } from '../services/hook-manager';
+import type { FeatureToolPolicy } from '../types/tool-policy';
+import { ToolPolicyEditor } from './components/tool-policy-editor';
 
 type View = 'list' | 'create' | 'edit';
-
-const TOOL_CATEGORIES = ['read_only', 'read_write', 'destructive'] as const;
 
 const TRIGGER_OPTIONS: { value: HookTrigger; label: string; hint: string }[] = [
 	{ value: 'file-modified', label: 'File modified (save)', hint: 'Fires when a file is saved.' },
@@ -44,7 +44,15 @@ export class HookManagementModal extends Modal {
 	private view: View;
 	private editingSlug: string | null = null;
 	private eventUnsubscribers: Array<() => void> = [];
+	private toolPolicyEditor: ToolPolicyEditor | null = null;
 	private form = this.blankForm();
+
+	private disposeToolPolicyEditor(): void {
+		if (this.toolPolicyEditor) {
+			this.toolPolicyEditor.destroy();
+			this.toolPolicyEditor = null;
+		}
+	}
 
 	constructor(
 		app: App,
@@ -63,6 +71,7 @@ export class HookManagementModal extends Modal {
 	onClose(): void {
 		this.eventUnsubscribers.forEach((fn) => fn());
 		this.eventUnsubscribers = [];
+		this.disposeToolPolicyEditor();
 		this.contentEl.empty();
 	}
 
@@ -309,7 +318,7 @@ export class HookManagementModal extends Modal {
 			debounceMs: hook.debounceMs,
 			cooldownMs: hook.cooldownMs,
 			maxRunsPerHour: hook.maxRunsPerHour ?? 0,
-			enabledTools: [...hook.enabledTools],
+			toolPolicy: hook.toolPolicy,
 			enabledSkills: [...hook.enabledSkills],
 			model: hook.model ?? '',
 			outputPath: hook.outputPath ?? '',
@@ -428,22 +437,21 @@ export class HookManagementModal extends Modal {
 			);
 		const focusFileEl = focusFileSetting.settingEl;
 
-		// Tool access — only meaningful for the agent-task action.
-		const toolsSetting = new Setting(form).setName('Tool access').setDesc('Which tool categories the agent may use.');
+		// Tool access — only meaningful for the agent-task action. Uses the
+		// shared ToolPolicyEditor, replacing the old category checkbox row
+		// whose hardcoded string list didn't match real ToolCategory values.
 		const toolsContainer = form.createDiv({ cls: 'gemini-scheduler-tools' });
-		for (const cat of TOOL_CATEGORIES) {
-			const label = toolsContainer.createEl('label', { cls: 'gemini-scheduler-tool-label' });
-			const cb = label.createEl('input', { attr: { type: 'checkbox' } }) as HTMLInputElement;
-			cb.checked = this.form.enabledTools.includes(cat);
-			cb.addEventListener('change', () => {
-				if (cb.checked) {
-					if (!this.form.enabledTools.includes(cat)) this.form.enabledTools.push(cat);
-				} else {
-					this.form.enabledTools = this.form.enabledTools.filter((t) => t !== cat);
-				}
-			});
-			label.appendText(` ${cat}`);
-		}
+		this.disposeToolPolicyEditor();
+		this.toolPolicyEditor = new ToolPolicyEditor(this.plugin, toolsContainer, {
+			title: 'Tool access',
+			description: 'When inherited, this hook uses the plugin’s global tool policy.',
+			value: this.form.toolPolicy,
+			onChange: (next) => {
+				this.form.toolPolicy = next;
+			},
+		});
+		// Container reference for action-visibility toggle below.
+		const toolsSetting = { settingEl: toolsContainer } as { settingEl: HTMLElement };
 
 		// Prompt — required for agent-task and rewrite, ignored for the rest.
 		const promptSetting = new Setting(form)
@@ -628,7 +636,7 @@ export class HookManagementModal extends Modal {
 					debounceMs: this.form.debounceMs,
 					cooldownMs: this.form.cooldownMs,
 					maxRunsPerHour: this.form.maxRunsPerHour > 0 ? this.form.maxRunsPerHour : undefined,
-					enabledTools: this.form.enabledTools,
+					toolPolicy: this.form.toolPolicy,
 					enabledSkills: this.form.enabledSkills,
 					model: this.form.model || undefined,
 					outputPath: this.form.outputPath || undefined,
@@ -649,7 +657,7 @@ export class HookManagementModal extends Modal {
 					debounceMs: this.form.debounceMs,
 					cooldownMs: this.form.cooldownMs,
 					maxRunsPerHour: this.form.maxRunsPerHour > 0 ? this.form.maxRunsPerHour : undefined,
-					enabledTools: this.form.enabledTools,
+					toolPolicy: this.form.toolPolicy,
 					enabledSkills: this.form.enabledSkills,
 					model: this.form.model || undefined,
 					outputPath: this.form.outputPath || undefined,
@@ -680,7 +688,7 @@ export class HookManagementModal extends Modal {
 			debounceMs: DEFAULT_DEBOUNCE_MS,
 			cooldownMs: DEFAULT_COOLDOWN_MS,
 			maxRunsPerHour: 0,
-			enabledTools: ['read_only'] as string[],
+			toolPolicy: undefined as FeatureToolPolicy | undefined,
 			enabledSkills: [] as string[],
 			model: '',
 			outputPath: '',

--- a/src/ui/scheduler-management-modal.ts
+++ b/src/ui/scheduler-management-modal.ts
@@ -1,10 +1,10 @@
 import { App, Modal, Notice, Setting, setIcon } from 'obsidian';
 import type ObsidianGemini from '../main';
 import type { ScheduledTask, TaskState } from '../services/scheduled-task-manager';
+import type { FeatureToolPolicy } from '../types/tool-policy';
+import { ToolPolicyEditor } from './components/tool-policy-editor';
 
 type View = 'list' | 'create' | 'edit';
-
-const TOOL_CATEGORIES = ['read_only', 'read_write', 'destructive'] as const;
 
 const SCHEDULE_PRESETS = [
 	{ label: 'Once', value: 'once' },
@@ -40,9 +40,22 @@ export class SchedulerManagementModal extends Modal {
 	private view: View;
 	private editingSlug: string | null = null;
 	private eventUnsubscribers: Array<() => void> = [];
+	/**
+	 * The form is re-rendered on every view switch, so the editor instance is
+	 * re-created from scratch each time. Tracked here so we can dispose the
+	 * previous instance before the new one is built.
+	 */
+	private toolPolicyEditor: ToolPolicyEditor | null = null;
 
 	// Form state (shared between create and edit views)
 	private form = this.blankForm();
+
+	private disposeToolPolicyEditor(): void {
+		if (this.toolPolicyEditor) {
+			this.toolPolicyEditor.destroy();
+			this.toolPolicyEditor = null;
+		}
+	}
 
 	constructor(
 		app: App,
@@ -61,6 +74,7 @@ export class SchedulerManagementModal extends Modal {
 	onClose(): void {
 		this.eventUnsubscribers.forEach((fn) => fn());
 		this.eventUnsubscribers = [];
+		this.disposeToolPolicyEditor();
 		this.contentEl.empty();
 	}
 
@@ -327,7 +341,7 @@ export class SchedulerManagementModal extends Modal {
 			scheduleCustom: task.schedule.startsWith('interval:') ? task.schedule.slice('interval:'.length) : '',
 			scheduleTime: time ?? blank.scheduleTime,
 			scheduleDays: days ?? blank.scheduleDays,
-			enabledTools: [...task.enabledTools],
+			toolPolicy: task.toolPolicy,
 			outputPath: task.outputPath,
 			model: task.model ?? '',
 			enabled: task.enabled,
@@ -437,22 +451,20 @@ export class SchedulerManagementModal extends Modal {
 			this.form.scheduleTime = timeInput.value;
 		});
 
-		// Tool access
-		new Setting(form).setName('Tool access').setDesc('Which tool categories the agent may use during a run.');
+		// Tool access — shared editor (preset + per-tool overrides). Replaces
+		// the old category checkbox row, which silently dropped vault-ops and
+		// destructive tools because the checkbox values didn't match real
+		// ToolCategory enum values.
 		const toolsContainer = form.createDiv({ cls: 'gemini-scheduler-tools' });
-		for (const cat of TOOL_CATEGORIES) {
-			const label = toolsContainer.createEl('label', { cls: 'gemini-scheduler-tool-label' });
-			const cb = label.createEl('input', { attr: { type: 'checkbox' } }) as HTMLInputElement;
-			cb.checked = this.form.enabledTools.includes(cat);
-			cb.addEventListener('change', () => {
-				if (cb.checked) {
-					if (!this.form.enabledTools.includes(cat)) this.form.enabledTools.push(cat);
-				} else {
-					this.form.enabledTools = this.form.enabledTools.filter((t) => t !== cat);
-				}
-			});
-			label.appendText(` ${cat}`);
-		}
+		this.disposeToolPolicyEditor();
+		this.toolPolicyEditor = new ToolPolicyEditor(this.plugin, toolsContainer, {
+			title: 'Tool access',
+			description: 'When inherited, this task uses the plugin’s global tool policy.',
+			value: this.form.toolPolicy,
+			onChange: (next) => {
+				this.form.toolPolicy = next;
+			},
+		});
 
 		// Prompt
 		new Setting(form)
@@ -563,7 +575,7 @@ export class SchedulerManagementModal extends Modal {
 			if (isEdit && this.editingSlug) {
 				await manager.updateTask(this.editingSlug, {
 					schedule,
-					enabledTools: this.form.enabledTools,
+					toolPolicy: this.form.toolPolicy,
 					outputPath: this.form.outputPath || undefined,
 					model: this.form.model || undefined,
 					enabled: this.form.enabled,
@@ -575,7 +587,7 @@ export class SchedulerManagementModal extends Modal {
 				await manager.createTask({
 					slug: this.form.slug,
 					schedule,
-					enabledTools: this.form.enabledTools,
+					toolPolicy: this.form.toolPolicy,
 					outputPath: this.form.outputPath || undefined,
 					model: this.form.model || undefined,
 					enabled: this.form.enabled,
@@ -604,7 +616,7 @@ export class SchedulerManagementModal extends Modal {
 			scheduleCustom: '',
 			scheduleTime: '09:00',
 			scheduleDays: ['mon', 'tue', 'wed', 'thu', 'fri'] as string[],
-			enabledTools: ['read_only'] as string[],
+			toolPolicy: undefined as FeatureToolPolicy | undefined,
 			outputPath: '',
 			model: '',
 			enabled: true,

--- a/test/agent/session-manager-integration.test.ts
+++ b/test/agent/session-manager-integration.test.ts
@@ -1,6 +1,7 @@
 import { SessionManager } from '../../src/agent/session-manager';
 import { SessionHistory } from '../../src/agent/session-history';
-import { SessionType, ToolCategory, DestructiveAction } from '../../src/types/agent';
+import { SessionType, DestructiveAction } from '../../src/types/agent';
+import { PolicyPreset } from '../../src/types/tool-policy';
 import { TFile, TFolder } from 'obsidian';
 
 // Mock Obsidian
@@ -76,7 +77,7 @@ describe('SessionManager Integration Tests', () => {
 			// Create session
 			const session = await sessionManager.createAgentSession('Test Session', {
 				contextFiles: [],
-				enabledTools: [ToolCategory.READ_ONLY],
+				toolPolicy: { preset: PolicyPreset.READ_ONLY },
 			});
 
 			expect(session).toBeDefined();
@@ -129,7 +130,7 @@ describe('SessionManager Integration Tests', () => {
 			// Create session with custom config
 			const session = await sessionManager.createAgentSession('Test Session', {
 				contextFiles: [{ path: 'context.md', basename: 'context' } as TFile],
-				enabledTools: [ToolCategory.READ_ONLY, ToolCategory.VAULT_OPERATIONS],
+				toolPolicy: { preset: PolicyPreset.EDIT_MODE },
 				requireConfirmation: [DestructiveAction.DELETE_FILES],
 			});
 
@@ -202,18 +203,18 @@ describe('SessionManager Integration Tests', () => {
 	describe('Permission Updates', () => {
 		it('should update session permissions dynamically', async () => {
 			const session = await sessionManager.createAgentSession('Test Session', {
-				enabledTools: [ToolCategory.READ_ONLY],
+				toolPolicy: { preset: PolicyPreset.READ_ONLY },
 				requireConfirmation: [DestructiveAction.MODIFY_FILES],
 			});
 
-			// Update permissions
+			// Update permissions — broaden from READ_ONLY to EDIT_MODE.
 			await sessionManager.updateSessionContext(session.id, {
-				enabledTools: [ToolCategory.READ_ONLY, ToolCategory.VAULT_OPERATIONS],
+				toolPolicy: { preset: PolicyPreset.EDIT_MODE },
 				requireConfirmation: [],
 			});
 
 			const updated = sessionManager.getSession(session.id);
-			expect(updated?.context.enabledTools).toContain(ToolCategory.VAULT_OPERATIONS);
+			expect(updated?.context.toolPolicy?.preset).toBe(PolicyPreset.EDIT_MODE);
 			expect(updated?.context.requireConfirmation).toHaveLength(0);
 		});
 	});

--- a/test/services/hook-manager.test.ts
+++ b/test/services/hook-manager.test.ts
@@ -8,6 +8,7 @@ import {
 	renderPrompt,
 	type Hook,
 } from '../../src/services/hook-manager';
+import { PolicyPreset } from '../../src/types/tool-policy';
 
 // ─── Module mocks ────────────────────────────────────────────────────────────
 
@@ -139,7 +140,7 @@ function makeHook(overrides: Partial<Hook> = {}): Hook {
 		debounceMs: 100,
 		cooldownMs: 0,
 		action: 'agent-task',
-		toolPolicy: { preset: 'read_only' as any },
+		toolPolicy: { preset: PolicyPreset.READ_ONLY },
 		enabledSkills: [],
 		enabled: true,
 		desktopOnly: false,
@@ -293,7 +294,7 @@ describe('HookManager CRUD', () => {
 			debounceMs: 7500,
 			cooldownMs: 60_000,
 			maxRunsPerHour: 12,
-			toolPolicy: { preset: 'read_only' as any },
+			toolPolicy: { preset: PolicyPreset.READ_ONLY },
 			enabledSkills: ['index-files'],
 			model: 'gemini-2.5-flash-lite',
 			outputPath: 'Hooks/Runs/{slug}/{date}.md',

--- a/test/services/hook-manager.test.ts
+++ b/test/services/hook-manager.test.ts
@@ -139,7 +139,7 @@ function makeHook(overrides: Partial<Hook> = {}): Hook {
 		debounceMs: 100,
 		cooldownMs: 0,
 		action: 'agent-task',
-		enabledTools: ['read_only'],
+		toolPolicy: { preset: 'read_only' as any },
 		enabledSkills: [],
 		enabled: true,
 		desktopOnly: false,
@@ -293,7 +293,7 @@ describe('HookManager CRUD', () => {
 			debounceMs: 7500,
 			cooldownMs: 60_000,
 			maxRunsPerHour: 12,
-			enabledTools: ['read_only'],
+			toolPolicy: { preset: 'read_only' as any },
 			enabledSkills: ['index-files'],
 			model: 'gemini-2.5-flash-lite',
 			outputPath: 'Hooks/Runs/{slug}/{date}.md',
@@ -306,8 +306,8 @@ describe('HookManager CRUD', () => {
 		expect(content).toContain('debounceMs: 7500');
 		expect(content).toContain('cooldownMs: 60000');
 		expect(content).toContain('maxRunsPerHour: 12');
-		expect(content).toContain('enabledTools:');
-		expect(content).toContain('  - read_only');
+		expect(content).toContain('toolPolicy:');
+		expect(content).toContain('preset: read_only');
 		expect(content).toContain('enabledSkills:');
 		expect(content).toContain('  - index-files');
 		expect(content).toContain('model: "gemini-2.5-flash-lite"');

--- a/test/services/hook-manager.test.ts
+++ b/test/services/hook-manager.test.ts
@@ -309,6 +309,11 @@ describe('HookManager CRUD', () => {
 		expect(content).toContain('maxRunsPerHour: 12');
 		expect(content).toContain('toolPolicy:');
 		expect(content).toContain('preset: read_only');
+		// Regression guard: the serializer must not also emit the legacy
+		// `enabledTools:` key. Dual-writing both shapes would re-introduce
+		// the pre-refactor confusion where readers had to pick which one to
+		// trust on subsequent loads.
+		expect(content).not.toContain('enabledTools');
 		expect(content).toContain('enabledSkills:');
 		expect(content).toContain('  - index-files');
 		expect(content).toContain('model: "gemini-2.5-flash-lite"');

--- a/test/services/hook-runner.test.ts
+++ b/test/services/hook-runner.test.ts
@@ -3,6 +3,7 @@ import { TFile as MockTFile } from 'obsidian';
 import { HookRunner } from '../../src/services/hook-runner';
 import type { Hook, HookFireContext } from '../../src/services/hook-manager';
 import type { AgentLoopResult } from '../../src/agent/agent-loop';
+import { PolicyPreset } from '../../src/types/tool-policy';
 
 // ─── Mocks ────────────────────────────────────────────────────────────────────
 
@@ -88,7 +89,7 @@ function makeHook(overrides: Partial<Hook> = {}): Hook {
 		debounceMs: 100,
 		cooldownMs: 0,
 		action: 'agent-task',
-		toolPolicy: { preset: 'read_only' as any },
+		toolPolicy: { preset: PolicyPreset.READ_ONLY },
 		enabledSkills: [],
 		enabled: true,
 		desktopOnly: false,
@@ -142,7 +143,10 @@ function createMockPlugin(opts: { existingPaths?: string[]; createBehaviour?: Va
 				modelConfig: {},
 			}),
 		},
-		toolRegistry: { getEnabledTools: vi.fn().mockReturnValue([]) },
+		toolRegistry: {
+			getEnabledTools: vi.fn().mockReturnValue([]),
+			getAutoApprovedTools: vi.fn().mockReturnValue([]),
+		},
 		toolExecutionEngine: { executeTool: vi.fn() },
 		// Optional injected services — left undefined by default; tests
 		// override per scenario (e.g. summarize tests set `summarizer`).

--- a/test/services/hook-runner.test.ts
+++ b/test/services/hook-runner.test.ts
@@ -88,7 +88,7 @@ function makeHook(overrides: Partial<Hook> = {}): Hook {
 		debounceMs: 100,
 		cooldownMs: 0,
 		action: 'agent-task',
-		enabledTools: ['read_only'],
+		toolPolicy: { preset: 'read_only' as any },
 		enabledSkills: [],
 		enabled: true,
 		desktopOnly: false,

--- a/test/services/project-manager.test.ts
+++ b/test/services/project-manager.test.ts
@@ -130,7 +130,7 @@ describe('ProjectManager', () => {
 			expect(project).not.toBeNull();
 			expect(project!.config.name).toBe('Test Project');
 			expect(project!.config.skills).toEqual(['writing-coach', 'continuity-tracker']);
-			expect(project!.config.permissions).toEqual({
+			expect(project!.config.toolPolicy?.overrides).toEqual({
 				edit_file: ToolPermission.APPROVE,
 				delete_file: ToolPermission.DENY,
 			});
@@ -268,7 +268,7 @@ describe('ProjectManager', () => {
 			mockPlugin.app.vault.read.mockResolvedValue('');
 
 			const project = await manager.parseProjectFile(file);
-			expect(project!.config.permissions.write_file).toBe(ToolPermission.APPROVE);
+			expect(project!.config.toolPolicy!.overrides!.write_file).toBe(ToolPermission.APPROVE);
 		});
 
 		it('should map deny to DENY', async () => {
@@ -280,7 +280,7 @@ describe('ProjectManager', () => {
 			mockPlugin.app.vault.read.mockResolvedValue('');
 
 			const project = await manager.parseProjectFile(file);
-			expect(project!.config.permissions.delete_file).toBe(ToolPermission.DENY);
+			expect(project!.config.toolPolicy!.overrides!.delete_file).toBe(ToolPermission.DENY);
 		});
 
 		it('should map ask to ASK_USER', async () => {
@@ -292,7 +292,7 @@ describe('ProjectManager', () => {
 			mockPlugin.app.vault.read.mockResolvedValue('');
 
 			const project = await manager.parseProjectFile(file);
-			expect(project!.config.permissions.move_file).toBe(ToolPermission.ASK_USER);
+			expect(project!.config.toolPolicy!.overrides!.move_file).toBe(ToolPermission.ASK_USER);
 		});
 
 		it('should warn and default unknown values to ASK_USER', async () => {
@@ -304,7 +304,7 @@ describe('ProjectManager', () => {
 			mockPlugin.app.vault.read.mockResolvedValue('');
 
 			const project = await manager.parseProjectFile(file);
-			expect(project!.config.permissions.write_file).toBe(ToolPermission.ASK_USER);
+			expect(project!.config.toolPolicy!.overrides!.write_file).toBe(ToolPermission.ASK_USER);
 			expect(mockPlugin.logger.warn).toHaveBeenCalled();
 		});
 	});

--- a/test/services/project-manager.test.ts
+++ b/test/services/project-manager.test.ts
@@ -307,6 +307,25 @@ describe('ProjectManager', () => {
 			expect(project!.config.toolPolicy!.overrides!.write_file).toBe(ToolPermission.ASK_USER);
 			expect(mockPlugin.logger.warn).toHaveBeenCalled();
 		});
+
+		// Regression: an explicit but empty `toolPolicy:` block means "inherit
+		// global policy", not "fall back to legacy permissions" — otherwise
+		// stale legacy overrides would silently override the user's intent.
+		it('treats an explicit empty toolPolicy as inherit-global, ignoring legacy permissions', async () => {
+			const file = createMockFile('project/EmptyPolicy.md');
+			mockPlugin.app.metadataCache.getFileCache.mockReturnValue({
+				frontmatter: {
+					tags: [PROJECT_TAG],
+					toolPolicy: {},
+					permissions: { write_file: 'allow' },
+				},
+				frontmatterPosition: { end: { offset: 0 } },
+			});
+			mockPlugin.app.vault.read.mockResolvedValue('');
+
+			const project = await manager.parseProjectFile(file);
+			expect(project!.config.toolPolicy).toBeUndefined();
+		});
 	});
 
 	describe('getProjectForPath', () => {

--- a/test/services/scheduled-task-manager.test.ts
+++ b/test/services/scheduled-task-manager.test.ts
@@ -1,7 +1,7 @@
 import type { Mock } from 'vitest';
 import { TFile as MockTFile } from 'obsidian';
 import { ScheduledTaskManager, computeNextRunAt, ScheduledTask } from '../../src/services/scheduled-task-manager';
-import { ToolPermission } from '../../src/types/tool-policy';
+import { PolicyPreset, ToolPermission } from '../../src/types/tool-policy';
 
 // ─── Mocks ────────────────────────────────────────────────────────────────────
 
@@ -915,7 +915,7 @@ describe('ScheduledTaskManager', () => {
 			await manager.createTask({
 				slug: 'new-task',
 				schedule: 'daily',
-				toolPolicy: { preset: 'read_only' as any },
+				toolPolicy: { preset: PolicyPreset.READ_ONLY },
 				prompt: 'Do something daily.',
 			});
 
@@ -982,7 +982,7 @@ describe('ScheduledTaskManager', () => {
 				slug: 'tools-task',
 				schedule: 'daily',
 				toolPolicy: {
-					preset: 'edit_mode' as any,
+					preset: PolicyPreset.EDIT_MODE,
 					overrides: { write_file: ToolPermission.DENY },
 				},
 				prompt: 'With tools.',

--- a/test/services/scheduled-task-manager.test.ts
+++ b/test/services/scheduled-task-manager.test.ts
@@ -1,6 +1,7 @@
 import type { Mock } from 'vitest';
 import { TFile as MockTFile } from 'obsidian';
 import { ScheduledTaskManager, computeNextRunAt, ScheduledTask } from '../../src/services/scheduled-task-manager';
+import { ToolPermission } from '../../src/types/tool-policy';
 
 // ─── Mocks ────────────────────────────────────────────────────────────────────
 
@@ -381,7 +382,8 @@ describe('ScheduledTaskManager', () => {
 			expect(tasks).toHaveLength(1);
 			expect(tasks[0].slug).toBe('daily-summary');
 			expect(tasks[0].schedule).toBe('daily');
-			expect(tasks[0].enabledTools).toEqual(['read_only']);
+			// Legacy `enabledTools: ['read_only']` migrates to the READ_ONLY preset.
+			expect(tasks[0].toolPolicy).toEqual({ preset: 'read_only' });
 			expect(tasks[0].prompt).toBe('Summarise recent notes.');
 
 			// State entry seeded for newly-discovered task
@@ -451,7 +453,7 @@ describe('ScheduledTaskManager', () => {
 			expect(manager.getTasks()[0].enabled).toBe(true);
 		});
 
-		it('enabledTools defaults to empty array when omitted from frontmatter', async () => {
+		it('toolPolicy is undefined when no toolPolicy or enabledTools frontmatter is present', async () => {
 			const plugin = createMockPlugin();
 			plugin.app.vault.getMarkdownFiles.mockReturnValue([
 				{ path: 'gemini-scribe/Scheduled-Tasks/no-tools.md', basename: 'no-tools' },
@@ -463,7 +465,8 @@ describe('ScheduledTaskManager', () => {
 			const manager = new ScheduledTaskManager(plugin);
 			await manager.initialize();
 
-			expect(manager.getTasks()[0].enabledTools).toEqual([]);
+			// Absent policy means inherit-global, encoded as undefined on the task.
+			expect(manager.getTasks()[0].toolPolicy).toBeUndefined();
 		});
 
 		it('purges state entries for slugs whose task file no longer exists', async () => {
@@ -912,7 +915,7 @@ describe('ScheduledTaskManager', () => {
 			await manager.createTask({
 				slug: 'new-task',
 				schedule: 'daily',
-				enabledTools: ['read_only'],
+				toolPolicy: { preset: 'read_only' as any },
 				prompt: 'Do something daily.',
 			});
 
@@ -969,7 +972,7 @@ describe('ScheduledTaskManager', () => {
 			);
 		});
 
-		it('serialized content includes enabledTools list', async () => {
+		it('serialized content includes toolPolicy block when policy is set', async () => {
 			const plugin = createMockPlugin();
 			plugin.app.vault.create = vi.fn().mockResolvedValue(undefined);
 			const manager = new ScheduledTaskManager(plugin);
@@ -978,13 +981,17 @@ describe('ScheduledTaskManager', () => {
 			await manager.createTask({
 				slug: 'tools-task',
 				schedule: 'daily',
-				enabledTools: ['read_only', 'read_write'],
+				toolPolicy: {
+					preset: 'edit_mode' as any,
+					overrides: { write_file: ToolPermission.DENY },
+				},
 				prompt: 'With tools.',
 			});
 
 			const written = (plugin.app.vault.create as Mock).mock.calls[0][1] as string;
-			expect(written).toContain('- read_only');
-			expect(written).toContain('- read_write');
+			expect(written).toContain('toolPolicy:');
+			expect(written).toContain('preset: edit_mode');
+			expect(written).toContain('write_file: deny');
 		});
 
 		it('omits optional fields from serialized content when not set', async () => {

--- a/test/services/scheduled-task-runner.test.ts
+++ b/test/services/scheduled-task-runner.test.ts
@@ -2,6 +2,7 @@ import type { Mock } from 'vitest';
 import { ScheduledTaskRunner } from '../../src/services/scheduled-task-runner';
 import type { ScheduledTask } from '../../src/services/scheduled-task-manager';
 import type { AgentLoopResult } from '../../src/agent/agent-loop';
+import { PolicyPreset } from '../../src/types/tool-policy';
 
 // ─── Mocks ────────────────────────────────────────────────────────────────────
 
@@ -81,6 +82,7 @@ function createMockPlugin(vaultFiles: Record<string, string> = {}): any {
 		},
 		toolRegistry: {
 			getEnabledTools: vi.fn().mockReturnValue([]),
+			getAutoApprovedTools: vi.fn().mockReturnValue([]),
 		},
 		toolExecutionEngine: {
 			executeTool: vi.fn().mockResolvedValue({ success: true, output: 'ok' }),
@@ -304,7 +306,7 @@ describe('ScheduledTaskRunner', () => {
 
 		it('forwards an explicit task.toolPolicy to the session', async () => {
 			const plugin = createMockPlugin();
-			const taskPolicy = { preset: 'read_only' as any };
+			const taskPolicy = { preset: PolicyPreset.READ_ONLY };
 			const runner = new ScheduledTaskRunner(plugin, makeTask({ toolPolicy: taskPolicy }));
 
 			await runner.run(() => false);

--- a/test/services/scheduled-task-runner.test.ts
+++ b/test/services/scheduled-task-runner.test.ts
@@ -103,7 +103,7 @@ function makeTask(overrides: Partial<ScheduledTask> = {}): ScheduledTask {
 	return {
 		slug: 'test-task',
 		schedule: 'daily',
-		enabledTools: [],
+		toolPolicy: undefined,
 		outputPath: 'gemini-scribe/Scheduled-Tasks/Runs/test-task/{date}.md',
 		enabled: true,
 		runIfMissed: false,
@@ -286,36 +286,32 @@ describe('ScheduledTaskRunner', () => {
 		expect(plugin.app.vault.modify).not.toHaveBeenCalled();
 	});
 
-	describe('default enabledTools', () => {
-		// Pin the broadened default added to fix #728: scheduled tasks with empty
-		// enabledTools should get read_only + skills (not just read_only) so the
-		// "run skill X on a schedule" pattern works without extra setup.
-		it('defaults to read_only + skills when frontmatter enabledTools is empty', async () => {
+	describe('toolPolicy plumbing', () => {
+		// Under the unified-policy model, an unset task.toolPolicy means
+		// "inherit the global plugin tool policy" — the runner should pass
+		// `toolPolicy: undefined` to createAgentSession so the session inherits.
+		it('passes toolPolicy: undefined when the task has no policy', async () => {
 			const plugin = createMockPlugin();
-			const runner = new ScheduledTaskRunner(plugin, makeTask({ enabledTools: [] }));
+			const runner = new ScheduledTaskRunner(plugin, makeTask({ toolPolicy: undefined }));
 
 			await runner.run(() => false);
 
 			expect(plugin.sessionManager.createAgentSession).toHaveBeenCalledWith(
 				expect.any(String),
-				expect.objectContaining({
-					enabledTools: ['read_only', 'skills'],
-				})
+				expect.objectContaining({ toolPolicy: undefined })
 			);
 		});
 
-		it('honors an explicit enabledTools list and does not augment it', async () => {
+		it('forwards an explicit task.toolPolicy to the session', async () => {
 			const plugin = createMockPlugin();
-			const runner = new ScheduledTaskRunner(plugin, makeTask({ enabledTools: ['read_only'] }));
+			const taskPolicy = { preset: 'read_only' as any };
+			const runner = new ScheduledTaskRunner(plugin, makeTask({ toolPolicy: taskPolicy }));
 
 			await runner.run(() => false);
 
-			// User explicitly chose read_only — must NOT silently add skills.
 			expect(plugin.sessionManager.createAgentSession).toHaveBeenCalledWith(
 				expect.any(String),
-				expect.objectContaining({
-					enabledTools: ['read_only'],
-				})
+				expect.objectContaining({ toolPolicy: taskPolicy })
 			);
 		});
 	});

--- a/test/tools/execution-engine.test.ts
+++ b/test/tools/execution-engine.test.ts
@@ -282,7 +282,10 @@ describe('ToolExecutionEngine - Error Handling', () => {
 		expect(result.error).toBe('Tool non_existent_tool not found');
 	});
 
-	it('should handle tool not in enabled category', async () => {
+	it('should reject tools the feature policy maps to DENY', async () => {
+		// Under the unified-policy model the registry no longer filters by
+		// ToolCategory — disabling a tool is expressed as a DENY permission
+		// via the feature-level policy (or the global policy).
 		const context = {
 			plugin,
 			session: {
@@ -291,13 +294,14 @@ describe('ToolExecutionEngine - Error Handling', () => {
 				context: {
 					contextFiles: [],
 					contextDepth: 2,
-					enabledTools: [ToolCategory.READ_ONLY], // Only READ_ONLY enabled
 					requireConfirmation: [],
 				},
 			},
+			featureToolPolicy: {
+				overrides: { write_file: 'deny' as any },
+			},
 		} as any;
 
-		// Register a VAULT_OPERATIONS tool
 		registry.registerTool(new WriteFileTool());
 
 		const result = await engine.executeTool(

--- a/test/tools/tool-integration.test.ts
+++ b/test/tools/tool-integration.test.ts
@@ -298,7 +298,7 @@ describe('Tool Integration Tests', () => {
 	});
 
 	describe('Permission Boundaries', () => {
-		it('should respect tool category restrictions', async () => {
+		it('should respect tool restrictions expressed as a READ_ONLY feature policy', async () => {
 			const context = {
 				plugin,
 				session: {
@@ -306,10 +306,13 @@ describe('Tool Integration Tests', () => {
 					type: SessionType.AGENT_SESSION,
 					context: {
 						contextFiles: [],
-						enabledTools: [ToolCategory.READ_ONLY], // Only read operations
 						requireConfirmation: [],
 					},
 				},
+				// READ_ONLY preset maps WRITE/DESTRUCTIVE/EXTERNAL to DENY, so
+				// write_file is filtered out of getEnabledTools while read_file
+				// stays available.
+				featureToolPolicy: { preset: 'read_only' },
 			} as any;
 
 			// Try to execute write operation

--- a/test/tools/tool-registry.test.ts
+++ b/test/tools/tool-registry.test.ts
@@ -206,37 +206,37 @@ describe('ToolRegistry', () => {
 	});
 
 	describe('getEnabledTools', () => {
-		it('should return tools enabled for context', () => {
+		it('should return all tools when no policy denies them', () => {
 			const readOnlyTool = new TestTool();
 			const vaultTool = new DestructiveTestTool();
 
 			registry.registerTool(readOnlyTool);
 			registry.registerTool(vaultTool);
 
+			// Cautious (default) maps READ to APPROVE and DESTRUCTIVE to ASK_USER;
+			// nothing is DENY, so both tools are enabled.
+			const context = { session: { context: {} } } as any;
+			const enabledTools = registry.getEnabledTools(context);
+			expect(enabledTools).toHaveLength(2);
+		});
+
+		it('should drop tools that the feature preset maps to DENY', () => {
+			const readOnlyTool = new TestTool();
+			const vaultTool = new DestructiveTestTool();
+
+			registry.registerTool(readOnlyTool);
+			registry.registerTool(vaultTool);
+
+			// READ_ONLY preset maps WRITE / DESTRUCTIVE / EXTERNAL to DENY, so a
+			// session carrying that preset should only see the read tool.
 			const context = {
-				session: {
-					context: {
-						enabledTools: [ToolCategory.READ_ONLY],
-					},
-				},
+				session: { context: {} },
+				featureToolPolicy: { preset: PolicyPreset.READ_ONLY },
 			} as any;
 
 			const enabledTools = registry.getEnabledTools(context);
 			expect(enabledTools).toHaveLength(1);
 			expect(enabledTools[0]).toBe(readOnlyTool);
-		});
-
-		it('should return empty array when no tools enabled', () => {
-			const context = {
-				session: {
-					context: {
-						enabledTools: [],
-					},
-				},
-			} as any;
-
-			const enabledTools = registry.getEnabledTools(context);
-			expect(enabledTools).toHaveLength(0);
 		});
 
 		it('should filter out DENY tools from enabled list', () => {
@@ -251,14 +251,7 @@ describe('ToolRegistry', () => {
 				destructive_tool: ToolPermission.DENY,
 			};
 
-			const context = {
-				session: {
-					context: {
-						enabledTools: [ToolCategory.READ_ONLY, ToolCategory.VAULT_OPERATIONS],
-					},
-				},
-			} as any;
-
+			const context = { session: { context: {} } } as any;
 			const enabledTools = registry.getEnabledTools(context);
 			expect(enabledTools).toHaveLength(1);
 			expect(enabledTools[0]).toBe(readOnlyTool);
@@ -309,7 +302,7 @@ describe('ToolRegistry', () => {
 			// destructive_tool is ASK_USER in Cautious mode
 			expect(
 				registry.requiresConfirmation('destructive_tool', {
-					destructive_tool: ToolPermission.APPROVE,
+					overrides: { destructive_tool: ToolPermission.APPROVE },
 				})
 			).toBe(false);
 		});
@@ -317,7 +310,7 @@ describe('ToolRegistry', () => {
 		it('should return false when project overrides to DENY (tool blocked, not asked)', () => {
 			expect(
 				registry.requiresConfirmation('destructive_tool', {
-					destructive_tool: ToolPermission.DENY,
+					overrides: { destructive_tool: ToolPermission.DENY },
 				})
 			).toBe(false);
 		});
@@ -326,7 +319,7 @@ describe('ToolRegistry', () => {
 			// test_tool is READ → APPROVE in Cautious mode
 			expect(
 				registry.requiresConfirmation('test_tool', {
-					test_tool: ToolPermission.ASK_USER,
+					overrides: { test_tool: ToolPermission.ASK_USER },
 				})
 			).toBe(true);
 		});

--- a/test/tools/tool-registry.test.ts
+++ b/test/tools/tool-registry.test.ts
@@ -257,6 +257,35 @@ describe('ToolRegistry', () => {
 			expect(enabledTools[0]).toBe(readOnlyTool);
 		});
 
+		// Pins the documented resolveEffectivePermission precedence:
+		// feature overrides > global overrides > feature preset > global preset.
+		// Without this, a future "let's just merge the maps" refactor could
+		// silently flip the priority and DENY-stuck tools couldn't be opened up
+		// by a project / scheduled-task / hook.
+		it('feature override wins over a conflicting global override for the same tool', () => {
+			const readOnlyTool = new TestTool();
+			const vaultTool = new DestructiveTestTool();
+
+			registry.registerTool(readOnlyTool);
+			registry.registerTool(vaultTool);
+
+			// Global says DENY...
+			mockPlugin.settings.toolPolicy.toolPermissions = {
+				destructive_tool: ToolPermission.DENY,
+			};
+
+			// ...but the feature explicitly opens it back up.
+			const context = {
+				session: { context: {} },
+				featureToolPolicy: {
+					overrides: { destructive_tool: ToolPermission.APPROVE },
+				},
+			} as any;
+
+			const enabledTools = registry.getEnabledTools(context);
+			expect(enabledTools.map((t) => t.name).sort()).toEqual(['destructive_tool', 'test_tool']);
+		});
+
 		it('should preserve permissions for untouched tools when switching to CUSTOM', () => {
 			const writeToolA = new WriteTestTool('write_tool_a');
 			const writeToolB = new WriteTestTool('write_tool_b');

--- a/test/tools/tool-registry.test.ts
+++ b/test/tools/tool-registry.test.ts
@@ -284,6 +284,44 @@ describe('ToolRegistry', () => {
 		});
 	});
 
+	describe('getAutoApprovedTools', () => {
+		// Regression for the headless ASK_USER bypass: scheduled tasks and
+		// hooks must only see tools with APPROVE permission. ASK_USER tools
+		// would otherwise be auto-approved by the headless confirmation
+		// provider, silently bypassing the user's "ask first" intent.
+		it('returns only tools whose effective permission is APPROVE', () => {
+			const readOnlyTool = new TestTool();
+			const destructiveTool = new DestructiveTestTool();
+
+			registry.registerTool(readOnlyTool);
+			registry.registerTool(destructiveTool);
+
+			// Default CAUTIOUS: READ → APPROVE, DESTRUCTIVE → ASK_USER.
+			const context = { session: { context: {} } } as any;
+			const tools = registry.getAutoApprovedTools(context);
+			expect(tools).toHaveLength(1);
+			expect(tools[0]).toBe(readOnlyTool);
+		});
+
+		it('upgrades ASK_USER tools to APPROVE when the feature policy says so', () => {
+			const readOnlyTool = new TestTool();
+			const destructiveTool = new DestructiveTestTool();
+
+			registry.registerTool(readOnlyTool);
+			registry.registerTool(destructiveTool);
+
+			const context = {
+				session: { context: {} },
+				featureToolPolicy: {
+					overrides: { destructive_tool: ToolPermission.APPROVE },
+				},
+			} as any;
+
+			const tools = registry.getAutoApprovedTools(context);
+			expect(tools.map((t) => t.name).sort()).toEqual(['destructive_tool', 'test_tool']);
+		});
+	});
+
 	describe('requiresConfirmation', () => {
 		beforeEach(() => {
 			registry.registerTool(new TestTool());

--- a/test/types/tool-policy.test.ts
+++ b/test/types/tool-policy.test.ts
@@ -8,9 +8,15 @@ import {
 	CLASSIFICATION_LABELS,
 	DEFAULT_TOOL_POLICY,
 	resolvePermission,
+	resolveEffectivePermission,
 	buildPermissionsForPreset,
+	parseToolPolicyFrontmatter,
+	serializeToolPolicy,
+	clonePolicy,
+	FeatureToolPolicy,
 	ToolPolicySettings,
 } from '../../src/types/tool-policy';
+import { migrateLegacyToolCategoryArray, formatToolPolicyYaml } from '../../src/services/feature-policy-yaml';
 
 describe('tool-policy types', () => {
 	describe('enums', () => {
@@ -182,6 +188,184 @@ describe('tool-policy types', () => {
 		it('should return empty object for empty tool list', () => {
 			const result = buildPermissionsForPreset(PolicyPreset.CAUTIOUS, []);
 			expect(result).toEqual({});
+		});
+	});
+
+	// ── Unified feature-level policy helpers ────────────────────────────────
+
+	describe('resolveEffectivePermission', () => {
+		const global = (extra: Partial<ToolPolicySettings> = {}): ToolPolicySettings => ({
+			activePreset: PolicyPreset.CAUTIOUS,
+			toolPermissions: {},
+			...extra,
+		});
+
+		it('feature overrides win over every other layer', () => {
+			const settings = global({
+				toolPermissions: { write_file: ToolPermission.DENY },
+			});
+			const feature: FeatureToolPolicy = {
+				overrides: { write_file: ToolPermission.APPROVE },
+			};
+			expect(resolveEffectivePermission('write_file', ToolClassification.WRITE, settings, feature)).toBe(
+				ToolPermission.APPROVE
+			);
+		});
+
+		it('global overrides win over feature preset', () => {
+			const settings = global({
+				toolPermissions: { write_file: ToolPermission.DENY },
+			});
+			const feature: FeatureToolPolicy = { preset: PolicyPreset.EDIT_MODE };
+			expect(resolveEffectivePermission('write_file', ToolClassification.WRITE, settings, feature)).toBe(
+				ToolPermission.DENY
+			);
+		});
+
+		it('feature preset wins over global preset', () => {
+			// CAUTIOUS would map WRITE → ASK_USER; READ_ONLY maps it to DENY.
+			const feature: FeatureToolPolicy = { preset: PolicyPreset.READ_ONLY };
+			expect(resolveEffectivePermission('write_file', ToolClassification.WRITE, global(), feature)).toBe(
+				ToolPermission.DENY
+			);
+		});
+
+		it('inherits global preset when no feature policy is supplied', () => {
+			expect(resolveEffectivePermission('read_file', ToolClassification.READ, global())).toBe(ToolPermission.APPROVE);
+			expect(resolveEffectivePermission('delete_file', ToolClassification.DESTRUCTIVE, global())).toBe(
+				ToolPermission.ASK_USER
+			);
+		});
+
+		it('feature CUSTOM preset is treated as "no preset contribution"', () => {
+			const feature: FeatureToolPolicy = { preset: PolicyPreset.CUSTOM };
+			expect(resolveEffectivePermission('write_file', ToolClassification.WRITE, global(), feature)).toBe(
+				ToolPermission.ASK_USER
+			);
+		});
+	});
+
+	describe('parseToolPolicyFrontmatter', () => {
+		it('returns undefined for null/undefined input', () => {
+			expect(parseToolPolicyFrontmatter(null)).toBeUndefined();
+			expect(parseToolPolicyFrontmatter(undefined)).toBeUndefined();
+		});
+
+		it('parses a preset-only block', () => {
+			expect(parseToolPolicyFrontmatter({ preset: 'read_only' })).toEqual({
+				preset: PolicyPreset.READ_ONLY,
+			});
+		});
+
+		it('parses overrides via the YAML permission strings', () => {
+			expect(
+				parseToolPolicyFrontmatter({
+					overrides: { write_file: 'allow', delete_file: 'deny', move_file: 'ask' },
+				})
+			).toEqual({
+				overrides: {
+					write_file: ToolPermission.APPROVE,
+					delete_file: ToolPermission.DENY,
+					move_file: ToolPermission.ASK_USER,
+				},
+			});
+		});
+
+		it('drops unknown preset values', () => {
+			expect(parseToolPolicyFrontmatter({ preset: 'made_up' })).toBeUndefined();
+		});
+
+		it('drops unknown override values without throwing', () => {
+			expect(
+				parseToolPolicyFrontmatter({
+					overrides: { ok: 'allow', bad: 'lolwut' },
+				})
+			).toEqual({ overrides: { ok: ToolPermission.APPROVE } });
+		});
+	});
+
+	describe('serializeToolPolicy', () => {
+		it('round-trips through parseToolPolicyFrontmatter', () => {
+			const original: FeatureToolPolicy = {
+				preset: PolicyPreset.EDIT_MODE,
+				overrides: { write_file: ToolPermission.DENY },
+			};
+			expect(parseToolPolicyFrontmatter(serializeToolPolicy(original))).toEqual(original);
+		});
+
+		it('returns undefined for an empty policy', () => {
+			expect(serializeToolPolicy(undefined)).toBeUndefined();
+			expect(serializeToolPolicy({})).toBeUndefined();
+			expect(serializeToolPolicy({ overrides: {} })).toBeUndefined();
+		});
+	});
+
+	describe('clonePolicy', () => {
+		it('deep-clones overrides so mutations do not alias the source', () => {
+			const source: FeatureToolPolicy = {
+				preset: PolicyPreset.READ_ONLY,
+				overrides: { write_file: ToolPermission.DENY },
+			};
+			const clone = clonePolicy(source)!;
+			clone.overrides!.write_file = ToolPermission.APPROVE;
+			expect(source.overrides!.write_file).toBe(ToolPermission.DENY);
+		});
+
+		it('returns undefined for undefined input', () => {
+			expect(clonePolicy(undefined)).toBeUndefined();
+		});
+	});
+
+	describe('migrateLegacyToolCategoryArray', () => {
+		it('read_only only ⇒ READ_ONLY preset', () => {
+			expect(migrateLegacyToolCategoryArray(['read_only'])).toEqual({
+				preset: PolicyPreset.READ_ONLY,
+			});
+		});
+
+		it('read_only + vault_ops ⇒ EDIT_MODE preset', () => {
+			expect(migrateLegacyToolCategoryArray(['read_only', 'vault_ops'])).toEqual({
+				preset: PolicyPreset.EDIT_MODE,
+			});
+		});
+
+		it('bugged read_write string maps to EDIT_MODE (treated as vault_ops)', () => {
+			expect(migrateLegacyToolCategoryArray(['read_only', 'read_write'])).toEqual({
+				preset: PolicyPreset.EDIT_MODE,
+			});
+		});
+
+		it('bugged destructive string maps to YOLO preset', () => {
+			expect(migrateLegacyToolCategoryArray(['read_only', 'destructive'])).toEqual({
+				preset: PolicyPreset.YOLO,
+			});
+		});
+
+		it('full default-agent list ⇒ inherit global', () => {
+			expect(migrateLegacyToolCategoryArray(['read_only', 'vault_ops', 'external_mcp', 'skills'])).toBeUndefined();
+		});
+
+		it('empty / non-array input ⇒ undefined', () => {
+			expect(migrateLegacyToolCategoryArray([])).toBeUndefined();
+			expect(migrateLegacyToolCategoryArray(null)).toBeUndefined();
+			expect(migrateLegacyToolCategoryArray('read_only')).toBeUndefined();
+		});
+	});
+
+	describe('formatToolPolicyYaml', () => {
+		it('renders a preset + overrides block', () => {
+			expect(
+				formatToolPolicyYaml({
+					preset: PolicyPreset.READ_ONLY,
+					overrides: { write_file: ToolPermission.DENY },
+				})
+			).toEqual(['toolPolicy:', '  preset: read_only', '  overrides:', '    write_file: deny']);
+		});
+
+		it('returns null for an empty policy so callers can omit the field', () => {
+			expect(formatToolPolicyYaml(undefined)).toBeNull();
+			expect(formatToolPolicyYaml({})).toBeNull();
+			expect(formatToolPolicyYaml({ overrides: {} })).toBeNull();
 		});
 	});
 });


### PR DESCRIPTION
## Summary

Four features in the plugin let the user scope which tools the agent can call: Agent Sessions, Projects, Scheduled Tasks, and Hooks. Until now each one used a different config shape: Sessions/Tasks/Hooks carried a `ToolCategory[]` allowlist; Projects carried a per-tool `permissions` map. This PR collapses all four onto a single `FeatureToolPolicy` shape (`{ preset?, overrides? }`) layered on top of the global plugin tool policy at every resolution. The new shape mirrors the existing global `ToolPolicySettings`, so users only have one mental model to learn.

While unifying the shape I also fixed a silent bug in the Scheduler and Hook modals: `TOOL_CATEGORIES = ['read_only', 'read_write', 'destructive']` didn't match any real `ToolCategory` enum value (`vault_ops`, `external_mcp`, `system`, `skills`). Checking "read_write" or "destructive" wrote dead strings to YAML, the runner blind-cast them with `as ToolCategory[]`, and the registry filter then excluded every non-`read_only` tool. Users who thought they enabled vault ops were getting nothing. The new editor uses the canonical preset/permission vocabulary so the bug can't recur.

The approach was discussed and approved with the maintainer (myself) in the planning step at `~/.claude/plans/we-now-have-a-playful-cray.md`.

## Changes

- **New `FeatureToolPolicy` type and `resolveEffectivePermission()` resolver** in [src/types/tool-policy.ts](src/types/tool-policy.ts). Resolution order: feature overrides → global overrides → feature preset → global preset.
- **`ToolRegistry.getEnabledTools()` drops the `ToolCategory` filter** — tools are enabled iff their effective permission is not `DENY`. `ToolCategory` survives as a UI grouping label on `Tool.category` but no longer gates execution.
- **Each feature now carries `toolPolicy?: FeatureToolPolicy`** instead of its bespoke field:
  - `AgentContext.enabledTools` → `AgentContext.toolPolicy`
  - `ScheduledTask.enabledTools` → `ScheduledTask.toolPolicy`
  - `Hook.enabledTools` → `Hook.toolPolicy`
  - `ProjectConfig.permissions` → `ProjectConfig.toolPolicy`
- **`ToolExecutionContext` carries `featureToolPolicy`** instead of `projectPermissions`. Agent loop, view, and runners updated accordingly.
- **Auto-migration on load** — each feature's loader accepts the legacy shape and rewrites the file to the new shape the first time it's read. Broken legacy values (`read_write` → `EDIT_MODE`, `destructive` → `YOLO`) get folded into the closest preset with a logger warning.
- **New shared `ToolPolicyEditor`** ([src/ui/components/tool-policy-editor.ts](src/ui/components/tool-policy-editor.ts)) — inherit toggle, preset dropdown, per-tool overrides grouped by classification. Wired into the Scheduler and Hook modals, replacing the broken checkbox blocks.
- **Docs updated** — [projects.md](docs/guide/projects.md), [scheduled-tasks.md](docs/guide/scheduled-tasks.md), [lifecycle-hooks.md](docs/guide/lifecycle-hooks.md), and [tool-development.md](docs/contributing/tool-development.md) all describe the unified `toolPolicy` shape with a legacy-migration note.

## Screenshots / Screencast

The Scheduler and Hook modals replace the three-checkbox `read_only / read_write / destructive` block with the unified editor (inherit toggle, preset dropdown, per-tool overrides grouped by classification). Visual change is contained to those two modals; no other UI surface moved.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer — approved via the in-conversation planning step with the repo maintainer (no GitHub issue filed in advance; the plan file in the user's local `~/.claude/plans/` records the design decisions)
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — 1721 tests pass, build clean, format clean
- [x] I have tested this change on Desktop
- [ ] I have verified this change does not break Mobile — no platform-specific code touched; the change is data-shape + permission-resolution only, no native APIs or mobile-sensitive paths
- [x] Documentation has been updated
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (Opus 4.7)
- [x] I have reviewed and understand all AI-generated code in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Feature-level tool policies with presets and per-tool overrides for finer access control.
  * Tool Policy editor UI for configuring per-feature tool access.
  * Headless runs now expose only auto-approved tools; denied tools are blocked and ASK_USER triggers confirmations.

* **Documentation**
  * Guides and examples updated to use toolPolicy frontmatter with legacy migration notes.

* **Refactor**
  * Unified runtime/on-disk toolPolicy model with automatic legacy migration.

* **Tests**
  * Updated and added tests covering policy behavior and serialization.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/allenhutchison/obsidian-gemini/pull/806)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->