### PR TITLE
refactor: remove dead exports flagged by knip

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -1,0 +1,7 @@
+{
+	"$schema": "https://unpkg.com/knip@5/schema.json",
+	"entry": ["src/main.ts"],
+	"project": ["src/**/*.ts"],
+	"ignore": ["src/services/generated-help-references.ts"],
+	"ignoreDependencies": ["obsidian", "tslib"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
 				"handlebars": "^4.7.9",
 				"husky": "^9.1.7",
 				"jsdom": "^29.1.1",
+				"knip": "^6.14.0",
 				"lint-staged": "^17.0.4",
 				"obsidian": "latest",
 				"prettier": "^3.8.3",
@@ -1781,6 +1782,372 @@
 				"@emnapi/runtime": "^1.7.1"
 			}
 		},
+		"node_modules/@oxc-parser/binding-android-arm-eabi": {
+			"version": "0.130.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.130.0.tgz",
+			"integrity": "sha512-h/xYU8/7ADWzVSf5I+YalLpj33LOy9CI/zgbJNIZ5eunRBG+Czqa3lZsvuPHHf3rOt6z1c5+UzoxjbAzAvhwVw==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-parser/binding-android-arm64": {
+			"version": "0.130.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.130.0.tgz",
+			"integrity": "sha512-oFWFJrsGv9siFM4HjMqKNB7IuIZD/SMmZdCXl8xyx7lDplGvPKyewpOo272rSWgMXe2Wx7bWI0Yj+gkHv4qbeg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-parser/binding-darwin-arm64": {
+			"version": "0.130.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.130.0.tgz",
+			"integrity": "sha512-sGUzupdTplK9jQg7eJZ878HfEgQjJNBc6dAYVWJ9W5aU+J8rLfRJhTVsKThiu1pNwm6Y1qKCcbC6WhNWSXR3Ig==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-parser/binding-darwin-x64": {
+			"version": "0.130.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.130.0.tgz",
+			"integrity": "sha512-PsB4cdCISbC00Uy8eiD8bc2AkGWjZqrSrJnkBFuG2ptrrf6mZ2F5gLFSjOAVMMgZPg8B1D7OydJwLWSfyI2Plg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-parser/binding-freebsd-x64": {
+			"version": "0.130.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.130.0.tgz",
+			"integrity": "sha512-DgABp3l38hS77JbXCV4qk1+n6DPym5u8zzwuweokezm2tX194nDSJDENbDRECxVsiNbprKATLbk+Z5wlHT0OHw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-parser/binding-linux-arm-gnueabihf": {
+			"version": "0.130.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.130.0.tgz",
+			"integrity": "sha512-4Kn3CTEmwFrzhTSC/JuUW16qovmaMdX7jeSKbL8w0pLtLww7To1a2XJi9Z5uD8QWUkfUHhqfV+VD6dVzBnWzoA==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-parser/binding-linux-arm-musleabihf": {
+			"version": "0.130.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.130.0.tgz",
+			"integrity": "sha512-D35KZM3F4rRu1uAFKyBlg3Gaf/ybCjyaPR1hfgvk5ex8NtcTmRgc0JgSighEyNg96TPrFhemFba68SZuxaha8w==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-parser/binding-linux-arm64-gnu": {
+			"version": "0.130.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.130.0.tgz",
+			"integrity": "sha512-Q9o7oVlo955KHwS8l1u0bCzIx+JsZUA3XToLXC+MsMhye/9LeBQbt84nh120cl2XLy+TEzvugYDiHShg5yaX6Q==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-parser/binding-linux-arm64-musl": {
+			"version": "0.130.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.130.0.tgz",
+			"integrity": "sha512-EiJ/gC0ljbcwVpycC8YWw6ggMbtsPX8XMOt0mPx0aqWeMsNR+L9m05Flbvd5T+GlivG+GkSWQL7tM9SRFpM/dw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-parser/binding-linux-ppc64-gnu": {
+			"version": "0.130.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.130.0.tgz",
+			"integrity": "sha512-b+h/lsLLurp756dMGizNs5uPaJfyEdWrTcV5t8M609jWm1DEHB1StpRXCkyvwtkJx3m+qL5BNQ0dEKan/4yGFA==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-parser/binding-linux-riscv64-gnu": {
+			"version": "0.130.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.130.0.tgz",
+			"integrity": "sha512-O19Cil83XAyjEFfo8WhkMwY58ALqZ7ckjGL+25mjMIuF84urWBeANH0FC8B8BsSSygWU3/1aY3ADdDbp+wlBnw==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-parser/binding-linux-riscv64-musl": {
+			"version": "0.130.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.130.0.tgz",
+			"integrity": "sha512-BgXRVC0+83n3YzCscLQjj6nbyeBIVeZYPTI4fFMAE4WNm2+4RXhWp03IVizL7esIz36kgmT48aebk1iM+cs8sw==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-parser/binding-linux-s390x-gnu": {
+			"version": "0.130.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.130.0.tgz",
+			"integrity": "sha512-6tJz0xvnGhsokE7N1WlUSBXibpYmT9xSJFS1Ce41Km/+8gQvdlW8MLhRv8PD0L7ix8vRG0FDDepp3jdOFzdVdw==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-parser/binding-linux-x64-gnu": {
+			"version": "0.130.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.130.0.tgz",
+			"integrity": "sha512-9aCWj83dp3heTQGmGnZGdIWgxjZrr/7VQ0TGFHH5PKByxJKF2Hcr4qvaSUHhhGEa3MSsDjTL1YDP8RAgdL5/Cg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-parser/binding-linux-x64-musl": {
+			"version": "0.130.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.130.0.tgz",
+			"integrity": "sha512-afXt87aZBqrUVli8TB/I8H1G50RDWcwirjWtXGXYqJ2ZqWEiErH7V72j3LUSDZaivmtu2OLX0KQ/mbhP81mr7A==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-parser/binding-openharmony-arm64": {
+			"version": "0.130.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.130.0.tgz",
+			"integrity": "sha512-I0NCrZV/YZuCGWgqwNN/GO/iXlLF2z+Wgc7u+Aa9N4P51oYeIa0XT+zVBUne4csO9GqxskXgI4g8JzzWGRpfOw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-parser/binding-wasm32-wasi": {
+			"version": "0.130.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.130.0.tgz",
+			"integrity": "sha512-sJgQkGaBX0WJvPUDfwciex6IcTk5O5NLQ1bhEb6f3nBruh1GshKMRSMt2bxZlYrgBzjyBbJzsnO+InPG0bg+fA==",
+			"cpu": [
+				"wasm32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@emnapi/core": "1.10.0",
+				"@emnapi/runtime": "1.10.0",
+				"@napi-rs/wasm-runtime": "^1.1.4"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-parser/binding-win32-arm64-msvc": {
+			"version": "0.130.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.130.0.tgz",
+			"integrity": "sha512-bjcma99sQrNh6RY4mPO9yTkfxql6TDFoN3HWdK31RCKXwNhcDgJXW/l8PUtzKNiQ+9vpKJfJtQq+LklBuxSOBA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-parser/binding-win32-ia32-msvc": {
+			"version": "0.130.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.130.0.tgz",
+			"integrity": "sha512-hRYbv6HhpSTzT4xTiIkadLI7upLQxuOdLPR/9nL1fTjwhgutBTPXrwaAPb/jTFVx6/8C7Jb5HcUKhmNwloTbFA==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-parser/binding-win32-x64-msvc": {
+			"version": "0.130.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.130.0.tgz",
+			"integrity": "sha512-RBpA9TsRucJq6HNVNCFF1iKg+QeTkLdZf7hi4xaOGCPvMZWvDHjQgSOEZMUpuW4JNciHbxNhLEYmz5CVygjVGQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
 		"node_modules/@oxc-project/types": {
 			"version": "0.129.0",
 			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.129.0.tgz",
@@ -1790,6 +2157,313 @@
 			"funding": {
 				"url": "https://github.com/sponsors/Boshen"
 			}
+		},
+		"node_modules/@oxc-resolver/binding-android-arm-eabi": {
+			"version": "11.19.1",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-android-arm-eabi/-/binding-android-arm-eabi-11.19.1.tgz",
+			"integrity": "sha512-aUs47y+xyXHUKlbhqHUjBABjvycq6YSD7bpxSW7vplUmdzAlJ93yXY6ZR0c1o1x5A/QKbENCvs3+NlY8IpIVzg==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			]
+		},
+		"node_modules/@oxc-resolver/binding-android-arm64": {
+			"version": "11.19.1",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-android-arm64/-/binding-android-arm64-11.19.1.tgz",
+			"integrity": "sha512-oolbkRX+m7Pq2LNjr/kKgYeC7bRDMVTWPgxBGMjSpZi/+UskVo4jsMU3MLheZV55jL6c3rNelPl4oD60ggYmqA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			]
+		},
+		"node_modules/@oxc-resolver/binding-darwin-arm64": {
+			"version": "11.19.1",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-darwin-arm64/-/binding-darwin-arm64-11.19.1.tgz",
+			"integrity": "sha512-nUC6d2i3R5B12sUW4O646qD5cnMXf2oBGPLIIeaRfU9doJRORAbE2SGv4eW6rMqhD+G7nf2Y8TTJTLiiO3Q/dQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@oxc-resolver/binding-darwin-x64": {
+			"version": "11.19.1",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-darwin-x64/-/binding-darwin-x64-11.19.1.tgz",
+			"integrity": "sha512-cV50vE5+uAgNcFa3QY1JOeKDSkM/9ReIcc/9wn4TavhW/itkDGrXhw9jaKnkQnGbjJ198Yh5nbX/Gr2mr4Z5jQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@oxc-resolver/binding-freebsd-x64": {
+			"version": "11.19.1",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-freebsd-x64/-/binding-freebsd-x64-11.19.1.tgz",
+			"integrity": "sha512-xZOQiYGFxtk48PBKff+Zwoym7ScPAIVp4c14lfLxizO2LTTTJe5sx9vQNGrBymrf/vatSPNMD4FgsaaRigPkqw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			]
+		},
+		"node_modules/@oxc-resolver/binding-linux-arm-gnueabihf": {
+			"version": "11.19.1",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-11.19.1.tgz",
+			"integrity": "sha512-lXZYWAC6kaGe/ky2su94e9jN9t6M0/6c+GrSlCqL//XO1cxi5lpAhnJYdyrKfm0ZEr/c7RNyAx3P7FSBcBd5+A==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@oxc-resolver/binding-linux-arm-musleabihf": {
+			"version": "11.19.1",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-11.19.1.tgz",
+			"integrity": "sha512-veG1kKsuK5+t2IsO9q0DErYVSw2azvCVvWHnfTOS73WE0STdLLB7Q1bB9WR+yHPQM76ASkFyRbogWo1GR1+WbQ==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@oxc-resolver/binding-linux-arm64-gnu": {
+			"version": "11.19.1",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-11.19.1.tgz",
+			"integrity": "sha512-heV2+jmXyYnUrpUXSPugqWDRpnsQcDm2AX4wzTuvgdlZfoNYO0O3W2AVpJYaDn9AG4JdM6Kxom8+foE7/BcSig==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@oxc-resolver/binding-linux-arm64-musl": {
+			"version": "11.19.1",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-musl/-/binding-linux-arm64-musl-11.19.1.tgz",
+			"integrity": "sha512-jvo2Pjs1c9KPxMuMPIeQsgu0mOJF9rEb3y3TdpsrqwxRM+AN6/nDDwv45n5ZrUnQMsdBy5gIabioMKnQfWo9ew==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@oxc-resolver/binding-linux-ppc64-gnu": {
+			"version": "11.19.1",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-11.19.1.tgz",
+			"integrity": "sha512-vLmdNxWCdN7Uo5suays6A/+ywBby2PWBBPXctWPg5V0+eVuzsJxgAn6MMB4mPlshskYbppjpN2Zg83ArHze9gQ==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@oxc-resolver/binding-linux-riscv64-gnu": {
+			"version": "11.19.1",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-11.19.1.tgz",
+			"integrity": "sha512-/b+WgR+VTSBxzgOhDO7TlMXC1ufPIMR6Vj1zN+/x+MnyXGW7prTLzU9eW85Aj7Th7CCEG9ArCbTeqxCzFWdg2w==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@oxc-resolver/binding-linux-riscv64-musl": {
+			"version": "11.19.1",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-11.19.1.tgz",
+			"integrity": "sha512-YlRdeWb9j42p29ROh+h4eg/OQ3dTJlpHSa+84pUM9+p6i3djtPz1q55yLJhgW9XfDch7FN1pQ/Vd6YP+xfRIuw==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@oxc-resolver/binding-linux-s390x-gnu": {
+			"version": "11.19.1",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-11.19.1.tgz",
+			"integrity": "sha512-EDpafVOQWF8/MJynsjOGFThcqhRHy417sRyLfQmeiamJ8qVhSKAn2Dn2VVKUGCjVB9C46VGjhNo7nOPUi1x6uA==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@oxc-resolver/binding-linux-x64-gnu": {
+			"version": "11.19.1",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-gnu/-/binding-linux-x64-gnu-11.19.1.tgz",
+			"integrity": "sha512-NxjZe+rqWhr+RT8/Ik+5ptA3oz7tUw361Wa5RWQXKnfqwSSHdHyrw6IdcTfYuml9dM856AlKWZIUXDmA9kkiBQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@oxc-resolver/binding-linux-x64-musl": {
+			"version": "11.19.1",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-musl/-/binding-linux-x64-musl-11.19.1.tgz",
+			"integrity": "sha512-cM/hQwsO3ReJg5kR+SpI69DMfvNCp+A/eVR4b4YClE5bVZwz8rh2Nh05InhwI5HR/9cArbEkzMjcKgTHS6UaNw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@oxc-resolver/binding-openharmony-arm64": {
+			"version": "11.19.1",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-openharmony-arm64/-/binding-openharmony-arm64-11.19.1.tgz",
+			"integrity": "sha512-QF080IowFB0+9Rh6RcD19bdgh49BpQHUW5TajG1qvWHvmrQznTZZjYlgE2ltLXyKY+qs4F/v5xuX1XS7Is+3qA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			]
+		},
+		"node_modules/@oxc-resolver/binding-wasm32-wasi": {
+			"version": "11.19.1",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-wasm32-wasi/-/binding-wasm32-wasi-11.19.1.tgz",
+			"integrity": "sha512-w8UCKhX826cP/ZLokXDS6+milN8y4X7zidsAttEdWlVoamTNf6lhBJldaWr3ukTDiye7s4HRcuPEPOXNC432Vg==",
+			"cpu": [
+				"wasm32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@napi-rs/wasm-runtime": "^1.1.1"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@oxc-resolver/binding-win32-arm64-msvc": {
+			"version": "11.19.1",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-11.19.1.tgz",
+			"integrity": "sha512-nJ4AsUVZrVKwnU/QRdzPCCrO0TrabBqgJ8pJhXITdZGYOV28TIYystV1VFLbQ7DtAcaBHpocT5/ZJnF78YJPtQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@oxc-resolver/binding-win32-ia32-msvc": {
+			"version": "11.19.1",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-11.19.1.tgz",
+			"integrity": "sha512-EW+ND5q2Tl+a3pH81l1QbfgbF3HmqgwLfDfVithRFheac8OTcnbXt/JxqD2GbDkb7xYEqy1zNaVFRr3oeG8npA==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@oxc-resolver/binding-win32-x64-msvc": {
+			"version": "11.19.1",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-x64-msvc/-/binding-win32-x64-msvc-11.19.1.tgz",
+			"integrity": "sha512-6hIU3RQu45B+VNTY4Ru8ppFwjVS/S5qwYyGhBotmjxfEKk41I2DlGtRfGJndZ5+6lneE2pwloqunlOyZuX/XAw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
 		},
 		"node_modules/@pkgr/core": {
 			"version": "0.1.2",
@@ -5943,6 +6617,34 @@
 			],
 			"license": "BSD-3-Clause"
 		},
+		"node_modules/fd-package-json": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/fd-package-json/-/fd-package-json-2.0.0.tgz",
+			"integrity": "sha512-jKmm9YtsNXN789RS/0mSzOC1NUq9mkVd65vbSSVsKdjGvYXBuE4oWe2QOEoFeRmJg+lPuZxpmrfFclNhoRMneQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"walk-up-path": "^4.0.0"
+			}
+		},
+		"node_modules/fdir": {
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+			"integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"peerDependencies": {
+				"picomatch": "^3 || ^4"
+			},
+			"peerDependenciesMeta": {
+				"picomatch": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/fetch-blob": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
@@ -6070,6 +6772,22 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/formatly": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/formatly/-/formatly-0.3.0.tgz",
+			"integrity": "sha512-9XNj/o4wrRFyhSMJOvsuyMwy8aUfBaZ1VrqHVfohyXf0Sw0e+yfKG+xZaY3arGCOMdwFsqObtzVOc1gU9KiT9w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fd-package-json": "^2.0.0"
+			},
+			"bin": {
+				"formatly": "bin/index.mjs"
+			},
+			"engines": {
+				"node": ">=18.3.0"
 			}
 		},
 		"node_modules/formdata-polyfill": {
@@ -7196,6 +7914,16 @@
 				"node": ">= 0.4"
 			}
 		},
+		"node_modules/jiti": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+			"integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"jiti": "lib/jiti-cli.mjs"
+			}
+		},
 		"node_modules/jose": {
 			"version": "6.1.3",
 			"resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
@@ -7458,6 +8186,59 @@
 			"license": "MIT",
 			"dependencies": {
 				"json-buffer": "3.0.1"
+			}
+		},
+		"node_modules/knip": {
+			"version": "6.14.0",
+			"resolved": "https://registry.npmjs.org/knip/-/knip-6.14.0.tgz",
+			"integrity": "sha512-yEI9ysdGQ3h77gLObvovH0KUYs6ITtJ1f6owmXRalOO32TbolYvHY7Z+2AEOXqw0ZWeh9219/agh2K/GmtfsxQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/webpro"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/knip"
+				}
+			],
+			"license": "ISC",
+			"dependencies": {
+				"fdir": "^6.5.0",
+				"formatly": "^0.3.0",
+				"get-tsconfig": "4.14.0",
+				"jiti": "^2.7.0",
+				"minimist": "^1.2.8",
+				"oxc-parser": "^0.130.0",
+				"oxc-resolver": "^11.19.1",
+				"picomatch": "^4.0.4",
+				"smol-toml": "^1.6.1",
+				"strip-json-comments": "5.0.3",
+				"tinyglobby": "^0.2.16",
+				"unbash": "^3.0.0",
+				"yaml": "^2.9.0",
+				"zod": "^4.1.11"
+			},
+			"bin": {
+				"knip": "bin/knip.js",
+				"knip-bun": "bin/knip-bun.js"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/knip/node_modules/strip-json-comments": {
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-5.0.3.tgz",
+			"integrity": "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/levn": {
@@ -8547,6 +9328,86 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/oxc-parser": {
+			"version": "0.130.0",
+			"resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.130.0.tgz",
+			"integrity": "sha512-X0PJ+NmOok8qP3vK9uaW431ngkdM9UPEK7KG466urtIL2+EYTEgbZK2yqe2MWKJKBjRlFweP/pJPx0x9muMEVw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@oxc-project/types": "^0.130.0"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/Boshen"
+			},
+			"optionalDependencies": {
+				"@oxc-parser/binding-android-arm-eabi": "0.130.0",
+				"@oxc-parser/binding-android-arm64": "0.130.0",
+				"@oxc-parser/binding-darwin-arm64": "0.130.0",
+				"@oxc-parser/binding-darwin-x64": "0.130.0",
+				"@oxc-parser/binding-freebsd-x64": "0.130.0",
+				"@oxc-parser/binding-linux-arm-gnueabihf": "0.130.0",
+				"@oxc-parser/binding-linux-arm-musleabihf": "0.130.0",
+				"@oxc-parser/binding-linux-arm64-gnu": "0.130.0",
+				"@oxc-parser/binding-linux-arm64-musl": "0.130.0",
+				"@oxc-parser/binding-linux-ppc64-gnu": "0.130.0",
+				"@oxc-parser/binding-linux-riscv64-gnu": "0.130.0",
+				"@oxc-parser/binding-linux-riscv64-musl": "0.130.0",
+				"@oxc-parser/binding-linux-s390x-gnu": "0.130.0",
+				"@oxc-parser/binding-linux-x64-gnu": "0.130.0",
+				"@oxc-parser/binding-linux-x64-musl": "0.130.0",
+				"@oxc-parser/binding-openharmony-arm64": "0.130.0",
+				"@oxc-parser/binding-wasm32-wasi": "0.130.0",
+				"@oxc-parser/binding-win32-arm64-msvc": "0.130.0",
+				"@oxc-parser/binding-win32-ia32-msvc": "0.130.0",
+				"@oxc-parser/binding-win32-x64-msvc": "0.130.0"
+			}
+		},
+		"node_modules/oxc-parser/node_modules/@oxc-project/types": {
+			"version": "0.130.0",
+			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.130.0.tgz",
+			"integrity": "sha512-ibD2usx9JRu7f5pu2tMKMI4cpA4NgXJQoYRP4pQ7Pxmn1l6k/53qWtQWZayhYy3X4QZkt90Ot+mJEaeXouio6Q==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/Boshen"
+			}
+		},
+		"node_modules/oxc-resolver": {
+			"version": "11.19.1",
+			"resolved": "https://registry.npmjs.org/oxc-resolver/-/oxc-resolver-11.19.1.tgz",
+			"integrity": "sha512-qE/CIg/spwrTBFt5aKmwe3ifeDdLfA2NESN30E42X/lII5ClF8V7Wt6WIJhcGZjp0/Q+nQ+9vgxGk//xZNX2hg==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/Boshen"
+			},
+			"optionalDependencies": {
+				"@oxc-resolver/binding-android-arm-eabi": "11.19.1",
+				"@oxc-resolver/binding-android-arm64": "11.19.1",
+				"@oxc-resolver/binding-darwin-arm64": "11.19.1",
+				"@oxc-resolver/binding-darwin-x64": "11.19.1",
+				"@oxc-resolver/binding-freebsd-x64": "11.19.1",
+				"@oxc-resolver/binding-linux-arm-gnueabihf": "11.19.1",
+				"@oxc-resolver/binding-linux-arm-musleabihf": "11.19.1",
+				"@oxc-resolver/binding-linux-arm64-gnu": "11.19.1",
+				"@oxc-resolver/binding-linux-arm64-musl": "11.19.1",
+				"@oxc-resolver/binding-linux-ppc64-gnu": "11.19.1",
+				"@oxc-resolver/binding-linux-riscv64-gnu": "11.19.1",
+				"@oxc-resolver/binding-linux-riscv64-musl": "11.19.1",
+				"@oxc-resolver/binding-linux-s390x-gnu": "11.19.1",
+				"@oxc-resolver/binding-linux-x64-gnu": "11.19.1",
+				"@oxc-resolver/binding-linux-x64-musl": "11.19.1",
+				"@oxc-resolver/binding-openharmony-arm64": "11.19.1",
+				"@oxc-resolver/binding-wasm32-wasi": "11.19.1",
+				"@oxc-resolver/binding-win32-arm64-msvc": "11.19.1",
+				"@oxc-resolver/binding-win32-ia32-msvc": "11.19.1",
+				"@oxc-resolver/binding-win32-x64-msvc": "11.19.1"
+			}
+		},
 		"node_modules/p-limit": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -9621,6 +10482,19 @@
 				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
 		},
+		"node_modules/smol-toml": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
+			"integrity": "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">= 18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/cyyynthia"
+			}
+		},
 		"node_modules/source-map": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -10003,24 +10877,6 @@
 				"url": "https://github.com/sponsors/SuperchupuDev"
 			}
 		},
-		"node_modules/tinyglobby/node_modules/fdir": {
-			"version": "6.5.0",
-			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-			"integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12.0.0"
-			},
-			"peerDependencies": {
-				"picomatch": "^3 || ^4"
-			},
-			"peerDependenciesMeta": {
-				"picomatch": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/tinyrainbow": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
@@ -10379,6 +11235,16 @@
 			},
 			"engines": {
 				"node": ">=0.8.0"
+			}
+		},
+		"node_modules/unbash": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/unbash/-/unbash-3.0.0.tgz",
+			"integrity": "sha512-FeFPZ/WFT0mbRCuydiZzpPFlrYN8ZUpphQKoq4EeElVIYjYyGzPMxQR/simUwCOJIyVhpFk4RbtyO7RuMpMnHA==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=14"
 			}
 		},
 		"node_modules/unbox-primitive": {
@@ -10895,6 +11761,16 @@
 			},
 			"engines": {
 				"node": ">=18"
+			}
+		},
+		"node_modules/walk-up-path": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/walk-up-path/-/walk-up-path-4.0.0.tgz",
+			"integrity": "sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "20 || >=22"
 			}
 		},
 		"node_modules/web-streams-polyfill": {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
 		"handlebars": "^4.7.9",
 		"husky": "^9.1.7",
 		"jsdom": "^29.1.1",
+		"knip": "^6.14.0",
 		"lint-staged": "^17.0.4",
 		"obsidian": "latest",
 		"prettier": "^3.8.3",

--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -135,7 +135,7 @@ export interface AgentLoopResult {
  * keeps re-attempting the same call after being told "loop detected" still
  * gets stopped cleanly instead of burning iterations and tokens.
  */
-export const AGENT_LOOP_ABORT_THRESHOLD = 3;
+const AGENT_LOOP_ABORT_THRESHOLD = 3;
 
 /**
  * Drives the tool-execution loop after the initial model response. Iterates

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -3,22 +3,10 @@
  */
 
 // Interfaces
-export type {
-	ModelApi,
-	ModelResponse,
-	BaseModelRequest,
-	ExtendedModelRequest,
-	InlineDataPart,
-	ImagePart,
-	ToolCall,
-	ToolDefinition,
-} from './interfaces/model-api';
+export type { BaseModelRequest, ExtendedModelRequest } from './interfaces/model-api';
 
 // Factory
 export { ModelClientFactory, ModelUseCase } from './factory';
 
 // Providers
-export { GeminiClient, createGoogleGenAI } from './providers/gemini';
-export type { GeminiClientConfig } from './providers/gemini';
-export { OllamaClient } from './providers/ollama';
-export type { OllamaClientConfig } from './providers/ollama';
+export { GeminiClient } from './providers/gemini';

--- a/src/api/providers/gemini/index.ts
+++ b/src/api/providers/gemini/index.ts
@@ -1,3 +1,2 @@
 export { GeminiClient } from './client';
 export type { GeminiClientConfig } from './config';
-export { createGoogleGenAI } from './google-genai-factory';

--- a/src/mcp/mcp-oauth-callback.ts
+++ b/src/mcp/mcp-oauth-callback.ts
@@ -141,11 +141,3 @@ export async function startOAuthCallbackServer(timeoutMs = CALLBACK_TIMEOUT_MS):
 		},
 	};
 }
-
-/**
- * Convenience wrapper: start server, wait for code, return result.
- * @deprecated Use `startOAuthCallbackServer` for two-phase control.
- */
-export function waitForOAuthCallback(timeoutMs = CALLBACK_TIMEOUT_MS): Promise<OAuthCallbackResult> {
-	return startOAuthCallbackServer(timeoutMs).then((handle) => handle.waitForCode);
-}

--- a/src/tools/vault-tools-extended.ts
+++ b/src/tools/vault-tools-extended.ts
@@ -9,7 +9,7 @@ import { shouldExcludePathForPlugin as shouldExcludePath } from '../utils/file-u
  * Tool to safely update YAML frontmatter without touching content
  * Critical for integration with Obsidian Bases and other metadata-driven plugins
  */
-export class UpdateFrontmatterTool implements Tool {
+class UpdateFrontmatterTool implements Tool {
 	name = 'update_frontmatter';
 	displayName = 'Update Frontmatter';
 	category = ToolCategory.VAULT_OPERATIONS;
@@ -141,7 +141,7 @@ export class UpdateFrontmatterTool implements Tool {
  * Tool to append content to the end of a file
  * Useful for logging, journaling, or adding items to lists without rewriting the whole file
  */
-export class AppendContentTool implements Tool {
+class AppendContentTool implements Tool {
 	name = 'append_content';
 	displayName = 'Append Content';
 	category = ToolCategory.VAULT_OPERATIONS;

--- a/src/tools/vault/index.ts
+++ b/src/tools/vault/index.ts
@@ -18,7 +18,6 @@ export { MoveFileTool } from './move-file-tool';
 export { SearchFilesTool } from './search-files-tool';
 export { SearchFileContentsTool } from './search-file-contents-tool';
 export { GetWorkspaceStateTool } from './get-workspace-state-tool';
-export { resolvePathToFile, resolvePathToFileOrFolder } from './utils';
 
 /**
  * Get all available vault tools

--- a/src/types/agent.ts
+++ b/src/types/agent.ts
@@ -13,7 +13,6 @@ export enum ToolCategory {
 	READ_ONLY = 'read_only', // Search, read files, analyze
 	VAULT_OPERATIONS = 'vault_ops', // Create, modify, delete notes
 	EXTERNAL_MCP = 'external_mcp', // MCP server integrations
-	SYSTEM = 'system', // System operations
 	SKILLS = 'skills', // Agent skill management
 }
 

--- a/test/mcp/mcp-manager.test.ts
+++ b/test/mcp/mcp-manager.test.ts
@@ -63,7 +63,6 @@ vi.mock('../../src/mcp/mcp-oauth-callback', () => ({
 		waitForCode: new Promise(() => {}), // never resolves — tests don't exercise full OAuth
 		close: vi.fn(),
 	}),
-	waitForOAuthCallback: vi.fn(),
 }));
 
 // Import after mocks

--- a/test/mcp/mcp-oauth-callback.test.ts
+++ b/test/mcp/mcp-oauth-callback.test.ts
@@ -209,30 +209,3 @@ describe('startOAuthCallbackServer', () => {
 		await expect(startOAuthCallbackServer()).rejects.toThrow('EADDRINUSE');
 	});
 });
-
-describe('waitForOAuthCallback', () => {
-	beforeEach(() => {
-		vi.clearAllMocks();
-		mockListen.mockImplementation((_port: number, _host: string, cb: () => void) => {
-			cb();
-		});
-		mockOn.mockImplementation(() => mockServer);
-		(window as any).setTimeout = vi.fn(() => 999);
-		(window as any).clearTimeout = vi.fn();
-	});
-
-	it('should return the waitForCode promise from the handle', async () => {
-		const { waitForOAuthCallback } = await import('../../src/mcp/mcp-oauth-callback');
-
-		// Start the callback and simulate a code
-		const promise = waitForOAuthCallback();
-
-		const handler = (mockServer as any)._handler;
-		const mockReq = { url: '/callback?code=abc' };
-		const mockRes = { writeHead: vi.fn(), end: vi.fn() };
-		handler(mockReq, mockRes);
-
-		const result = await promise;
-		expect(result.code).toBe('abc');
-	});
-});

--- a/test/tools/vault/vault-tools-extended.test.ts
+++ b/test/tools/vault/vault-tools-extended.test.ts
@@ -5,6 +5,21 @@ import { ToolExecutionContext } from '../../../src/tools/types';
 import { ToolCategory } from '../../../src/types/agent';
 import { ToolClassification } from '../../../src/types/tool-policy';
 
+/** Tool narrowed to include the optional methods these tests exercise. */
+type ToolWithOptionals = Tool & {
+	getProgressDescription: NonNullable<Tool['getProgressDescription']>;
+	confirmationMessage: NonNullable<Tool['confirmationMessage']>;
+};
+
+function getToolByName(name: string): ToolWithOptionals {
+	const tool = getExtendedVaultTools().find(
+		(t): t is ToolWithOptionals =>
+			t.name === name && typeof t.getProgressDescription === 'function' && typeof t.confirmationMessage === 'function'
+	);
+	if (!tool) throw new Error(`Tool not found: ${name}`);
+	return tool;
+}
+
 vi.mock('obsidian', async () => ({
 	...(await vi.importActual<any>('../../../__mocks__/obsidian.js')),
 }));
@@ -58,11 +73,11 @@ function makeTFile(path: string, extension = 'md'): TFile {
 // ─── UpdateFrontmatterTool ───────────────────────────────────────────────────
 
 describe('UpdateFrontmatterTool', () => {
-	let tool: Tool;
+	let tool: ToolWithOptionals;
 
 	beforeEach(() => {
 		vi.clearAllMocks();
-		tool = getExtendedVaultTools().find((t) => t.name === 'update_frontmatter')!;
+		tool = getToolByName('update_frontmatter');
 	});
 
 	// ── Static properties ────────────────────────────────────────────────
@@ -281,11 +296,11 @@ describe('UpdateFrontmatterTool', () => {
 // ─── AppendContentTool ───────────────────────────────────────────────────────
 
 describe('AppendContentTool', () => {
-	let tool: Tool;
+	let tool: ToolWithOptionals;
 
 	beforeEach(() => {
 		vi.clearAllMocks();
-		tool = getExtendedVaultTools().find((t) => t.name === 'append_content')!;
+		tool = getToolByName('append_content');
 	});
 
 	// ── Static properties ────────────────────────────────────────────────

--- a/test/tools/vault/vault-tools-extended.test.ts
+++ b/test/tools/vault/vault-tools-extended.test.ts
@@ -1,9 +1,6 @@
 import { TFile } from 'obsidian';
-import {
-	UpdateFrontmatterTool,
-	AppendContentTool,
-	getExtendedVaultTools,
-} from '../../../src/tools/vault-tools-extended';
+import { getExtendedVaultTools } from '../../../src/tools/vault-tools-extended';
+import type { Tool } from '../../../src/tools/types';
 import { ToolExecutionContext } from '../../../src/tools/types';
 import { ToolCategory } from '../../../src/types/agent';
 import { ToolClassification } from '../../../src/types/tool-policy';
@@ -61,11 +58,11 @@ function makeTFile(path: string, extension = 'md'): TFile {
 // ─── UpdateFrontmatterTool ───────────────────────────────────────────────────
 
 describe('UpdateFrontmatterTool', () => {
-	let tool: UpdateFrontmatterTool;
+	let tool: Tool;
 
 	beforeEach(() => {
 		vi.clearAllMocks();
-		tool = new UpdateFrontmatterTool();
+		tool = getExtendedVaultTools().find((t) => t.name === 'update_frontmatter')!;
 	});
 
 	// ── Static properties ────────────────────────────────────────────────
@@ -284,11 +281,11 @@ describe('UpdateFrontmatterTool', () => {
 // ─── AppendContentTool ───────────────────────────────────────────────────────
 
 describe('AppendContentTool', () => {
-	let tool: AppendContentTool;
+	let tool: Tool;
 
 	beforeEach(() => {
 		vi.clearAllMocks();
-		tool = new AppendContentTool();
+		tool = getExtendedVaultTools().find((t) => t.name === 'append_content')!;
 	});
 
 	// ── Static properties ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Remove ~15 dead barrel re-exports, unused export keywords, one dead function, and one unused enum member flagged by `knip --exports`. No behavior change.

Fixes #822 (Groups A, B, C). Group D (per-symbol type triage) filed as #824.

## Changes

**Group A — Dead barrel re-exports (deleted):**
- `src/api/index.ts`: Removed `createGoogleGenAI`, `OllamaClient`, and 8 unused type re-exports (`ModelApi`, `ModelResponse`, `InlineDataPart`, `ImagePart`, `ToolCall`, `ToolDefinition`, `GeminiClientConfig`, `OllamaClientConfig`). All consumers import directly from provider modules.
- `src/api/providers/gemini/index.ts`: Removed `createGoogleGenAI` re-export.
- `src/tools/vault/index.ts`: Removed `resolvePathToFile` and `resolvePathToFileOrFolder` re-exports. Consumers import from `./utils` directly.

**Group B — Dropped `export` on internal-only symbols:**
- `src/agent/agent-loop.ts`: `AGENT_LOOP_ABORT_THRESHOLD` — used only within `AgentLoop`.
- `src/tools/vault-tools-extended.ts`: `UpdateFrontmatterTool` and `AppendContentTool` — instantiated only by `getExtendedVaultTools()` in the same file.

**Group C — Dead function deleted:**
- `src/mcp/mcp-oauth-callback.ts`: Deleted `waitForOAuthCallback` (already `@deprecated`, zero call sites).

**Other:**
- Removed unused `ToolCategory.SYSTEM` enum member (zero references).
- Added `knip` as devDependency with `knip.json` config scoped to `src/`.
- Updated `test/tools/vault/vault-tools-extended.test.ts` to use `getExtendedVaultTools()` factory instead of direct class imports.
- Removed `waitForOAuthCallback` test and mock reference.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A: pure refactor, no runtime behavior change
- [x] Documentation has been updated (if applicable) — N/A: internal refactor, no user-facing changes

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Google Antigravity
- [x] I have reviewed and understand all AI-generated code in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified public API by reducing module exports and making some constants and tool classes internal
  * Removed deprecated OAuth convenience function
  * Removed SYSTEM tool category from ToolCategory enum

* **Chores**
  * Added knip static-analysis configuration and knip devDependency

* **Tests**
  * Updated tests to align with OAuth callback and vault tool visibility changes

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/allenhutchison/obsidian-gemini/pull/825?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->