### PR TITLE
chore(daily): 2026-05-15 daily update

### DIFF
--- a/docs/guide/lifecycle-hooks.md
+++ b/docs/guide/lifecycle-hooks.md
@@ -8,7 +8,7 @@ Hooks are disabled by default. Set **Enable lifecycle hooks** in plugin settings
 
 ## Overview
 
-A hook is a markdown file stored in `<history-folder>/Hooks/`. The file's frontmatter controls the trigger, filter, and action; the body is the prompt template.
+A hook is a markdown file stored in `[state-folder]/Hooks/`. The file's frontmatter controls the trigger, filter, and action; the body is the prompt template.
 
 ```text
 gemini-scribe/Hooks/
@@ -35,7 +35,7 @@ The fastest path is the **Hook Manager** modal. Two ways to open it:
 
 The modal has a list view (toggle / edit / delete / reset on each row) and a create/edit form covering trigger, path glob, tool access, prompt, plus an Advanced section for debounce, cooldown, rate limit, model override, output path, and the desktop-only flag.
 
-You can also create hooks by hand-editing markdown files inside `<history-folder>/Hooks/`. The filename (without `.md`) becomes the hook's **slug**.
+You can also create hooks by hand-editing markdown files inside `[state-folder]/Hooks/`. The filename (without `.md`) becomes the hook's **slug**.
 
 **Minimal example** — `gemini-scribe/Hooks/summarise-on-save.md`:
 
@@ -143,7 +143,7 @@ Hooks fire reactively and can run continuously, so the engine has several guardr
 
 Two folders never trigger hooks regardless of glob:
 
-- The plugin state folder (`<history-folder>/`)
+- The plugin state folder (`[state-folder]/`)
 - Obsidian's own configuration folder (`.obsidian/`)
 
 This prevents trivial loops where a hook's own output (in `Hooks/Runs/...`) would re-trigger it.
@@ -166,7 +166,7 @@ If a single hook fires 5+ times within 60 seconds (regardless of file), the engi
 
 ### Auto-Pause on Repeated Failure
 
-After three consecutive errors, a hook is auto-paused. Inspect `<history-folder>/Hooks/hooks-state.json` to see the last error message and clear the `pausedDueToErrors` flag to resume.
+After three consecutive errors, a hook is auto-paused. Inspect `[state-folder]/Hooks/hooks-state.json` to see the last error message and clear the `pausedDueToErrors` flag to resume.
 
 ## Examples
 

--- a/docs/guide/scheduled-tasks.md
+++ b/docs/guide/scheduled-tasks.md
@@ -4,7 +4,7 @@ Scheduled Tasks let you automate recurring AI prompts — daily summaries, weekl
 
 ## Overview
 
-A scheduled task is a markdown file stored in `<history-folder>/Scheduled-Tasks/`. The file's frontmatter controls when and how it runs; the body is the prompt sent to the model.
+A scheduled task is a markdown file stored in `[state-folder]/Scheduled-Tasks/`. The file's frontmatter controls when and how it runs; the body is the prompt sent to the model.
 
 ```text
 gemini-scribe/Scheduled-Tasks/
@@ -26,7 +26,7 @@ The easiest way to create a task is through the **Scheduler** UI:
 
 You can also create tasks manually by writing a markdown file directly:
 
-Create a markdown file inside `<history-folder>/Scheduled-Tasks/`. The filename (without `.md`) becomes the task's **slug** — used in output paths and the task monitor.
+Create a markdown file inside `[state-folder]/Scheduled-Tasks/`. The filename (without `.md`) becomes the task's **slug** — used in output paths and the task monitor.
 
 **Minimal example** — `gemini-scribe/Scheduled-Tasks/daily-summary.md`:
 
@@ -42,14 +42,14 @@ Summarise the notes I created or modified today. List the key topics and any ope
 
 ### Frontmatter Fields
 
-| Field         | Required | Default                                                  | Description                                                                                                                 |
-| ------------- | -------- | -------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
-| `schedule`    | Yes      | —                                                        | When to run. See [Schedule Formats](#schedule-formats) below.                                                               |
-| `toolPolicy`  | No       | _inherit global plugin policy_                           | Per-run tool policy (preset + per-tool overrides). See [Tool Access](#tool-access).                                         |
-| `outputPath`  | No       | `<history-folder>/Scheduled-Tasks/Runs/<slug>/{date}.md` | Where to write results. Supports `{slug}` and `{date}` placeholders.                                                        |
-| `model`       | No       | Plugin chat model                                        | Override the model for this task (e.g. `gemini-flash-latest`).                                                              |
-| `enabled`     | No       | `true`                                                   | Set to `false` to disable the task without deleting it.                                                                     |
-| `runIfMissed` | No       | `false`                                                  | When `true`, tasks missed while Obsidian was closed are caught up on the next startup. See [Catch-up Runs](#catch-up-runs). |
+| Field         | Required | Default                                                | Description                                                                                                                 |
+| ------------- | -------- | ------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------- |
+| `schedule`    | Yes      | —                                                      | When to run. See [Schedule Formats](#schedule-formats) below.                                                               |
+| `toolPolicy`  | No       | _inherit global plugin policy_                         | Per-run tool policy (preset + per-tool overrides). See [Tool Access](#tool-access).                                         |
+| `outputPath`  | No       | `[state-folder]/Scheduled-Tasks/Runs/<slug>/{date}.md` | Where to write results. Supports `{slug}` and `{date}` placeholders.                                                        |
+| `model`       | No       | Plugin chat model                                      | Override the model for this task (e.g. `gemini-flash-latest`).                                                              |
+| `enabled`     | No       | `true`                                                 | Set to `false` to disable the task without deleting it.                                                                     |
+| `runIfMissed` | No       | `false`                                                | When `true`, tasks missed while Obsidian was closed are caught up on the next startup. See [Catch-up Runs](#catch-up-runs). |
 
 ### Schedule Formats
 

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -184,7 +184,7 @@ See the [Custom Prompts Guide](/guide/custom-prompts) for detailed instructions.
 - **Setting**: `hooksEnabled`
 - **Type**: Boolean
 - **Default**: `false`
-- **Description**: Subscribe to vault events (file created/modified/deleted/renamed) and dispatch them to hook definitions in `<history-folder>/Hooks/`. Each matching event fires a headless agent run with debounce, rate-limit, and loop-prevention guards.
+- **Description**: Subscribe to vault events (file created/modified/deleted/renamed) and dispatch them to hook definitions in `[state-folder]/Hooks/`. Each matching event fires a headless agent run with debounce, rate-limit, and loop-prevention guards.
 - **Why opt-in**: Vault events fire continuously; an unintentionally-broad hook can drain API quota quickly. The default is off so users opt in deliberately.
 - **See also**: [Lifecycle Hooks](/guide/lifecycle-hooks)
 

--- a/planning/changelog/2026-05-14.md
+++ b/planning/changelog/2026-05-14.md
@@ -1,0 +1,24 @@
+# Daily changelog — May 14, 2026
+
+**Date:** 2026-05-14
+**PRs merged:** 3
+
+---
+
+## Summary
+
+A catching-up day: two stale daily-update PRs (for May 12 and May 13) were merged in quick succession in the afternoon. The headline change is a refactor that extracts a shared abstract base class from the hook and scheduler management modals, shrinking each by roughly 260 lines while adding test coverage.
+
+## What shipped
+
+### [#814 chore(daily): 2026-05-12 daily update](https://github.com/allenhutchison/obsidian-gemini/pull/814)
+
+Merged the May 12 daily-update PR that had been waiting for review. It adds `planning/changelog/2026-05-12.md` covering nine PRs from that day (including the custom-API-endpoint feature by @cherubines and the per-provider package layout refactor), documents the new `npm run install:test-vault` script in `docs/contributing/testing.md`, and adds that command to the Development commands table in `AGENTS.md`.
+
+### [#816 chore(daily): 2026-05-13 daily update](https://github.com/allenhutchison/obsidian-gemini/pull/816)
+
+Merged the May 13 daily-update PR immediately after #814. Adds `planning/changelog/2026-05-13.md` for a quiet two-PR day (Dependabot dev-dependency bump and an export-keyword cleanup), removes a stale "Enable Custom Prompts" troubleshooting bullet from `README.md` that no longer reflected the codebase, and normalizes a minor `package-lock.json` drift introduced during pre-flight checks.
+
+### [#817 refactor: extract ManagementModalBase from hook and scheduler modals](https://github.com/allenhutchison/obsidian-gemini/pull/817)
+
+Consolidates ~250 lines of shared scaffolding duplicated across `HookManagementModal` and `SchedulerManagementModal` into a new abstract generic `ManagementModalBase<TEntity, TEntityState>` in `src/ui/components/management-modal-base.ts`. The base class owns the view-state machine (`list | create | edit`), `onOpen`/`onClose` lifecycle, `ToolPolicyEditor` management, list and form skeletons, delete confirmation, and shared utilities (`formatDate`, `truncateError`). Each concrete modal now extends the base and provides only its entity-specific rendering and CRUD logic (hook modal down from 712 → 452 lines; scheduler modal from 707 → 424 lines). Fifteen new tests cover the base-class behavior. Fixes #815.


### PR DESCRIPTION
## Summary

Automated daily housekeeping for 2026-05-15. Covers the May 14 changelog, a doc terminology fix, and issue triage.

## Changes

- **Add `planning/changelog/2026-05-14.md`**: Documents 3 PRs merged on May 14 — #814 (May 12 daily-update backfill), #816 (May 13 daily-update backfill), and #817 (ManagementModalBase refactor that extracts shared scaffolding from hook and scheduler modals).
- **Fix `docs/guide/scheduled-tasks.md`**: Replace `<history-folder>` placeholder with `[state-folder]` to match the canonical terminology used across all other docs (background-tasks.md, deep-research.md, faq.md, settings.md, AGENTS.md). The old placeholder was both inconsistent and rendered literally as an HTML tag in some markdown renderers.
- **Fix `docs/guide/lifecycle-hooks.md`**: Same `<history-folder>` → `[state-folder]` fix applied to 4 occurrences in this file.

## Sub-skill outcomes

| Sub-skill | Outcome |
| --- | --- |
| daily-changelog | wrote `planning/changelog/2026-05-14.md`, 3 PRs: #814, #816, #817 |
| audit-docs | terminology drift fixed in `docs/guide/scheduled-tasks.md` (3 occurrences) and `docs/guide/lifecycle-hooks.md` (4 occurrences) — `<history-folder>` → `[state-folder]` |
| triage-issues | 0 unlabeled open issues — no labels applied |

## Screenshots / Screencast

N/A — no UI changes.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A; automated housekeeping
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [ ] I have tested this change on Desktop — N/A; changelog and doc updates only
- [ ] I have verified this change does not break Mobile — N/A; no code changes
- [x] Documentation has been updated (if applicable) — this PR IS the doc update
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (`daily-update` skill)
- [x] I have reviewed and understand all AI-generated code in this PR

---

https://claude.ai/code/session_01MQroLfZpJmQ6Z8Gjwtod5D

---
_Generated by [Claude Code](https://claude.ai/code/session_01MQroLfZpJmQ6Z8Gjwtod5D)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated lifecycle hooks guide to reflect the new runtime hooks path
  * Updated scheduled tasks guide to reflect the new task files path and default run output location
  * Updated settings reference to use the new lifecycle hooks path placeholder
  * Added daily changelog (2026-05-14) summarizing recent merged PRs and a refactor

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/allenhutchison/obsidian-gemini/pull/823)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->