### PR TITLE
fix(evals): wait on turn events after dispatch

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -215,7 +215,7 @@ If you need to compare models, run them sequentially. A typical 21-run sweep tak
 
 ### CLI-bridge hangs (#776)
 
-`obsidian eval` child processes occasionally don't exit after their work completes — they sit in `S` state with 0 CPU. The next CLI call from the same harness queues behind them indefinitely. The harness's `execFile` `timeoutMs: 10_000` doesn't always fire.
+`obsidian eval` child processes have occasionally failed to exit after their work completed — they sat in `S` state with 0 CPU. The harness now avoids long-lived turn-driving CLI calls and uses a hard SIGTERM-to-SIGKILL timeout for every Obsidian CLI call, so these failures should settle as harness errors instead of wedging a sweep indefinitely.
 
 Symptoms in the log:
 
@@ -223,7 +223,7 @@ Symptoms in the log:
 - The harness's node process at near-zero CPU
 - A standalone `obsidian eval code="1+1"` from another shell **does** respond instantly (so the CLI itself is fine; the harness's specific child is wedged)
 
-Workaround until #776 is fixed:
+If a future run still appears stuck, check for stale children:
 
 ```bash
 # Find stuck children (zero CPU, alive for minutes)
@@ -233,7 +233,7 @@ ps aux | grep "obsidian eval" | grep -v grep
 kill -KILL <pid>
 ```
 
-The parent's `exec` promise will reject with `"Command failed"`, which `runTask`'s catch block records as **ERROR** and moves to the next run. **Do not bless** a baseline that includes a manual-kill ERROR — the verdict was caused by the harness, not the model. Rerun the whole sweep instead.
+The harness records CLI failures as **ERROR** and moves to the next run. **Do not bless** a baseline that includes a manual-kill ERROR — the verdict was caused by the harness, not the model. Rerun the whole sweep instead.
 
 ### Don't bless a corrupted run
 
@@ -265,7 +265,6 @@ If any of these show stale state, kill / clean before starting the new run. The 
 ### Model-specific caveats
 
 - **`*-latest` model pointers** (`gemini-flash-latest`, etc.) shift under us — Google may swap the underlying model on any given day. Don't bless a baseline against `-latest`; the comparison won't be stable. Use pinned IDs (`gemini-2.5-flash`, `gemini-2.5-pro`, etc.).
-- **`gemini-2.5-flash-lite`** reproducibly hangs the harness mid-sweep (#778). Skip it for now.
 
 ## Scoring
 

--- a/evals/lib/obsidian-driver.mjs
+++ b/evals/lib/obsidian-driver.mjs
@@ -190,7 +190,10 @@ export async function setupFixtures(files) {
 
 /**
  * Send a message to the agent via the programmatic API.
- * Returns immediately — use waitForTurnEnd() to wait.
+ * Returns after dispatch; the runner waits for `turnEnd` / `turnError` via
+ * the event collector. Do not await the full agent turn inside this eval call:
+ * keeping a CLI child open for the whole model request is what made sweeps
+ * vulnerable to mid-suite CLI bridge hangs (#778).
  */
 export async function sendMessage(text) {
 	// JSON.stringify produces a safely quoted/escaped JS string literal that can
@@ -199,10 +202,13 @@ export async function sendMessage(text) {
 	await obsidianEval(
 		`(async () => {
     const p = app.plugins.plugins['gemini-scribe'];
-    await p.agentView.sendMessageProgrammatically(${textLiteral});
+    const run = p.agentView.sendMessageProgrammatically(${textLiteral});
+    window.__evalInFlightSend = run.catch((err) => {
+      window.__evalLastSendError = err instanceof Error ? err.message : String(err);
+    });
     return '"sent"';
   })()`,
-		{ timeoutMs: 300_000 }
+		{ timeoutMs: 15_000 }
 	);
 }
 

--- a/evals/lib/obsidian-driver.mjs
+++ b/evals/lib/obsidian-driver.mjs
@@ -202,10 +202,14 @@ export async function sendMessage(text) {
 	await obsidianEval(
 		`(async () => {
     const p = app.plugins.plugins['gemini-scribe'];
+    const sendToken = (window.__evalLastDispatchToken ?? 0) + 1;
+    window.__evalLastDispatchToken = sendToken;
     window.__evalLastSendError = null;
     const run = p.agentView.sendMessageProgrammatically(${textLiteral});
-    window.__evalInFlightSend = run.catch((err) => {
-      window.__evalLastSendError = err instanceof Error ? err.message : String(err);
+    run.catch((err) => {
+      if (window.__evalLastDispatchToken === sendToken) {
+        window.__evalLastSendError = err instanceof Error ? err.message : String(err);
+      }
     });
     return '"sent"';
   })()`,

--- a/evals/lib/obsidian-driver.mjs
+++ b/evals/lib/obsidian-driver.mjs
@@ -202,6 +202,7 @@ export async function sendMessage(text) {
 	await obsidianEval(
 		`(async () => {
     const p = app.plugins.plugins['gemini-scribe'];
+    window.__evalLastSendError = null;
     const run = p.agentView.sendMessageProgrammatically(${textLiteral});
     window.__evalInFlightSend = run.catch((err) => {
       window.__evalLastSendError = err instanceof Error ? err.message : String(err);
@@ -210,6 +211,21 @@ export async function sendMessage(text) {
   })()`,
 		{ timeoutMs: 15_000 }
 	);
+}
+
+/**
+ * Read and clear the last async send failure captured by sendMessage().
+ */
+export async function readAndClearLastSendError() {
+	const result = await obsidianEval(
+		`(() => {
+    const error = window.__evalLastSendError ?? null;
+    window.__evalLastSendError = null;
+    return JSON.stringify(error);
+  })()`,
+		{ timeoutMs: 2_000 }
+	);
+	return JSON.parse(result);
 }
 
 /**

--- a/evals/lib/turn-waiter.mjs
+++ b/evals/lib/turn-waiter.mjs
@@ -1,0 +1,65 @@
+/**
+ * Wait for an agent turn to reach a terminal event in the eval collector.
+ *
+ * The eval harness intentionally dispatches the message with a short-lived
+ * `obsidian eval` call, then observes progress via the collector. Keeping the
+ * CLI child open for the full model turn made long sweeps vulnerable to CLI
+ * bridge hangs even after the plugin had emitted `turnEnd`.
+ */
+
+const TERMINAL_EVENTS = new Set(['turnEnd', 'turnError']);
+
+function defaultSleep(ms) {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * @param {object[]} events
+ * @returns {boolean}
+ */
+export function hasTerminalTurnEvent(events) {
+	return (events || []).some((event) => TERMINAL_EVENTS.has(event?.event));
+}
+
+/**
+ * @param {object} opts
+ * @param {() => Promise<object[]>} opts.peekEvents
+ * @param {number} opts.timeoutMs
+ * @param {number} opts.pollIntervalMs
+ * @param {(events: object[]) => void|Promise<void>} [opts.onPoll]
+ * @param {(error: Error) => void|Promise<void>} [opts.onPollError]
+ * @param {() => number} [opts.now]
+ * @param {(ms: number) => Promise<void>} [opts.sleep]
+ * @returns {Promise<{ completed: boolean, events: object[] }>}
+ */
+export async function waitForTurnCompletion({
+	peekEvents,
+	timeoutMs,
+	pollIntervalMs,
+	onPoll = async () => {},
+	onPollError = async () => {},
+	now = Date.now,
+	sleep = defaultSleep,
+}) {
+	const deadline = now() + timeoutMs;
+	let lastEvents = [];
+
+	while (true) {
+		try {
+			const events = await peekEvents();
+			lastEvents = events;
+			await onPoll(events);
+			if (hasTerminalTurnEvent(events)) {
+				return { completed: true, events };
+			}
+		} catch (err) {
+			await onPollError(err);
+		}
+
+		const remainingMs = deadline - now();
+		if (remainingMs <= 0) {
+			return { completed: false, events: lastEvents };
+		}
+		await sleep(Math.min(pollIntervalMs, remainingMs));
+	}
+}

--- a/evals/lib/turn-waiter.mjs
+++ b/evals/lib/turn-waiter.mjs
@@ -9,6 +9,12 @@
 
 const TERMINAL_EVENTS = new Set(['turnEnd', 'turnError']);
 
+/**
+ * Pause the polling loop between collector reads.
+ *
+ * @param {number} ms
+ * @returns {Promise<void>}
+ */
 function defaultSleep(ms) {
 	return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/evals/run.mjs
+++ b/evals/run.mjs
@@ -26,6 +26,7 @@ import {
 	setupFixtures,
 	addContextFiles,
 	sendMessage,
+	readAndClearLastSendError,
 	cancelAgent,
 	cleanup,
 	getLastModelResponse,
@@ -245,6 +246,12 @@ async function runTask(task, keepArtifacts, provider, judgeFn) {
 		// already emitted `turnEnd` (#778).
 		console.log(`  Sending message... (budget ${Math.round(taskTimeoutMs / 1000)}s)`);
 		await sendMessage(task.userMessage);
+		const sendError = await readAndClearLastSendError();
+		if (sendError) {
+			await cancelAgent();
+			throw new Error(`sendMessageProgrammatically failed: ${sendError}`);
+		}
+
 		let lastSummary = null;
 		const waitResult = await waitForTurnCompletion({
 			peekEvents: peekCollector,

--- a/evals/run.mjs
+++ b/evals/run.mjs
@@ -267,6 +267,12 @@ async function runTask(task, keepArtifacts, provider, judgeFn) {
 		});
 
 		if (!waitResult.completed) {
+			const lateSendError = await readAndClearLastSendError();
+			if (lateSendError) {
+				await cancelAgent();
+				throw new Error(`sendMessageProgrammatically failed: ${lateSendError}`);
+			}
+
 			timedOut = true;
 			console.log(`  task exceeded ${Math.round(taskTimeoutMs / 1000)}s budget — cancelling agent.`);
 			await cancelAgent();

--- a/evals/run.mjs
+++ b/evals/run.mjs
@@ -39,6 +39,7 @@ import { aggregateTaskRuns, buildResult, writeResults, printSummary } from './li
 import { compareResults, loadBaseline, printRegressionSummary, getBaselinePath } from './lib/compare.mjs';
 import { createJudge } from './lib/judge.mjs';
 import { summarizeProgress, formatProgressLine, progressChanged } from './lib/progress.mjs';
+import { waitForTurnCompletion } from './lib/turn-waiter.mjs';
 
 const EVALS_DIR = resolve(import.meta.dirname);
 
@@ -50,15 +51,6 @@ const DEFAULT_TASK_TIMEOUT_MS = 5 * 60 * 1000;
 // keeps the operator's "is this thing alive?" feedback loop short without
 // hammering the obsidian CLI bridge.
 const PROGRESS_POLL_INTERVAL_MS = 2_000;
-// Grace window we give the in-flight sendMessage to settle after a timeout
-// fires + cancelAgent runs, so the plugin's eval call returns instead of
-// dangling.
-const TIMEOUT_SETTLE_MS = 5_000;
-
-function sleep(ms) {
-	return new Promise((r) => setTimeout(r, ms));
-}
-
 function parseArgs() {
 	const args = process.argv.slice(2);
 	const repeatArg = args.find((a) => a.startsWith('--repeat='))?.split('=')[1];
@@ -246,68 +238,48 @@ async function runTask(task, keepArtifacts, provider, judgeFn) {
 		// 3. Install collector
 		await installCollector();
 
-		// 4. Send the user message and race against the per-task wall-clock
-		// budget. A polling loop reads events while sendMessage is in flight
-		// so the operator sees per-turn progress instead of a silent wait.
+		// 4. Dispatch the user message, then observe terminal state via the
+		// collector. `sendMessage` intentionally returns after dispatch instead
+		// of holding an `obsidian eval` child open for the whole model turn; long
+		// sweeps used to wedge when that CLI child got stuck after the plugin had
+		// already emitted `turnEnd` (#778).
 		console.log(`  Sending message... (budget ${Math.round(taskTimeoutMs / 1000)}s)`);
-		const sendPromise = sendMessage(task.userMessage);
-		// Capture (rather than swallow) any rejection. Without this, a
-		// sendMessage failure would let the race resolve as 'OK', score
-		// against an empty collector, and silently report FAILED with no
-		// reason — masking the real error from the outer try/catch.
-		// `sendError` is rethrown after the race resolves to a non-TIMEOUT
-		// winner so the existing error path (catch block below) handles it
-		// the same way it did before the timeout refactor.
-		let sendError = null;
-		const sendSafe = sendPromise.catch((err) => {
-			sendError = err;
+		await sendMessage(task.userMessage);
+		let lastSummary = null;
+		const waitResult = await waitForTurnCompletion({
+			peekEvents: peekCollector,
+			timeoutMs: taskTimeoutMs,
+			pollIntervalMs: PROGRESS_POLL_INTERVAL_MS,
+			onPoll: (events) => {
+				const summary = summarizeProgress(events, startTime, Date.now(), task.maxTurns);
+				if (progressChanged(lastSummary, summary)) {
+					console.log(formatProgressLine(summary));
+					lastSummary = summary;
+				}
+			},
 		});
 
-		let pollerActive = true;
-		let lastSummary = null;
-		const pollLoop = (async () => {
-			while (pollerActive) {
-				await sleep(PROGRESS_POLL_INTERVAL_MS);
-				if (!pollerActive) break;
-				try {
-					const peek = await peekCollector();
-					const summary = summarizeProgress(peek, startTime, Date.now(), task.maxTurns);
-					if (progressChanged(lastSummary, summary)) {
-						console.log(formatProgressLine(summary));
-						lastSummary = summary;
-					}
-				} catch {
-					// Transient eval failure (CLI hiccup mid-run); ignore and
-					// keep polling — the next tick will succeed.
-				}
-			}
-		})();
-
-		const timeoutPromise = sleep(taskTimeoutMs).then(() => 'TIMEOUT');
-		const winner = await Promise.race([sendSafe.then(() => 'OK'), timeoutPromise]);
-
-		pollerActive = false;
-		await pollLoop;
-
-		if (winner === 'TIMEOUT') {
+		if (!waitResult.completed) {
 			timedOut = true;
-			console.log(`  ⏱ task exceeded ${Math.round(taskTimeoutMs / 1000)}s budget — cancelling agent.`);
+			console.log(`  task exceeded ${Math.round(taskTimeoutMs / 1000)}s budget — cancelling agent.`);
 			await cancelAgent();
-			// Give the in-flight sendMessage a brief settle window so its
-			// obsidianEval child can exit cleanly. After that we proceed —
-			// the dangling promise is left to its own outer timeout.
-			await Promise.race([sendSafe, sleep(TIMEOUT_SETTLE_MS)]);
-		} else if (sendError) {
-			// sendMessage rejected before the timeout fired — propagate to the
-			// outer catch so the run is recorded as ERROR (with the message)
-			// rather than silently FAILED against an empty event stream.
-			throw sendError;
 		} else {
 			console.log(`  Turn completed.`);
 		}
 
-		// 5. Read events and model response
-		const events = await readAndClearCollector();
+		// 5. Read events and model response. Prefer the last snapshot from the
+		// wait loop if a final read hits a transient CLI hiccup; the collector is
+		// only an observability buffer, and scoring stale terminal events is
+		// better than converting a completed model turn into a harness ERROR.
+		let events;
+		try {
+			events = await readAndClearCollector();
+		} catch (err) {
+			if (!waitResult.completed) throw err;
+			console.warn(`  Collector read warning: ${err.message}`);
+			events = waitResult.events;
+		}
+
 		const modelResponse = timedOut ? '' : await getLastModelResponse();
 		const durationMs = Date.now() - startTime;
 

--- a/test/evals/turn-waiter.test.ts
+++ b/test/evals/turn-waiter.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it, vi } from 'vitest';
+import { hasTerminalTurnEvent, waitForTurnCompletion } from '../../evals/lib/turn-waiter.mjs';
+
+describe('hasTerminalTurnEvent', () => {
+	it('detects turnEnd and turnError as terminal states', () => {
+		expect(hasTerminalTurnEvent([{ event: 'apiResponseReceived' }, { event: 'turnEnd' }])).toBe(true);
+		expect(hasTerminalTurnEvent([{ event: 'turnError' }])).toBe(true);
+	});
+
+	it('ignores progress-only event streams', () => {
+		expect(hasTerminalTurnEvent([{ event: 'apiResponseReceived' }, { event: 'toolExecutionComplete' }])).toBe(false);
+		expect(hasTerminalTurnEvent([])).toBe(false);
+	});
+});
+
+describe('waitForTurnCompletion', () => {
+	it('returns as soon as the collector has a terminal event', async () => {
+		let now = 0;
+		const snapshots = [[{ event: 'apiResponseReceived' }], [{ event: 'apiResponseReceived' }, { event: 'turnEnd' }]];
+		const peekEvents = vi.fn(async () => snapshots.shift() ?? []);
+		const sleep = vi.fn(async (ms: number) => {
+			now += ms;
+		});
+		const onPoll = vi.fn();
+
+		const result = await waitForTurnCompletion({
+			peekEvents,
+			timeoutMs: 10_000,
+			pollIntervalMs: 2_000,
+			onPoll,
+			now: () => now,
+			sleep,
+		});
+
+		expect(result.completed).toBe(true);
+		expect(result.events).toEqual([{ event: 'apiResponseReceived' }, { event: 'turnEnd' }]);
+		expect(peekEvents).toHaveBeenCalledTimes(2);
+		expect(sleep).toHaveBeenCalledOnce();
+		expect(onPoll).toHaveBeenCalledTimes(2);
+	});
+
+	it('returns incomplete when the timeout expires before terminal state', async () => {
+		let now = 0;
+		const events = [{ event: 'apiResponseReceived' }];
+		const peekEvents = vi.fn(async () => events);
+		const sleep = vi.fn(async (ms: number) => {
+			now += ms;
+		});
+
+		const result = await waitForTurnCompletion({
+			peekEvents,
+			timeoutMs: 3_000,
+			pollIntervalMs: 2_000,
+			now: () => now,
+			sleep,
+		});
+
+		expect(result.completed).toBe(false);
+		expect(result.events).toEqual(events);
+		expect(sleep).toHaveBeenNthCalledWith(1, 2_000);
+		expect(sleep).toHaveBeenNthCalledWith(2, 1_000);
+	});
+
+	it('continues polling after transient collector read failures', async () => {
+		let now = 0;
+		const peekEvents = vi
+			.fn()
+			.mockRejectedValueOnce(new Error('cli hiccup'))
+			.mockResolvedValueOnce([{ event: 'turnEnd' }]);
+		const sleep = vi.fn(async (ms: number) => {
+			now += ms;
+		});
+		const onPollError = vi.fn();
+
+		const result = await waitForTurnCompletion({
+			peekEvents,
+			timeoutMs: 10_000,
+			pollIntervalMs: 2_000,
+			onPollError,
+			now: () => now,
+			sleep,
+		});
+
+		expect(result.completed).toBe(true);
+		expect(result.events).toEqual([{ event: 'turnEnd' }]);
+		expect(onPollError).toHaveBeenCalledOnce();
+		expect(sleep).toHaveBeenCalledOnce();
+	});
+});


### PR DESCRIPTION
## Summary

Fixes #778 by removing the long-lived `obsidian eval` child from agent turns. The harness now dispatches the message with a short CLI call, then waits for collector `turnEnd` / `turnError` events under the task timeout budget.

## Changes

- Dispatch eval messages without awaiting the full model turn inside the Obsidian CLI process.
- Add a `turn-waiter` helper that polls collector events, tolerates transient collector read failures, and returns timeout state deterministically.
- Update eval docs to remove the `gemini-2.5-flash-lite` skip caveat and describe the current CLI-hang behavior.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [ ] I have tested this change on Desktop (not run: this container does not have Obsidian/obsidian-cli available for a live eval sweep)
- [x] I have verified this change does not break Mobile (N/A: eval harness runs outside the Obsidian mobile app)
- [x] Documentation has been updated (if applicable)
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Codex
- [x] I have reviewed and understand all AI-generated code in this PR

## Tests

- `npm test -- test/evals/turn-waiter.test.ts test/evals/progress.test.ts test/evals/spawn-with-timeout.test.ts test/evals/scorer.test.ts`
- `npm run format-check`
- `npm run build`
- `npm test`
- `npm run lint` (passes with existing warnings unrelated to this PR)
- pre-push hook: `npm run build` and `npm test`

Not run: `npm run eval -- --model=gemini-2.5-flash-lite`; this environment has no `obsidian` CLI/live Obsidian instance configured.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents long-lived CLI hangs by changing message dispatch to return immediately, enforcing shorter per-call timeouts, and treating stuck child processes as harness errors.

* **Documentation**
  * Clarified CLI timeout behavior and updated baseline-promotion guidance to mark CLI failures as ERROR and warn against blessing manually-killed baselines.

* **Tests**
  * Added unit tests for turn-completion polling and terminal-event detection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/allenhutchison/obsidian-gemini/pull/827?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->