### PR TITLE
feat(dev): add install:test-vault npm script

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
 		"format-check": "prettier --check .",
 		"lint": "eslint .",
 		"lint:fix": "eslint . --fix",
+		"install:test-vault": "node scripts/install-test-vault.mjs",
 		"test": "npm run generate-refs && vitest run",
 		"test:watch": "npm run generate-refs && vitest",
 		"prepare": "husky",

--- a/scripts/install-test-vault.mjs
+++ b/scripts/install-test-vault.mjs
@@ -27,7 +27,9 @@ if (missing.length > 0) {
 }
 
 if (!existsSync(dirname(dest))) {
-	console.error(`Plugins folder not found: ${dirname(dest)}. Is the test vault open in Obsidian at least once?`);
+	console.error(
+		`Parent directory not found: ${dirname(dest)}. Check TEST_VAULT_PLUGIN_DIR, or ensure the test vault has been opened in Obsidian at least once.`
+	);
 	process.exit(1);
 }
 

--- a/scripts/install-test-vault.mjs
+++ b/scripts/install-test-vault.mjs
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+// Copies the current worktree's built plugin artifacts (main.js, manifest.json,
+// styles.css) into the test vault's plugin directory.
+//
+// Why this exists: with multiple git worktrees each producing their own build,
+// a single symlink in the test vault binds it to one worktree — usually the
+// wrong one. This script lets `npm run install:test-vault` from inside any
+// worktree push that worktree's build into the vault. Pair it with the
+// `hot-reload` community plugin (an empty `.hotreload` file in the plugin
+// directory) for live reloads on rebuild.
+//
+// Override the destination with TEST_VAULT_PLUGIN_DIR if your test vault is
+// elsewhere.
+
+import { copyFileSync, existsSync, mkdirSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+const DEFAULT_DEST = join(homedir(), 'Obsidian', 'Test Vault', '.obsidian', 'plugins', 'obsidian-gemini');
+const dest = process.env.TEST_VAULT_PLUGIN_DIR ?? DEFAULT_DEST;
+const files = ['main.js', 'manifest.json', 'styles.css'];
+
+const missing = files.filter((f) => !existsSync(f));
+if (missing.length > 0) {
+	console.error(`Missing build artifacts: ${missing.join(', ')}. Run 'npm run build' first.`);
+	process.exit(1);
+}
+
+if (!existsSync(dirname(dest))) {
+	console.error(`Plugins folder not found: ${dirname(dest)}. Is the test vault open in Obsidian at least once?`);
+	process.exit(1);
+}
+
+mkdirSync(dest, { recursive: true });
+
+for (const file of files) {
+	const target = join(dest, file);
+	copyFileSync(file, target);
+	console.log(`  ${file} → ${target}`);
+}
+
+console.log(`\nInstalled to ${dest}`);
+console.log('Reload the plugin in Obsidian (or use the hot-reload plugin) to pick up changes.');


### PR DESCRIPTION
## Summary

Adds a small `npm run install:test-vault` script that copies the current worktree's built plugin artifacts (`main.js`, `manifest.json`, `styles.css`) into a local test vault's plugin folder.

This unblocks per-worktree manual testing in Obsidian. The pre-existing pattern of symlinking the vault's plugin folder to a single repo path (e.g. `/Users/<you>/src/obsidian-gemini/main.js`) binds the vault to one worktree at a time — running tests from any other worktree silently loads the wrong bundle. (Surfaced while running the plugin acceptance tests against #805 in a worktree — the vault was loading parent-master's bundle, not the PR under test.)

Pair with the hot-reload community plugin (drop an empty `.hotreload` file into the plugin directory once) for auto-reload on rebuild.

No runtime effect on the plugin itself — pure dev infrastructure.

## Changes

- New [scripts/install-test-vault.mjs](scripts/install-test-vault.mjs): node script that copies `main.js` / `manifest.json` / `styles.css` from `process.cwd()` into `~/Obsidian/Test Vault/.obsidian/plugins/obsidian-gemini/` (override with `TEST_VAULT_PLUGIN_DIR`). Errors clearly if build artifacts are missing or the plugins folder doesn't exist.
- New `install:test-vault` entry in [package.json](package.json) scripts.

## Verification

- `npm run format-check` — clean
- `npm run build` — clean
- `npm test` — 1699 passed, 5 skipped
- Manually verified the script copies all three files into a real test vault and the plugin reloads correctly with the worktree's bundle.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer — discussed directly with maintainer in the chat that surfaced the underlying symlink issue
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — script never runs in the plugin runtime; dev-only tooling
- [x] Documentation has been updated (if applicable) — N/A, dev-only script; AGENTS.md mention can follow if desired
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an npm script and a small CLI utility to deploy built plugin artifacts into a local test vault. The tool validates required build outputs and destination folders, copies the artifacts into the vault, and prints per-file and completion messages or exits with clear errors on failure.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/allenhutchison/obsidian-gemini/pull/807)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/allenhutchison/obsidian-gemini/pull/807)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->