### PR TITLE
chore(daily): 2026-05-12 daily update

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,7 @@ npm run format       # Format code with Prettier
 npm run format-check # Check formatting without changes
 npm run lint         # Lint with ESLint (eslint-plugin-obsidianmd recommended preset)
 npm run lint:fix     # Auto-fix ESLint violations where possible
+npm run install:test-vault # Copy built artifacts into test vault (override path with TEST_VAULT_PLUGIN_DIR)
 ```
 
 **IMPORTANT**: Always run `npm install` first if you encounter TypeScript errors or missing module errors during build. The build requires all dependencies in `node_modules` to be present. If you get errors about missing modules like `obsidian`, `@google/genai`, `handlebars`, or `tslib`, run `npm install` before attempting `npm run build` again.

--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -12,9 +12,39 @@ This guide covers how to test Gemini Scribe changes on desktop and mobile, what 
 - A dedicated test vault (separate from your primary vault)
 - The plugin repository cloned locally
 
-### Symlink Setup
+### Wiring the Plugin into a Test Vault
 
-Link your development build into your test vault so changes appear immediately:
+There are two ways to connect your development build to a test vault. Choose whichever fits your workflow.
+
+#### Option A: `npm run install:test-vault` (recommended for multi-worktree setups)
+
+This script copies the built artifacts (`main.js`, `manifest.json`, `styles.css`) from the current worktree into the test vault's plugin directory:
+
+```bash
+npm run install:test-vault
+```
+
+By default it targets `~/Obsidian/Test Vault/.obsidian/plugins/obsidian-gemini`. Override it with the `TEST_VAULT_PLUGIN_DIR` environment variable:
+
+```bash
+TEST_VAULT_PLUGIN_DIR=/path/to/vault/.obsidian/plugins/gemini-scribe npm run install:test-vault
+```
+
+Pair this with the [pjeby/hot-reload](https://github.com/pjeby/hot-reload) community plugin (touch an empty `.hotreload` file in the plugin directory) and `npm run dev` for a live-reload loop:
+
+```bash
+# terminal 1
+npm run dev
+
+# terminal 2 (after each rebuild, or wired to a file-watcher)
+npm run install:test-vault
+```
+
+Use this approach when you work across multiple git worktrees — a symlink would bind the test vault to one worktree's output, whereas this script always pushes the current worktree's build.
+
+#### Option B: Symlink (simpler for single-worktree setups)
+
+Link your development build into your test vault so changes appear immediately (no copy needed on every rebuild):
 
 ```bash
 # macOS / Linux

--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -24,7 +24,7 @@ This script copies the built artifacts (`main.js`, `manifest.json`, `styles.css`
 npm run install:test-vault
 ```
 
-By default it targets `~/Obsidian/Test Vault/.obsidian/plugins/obsidian-gemini`. Override it with the `TEST_VAULT_PLUGIN_DIR` environment variable:
+By default it targets `~/Obsidian/Test Vault/.obsidian/plugins/gemini-scribe`. Override it with the `TEST_VAULT_PLUGIN_DIR` environment variable:
 
 ```bash
 TEST_VAULT_PLUGIN_DIR=/path/to/vault/.obsidian/plugins/gemini-scribe npm run install:test-vault

--- a/planning/changelog/2026-05-12.md
+++ b/planning/changelog/2026-05-12.md
@@ -1,0 +1,50 @@
+# Daily changelog — May 12, 2026
+
+**Date:** 2026-05-12
+**PRs merged:** 9
+
+---
+
+## Summary
+
+Heavy day: a long-running external contribution finally landed (custom API endpoint, by @cherubines), followed by a cascade of follow-up cleanups, a dead-code sweep driven by an architecture-audit trial run, a significant provider-package refactor, and the new `architecture-audit` skill itself. The API layer is now meaningfully better organised and the codebase is 170+ lines lighter from dead-code removal.
+
+## What shipped
+
+### [#760 feat: add custom API endpoint setting with full SDK call site coverage](https://github.com/allenhutchison/obsidian-gemini/pull/760)
+
+Adds a `customBaseUrl` setting (under **API Configuration**) that routes all Google GenAI SDK calls through a user-specified base URL — useful for corporate proxies, local gateways, or regional mirrors. A new `createGoogleGenAI(plugin)` helper centralises all `GoogleGenAI` instance construction so the setting is honoured consistently across the 7+ call sites that previously each created their own instance. Settings UI includes `new URL()` validation; invalid input is silently rejected without disrupting existing config. Fixes #747.
+
+Contributed by @cherubines.
+
+### [#795 refactor(api): clean up follow-ups from PR #760](https://github.com/allenhutchison/obsidian-gemini/pull/795)
+
+Post-merge cleanup for the custom-endpoint feature: adds the missing `GeminiClient` unit test asserting `httpOptions.baseUrl` is wired correctly; fixes a misnamed factory test; removes dead `DeepResearchService.invalidateResearchManager()` (already a no-op due to re-init on settings change); hides the "Custom API endpoint" field for Ollama users (previously rendered but silently had no effect); and tightens the `createGoogleGenAI` signature to accept an explicit `apiKeyOverride` so the config field is actually authoritative when supplied.
+
+### [#793 fix(models): gate remote model fetch by provider and online state](https://github.com/allenhutchison/obsidian-gemini/pull/793)
+
+Defense-in-depth for the offline-startup hang reported in discussion #576. `startRemoteFetch()` now short-circuits when the active provider is not Gemini, or when `navigator.onLine === false`, before the existing 24h cache check. Investigation shows the model fetch was likely not the actual blocker in the reported hang (MCP HTTP servers and non-localhost Ollama are more probable culprits), but this patch eliminates the fetch as a variable. New test file covers all four paths.
+
+### [#796 chore(daily): 2026-05-11 daily update](https://github.com/allenhutchison/obsidian-gemini/pull/796)
+
+Automated daily housekeeping for May 11: changelog for that day (3 PRs) plus two doc drift fixes — corrected the settings navigation path for tool permissions in `agent-mode.md`, and corrected a permission key example in `projects.md` (`edit_file` → `write_file`).
+
+### [#800 refactor: remove unused exports from dom-context](https://github.com/allenhutchison/obsidian-gemini/pull/800)
+
+Architecture-audit sweep: three exported helpers in `src/utils/dom-context.ts` (`createContextElement`, `createContextTextNode`, `insertNodeAtCursor`) had zero callers anywhere in the codebase. Removed, shrinking the file from 183 → 115 lines. The six remaining exports are unaffected.
+
+### [#799 refactor: remove unused TrustedModeConfirmationModal](https://github.com/allenhutchison/obsidian-gemini/pull/799)
+
+Architecture-audit sweep: `src/ui/trusted-mode-modal.ts` was not imported anywhere in `src/` or `test/`. No references to a "Trusted Mode" feature exist anywhere outside this single file, indicating the feature was removed earlier and the modal file was missed during cleanup. File deleted (53 lines, 0 callers).
+
+### [#798 refactor: remove unused ToolConverter class](https://github.com/allenhutchison/obsidian-gemini/pull/798)
+
+Architecture-audit sweep: `src/tools/tool-converter.ts` had zero callers — its three static conversion methods (`toToolDefinition`, `toToolDefinitions`, `toGeminiFormat`) are not called from anywhere in the project, with conversion responsibilities living in `ToolRegistry` and the API client layer instead. File deleted (50 lines, 0 callers).
+
+### [#804 feat: add architecture-audit skill](https://github.com/allenhutchison/obsidian-gemini/pull/804)
+
+Adds a nightly TypeScript tech-debt sweep skill (`.agents/skills/architecture-audit/SKILL.md`). The skill walks the codebase, classifies findings into discrete units of work (oversized files, `any` overuse, dead code, DRY violations, missing tests, circular imports, etc.), and either opens focused PRs (capped at 3 per run) or files GitHub issues (capped at 5 per run) — never bundled. A trial run before this PR produced PRs #798–800 and issues #801–803, validating the design. Intentionally not part of `daily-update` because it can generate multiple PRs per run; schedule it as its own `/schedule` slot.
+
+### [#797 refactor(api): per-provider packages under src/api/providers](https://github.com/allenhutchison/obsidian-gemini/pull/797)
+
+Reorganises the model provider code so each provider lives in its own subdirectory: `src/api/providers/gemini/` and `src/api/providers/ollama/`. The previous flat layout mixed provider concerns and used a factory named `GeminiClientFactory` that actually handled both providers. Renamed to `ModelClientFactory` (breaking change — no back-compat alias) in `src/api/factory.ts`; `src/api/index.ts` rewritten as a clean barrel that exports Ollama types alongside Gemini equivalents. All 13+ internal call sites migrated. `createGoogleGenAI()` moved to `src/api/providers/gemini/google-genai-factory.ts`. Tests restructured to mirror the new layout. `src/release-notes.json` records the breaking change under a 4.9.0 stub entry. Gemini-only services that bypass the factory by design (image generation, deep research, Google Search, web fetch) are explicitly out of scope for this pass.

--- a/scripts/install-test-vault.mjs
+++ b/scripts/install-test-vault.mjs
@@ -16,7 +16,7 @@ import { copyFileSync, existsSync, mkdirSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 
-const DEFAULT_DEST = join(homedir(), 'Obsidian', 'Test Vault', '.obsidian', 'plugins', 'obsidian-gemini');
+const DEFAULT_DEST = join(homedir(), 'Obsidian', 'Test Vault', '.obsidian', 'plugins', 'gemini-scribe');
 const dest = process.env.TEST_VAULT_PLUGIN_DIR ?? DEFAULT_DEST;
 const files = ['main.js', 'manifest.json', 'styles.css'];
 


### PR DESCRIPTION
## Summary

Automated daily housekeeping for May 12, 2026. Writes the changelog for the day, fixes a documentation gap found during the audit, and reports zero triage actions.

## Changes

- **Add `planning/changelog/2026-05-12.md`**: Documents 9 PRs merged on May 12 — #760 (custom API endpoint by @cherubines), #795 (follow-up cleanup for #760), #793 (model fetch guard for offline/Ollama), #796 (prior daily update), #800/#799/#798 (three dead-code removals from architecture-audit trial run), #804 (architecture-audit skill), and #797 (per-provider package layout refactor).
- **Update `docs/contributing/testing.md`**: Document the new `npm run install:test-vault` script added in PR #807. The script copies built artifacts into the test vault and is the preferred approach over symlinks when working with multiple git worktrees. Added as "Option A" above the existing symlink section.
- **Update `AGENTS.md` commands section**: Add `npm run install:test-vault` to the Development commands table so contributors see it alongside other dev scripts.

## Triage report — 2026-05-12

Issues processed: 0
Issues labeled: 0
No unlabeled open issues found.

## Screenshots / Screencast

N/A — no UI changes.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A; automated housekeeping
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [ ] I have tested this change on Desktop — N/A; changelog and doc updates only
- [ ] I have verified this change does not break Mobile — N/A; no code changes
- [x] Documentation has been updated (if applicable)
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01ALTmTVvCBz8r1gCWCcqQBK)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Testing docs now offer two workflows for wiring a built plugin into a test vault, including a recommended install script and an option for symlinks.
  * Docs describe how to override the install target and pair the install script with a live-reload dev loop.
  * Added a daily changelog entry summarizing recent audits, provider reorganization, and maintenance notes.
* **Chores**
  * Updated the default test-vault install target to the renamed plugin directory.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/allenhutchison/obsidian-gemini/pull/814)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->