### PR TITLE
Guard MCP against offline machines and unreachable servers

### DIFF
--- a/docs/guide/mcp-servers.md
+++ b/docs/guide/mcp-servers.md
@@ -173,6 +173,29 @@ When an MCP server is connected:
 - Check that the tool hasn't been removed from the server
 - Try disconnecting and reconnecting the server
 - Enable Debug Mode for detailed error logs
+- Tool calls have a 60-second timeout; a tool that takes longer will return a timeout error
+
+## Timeouts and offline behavior
+
+To prevent a slow or unreachable MCP server from hanging Obsidian, the plugin enforces these timeouts:
+
+| Operation                                 | Timeout    |
+| ----------------------------------------- | ---------- |
+| Connect + first tool listing (per server) | 10 seconds |
+| Tool list refresh / **Test Connection**   | 10 seconds |
+| Tool invocation by the agent              | 60 seconds |
+| Underlying HTTP request                   | 15 seconds |
+| OAuth authorization wait                  | 2 minutes  |
+
+These values are not user-configurable. If a working server consistently exceeds them, please open a discussion.
+
+**Offline machines**
+
+When the machine reports that it has no network connection (`navigator.onLine === false`), HTTP MCP servers are skipped at startup and show an "offline" error in settings. The plugin listens for the network coming back and reconnects them automatically. Stdio (local process) servers are unaffected by network state and always attempt to start.
+
+**Startup is non-blocking**
+
+MCP servers are connected in the background after Obsidian's layout is ready. The plugin loads immediately even if every configured MCP server is unreachable. The agent may see fewer tools for a few seconds during this connection phase.
 
 ## Limitations
 

--- a/src/mcp/mcp-constants.ts
+++ b/src/mcp/mcp-constants.ts
@@ -1,0 +1,24 @@
+/**
+ * Hardcoded timeouts (ms) for MCP operations.
+ *
+ * These guard against the plugin (or the agent loop) hanging when an MCP
+ * server is unreachable — see GitHub discussion #576.
+ */
+
+/** Initial `client.connect()` + first `listTools()` during connectServer. */
+export const MCP_CONNECT_TIMEOUT_MS = 10_000;
+
+/** `client.listTools()` outside of initial connect (refresh, settings test). */
+export const MCP_LIST_TOOLS_TIMEOUT_MS = 10_000;
+
+/** `client.callTool()` for a single agent tool invocation. */
+export const MCP_CALL_TOOL_TIMEOUT_MS = 60_000;
+
+/** Per-HTTP-request ceiling inside obsidianFetch. */
+export const MCP_FETCH_TIMEOUT_MS = 15_000;
+
+/** Best-effort `transport.close()` during cleanup or disconnect. */
+export const MCP_CLOSE_TIMEOUT_MS = 5_000;
+
+/** Wait for OAuth callback after browser redirect. Matches CALLBACK_TIMEOUT_MS. */
+export const MCP_OAUTH_WAIT_TIMEOUT_MS = 120_000;

--- a/src/mcp/mcp-fetch.ts
+++ b/src/mcp/mcp-fetch.ts
@@ -82,10 +82,16 @@ export async function obsidianFetch(url: string | URL, init?: RequestInit): Prom
 		}, MCP_FETCH_TIMEOUT_MS);
 	});
 
-	// Also reject if the caller's signal aborts mid-flight.
+	// Also reject if the caller's signal aborts mid-flight. Re-check `aborted`
+	// inside the executor in case it flipped between the pre-check at the top
+	// of the function and now — this is the standard AbortController idiom.
 	let abortHandler: (() => void) | undefined;
 	const abortPromise: Promise<never> | undefined = init?.signal
 		? new Promise<never>((_, reject) => {
+				if (init.signal!.aborted) {
+					reject(new TypeError('Network request failed: aborted'));
+					return;
+				}
 				abortHandler = () => reject(new TypeError('Network request failed: aborted'));
 				init.signal!.addEventListener('abort', abortHandler, { once: true });
 			})

--- a/src/mcp/mcp-fetch.ts
+++ b/src/mcp/mcp-fetch.ts
@@ -1,4 +1,5 @@
 import { requestUrl } from 'obsidian';
+import { MCP_FETCH_TIMEOUT_MS } from './mcp-constants';
 
 /**
  * A fetch-compatible wrapper around Obsidian's `requestUrl`.
@@ -10,9 +11,18 @@ import { requestUrl } from 'obsidian';
  *
  * Conforms to the MCP SDK's `FetchLike` type:
  *   `(url: string | URL, init?: RequestInit) => Promise<Response>`
+ *
+ * Applies MCP_FETCH_TIMEOUT_MS as a ceiling on each request. `requestUrl`
+ * does not accept an AbortSignal, so when the timer fires we stop waiting
+ * but the underlying socket continues until the OS times it out.
  */
 export async function obsidianFetch(url: string | URL, init?: RequestInit): Promise<Response> {
 	const urlString = url instanceof URL ? url.toString() : url;
+
+	// Honour a pre-aborted caller signal before doing any work.
+	if (init?.signal?.aborted) {
+		throw new TypeError('Network request failed: aborted');
+	}
 
 	const headers: Record<string, string> = {};
 	if (init?.headers) {
@@ -47,24 +57,56 @@ export async function obsidianFetch(url: string | URL, init?: RequestInit): Prom
 		}
 	}
 
-	try {
-		const response = await requestUrl({
-			url: urlString,
-			method: init?.method || 'GET',
-			headers,
-			body,
-			throw: false, // Don't throw on 4xx/5xx — let the SDK handle errors
-		});
+	// Build the request promise (resolves to a Response or throws).
+	const requestPromise = requestUrl({
+		url: urlString,
+		method: init?.method || 'GET',
+		headers,
+		body,
+		throw: false, // Don't throw on 4xx/5xx — let the SDK handle errors
+	}).then(
+		(response) =>
+			new Response(response.text, {
+				status: response.status,
+				headers: new Headers(response.headers),
+			})
+	);
 
-		// Convert Obsidian's response to a Web API Response object
-		// Use response.text as the raw body (requestUrl always provides this)
-		return new Response(response.text, {
-			status: response.status,
-			headers: new Headers(response.headers),
-		});
+	// Race against the fetch-level timeout. We throw the same TypeError shape
+	// the existing catch block produced, so the MCP SDK's error handling is
+	// unchanged.
+	let timer: number | undefined;
+	const timeoutPromise = new Promise<never>((_, reject) => {
+		timer = window.setTimeout(() => {
+			reject(new TypeError(`Network request failed: timed out after ${MCP_FETCH_TIMEOUT_MS}ms`));
+		}, MCP_FETCH_TIMEOUT_MS);
+	});
+
+	// Also reject if the caller's signal aborts mid-flight.
+	let abortHandler: (() => void) | undefined;
+	const abortPromise: Promise<never> | undefined = init?.signal
+		? new Promise<never>((_, reject) => {
+				abortHandler = () => reject(new TypeError('Network request failed: aborted'));
+				init.signal!.addEventListener('abort', abortHandler, { once: true });
+			})
+		: undefined;
+
+	try {
+		const racers: Array<Promise<Response>> = [requestPromise, timeoutPromise];
+		if (abortPromise) racers.push(abortPromise);
+		return await Promise.race(racers);
 	} catch (error) {
-		// For network-level errors, create a Response-like TypeError
-		// to match what fetch() would throw
+		// Network/timeout/abort — keep the TypeError shape the SDK expects.
+		if (error instanceof TypeError) {
+			throw error;
+		}
 		throw new TypeError(`Network request failed: ${error instanceof Error ? error.message : String(error)}`);
+	} finally {
+		if (timer !== undefined) {
+			window.clearTimeout(timer);
+		}
+		if (abortHandler && init?.signal) {
+			init.signal.removeEventListener('abort', abortHandler);
+		}
 	}
 }

--- a/src/mcp/mcp-manager.ts
+++ b/src/mcp/mcp-manager.ts
@@ -5,9 +5,19 @@ import { MCPServerConfig, MCPConnectionStatus, MCPServerState, MCP_TRANSPORT_HTT
 import { MCPToolWrapper } from './mcp-tool-wrapper';
 import { ObsidianOAuthClientProvider, OAUTH_CALLBACK_PORT } from './mcp-oauth-provider';
 import { obsidianFetch } from './mcp-fetch';
+import {
+	MCP_CLOSE_TIMEOUT_MS,
+	MCP_CONNECT_TIMEOUT_MS,
+	MCP_LIST_TOOLS_TIMEOUT_MS,
+	MCP_OAUTH_WAIT_TIMEOUT_MS,
+} from './mcp-constants';
+import { withTimeout } from '../utils/timeout';
 import type ObsidianGemini from '../main';
 import { Logger } from '../utils/logger';
 import { Notice } from 'obsidian';
+
+/** Marker on MCPServerState.error so the online listener knows which servers to retry. */
+const OFFLINE_ERROR_PREFIX = 'Machine is offline';
 
 // Desktop-only modules loaded dynamically to avoid pulling in Node.js builtins
 // (http, child_process) that crash the plugin on iOS/mobile.
@@ -114,6 +124,7 @@ export class MCPManager {
 	private logger: Logger;
 	private connections = new Map<string, ServerConnection>();
 	private serverStates = new Map<string, MCPServerState>();
+	private onlineHandler: (() => void) | null = null;
 
 	constructor(plugin: ObsidianGemini) {
 		this.plugin = plugin;
@@ -121,10 +132,71 @@ export class MCPManager {
 	}
 
 	/**
+	 * True when the browser/Electron reports the machine is offline.
+	 * `navigator.onLine` is a hint, not a guarantee — a working LAN with no
+	 * upstream still reports online — but it lets us fail fast in the common
+	 * "Wi-Fi is off" case without waiting for a 10-second timeout.
+	 */
+	private isMachineOffline(): boolean {
+		return typeof navigator !== 'undefined' && navigator.onLine === false;
+	}
+
+	/**
+	 * Install a window 'online' listener (once) so HTTP servers marked offline
+	 * are retried automatically when the network returns. Idempotent.
+	 */
+	private setupOnlineListener(): void {
+		if (this.onlineHandler) return;
+		if (typeof window === 'undefined' || typeof window.addEventListener !== 'function') return;
+		this.onlineHandler = () => {
+			void this.handleOnline();
+		};
+		window.addEventListener('online', this.onlineHandler);
+	}
+
+	private teardownOnlineListener(): void {
+		if (!this.onlineHandler) return;
+		if (typeof window !== 'undefined' && typeof window.removeEventListener === 'function') {
+			window.removeEventListener('online', this.onlineHandler);
+		}
+		this.onlineHandler = null;
+	}
+
+	/**
+	 * Network came back: reconnect HTTP servers that were skipped because
+	 * the machine was offline. Errors are logged but not surfaced — this is
+	 * a background best-effort retry.
+	 */
+	private async handleOnline(): Promise<void> {
+		const servers = this.plugin.settings.mcpServers || [];
+		for (const config of servers) {
+			if (!config.enabled || config.transport !== MCP_TRANSPORT_HTTP) continue;
+			const state = this.serverStates.get(config.name);
+			if (!state || state.status !== MCPConnectionStatus.ERROR) continue;
+			if (!state.error?.startsWith(OFFLINE_ERROR_PREFIX)) continue;
+
+			this.logger.log(`MCP: Network online — reconnecting "${config.name}"`);
+			try {
+				await this.connectServer(config);
+			} catch (error) {
+				this.logger.warn(
+					`MCP: Reconnect on online event failed for "${config.name}":`,
+					error instanceof Error ? error.message : error
+				);
+			}
+		}
+	}
+
+	/**
 	 * Connect to all enabled MCP servers.
-	 * Called during plugin startup. Failures are logged but do not block startup.
+	 * Called during plugin startup (deferred to onLayoutReady; fire-and-forget).
+	 * Failures are logged but do not block startup.
 	 */
 	async connectAllEnabled(): Promise<void> {
+		// Set up the online listener once, regardless of whether any HTTP
+		// servers are currently configured — the user may add one mid-session.
+		this.setupOnlineListener();
+
 		const servers = this.plugin.settings.mcpServers || [];
 		const enabledServers = servers.filter((s) => s.enabled);
 
@@ -161,6 +233,22 @@ export class MCPManager {
 			return;
 		}
 
+		// HTTP servers can't reach anywhere when the machine is offline. Skip
+		// fast and let the online listener retry when the network returns.
+		// Stdio servers are local processes and unaffected by network state.
+		if (useHttp && this.isMachineOffline()) {
+			this.logger.log(
+				`MCP: Skipping HTTP server "${config.name}" — machine is offline, will retry when network returns`
+			);
+			this.updateState(config.name, {
+				status: MCPConnectionStatus.ERROR,
+				error: `${OFFLINE_ERROR_PREFIX} — will retry when network returns`,
+				toolNames: [],
+			});
+			this.setupOnlineListener();
+			return;
+		}
+
 		// Disconnect if already connected
 		if (this.connections.has(config.name)) {
 			await this.disconnectServer(config.name);
@@ -184,9 +272,14 @@ export class MCPManager {
 
 			this.logger.debug(`MCP: client.connect() succeeded for "${config.name}"`);
 
-			// Discover tools
+			// Discover tools (bounded — a server can accept the connection but
+			// hang forever on listTools, which would freeze the agent setup).
 			this.logger.debug(`MCP: Listing tools for "${config.name}"...`);
-			const { tools } = await client.listTools();
+			const { tools } = await withTimeout(
+				client.listTools(),
+				MCP_LIST_TOOLS_TIMEOUT_MS,
+				`MCP listTools for "${config.name}"`
+			);
 			this.logger.log(`MCP: Server "${config.name}" connected with ${tools.length} tool(s)`);
 
 			// Create tool wrappers and register them
@@ -204,10 +297,11 @@ export class MCPManager {
 				toolNames: tools.map((t) => t.name),
 			});
 		} catch (error) {
-			// Close the transport if it was created
+			// Close the transport if it was created (best-effort, bounded so a
+			// hung server can't keep us in the catch block indefinitely).
 			if (transport) {
 				try {
-					await transport.close();
+					await withTimeout(transport.close(), MCP_CLOSE_TIMEOUT_MS, 'MCP transport close');
 				} catch {
 					// Ignore close errors during cleanup
 				}
@@ -240,9 +334,10 @@ export class MCPManager {
 			this.plugin.toolRegistry.unregisterTool(wrapper.name);
 		}
 
-		// Close transport (which kills the spawned process)
+		// Close transport (which kills the spawned process). Bounded so a hung
+		// server can't make plugin teardown hang.
 		try {
-			await conn.transport.close();
+			await withTimeout(conn.transport.close(), MCP_CLOSE_TIMEOUT_MS, `MCP transport close for "${serverName}"`);
 		} catch (error) {
 			this.logger.debug(`MCP: Error closing transport for "${serverName}":`, error);
 		}
@@ -253,9 +348,10 @@ export class MCPManager {
 	}
 
 	/**
-	 * Disconnect all connected MCP servers.
+	 * Disconnect all connected MCP servers and stop listening for network changes.
 	 */
 	async disconnectAll(): Promise<void> {
+		this.teardownOnlineListener();
 		const serverNames = Array.from(this.connections.keys());
 		for (const name of serverNames) {
 			try {
@@ -284,7 +380,11 @@ export class MCPManager {
 
 		// Re-query and build new wrappers first so a listTools() failure
 		// doesn't leave us with no tools registered.
-		const { tools } = await conn.client.listTools();
+		const { tools } = await withTimeout(
+			conn.client.listTools(),
+			MCP_LIST_TOOLS_TIMEOUT_MS,
+			`MCP listTools (refresh) for "${serverName}"`
+		);
 		const newWrappers: MCPToolWrapper[] = [];
 		for (const toolDef of tools) {
 			const wrapper = new MCPToolWrapper(conn.client, config.name, toolDef);
@@ -339,6 +439,12 @@ export class MCPManager {
 			throw new Error('Stdio MCP server connections are not supported on mobile');
 		}
 
+		// HTTP test can't possibly succeed when offline — fail fast with a
+		// clear message instead of waiting out the connect timeout.
+		if (useHttp && this.isMachineOffline()) {
+			throw new Error(`${OFFLINE_ERROR_PREFIX} — cannot test HTTP MCP server`);
+		}
+
 		if (useHttp) {
 			this.logger.debug(`MCP: Test connection to "${config.name}" — url: ${config.url}`);
 		} else {
@@ -353,11 +459,15 @@ export class MCPManager {
 			transport = result.transport;
 
 			this.logger.debug(`MCP: Test — connected, listing tools...`);
-			const { tools } = await result.client.listTools();
+			const { tools } = await withTimeout(
+				result.client.listTools(),
+				MCP_LIST_TOOLS_TIMEOUT_MS,
+				`MCP listTools (test) for "${config.name}"`
+			);
 			const toolNames = tools.map((t) => t.name);
 			this.logger.debug(`MCP: Test — found ${toolNames.length} tool(s): ${toolNames.join(', ')}`);
 
-			await transport.close();
+			await withTimeout(transport.close(), MCP_CLOSE_TIMEOUT_MS, 'MCP transport close (test)');
 			return toolNames;
 		} catch (error) {
 			const errorMsg = error instanceof Error ? error.message : String(error);
@@ -368,7 +478,7 @@ export class MCPManager {
 			}
 			if (transport) {
 				try {
-					await transport.close();
+					await withTimeout(transport.close(), MCP_CLOSE_TIMEOUT_MS, 'MCP transport close (test cleanup)');
 				} catch {
 					// Ignore close errors during cleanup
 				}
@@ -438,7 +548,7 @@ export class MCPManager {
 		});
 
 		try {
-			await client.connect(transport);
+			await withTimeout(client.connect(transport), MCP_CONNECT_TIMEOUT_MS, `MCP connect to "${config.name}"`);
 		} catch (connectError) {
 			if (connectError instanceof UnauthorizedError && useHttp && transport instanceof StreamableHTTPClientTransport) {
 				this.logger.log(`MCP: OAuth required for "${config.name}", waiting for authorization...`);
@@ -448,8 +558,15 @@ export class MCPManager {
 					throw new Error('OAuth required but callback server is not available (mobile or port conflict)');
 				}
 
-				// Wait for OAuth callback — server is already listening
-				const { code } = await callbackHandle.waitForCode;
+				// Wait for OAuth callback — server is already listening. Bound this
+				// to the OAuth window so an abandoned browser tab can't hang us
+				// indefinitely (the callback server itself also enforces this, but
+				// belt-and-braces avoids drift if that ever changes).
+				const { code } = await withTimeout(
+					callbackHandle.waitForCode,
+					MCP_OAUTH_WAIT_TIMEOUT_MS,
+					`MCP OAuth callback for "${config.name}"`
+				);
 				callbackHandle = null; // Server auto-closes after receiving the code
 				await transport.finishAuth(code);
 				this.logger.log(`MCP: OAuth token exchange complete for "${config.name}", reconnecting...`);
@@ -457,7 +574,11 @@ export class MCPManager {
 				// Reconnect with the now-authenticated provider
 				await transport.close().catch(() => {});
 				transport = new StreamableHTTPClientTransport(new URL(config.url!), { authProvider, fetch: obsidianFetch });
-				await client.connect(transport);
+				await withTimeout(
+					client.connect(transport),
+					MCP_CONNECT_TIMEOUT_MS,
+					`MCP connect (post-OAuth) to "${config.name}"`
+				);
 			} else {
 				throw connectError;
 			}

--- a/src/mcp/mcp-tool-wrapper.ts
+++ b/src/mcp/mcp-tool-wrapper.ts
@@ -2,6 +2,8 @@ import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { Tool, ToolResult, ToolExecutionContext, ToolParameterSchema } from '../tools/types';
 import { ToolCategory } from '../types/agent';
 import { ToolClassification } from '../types/tool-policy';
+import { MCP_CALL_TOOL_TIMEOUT_MS } from './mcp-constants';
+import { withTimeout } from '../utils/timeout';
 
 /**
  * MCP tool definition as returned by client.listTools()
@@ -42,10 +44,17 @@ export class MCPToolWrapper implements Tool {
 
 	async execute(params: any, _context: ToolExecutionContext): Promise<ToolResult> {
 		try {
-			const result = await this.client.callTool({
-				name: this.originalToolName,
-				arguments: params,
-			});
+			// Bound the wait — a hung MCP server must not freeze the agent loop.
+			// Timeout surfaces as `{ success: false, error }` via the catch below,
+			// which is the same shape any other tool failure produces.
+			const result = await withTimeout(
+				this.client.callTool({
+					name: this.originalToolName,
+					arguments: params,
+				}),
+				MCP_CALL_TOOL_TIMEOUT_MS,
+				`MCP tool "${this.displayName}"`
+			);
 
 			// Convert MCP CallToolResult to plugin ToolResult
 			const textParts: string[] = [];

--- a/src/services/lifecycle-service.ts
+++ b/src/services/lifecycle-service.ts
@@ -185,6 +185,12 @@ export class LifecycleService {
 			await plugin.hookManager.initialize();
 		}
 
+		// Kick off MCP server connections in the background. Fire-and-forget so
+		// the layout-ready path never waits on a slow or unreachable server.
+		if (plugin.mcpManager && plugin.settings.mcpEnabled) {
+			void plugin.mcpManager.connectAllEnabled();
+		}
+
 		// Check for version updates and show notification
 		await this.checkForUpdates();
 	}
@@ -472,10 +478,17 @@ export class LifecycleService {
 		}
 		plugin.skillManager = new SkillManager(plugin);
 
-		// MCP server connections
+		// MCP server connections. Never block plugin startup on MCP — a slow or
+		// unreachable HTTP server with no timeout used to hang Obsidian for as
+		// long as the OS kept the socket alive (see discussion #576).
+		//
+		// First plugin load: layout is not ready yet, so we just construct the
+		// manager and let onLayoutReady() kick off the connect in the background.
+		// Re-init (settings change after layout is ready): we fire-and-forget
+		// here since onLayoutReady() won't run again.
 		plugin.mcpManager = new MCPManager(plugin);
-		if (plugin.settings.mcpEnabled) {
-			await plugin.mcpManager.connectAllEnabled();
+		if (plugin.settings.mcpEnabled && plugin.app.workspace.layoutReady) {
+			void plugin.mcpManager.connectAllEnabled();
 		}
 
 		// Context management

--- a/src/utils/timeout.ts
+++ b/src/utils/timeout.ts
@@ -1,0 +1,34 @@
+/**
+ * Bound the wait on a Promise.
+ *
+ * `withTimeout` does not cancel the underlying operation — the caller's promise
+ * may still settle in the background. Use AbortController if cancellation at
+ * the source is needed. This is sufficient for MCP guards because Obsidian's
+ * `requestUrl` does not accept a signal, so the best we can do is stop waiting.
+ */
+
+export class TimeoutError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = 'TimeoutError';
+	}
+}
+
+/**
+ * Race a promise against a timer. Resolves with the promise's value if it
+ * settles within `ms`, otherwise rejects with a TimeoutError whose message
+ * is `${label} timed out after ${ms}ms`.
+ */
+export function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
+	let timer: number | undefined;
+	const timeout = new Promise<never>((_, reject) => {
+		timer = window.setTimeout(() => {
+			reject(new TimeoutError(`${label} timed out after ${ms}ms`));
+		}, ms);
+	});
+	return Promise.race([promise, timeout]).finally(() => {
+		if (timer !== undefined) {
+			window.clearTimeout(timer);
+		}
+	});
+}

--- a/test/mcp/mcp-fetch.test.ts
+++ b/test/mcp/mcp-fetch.test.ts
@@ -1,0 +1,68 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+import { MCP_FETCH_TIMEOUT_MS } from '../../src/mcp/mcp-constants';
+
+const { mockRequestUrl } = vi.hoisted(() => ({ mockRequestUrl: vi.fn() }));
+
+vi.mock('obsidian', () => ({
+	requestUrl: mockRequestUrl,
+}));
+
+// Import after the mock so obsidianFetch picks up the mocked requestUrl.
+import { obsidianFetch } from '../../src/mcp/mcp-fetch';
+
+describe('obsidianFetch', () => {
+	beforeEach(() => {
+		mockRequestUrl.mockReset();
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	test('returns a Response when requestUrl resolves', async () => {
+		mockRequestUrl.mockResolvedValueOnce({
+			status: 200,
+			text: 'ok',
+			headers: { 'content-type': 'text/plain' },
+		});
+
+		const res = await obsidianFetch('https://example.com/');
+		expect(res.status).toBe(200);
+		expect(await res.text()).toBe('ok');
+	});
+
+	test('rejects with TypeError carrying "timed out" message when requestUrl never settles', async () => {
+		mockRequestUrl.mockImplementationOnce(() => new Promise(() => {}));
+
+		const settled = obsidianFetch('https://example.com/');
+		const typeAssertion = expect(settled).rejects.toBeInstanceOf(TypeError);
+		await vi.advanceTimersByTimeAsync(MCP_FETCH_TIMEOUT_MS + 50);
+		await typeAssertion;
+		await expect(settled).rejects.toThrow(/timed out/);
+	});
+
+	test('passes through requestUrl rejections as TypeErrors', async () => {
+		mockRequestUrl.mockRejectedValueOnce(new Error('ENOTFOUND example.com'));
+
+		await expect(obsidianFetch('https://example.com/')).rejects.toThrow(TypeError);
+	});
+
+	test('short-circuits when the caller signal is already aborted', async () => {
+		const controller = new AbortController();
+		controller.abort();
+
+		await expect(obsidianFetch('https://example.com/', { signal: controller.signal })).rejects.toThrow(TypeError);
+		expect(mockRequestUrl).not.toHaveBeenCalled();
+	});
+
+	test('rejects when the caller signal aborts mid-flight', async () => {
+		const controller = new AbortController();
+		mockRequestUrl.mockImplementationOnce(() => new Promise(() => {}));
+
+		const settled = obsidianFetch('https://example.com/', { signal: controller.signal });
+		const assertion = expect(settled).rejects.toThrow(/aborted/);
+		controller.abort();
+		await assertion;
+	});
+});

--- a/test/mcp/mcp-manager.test.ts
+++ b/test/mcp/mcp-manager.test.ts
@@ -1,4 +1,6 @@
 import { MCPServerConfig, MCPConnectionStatus, MCP_TRANSPORT_STDIO, MCP_TRANSPORT_HTTP } from '../../src/mcp/types';
+import { TimeoutError } from '../../src/utils/timeout';
+import { MCP_CONNECT_TIMEOUT_MS, MCP_LIST_TOOLS_TIMEOUT_MS } from '../../src/mcp/mcp-constants';
 
 // --- Mocks ---
 
@@ -316,6 +318,147 @@ describe('MCPManager', () => {
 			const status = manager.getServerStatus('unknown');
 			expect(status.status).toBe(MCPConnectionStatus.DISCONNECTED);
 			expect(status.toolNames).toEqual([]);
+		});
+	});
+
+	describe('timeouts', () => {
+		// These tests use fake timers so a stuck connect/listTools rejects on a
+		// schedule, not in real wall-clock time.
+		beforeEach(() => {
+			vi.useFakeTimers();
+		});
+
+		afterEach(() => {
+			vi.useRealTimers();
+		});
+
+		it('rejects with TimeoutError when client.connect() never settles', async () => {
+			mockClientConnect.mockImplementationOnce(() => new Promise(() => {}));
+
+			const settled = manager.connectServer(createHttpConfig());
+			// Attach assertion BEFORE advancing time so the rejection has a handler.
+			const assertion = expect(settled).rejects.toBeInstanceOf(TimeoutError);
+			await vi.advanceTimersByTimeAsync(MCP_CONNECT_TIMEOUT_MS + 50);
+			await assertion;
+
+			const status = manager.getServerStatus('test-http');
+			expect(status.status).toBe(MCPConnectionStatus.ERROR);
+			expect(status.error).toMatch(/timed out/);
+		});
+
+		it('rejects with TimeoutError when listTools() never settles', async () => {
+			mockClientConnect.mockResolvedValueOnce(undefined);
+			mockListTools.mockImplementationOnce(() => new Promise(() => {}));
+
+			const settled = manager.connectServer(createHttpConfig());
+			const assertion = expect(settled).rejects.toBeInstanceOf(TimeoutError);
+			await vi.advanceTimersByTimeAsync(MCP_LIST_TOOLS_TIMEOUT_MS + 50);
+			await assertion;
+
+			const status = manager.getServerStatus('test-http');
+			expect(status.status).toBe(MCPConnectionStatus.ERROR);
+		});
+
+		it('queryToolsForConfig also times out a hung listTools()', async () => {
+			mockClientConnect.mockResolvedValueOnce(undefined);
+			mockListTools.mockImplementationOnce(() => new Promise(() => {}));
+
+			const settled = manager.queryToolsForConfig(createHttpConfig());
+			const assertion = expect(settled).rejects.toBeInstanceOf(TimeoutError);
+			await vi.advanceTimersByTimeAsync(MCP_LIST_TOOLS_TIMEOUT_MS + 50);
+			await assertion;
+		});
+	});
+
+	describe('offline behaviour', () => {
+		let originalOnLine: PropertyDescriptor | undefined;
+
+		beforeEach(() => {
+			originalOnLine = Object.getOwnPropertyDescriptor(navigator, 'onLine');
+		});
+
+		afterEach(() => {
+			if (originalOnLine) {
+				Object.defineProperty(navigator, 'onLine', originalOnLine);
+			}
+		});
+
+		function setOnline(value: boolean): void {
+			Object.defineProperty(navigator, 'onLine', { configurable: true, get: () => value });
+		}
+
+		it('marks HTTP servers as offline without attempting connect when navigator.onLine is false', async () => {
+			setOnline(false);
+
+			await manager.connectServer(createHttpConfig());
+
+			expect(MockStreamableHTTPClientTransport).not.toHaveBeenCalled();
+			expect(mockClientConnect).not.toHaveBeenCalled();
+
+			const status = manager.getServerStatus('test-http');
+			expect(status.status).toBe(MCPConnectionStatus.ERROR);
+			expect(status.error).toContain('offline');
+		});
+
+		it('still attempts stdio connections when navigator.onLine is false', async () => {
+			setOnline(false);
+			mockListTools.mockResolvedValueOnce({ tools: [{ name: 'tool1' }] });
+
+			await manager.connectServer(createStdioConfig());
+
+			expect(MockStdioClientTransport).toHaveBeenCalled();
+			expect(mockClientConnect).toHaveBeenCalled();
+
+			const status = manager.getServerStatus('test-stdio');
+			expect(status.status).toBe(MCPConnectionStatus.CONNECTED);
+		});
+
+		it('queryToolsForConfig fails fast for HTTP when offline', async () => {
+			setOnline(false);
+
+			await expect(manager.queryToolsForConfig(createHttpConfig())).rejects.toThrow(/offline/);
+			expect(MockStreamableHTTPClientTransport).not.toHaveBeenCalled();
+		});
+
+		it("reconnects offline-marked HTTP servers when the 'online' event fires", async () => {
+			setOnline(false);
+			plugin.settings.mcpServers = [createHttpConfig()];
+
+			// connectAllEnabled registers the online listener and marks the server offline.
+			await manager.connectAllEnabled();
+			expect(manager.getServerStatus('test-http').status).toBe(MCPConnectionStatus.ERROR);
+			expect(MockStreamableHTTPClientTransport).not.toHaveBeenCalled();
+
+			// Network returns; the listener should reconnect.
+			setOnline(true);
+			mockClientConnect.mockResolvedValueOnce(undefined);
+			mockListTools.mockResolvedValueOnce({ tools: [{ name: 'tool1' }] });
+
+			window.dispatchEvent(new Event('online'));
+
+			// Let microtasks drain so the async handler completes.
+			await new Promise((r) => window.setTimeout(r, 0));
+
+			expect(MockStreamableHTTPClientTransport).toHaveBeenCalled();
+			expect(manager.getServerStatus('test-http').status).toBe(MCPConnectionStatus.CONNECTED);
+		});
+
+		it('disconnectAll removes the online listener', async () => {
+			plugin.settings.mcpServers = [createHttpConfig()];
+			setOnline(true);
+			mockListTools.mockResolvedValueOnce({ tools: [] });
+
+			await manager.connectAllEnabled();
+			await manager.disconnectAll();
+
+			// After disconnectAll, an online event should not trigger a reconnect.
+			setOnline(false);
+			setOnline(true);
+			window.dispatchEvent(new Event('online'));
+			await new Promise((r) => window.setTimeout(r, 0));
+
+			// HTTP transport was created only once (during the initial connect).
+			expect(MockStreamableHTTPClientTransport).toHaveBeenCalledTimes(1);
 		});
 	});
 });

--- a/test/mcp/mcp-tool-wrapper.test.ts
+++ b/test/mcp/mcp-tool-wrapper.test.ts
@@ -1,0 +1,74 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+import { MCPToolWrapper } from '../../src/mcp/mcp-tool-wrapper';
+import { MCP_CALL_TOOL_TIMEOUT_MS } from '../../src/mcp/mcp-constants';
+
+function makeClient(callToolImpl: () => Promise<any>) {
+	return {
+		callTool: vi.fn().mockImplementation(callToolImpl),
+	} as any;
+}
+
+describe('MCPToolWrapper', () => {
+	describe('execute', () => {
+		beforeEach(() => {
+			vi.useFakeTimers();
+		});
+
+		afterEach(() => {
+			vi.useRealTimers();
+		});
+
+		test('returns success with concatenated text content when callTool resolves', async () => {
+			const client = makeClient(() =>
+				Promise.resolve({
+					content: [{ type: 'text', text: 'hello' }],
+				})
+			);
+			const wrapper = new MCPToolWrapper(client, 'srv', { name: 'do_thing' });
+
+			const result = await wrapper.execute({}, {} as any);
+
+			expect(result.success).toBe(true);
+			expect(result.data).toBe('hello');
+			expect(client.callTool).toHaveBeenCalledWith({ name: 'do_thing', arguments: {} });
+		});
+
+		test('returns success=false with timeout message when callTool never settles', async () => {
+			const client = makeClient(() => new Promise(() => {}));
+			const wrapper = new MCPToolWrapper(client, 'srv', { name: 'slow_thing' });
+
+			const settled = wrapper.execute({ q: 'x' }, {} as any);
+			await vi.advanceTimersByTimeAsync(MCP_CALL_TOOL_TIMEOUT_MS + 50);
+			const result = await settled;
+
+			expect(result.success).toBe(false);
+			expect(result.error).toContain('timed out');
+			expect(result.error).toContain('slow_thing');
+		});
+
+		test('returns success=false when callTool rejects', async () => {
+			const client = makeClient(() => Promise.reject(new Error('server down')));
+			const wrapper = new MCPToolWrapper(client, 'srv', { name: 'do_thing' });
+
+			const result = await wrapper.execute({}, {} as any);
+
+			expect(result.success).toBe(false);
+			expect(result.error).toContain('server down');
+		});
+
+		test('marks isError=true responses as failures', async () => {
+			const client = makeClient(() =>
+				Promise.resolve({
+					isError: true,
+					content: [{ type: 'text', text: 'bad input' }],
+				})
+			);
+			const wrapper = new MCPToolWrapper(client, 'srv', { name: 'do_thing' });
+
+			const result = await wrapper.execute({}, {} as any);
+
+			expect(result.success).toBe(false);
+			expect(result.error).toBe('bad input');
+		});
+	});
+});

--- a/test/utils/timeout.test.ts
+++ b/test/utils/timeout.test.ts
@@ -1,0 +1,83 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+import { TimeoutError, withTimeout } from '../../src/utils/timeout';
+
+describe('withTimeout', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	test('resolves with the inner promise value when it settles first', async () => {
+		const promise = withTimeout(Promise.resolve('ok'), 1000, 'op');
+		await expect(promise).resolves.toBe('ok');
+	});
+
+	test('propagates rejection of the inner promise', async () => {
+		const error = new Error('inner failed');
+		const promise = withTimeout(Promise.reject(error), 1000, 'op');
+		await expect(promise).rejects.toBe(error);
+	});
+
+	test('rejects with TimeoutError when the inner promise does not settle in time', async () => {
+		const slow = new Promise<string>(() => {
+			/* never settles */
+		});
+		const promise = withTimeout(slow, 100, 'slow op');
+
+		// Capture the promise BEFORE advancing the timer so the rejection
+		// handler is attached and Node's unhandled-rejection guard stays quiet.
+		const assertion = expect(promise).rejects.toThrow(TimeoutError);
+		await vi.advanceTimersByTimeAsync(100);
+		await assertion;
+	});
+
+	test('TimeoutError carries the label and duration in its message', async () => {
+		const slow = new Promise<string>(() => {});
+		const promise = withTimeout(slow, 250, 'my operation');
+		const assertion = expect(promise).rejects.toThrow('my operation timed out after 250ms');
+		await vi.advanceTimersByTimeAsync(250);
+		await assertion;
+	});
+
+	test('does not fire the timeout after the inner promise resolves', async () => {
+		let resolveInner!: (v: string) => void;
+		const inner = new Promise<string>((r) => {
+			resolveInner = r;
+		});
+		const racer = withTimeout(inner, 1000, 'op');
+
+		resolveInner('done');
+		await expect(racer).resolves.toBe('done');
+
+		// Advance the clock past the timeout window; nothing should reject.
+		await vi.advanceTimersByTimeAsync(2000);
+	});
+
+	test('does not fire the timeout after the inner promise rejects', async () => {
+		let rejectInner!: (e: Error) => void;
+		const inner = new Promise<string>((_, r) => {
+			rejectInner = r;
+		});
+		const racer = withTimeout(inner, 1000, 'op');
+
+		const innerError = new Error('inner');
+		rejectInner(innerError);
+		await expect(racer).rejects.toBe(innerError);
+
+		// Advance the clock; the cleared timer must not produce a second rejection.
+		await vi.advanceTimersByTimeAsync(2000);
+	});
+});
+
+describe('TimeoutError', () => {
+	test('is a real Error subclass with name set', () => {
+		const err = new TimeoutError('boom');
+		expect(err).toBeInstanceOf(Error);
+		expect(err).toBeInstanceOf(TimeoutError);
+		expect(err.name).toBe('TimeoutError');
+		expect(err.message).toBe('boom');
+	});
+});


### PR DESCRIPTION
## Summary

Adds three layers of timeout protection so an offline machine or a dead MCP HTTP server can no longer hang plugin startup, freeze the settings "Test Connection" modal, or stall the agent mid-turn. Addresses [discussion #576](https://github.com/allenhutchison/obsidian-gemini/discussions/576).

## Problem

The plugin sequentially `await`s `client.connect()` and `client.listTools()` for each enabled MCP server during startup. Obsidian's `requestUrl` (which `obsidianFetch` wraps) has no timeout, so a stalled TCP/TLS handshake or hung HTTP response blocks the plugin for as long as the OS keeps the socket alive. The same hang affects:

- Plugin startup with an offline machine + enabled HTTP MCP server.
- Plugin startup when the machine is online but the MCP service is down (LAN address, dead remote host, hung process).
- The settings UI "Test Connection" button — freezes the modal indefinitely.
- Agent tool calls — `callTool()` can hang the chat mid-turn.

## Approach

Three layers of defense, all using hardcoded defaults (no new user settings).

**1. Fetch-level ceiling** in `obsidianFetch` (`src/mcp/mcp-fetch.ts`): every HTTP request the MCP SDK makes is now raced against a 15s timer. Honors a caller-supplied `AbortSignal` if present. Since `requestUrl` does not accept a signal, the underlying socket may still complete in the background — but we stop waiting.

**2. Operation-level timeouts** wrapped around the MCP SDK's calls (so stdio hangs are also bounded, not just HTTP):

| Operation                                           | Timeout    |
| --------------------------------------------------- | ---------- |
| `client.connect()` + first `listTools()` per server | 10 seconds |
| `client.listTools()` (refresh / Test Connection)    | 10 seconds |
| `client.callTool()` per agent invocation            | 60 seconds |
| `obsidianFetch` HTTP ceiling                        | 15 seconds |
| `transport.close()` during cleanup                  |  5 seconds |
| OAuth callback wait                                 | unchanged (2 min) |

Implemented via a new `withTimeout(promise, ms, label)` helper in `src/utils/timeout.ts` that races against `Promise.race` and cleans the timer on settle.

**3. Offline awareness + deferred startup** in `MCPManager`:

- HTTP servers are skipped immediately when `navigator.onLine === false`. They show an "offline" error and are auto-retried when the `window` `online` event fires.
- Stdio servers are unaffected by network state and always attempt to start.
- `connectAllEnabled()` is now fire-and-forget from `onLayoutReady`, so a slow or unreachable MCP server never delays plugin load.

## Files changed

- New: `src/utils/timeout.ts`, `src/mcp/mcp-constants.ts`
- New tests: `test/utils/timeout.test.ts`, `test/mcp/mcp-fetch.test.ts`, `test/mcp/mcp-tool-wrapper.test.ts`
- Modified: `src/mcp/mcp-fetch.ts`, `src/mcp/mcp-manager.ts`, `src/mcp/mcp-tool-wrapper.ts`, `src/services/lifecycle-service.ts`, `test/mcp/mcp-manager.test.ts`, `docs/guide/mcp-servers.md`

## Documentation

Added a "Timeouts and offline behavior" section to `docs/guide/mcp-servers.md` covering the timeout table, the offline/auto-reconnect behavior, and the non-blocking startup change. No README change needed — this is a reliability fix, not a new user-visible feature.

## Test plan

Automated (all green locally):

- [x] `npm test` — 1765 passed, 5 skipped, 0 failed (added 18 new tests across timeout/MCP)
- [x] `npm run lint` — 0 errors (only pre-existing warnings remain)
- [x] `npm run build` — TypeScript clean, esbuild succeeds
- [x] `npm run format-check` — clean

Manual smoke tests (recommended before merge):

- [ ] Offline at startup: configure an HTTP MCP server (`http://192.168.1.99:9999`), enable it, disable Wi-Fi, reload Obsidian. Plugin must load promptly; server shows ERROR state with "offline" message.
- [ ] Dead server, online machine: configure an HTTP MCP server pointing at an unreachable IP, reload. Plugin loads promptly; server shows ERROR with "timed out after 10000ms".
- [ ] Reconnect after offline: from the offline state, turn Wi-Fi back on. Server should auto-connect within a few seconds.
- [ ] Test Connection with dead URL: in settings, edit a server with a dead URL and click Test Connection — modal should show a timeout error after ~10s, not hang.
- [ ] Hung tool call: mock an MCP server to delay `callTool` indefinitely. Agent invocation should return a tool error after 60s, not freeze the chat.
- [ ] No regression: working HTTP and stdio servers connect normally; OAuth still completes within its 2-minute window.

https://claude.ai/code/session_012dAdZiiUuLYcjghFp2bvbH

---
_Generated by [Claude Code](https://claude.ai/code/session_012dAdZiiUuLYcjghFp2bvbH)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bounded operation timeouts across MCP flows (connect, listing, tool calls, HTTP fetches, OAuth) to prevent hangs
  * Non-blocking/background MCP connections so layout startup isn’t delayed; tools may appear shortly after load
  * Fast-fail offline handling and automatic reconnect for HTTP MCP servers when network returns

* **Documentation**
  * Added guide section describing timeouts, offline behavior, and reconnection semantics

* **Tests**
  * Added tests covering timeouts, aborts, offline/online behavior, and tool-call handling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/allenhutchison/obsidian-gemini/pull/819)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->