### PR TITLE
chore(daily): 2026-05-13 daily update

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,8 +301,7 @@ Create reusable AI instruction templates that customize how the AI behaves for s
   - Disable other completion plugins that might conflict
 - **Sessions Not Loading:** Ensure "Enable Session History" is on and the "Plugin State Folder" path is correct. Sessions live under `[Plugin State Folder]/Agent-Sessions/`.
 - **Custom Prompts Not Working:**
-  - Ensure "Enable Custom Prompts" is toggled on in settings
-  - Verify the prompt file exists in the Prompts folder
+  - Verify the prompt file exists in the `[Plugin State Folder]/Prompts/` folder
   - Check that the prompt is selected in session settings (gear icon)
   - See the [Custom Prompts Guide](docs/guide/custom-prompts.md) for detailed troubleshooting
 - **Parameter/Advanced Settings Issues:**

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
 				"husky": "^9.1.7",
 				"jsdom": "^29.1.1",
 				"lint-staged": "^17.0.4",
-				"obsidian": "*",
+				"obsidian": "latest",
 				"prettier": "^3.8.3",
 				"tslib": "2.8.1",
 				"typescript": "^6.0.3",

--- a/planning/changelog/2026-05-13.md
+++ b/planning/changelog/2026-05-13.md
@@ -1,0 +1,20 @@
+# Daily changelog — May 13, 2026
+
+**Date:** 2026-05-13
+**PRs merged:** 2
+
+---
+
+## Summary
+
+Quiet maintenance day. A Dependabot batch updated nine dev-tooling packages — notably bumping ESLint from v9 to v10 and lint-staged from v16 to v17. The architecture-audit nightly sweep also contributed a small internal cleanup that removes unused `export` keywords from five file-local symbols.
+
+## What shipped
+
+### [#812 chore(deps-dev): bump the dev-dependencies group across 1 directory with 9 updates](https://github.com/allenhutchison/obsidian-gemini/pull/812)
+
+Dependabot batch bump of dev dependencies. Key version jumps: ESLint `9.39.4 → 10.3.0` and `@eslint/js` `9.39.4 → 10.0.1` (major version crossing; ESLint 10 drops several legacy APIs), `@eslint/json` `0.14.0 → 1.2.0`, `lint-staged` `16.4.0 → 17.0.4`, plus minor updates to `@types/node`, `@vitest/coverage-v8`, and `builtin-modules`. No user-visible behavior change; affects only CI and local tooling.
+
+### [#813 refactor: drop unused export keywords on internal helpers](https://github.com/allenhutchison/obsidian-gemini/pull/813)
+
+The `architecture-audit` nightly sweep identified six exported symbols that have no references outside their own file. Dropping the `export` keyword removes them from the plugin's public surface and allows `knip` and the TypeScript compiler to treat them as truly file-local, making future refactors safer. Affected symbols across five files: `DEFAULT_TOOL_RESPONSE_KEEP_RECENT`, `getModelProvider`, `PERMISSION_TO_STRING`, `getExtensionFromMimeType`, `getAttachmentFolder`, and `getDOMContext`. Pure refactor — no behavior change.

--- a/planning/changelog/2026-05-13.md
+++ b/planning/changelog/2026-05-13.md
@@ -7,7 +7,7 @@
 
 ## Summary
 
-Quiet maintenance day. A Dependabot batch updated nine dev-tooling packages — notably bumping ESLint from v9 to v10 and lint-staged from v16 to v17. The architecture-audit nightly sweep also contributed a small internal cleanup that removes unused `export` keywords from five file-local symbols.
+Quiet maintenance day. A Dependabot batch updated nine dev-tooling packages — notably bumping ESLint from v9 to v10 and lint-staged from v16 to v17. The architecture-audit nightly sweep also contributed a small internal cleanup that removes unused `export` keywords from six file-local symbols across five files.
 
 ## What shipped
 


### PR DESCRIPTION
## Summary

Automated daily housekeeping run for 2026-05-13. Covers changelog, doc audit, and issue triage.

## Changes

- **daily-changelog**: wrote `planning/changelog/2026-05-13.md` — 2 PRs landed (Dependabot dev-dependency batch bump, architecture-audit export-keyword cleanup)
- **audit-docs**: fixed one drift in `README.md` — removed stale troubleshooting bullet "Ensure 'Enable Custom Prompts' is toggled on in settings" (that setting does not exist in the codebase)
- **triage-issues**: no unlabeled open issues (49 open issues, all already labeled — no-op)
- **package-lock.json**: minor lock file normalization (`"obsidian": "*"` → `"obsidian": "latest"`) from `npm install` during pre-flight

## Sub-skill outcomes

| Sub-skill | Outcome |
| --- | --- |
| daily-changelog | wrote `planning/changelog/2026-05-13.md`, 2 PRs: #812 (deps bump), #813 (export cleanup) |
| audit-docs | `README.md`: removed stale "Enable Custom Prompts" troubleshooting step |
| triage-issues | 49 open issues, 0 unlabeled — no labels applied |

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A, automated daily run
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [ ] I have tested this change on Desktop — N/A, doc/changelog only
- [ ] I have verified this change does not break Mobile — N/A, doc/changelog only
- [x] Documentation has been updated (if applicable) — this PR IS the doc update
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (`daily-update` skill)
- [x] I have reviewed and understand all AI-generated code in this PR

---

https://claude.ai/code/session_016LopqUUffvL4RA3KqjH78o

---
_Generated by [Claude Code](https://claude.ai/code/session_016LopqUUffvL4RA3KqjH78o)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified custom prompts troubleshooting to specify the plugin state folder path for Prompts.

* **Chores**
  * Updated development tooling dependencies (no user-facing changes).

* **Refactor**
  * Internal cleanup to reduce the plugin's public surface (no behavior change).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/allenhutchison/obsidian-gemini/pull/816)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->