### PR TITLE
chore(deps): bump @allenhutchison/gemini-utils to 1.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "4.8.0",
 			"license": "MIT",
 			"dependencies": {
-				"@allenhutchison/gemini-utils": "^0.6.0",
+				"@allenhutchison/gemini-utils": "^1.0.0",
 				"@codemirror/merge": "^6.12.1",
 				"@types/turndown": "^5.0.6",
 				"ollama": "^0.6.3",
@@ -18,7 +18,7 @@
 			"devDependencies": {
 				"@eslint/js": "^9.39.4",
 				"@eslint/json": "^0.14.0",
-				"@google/genai": "^1.51.0",
+				"@google/genai": "^2.2.0",
 				"@modelcontextprotocol/sdk": "^1.29.0",
 				"@types/node": "^25.6.0",
 				"@vitest/coverage-v8": "^4.1.5",
@@ -301,9 +301,9 @@
 			}
 		},
 		"node_modules/@allenhutchison/gemini-utils": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/@allenhutchison/gemini-utils/-/gemini-utils-0.6.0.tgz",
-			"integrity": "sha512-Fbllxagk9lfpOn7eF9e90CF0xsgNlopd0Cl/gve7NqT5m+iwuWhx7+YE6NkvZ3cE8HYxNaRRiu1ha35FTro9Tg==",
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@allenhutchison/gemini-utils/-/gemini-utils-1.0.0.tgz",
+			"integrity": "sha512-Q6zCGpVg/uc0amP2GPcWmPJS/xqJ2Z1R1TU7D4sINFj11ShiLbvXLTIW9lkpvhQ6hiGRUHshNF8KsssQ+5Jg7w==",
 			"license": "MIT",
 			"dependencies": {
 				"commander": "^14.0.0",
@@ -316,7 +316,7 @@
 				"node": ">=18.0.0"
 			},
 			"peerDependencies": {
-				"@google/genai": ">=1.29.0"
+				"@google/genai": ">=2.0.0"
 			}
 		},
 		"node_modules/@allenhutchison/gemini-utils/node_modules/commander": {
@@ -1468,9 +1468,9 @@
 			}
 		},
 		"node_modules/@google/genai": {
-			"version": "1.51.0",
-			"resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.51.0.tgz",
-			"integrity": "sha512-vTZZF3CSimN7cn2zsLpW2p5WF0eZa5Gz69ITMPCNHpPrDlAstOfGifSfi0p/s9Z9400f7xJRkgvkQNrcM7pJ6w==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@google/genai/-/genai-2.2.0.tgz",
+			"integrity": "sha512-RA3cuaKLldWTrpxhNm2nAe0Oez/UEuoH11jFjPzbYL7TSP83lMk+ic7pQKZ4ekJdZfnIdgxWl1DwJoUwxmvWGQ==",
 			"hasInstallScript": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -1596,102 +1596,6 @@
 			"integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/@isaacs/cliui": {
-			"version": "8.0.2",
-			"resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
-			"integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
-			"license": "ISC",
-			"dependencies": {
-				"string-width": "^5.1.2",
-				"string-width-cjs": "npm:string-width@^4.2.0",
-				"strip-ansi": "^7.0.1",
-				"strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
-				"wrap-ansi": "^8.1.0",
-				"wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/@isaacs/cliui/node_modules/ansi-regex": {
-			"version": "6.2.2",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-			"integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
-			}
-		},
-		"node_modules/@isaacs/cliui/node_modules/ansi-styles": {
-			"version": "6.2.3",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-			"integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"node_modules/@isaacs/cliui/node_modules/emoji-regex": {
-			"version": "9.2.2",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-			"integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-			"license": "MIT"
-		},
-		"node_modules/@isaacs/cliui/node_modules/string-width": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-			"integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-			"license": "MIT",
-			"dependencies": {
-				"eastasianwidth": "^0.2.0",
-				"emoji-regex": "^9.2.2",
-				"strip-ansi": "^7.0.1"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/@isaacs/cliui/node_modules/strip-ansi": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-			"integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^6.0.1"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
-			}
-		},
-		"node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-			"integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
-			"license": "MIT",
-			"dependencies": {
-				"ansi-styles": "^6.1.0",
-				"string-width": "^5.0.1",
-				"strip-ansi": "^7.0.1"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-			}
 		},
 		"node_modules/@jridgewell/resolve-uri": {
 			"version": "3.1.2",
@@ -1864,16 +1768,6 @@
 				"url": "https://github.com/sponsors/Boshen"
 			}
 		},
-		"node_modules/@pkgjs/parseargs": {
-			"version": "0.11.0",
-			"resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
-			"integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
-			"license": "MIT",
-			"optional": true,
-			"engines": {
-				"node": ">=14"
-			}
-		},
 		"node_modules/@pkgr/core": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.1.2.tgz",
@@ -1907,9 +1801,9 @@
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/@protobufjs/codegen": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-			"integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+			"integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/@protobufjs/eventemitter": {
@@ -1935,9 +1829,9 @@
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/@protobufjs/inquire": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-			"integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.1.tgz",
+			"integrity": "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==",
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/@protobufjs/path": {
@@ -1953,9 +1847,9 @@
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/@protobufjs/utf8": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-			"integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+			"integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/@rolldown/binding-android-arm64": {
@@ -3652,19 +3546,11 @@
 				"node": ">= 14.0.0"
 			}
 		},
-		"node_modules/ansi-regex": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/ansi-styles": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
 			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"color-convert": "^2.0.1"
@@ -4010,6 +3896,7 @@
 			"version": "5.0.5",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
 			"integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^4.0.2"
@@ -4022,6 +3909,7 @@
 			"version": "4.0.4",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
 			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": "18 || 20 || >=22"
@@ -4289,6 +4177,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
 			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"color-name": "~1.1.4"
@@ -4301,6 +4190,7 @@
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/colorette": {
@@ -4423,6 +4313,7 @@
 			"version": "7.0.6",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
 			"integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"path-key": "^3.1.0",
@@ -4669,12 +4560,6 @@
 			"engines": {
 				"node": ">= 0.4"
 			}
-		},
-		"node_modules/eastasianwidth": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
-			"integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-			"license": "MIT"
 		},
 		"node_modules/ecdsa-sig-formatter": {
 			"version": "1.0.11",
@@ -5979,34 +5864,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/foreground-child": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
-			"integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
-			"license": "ISC",
-			"dependencies": {
-				"cross-spawn": "^7.0.6",
-				"signal-exit": "^4.0.1"
-			},
-			"engines": {
-				"node": ">=14"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/foreground-child/node_modules/signal-exit": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-			"license": "ISC",
-			"engines": {
-				"node": ">=14"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
 		"node_modules/formdata-polyfill": {
 			"version": "4.0.10",
 			"resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
@@ -6096,15 +5953,14 @@
 			}
 		},
 		"node_modules/gaxios": {
-			"version": "7.1.3",
-			"resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.3.tgz",
-			"integrity": "sha512-YGGyuEdVIjqxkxVH1pUTMY/XtmmsApXrCVv5EU25iX6inEPbV+VakJfLealkBtJN69AQmh1eGOdCl9Sm1UP6XQ==",
+			"version": "7.1.4",
+			"resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
+			"integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"extend": "^3.0.2",
 				"https-proxy-agent": "^7.0.1",
-				"node-fetch": "^3.3.2",
-				"rimraf": "^5.0.1"
+				"node-fetch": "^3.3.2"
 			},
 			"engines": {
 				"node": ">=18"
@@ -6217,26 +6073,6 @@
 				"url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
 			}
 		},
-		"node_modules/glob": {
-			"version": "10.5.0",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
-			"integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
-			"license": "ISC",
-			"dependencies": {
-				"foreground-child": "^3.1.0",
-				"jackspeak": "^3.1.2",
-				"minimatch": "^9.0.4",
-				"minipass": "^7.1.2",
-				"package-json-from-dist": "^1.0.0",
-				"path-scurry": "^1.11.1"
-			},
-			"bin": {
-				"glob": "dist/esm/bin.mjs"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
 		"node_modules/glob-parent": {
 			"version": "6.0.2",
 			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -6281,17 +6117,16 @@
 			}
 		},
 		"node_modules/google-auth-library": {
-			"version": "10.5.0",
-			"resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.5.0.tgz",
-			"integrity": "sha512-7ABviyMOlX5hIVD60YOfHw4/CxOfBhyduaYB+wbFWCWoni4N7SLcV46hrVRktuBbZjFC9ONyqamZITN7q3n32w==",
+			"version": "10.6.2",
+			"resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
+			"integrity": "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"base64-js": "^1.3.0",
 				"ecdsa-sig-formatter": "^1.0.11",
-				"gaxios": "^7.0.0",
-				"gcp-metadata": "^8.0.0",
-				"google-logging-utils": "^1.0.0",
-				"gtoken": "^8.0.0",
+				"gaxios": "^7.1.4",
+				"gcp-metadata": "8.1.2",
+				"google-logging-utils": "1.1.3",
 				"jws": "^4.0.0"
 			},
 			"engines": {
@@ -6326,19 +6161,6 @@
 			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
 			"dev": true,
 			"license": "ISC"
-		},
-		"node_modules/gtoken": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/gtoken/-/gtoken-8.0.0.tgz",
-			"integrity": "sha512-+CqsMbHPiSTdtSO14O51eMNlrp9N79gmeqmXeouJOhfucAedHw9noVe/n5uJk3tbKE6a+6ZCQg3RPhVhHByAIw==",
-			"license": "MIT",
-			"dependencies": {
-				"gaxios": "^7.0.0",
-				"jws": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=18"
-			}
 		},
 		"node_modules/handlebars": {
 			"version": "4.7.9",
@@ -6831,15 +6653,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/is-fullwidth-code-point": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/is-generator-function": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
@@ -7099,6 +6912,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+			"devOptional": true,
 			"license": "ISC"
 		},
 		"node_modules/istanbul-lib-coverage": {
@@ -7156,21 +6970,6 @@
 			},
 			"engines": {
 				"node": ">= 0.4"
-			}
-		},
-		"node_modules/jackspeak": {
-			"version": "3.4.3",
-			"resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
-			"integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-			"license": "BlueOak-1.0.0",
-			"dependencies": {
-				"@isaacs/cliui": "^8.0.2"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			},
-			"optionalDependencies": {
-				"@pkgjs/parseargs": "^0.11.0"
 			}
 		},
 		"node_modules/jose": {
@@ -8229,6 +8028,7 @@
 			"version": "9.0.8",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.8.tgz",
 			"integrity": "sha512-reYkDYtj/b19TeqbNZCV4q9t+Yxylf/rYBsLb42SXJatTv4/ylq5lEiAmhA/IToxO7NI2UzNMghHoHuaqDkAjw==",
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"brace-expansion": "^5.0.2"
@@ -8248,15 +8048,6 @@
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/minipass": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-			"integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-			"license": "ISC",
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
 			}
 		},
 		"node_modules/minisearch": {
@@ -8690,12 +8481,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/package-json-from-dist": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
-			"integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
-			"license": "BlueOak-1.0.0"
-		},
 		"node_modules/parent-module": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -8733,6 +8518,7 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
 			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -8744,28 +8530,6 @@
 			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/path-scurry": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
-			"integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-			"license": "BlueOak-1.0.0",
-			"dependencies": {
-				"lru-cache": "^10.2.0",
-				"minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
-			},
-			"engines": {
-				"node": ">=16 || 14 >=14.18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/path-scurry/node_modules/lru-cache": {
-			"version": "10.4.3",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-			"license": "ISC"
 		},
 		"node_modules/path-to-regexp": {
 			"version": "8.4.2",
@@ -8909,22 +8673,22 @@
 			}
 		},
 		"node_modules/protobufjs": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
-			"integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
+			"version": "7.5.8",
+			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.8.tgz",
+			"integrity": "sha512-dvpCIeLPbXZS/Ete7yLaO7RenOdken2NHKykBXbsaGxZT0UTltcarBciw+A78SRQs9iMAAVpsYA+l8b1hTePIA==",
 			"hasInstallScript": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
 				"@protobufjs/aspromise": "^1.1.2",
 				"@protobufjs/base64": "^1.1.2",
-				"@protobufjs/codegen": "^2.0.4",
+				"@protobufjs/codegen": "^2.0.5",
 				"@protobufjs/eventemitter": "^1.1.0",
 				"@protobufjs/fetch": "^1.1.0",
 				"@protobufjs/float": "^1.0.2",
-				"@protobufjs/inquire": "^1.1.0",
+				"@protobufjs/inquire": "^1.1.1",
 				"@protobufjs/path": "^1.1.2",
 				"@protobufjs/pool": "^1.1.0",
-				"@protobufjs/utf8": "^1.1.0",
+				"@protobufjs/utf8": "^1.1.1",
 				"@types/node": ">=13.7.0",
 				"long": "^5.0.0"
 			},
@@ -9228,21 +8992,6 @@
 			"integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/rimraf": {
-			"version": "5.0.10",
-			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
-			"integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
-			"license": "ISC",
-			"dependencies": {
-				"glob": "^10.3.7"
-			},
-			"bin": {
-				"rimraf": "dist/esm/bin.mjs"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
 		},
 		"node_modules/rolldown": {
 			"version": "1.0.0-rc.17",
@@ -9600,6 +9349,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
 			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"shebang-regex": "^3.0.0"
@@ -9612,6 +9362,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
 			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -9867,47 +9618,6 @@
 				"node": ">=0.6.19"
 			}
 		},
-		"node_modules/string-width": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-			"license": "MIT",
-			"dependencies": {
-				"emoji-regex": "^8.0.0",
-				"is-fullwidth-code-point": "^3.0.0",
-				"strip-ansi": "^6.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/string-width-cjs": {
-			"name": "string-width",
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-			"license": "MIT",
-			"dependencies": {
-				"emoji-regex": "^8.0.0",
-				"is-fullwidth-code-point": "^3.0.0",
-				"strip-ansi": "^6.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/string-width-cjs/node_modules/emoji-regex": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-			"license": "MIT"
-		},
-		"node_modules/string-width/node_modules/emoji-regex": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-			"license": "MIT"
-		},
 		"node_modules/string.prototype.matchall": {
 			"version": "4.0.12",
 			"resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.12.tgz",
@@ -10019,31 +9729,6 @@
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/wooorm"
-			}
-		},
-		"node_modules/strip-ansi": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^5.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/strip-ansi-cjs": {
-			"name": "strip-ansi",
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^5.0.1"
-			},
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/strip-bom": {
@@ -11167,6 +10852,7 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
 			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+			"devOptional": true,
 			"license": "ISC",
 			"dependencies": {
 				"isexe": "^2.0.0"
@@ -11301,24 +10987,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/wrap-ansi-cjs": {
-			"name": "wrap-ansi",
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-			"license": "MIT",
-			"dependencies": {
-				"ansi-styles": "^4.0.0",
-				"string-width": "^4.1.0",
-				"strip-ansi": "^6.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-			}
-		},
 		"node_modules/wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -11327,9 +10995,9 @@
 			"license": "ISC"
 		},
 		"node_modules/ws": {
-			"version": "8.18.3",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-			"integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+			"version": "8.20.1",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+			"integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
 	"devDependencies": {
 		"@eslint/js": "^9.39.4",
 		"@eslint/json": "^0.14.0",
-		"@google/genai": "^1.51.0",
+		"@google/genai": "^2.2.0",
 		"@modelcontextprotocol/sdk": "^1.29.0",
 		"@types/node": "^25.6.0",
 		"@vitest/coverage-v8": "^4.1.5",
@@ -62,7 +62,7 @@
 		"vitest": "^4.1.5"
 	},
 	"dependencies": {
-		"@allenhutchison/gemini-utils": "^0.6.0",
+		"@allenhutchison/gemini-utils": "^1.0.0",
 		"@codemirror/merge": "^6.12.1",
 		"@types/turndown": "^5.0.6",
 		"ollama": "^0.6.3",

--- a/src/services/deep-research.ts
+++ b/src/services/deep-research.ts
@@ -1,5 +1,6 @@
 import { TFile, normalizePath } from 'obsidian';
 import type ObsidianGemini from '../main';
+import type { Interactions } from '@google/genai';
 import { ResearchManager, ReportGenerator, Interaction, InteractionOutput } from '@allenhutchison/gemini-utils';
 import { proxyFetch } from '../utils/proxy-fetch';
 import { executeWithRetry, RetryConfig, DEFAULT_RETRY_CONFIG } from '../utils/retry';
@@ -265,20 +266,33 @@ export class DeepResearchService {
 	}
 
 	/**
+	 * Extract a stable identifier from a citation annotation. The Gemini SDK's
+	 * Annotation union (URL/file/place) does not have a single shared field, so
+	 * pick the most identifying one per type.
+	 */
+	private annotationSource(annotation: Interactions.Annotation): string | undefined {
+		switch (annotation.type) {
+			case 'url_citation':
+				return annotation.url;
+			case 'file_citation':
+				return annotation.document_uri ?? annotation.file_name;
+			case 'place_citation':
+				return annotation.url ?? annotation.place_id;
+		}
+	}
+
+	/**
 	 * Count unique sources from the interaction outputs
 	 */
 	private countSources(interaction: Interaction): number {
 		const sources = new Set<string>();
 
 		for (const output of this.extractOutputs(interaction)) {
-			if (output.type === 'text') {
-				const annotations = (output as any).annotations as Array<{ source?: string }> | undefined;
-				if (annotations) {
-					for (const annotation of annotations) {
-						if (annotation.source) {
-							sources.add(annotation.source);
-						}
-					}
+			if (output.type !== 'text' || !output.annotations) continue;
+			for (const annotation of output.annotations) {
+				const source = this.annotationSource(annotation);
+				if (source) {
+					sources.add(source);
 				}
 			}
 		}

--- a/src/services/deep-research.ts
+++ b/src/services/deep-research.ts
@@ -1,6 +1,6 @@
 import { TFile, normalizePath } from 'obsidian';
 import type ObsidianGemini from '../main';
-import { ResearchManager, ReportGenerator, Interaction } from '@allenhutchison/gemini-utils';
+import { ResearchManager, ReportGenerator, Interaction, InteractionOutput } from '@allenhutchison/gemini-utils';
 import { proxyFetch } from '../utils/proxy-fetch';
 import { executeWithRetry, RetryConfig, DEFAULT_RETRY_CONFIG } from '../utils/retry';
 import { createGoogleGenAI } from '../api/providers/gemini/google-genai-factory';
@@ -231,11 +231,25 @@ export class DeepResearchService {
 	}
 
 	/**
+	 * Flatten the model_output steps of an interaction into a Content[] array,
+	 * matching the shape gemini-utils 0.x exposed as `interaction.outputs`.
+	 */
+	private extractOutputs(interaction: Interaction): InteractionOutput[] {
+		const outputs: InteractionOutput[] = [];
+		for (const step of interaction.steps ?? []) {
+			if (step.type === 'model_output' && step.content) {
+				outputs.push(...step.content);
+			}
+		}
+		return outputs;
+	}
+
+	/**
 	 * Generate a formatted markdown report from the interaction outputs
 	 */
 	private generateReport(topic: string, interaction: Interaction): string {
 		// Use the report generator from gemini-utils for basic structure
-		const baseReport = this.reportGenerator.generateMarkdown(interaction.outputs || []);
+		const baseReport = this.reportGenerator.generateMarkdown(this.extractOutputs(interaction));
 
 		// Add our custom header with topic and date
 		const header = `# ${topic}\n\n*Generated on ${new Date().toLocaleDateString()}*\n\n---\n\n`;
@@ -256,7 +270,7 @@ export class DeepResearchService {
 	private countSources(interaction: Interaction): number {
 		const sources = new Set<string>();
 
-		for (const output of interaction.outputs || []) {
+		for (const output of this.extractOutputs(interaction)) {
 			if (output.type === 'text') {
 				const annotations = (output as any).annotations as Array<{ source?: string }> | undefined;
 				if (annotations) {

--- a/test/services/deep-research.test.ts
+++ b/test/services/deep-research.test.ts
@@ -120,7 +120,7 @@ describe('DeepResearchService', () => {
 							{
 								type: 'text',
 								text: 'Research results here',
-								annotations: [{ source: 'https://example.com' }],
+								annotations: [{ type: 'url_citation', url: 'https://example.com' }],
 							},
 						],
 					},
@@ -401,15 +401,15 @@ describe('DeepResearchService', () => {
 								type: 'text',
 								text: 'Content',
 								annotations: [
-									{ source: 'https://source1.com' },
-									{ source: 'https://source2.com' },
-									{ source: 'https://source1.com' }, // Duplicate
+									{ type: 'url_citation', url: 'https://source1.com' },
+									{ type: 'url_citation', url: 'https://source2.com' },
+									{ type: 'url_citation', url: 'https://source1.com' }, // Duplicate
 								],
 							},
 							{
 								type: 'text',
 								text: 'More content',
-								annotations: [{ source: 'https://source3.com' }],
+								annotations: [{ type: 'url_citation', url: 'https://source3.com' }],
 							},
 						],
 					},

--- a/test/services/deep-research.test.ts
+++ b/test/services/deep-research.test.ts
@@ -113,11 +113,16 @@ describe('DeepResearchService', () => {
 			mockPoll.mockResolvedValue({
 				id: 'interaction-123',
 				status: 'completed',
-				outputs: [
+				steps: [
 					{
-						type: 'text',
-						text: 'Research results here',
-						annotations: [{ source: 'https://example.com' }],
+						type: 'model_output',
+						content: [
+							{
+								type: 'text',
+								text: 'Research results here',
+								annotations: [{ source: 'https://example.com' }],
+							},
+						],
 					},
 				],
 			});
@@ -144,7 +149,7 @@ describe('DeepResearchService', () => {
 			mockPoll.mockResolvedValue({
 				id: 'interaction-123',
 				status: 'completed',
-				outputs: [],
+				steps: [],
 			});
 			mockGenerateMarkdown.mockReturnValue('# Research Report\n\n');
 
@@ -166,7 +171,7 @@ describe('DeepResearchService', () => {
 			mockPoll.mockResolvedValue({
 				id: 'interaction-123',
 				status: 'completed',
-				outputs: [],
+				steps: [],
 			});
 			mockGenerateMarkdown.mockReturnValue('# Research Report\n\n');
 
@@ -202,7 +207,7 @@ describe('DeepResearchService', () => {
 			mockPoll.mockResolvedValue({
 				id: 'interaction-123',
 				status: 'completed',
-				outputs: [],
+				steps: [],
 			});
 			mockGenerateMarkdown.mockReturnValue('# Research Report\n\n');
 
@@ -223,7 +228,7 @@ describe('DeepResearchService', () => {
 			mockPoll.mockResolvedValue({
 				id: 'interaction-123',
 				status: 'completed',
-				outputs: [],
+				steps: [],
 			});
 			mockGenerateMarkdown.mockReturnValue('# Research Report\n\n');
 
@@ -247,7 +252,7 @@ describe('DeepResearchService', () => {
 			mockPoll.mockResolvedValue({
 				id: 'interaction-123',
 				status: 'completed',
-				outputs: [],
+				steps: [],
 			});
 			mockGenerateMarkdown.mockReturnValue('# Research Report\n\n');
 
@@ -301,7 +306,7 @@ describe('DeepResearchService', () => {
 			mockPoll.mockResolvedValue({
 				id: 'interaction-123',
 				status: 'completed',
-				outputs: [],
+				steps: [],
 			});
 			mockGenerateMarkdown.mockReturnValue('# Research Report\n\n');
 			mockVault.create.mockRejectedValue(new Error('Save failed'));
@@ -369,7 +374,7 @@ describe('DeepResearchService', () => {
 			mockPoll.mockResolvedValue({
 				id: 'interaction-123',
 				status: 'completed',
-				outputs: [{ type: 'text', text: 'Content here' }],
+				steps: [{ type: 'model_output', content: [{ type: 'text', text: 'Content here' }] }],
 			});
 			mockGenerateMarkdown.mockReturnValue('# Research Report\n\nContent here\n');
 
@@ -388,20 +393,25 @@ describe('DeepResearchService', () => {
 			mockPoll.mockResolvedValue({
 				id: 'interaction-123',
 				status: 'completed',
-				outputs: [
+				steps: [
 					{
-						type: 'text',
-						text: 'Content',
-						annotations: [
-							{ source: 'https://source1.com' },
-							{ source: 'https://source2.com' },
-							{ source: 'https://source1.com' }, // Duplicate
+						type: 'model_output',
+						content: [
+							{
+								type: 'text',
+								text: 'Content',
+								annotations: [
+									{ source: 'https://source1.com' },
+									{ source: 'https://source2.com' },
+									{ source: 'https://source1.com' }, // Duplicate
+								],
+							},
+							{
+								type: 'text',
+								text: 'More content',
+								annotations: [{ source: 'https://source3.com' }],
+							},
 						],
-					},
-					{
-						type: 'text',
-						text: 'More content',
-						annotations: [{ source: 'https://source3.com' }],
 					},
 				],
 			});
@@ -417,7 +427,7 @@ describe('DeepResearchService', () => {
 			mockPoll.mockResolvedValue({
 				id: 'interaction-123',
 				status: 'completed',
-				outputs: [{ type: 'text', text: 'Content without sources' }],
+				steps: [{ type: 'model_output', content: [{ type: 'text', text: 'Content without sources' }] }],
 			});
 			mockGenerateMarkdown.mockReturnValue('# Research Report\n\n');
 

--- a/test/services/deep-research.test.ts
+++ b/test/services/deep-research.test.ts
@@ -422,6 +422,46 @@ describe('DeepResearchService', () => {
 			expect(result.sourceCount).toBe(3); // Unique sources
 		});
 
+		it('should aggregate sources across multiple model_output steps and ignore other step types', async () => {
+			mockStartResearch.mockResolvedValue({ id: 'interaction-123' });
+			mockPoll.mockResolvedValue({
+				id: 'interaction-123',
+				status: 'completed',
+				steps: [
+					{ type: 'user_input', content: 'ignored' },
+					{
+						type: 'model_output',
+						content: [
+							{
+								type: 'text',
+								text: 'A',
+								annotations: [{ type: 'url_citation', url: 'https://a.com' }],
+							},
+						],
+					},
+					{ type: 'function_call', name: 'ignored' },
+					{
+						type: 'model_output',
+						content: [
+							{
+								type: 'text',
+								text: 'B',
+								annotations: [
+									{ type: 'url_citation', url: 'https://b.com' },
+									{ type: 'url_citation', url: 'https://a.com' }, // dedup across steps
+								],
+							},
+						],
+					},
+				],
+			});
+			mockGenerateMarkdown.mockReturnValue('# Research Report\n\n');
+
+			const result = await service.conductResearch({ topic: 'Test' });
+
+			expect(result.sourceCount).toBe(2);
+		});
+
 		it('should handle outputs without annotations', async () => {
 			mockStartResearch.mockResolvedValue({ id: 'interaction-123' });
 			mockPoll.mockResolvedValue({


### PR DESCRIPTION
## Summary

Bumps `@allenhutchison/gemini-utils` from `^0.6.0` to `^1.0.0`. The 1.0 release pulls its `@google/genai` peer requirement up to `>= 2.0.0`, so this PR also bumps `@google/genai` from `^1.51.0` to `^2.2.0` (the latest).

The 1.0 `Interaction` type re-exports the SDK shape directly: `outputs: Content[]` is gone in favor of `steps: Step[]`, where `model_output` steps carry `content: Content[]`. This required a small adapter in `deep-research.ts` so `ReportGenerator.generateMarkdown` and our source-counting still get a flat `Content[]`.

## Changes

- `package.json`: `@allenhutchison/gemini-utils ^0.6.0 → ^1.0.0`, `@google/genai ^1.51.0 → ^2.2.0`
- `package-lock.json`: refreshed via `npm install`
- `src/services/deep-research.ts`: add `extractOutputs(interaction)` helper that flattens `model_output` step content; thread it through `generateReport` and `countSources`; import `InteractionOutput`
- `test/services/deep-research.test.ts`: update mock `mockPoll` returns from `outputs: [...]` to `steps: [{ type: 'model_output', content: [...] }]` to match the new SDK shape

No other consumers of `@allenhutchison/gemini-utils` (file-classification, RAG `FileUploader`, `ObsidianVaultAdapter`) needed changes — their imported symbols are unchanged in 1.0.

## Testing

- `npm run format-check` — clean
- `npm run build` — clean (tsc + esbuild)
- `npm test` — 1725 passed, 5 skipped, 0 failed

**Not yet verified at runtime**: the deep-research feature uses an SDK-internals workaround (`interactions._client.fetch = proxyFetch` in `ensureResearchManager`) for CORS handling. The build + tests don't exercise it. If `@google/genai` 2.x changed those internals, the workaround will throw the explicit `'SDK structure has changed'` error at first use rather than failing silently — but a smoke test in Obsidian against deep research is recommended before relying on it in production.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A, requested directly by the maintainer
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [ ] I have tested this change on Desktop — unit tests + build only; deep-research runtime path not smoke-tested in Obsidian (see Testing note above)
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards) — same as desktop; no platform-specific code touched
- [x] Documentation has been updated (if applicable) — N/A, internal dep bump with no user-visible behavior change
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved report generation to more reliably extract outputs and aggregate unique sources across multiple steps, yielding more accurate citation counts in generated research reports.
* **Bug Fixes**
  * Fixed issues where some citation types were not consistently recognized, reducing duplicate or missing sources in reports.
* **Chores**
  * Updated dependency versions for improved stability and feature support.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/allenhutchison/obsidian-gemini/pull/811)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->