### PR TITLE
refactor: remove redundant @ts-ignore on bundled asset imports

### DIFF
--- a/src/agent/session-history.ts
+++ b/src/agent/session-history.ts
@@ -6,7 +6,6 @@ import { pathToWikilink } from '../utils/accessed-files';
 import { formatLocalTimestamp } from '../utils/format-utils';
 import { serializeToolPolicy } from '../types/tool-policy';
 import * as Handlebars from 'handlebars';
-// @ts-ignore
 import historyEntryTemplate from '../history/templates/historyEntry.hbs';
 
 /**

--- a/src/models.ts
+++ b/src/models.ts
@@ -1,4 +1,3 @@
-// @ts-ignore — esbuild JSON loader
 import modelData from './data/models.json';
 
 export type ModelRole = 'chat' | 'summary' | 'completions' | 'rewrite' | 'image';

--- a/src/prompts/bundled-prompts.ts
+++ b/src/prompts/bundled-prompts.ts
@@ -1,13 +1,8 @@
 // Import bundled prompt files
-// @ts-ignore - esbuild handles .md files as strings
 import explainSelectionMd from '../../prompts/bundled-prompts/explain-selection.md';
-// @ts-ignore
 import explainCodeMd from '../../prompts/bundled-prompts/explain-code.md';
-// @ts-ignore
 import summarizeSelectionMd from '../../prompts/bundled-prompts/summarize-selection.md';
-// @ts-ignore
 import fixGrammarMd from '../../prompts/bundled-prompts/fix-grammar.md';
-// @ts-ignore
 import convertToBulletsMd from '../../prompts/bundled-prompts/convert-to-bullets.md';
 
 interface BundledPrompt {

--- a/src/services/context-manager.ts
+++ b/src/services/context-manager.ts
@@ -16,7 +16,6 @@ import { ModelClientFactory, ModelUseCase } from '../api';
 import { createGoogleGenAI } from '../api/providers/gemini/google-genai-factory';
 import { truncateOldToolResults } from '../agent/agent-loop-helpers';
 
-// @ts-ignore
 import contextSummaryPromptContent from '../../prompts/contextSummaryPrompt.hbs';
 
 /** Aggressive compaction triggers at this % of total model context window */

--- a/src/services/lifecycle-service.ts
+++ b/src/services/lifecycle-service.ts
@@ -34,7 +34,6 @@ import { BackgroundStatusBar } from './background-status-bar';
 import { ScheduledTaskManager } from './scheduled-task-manager';
 import { HookManager } from './hook-manager';
 
-// @ts-ignore
 import agentsMemoryTemplateContent from '../../prompts/agentsMemoryTemplate.hbs';
 
 /**

--- a/src/services/model-list-provider.ts
+++ b/src/services/model-list-provider.ts
@@ -2,7 +2,6 @@ import { requestUrl } from 'obsidian';
 import type ObsidianGemini from '../main';
 import { GeminiModel } from '../models';
 
-// @ts-ignore — esbuild JSON loader
 import bundledModelData from '../data/models.json';
 
 interface ModelListJson {


### PR DESCRIPTION
## Summary

Architecture-audit nightly sweep flagged: **`@ts-ignore` overuse** on bundled asset imports.

Six source files carried `@ts-ignore` comments on their `.json`, `.hbs`, and `.md` import lines. These suppressions are dead: `resolveJsonModule` is enabled in `tsconfig.json`, and `src/declarations.d.ts` / `src/types/text-imports.d.ts` already declare `*.hbs` and `*.md` as string modules. `tsc --noEmit` is clean with the comments removed. Keeping a suppression on a line that has no error masks any real future error on that import, so removing them is both safe and a small correctness improvement.

## Changes

- `src/models.ts` — drop `@ts-ignore` on `models.json` import
- `src/services/model-list-provider.ts` — drop `@ts-ignore` on `models.json` import
- `src/services/context-manager.ts` — drop `@ts-ignore` on `contextSummaryPrompt.hbs` import
- `src/services/lifecycle-service.ts` — drop `@ts-ignore` on `agentsMemoryTemplate.hbs` import
- `src/agent/session-history.ts` — drop `@ts-ignore` on `historyEntry.hbs` import
- `src/prompts/bundled-prompts.ts` — drop `@ts-ignore` on five `.md` imports

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A, automated architecture-audit sweep
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — type-only change, no runtime impact
- [x] Documentation has been updated (if applicable) — N/A, internal-only change
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01HF4KvdUutmux4CpLR3FtzX)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed internal TypeScript directives across multiple modules to improve code maintainability. No user-facing functionality or behavior has changed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/allenhutchison/obsidian-gemini/pull/820)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->