### PR TITLE
chore(daily): 2026-05-16 daily update

### DIFF
--- a/docs/contributing/tool-development.md
+++ b/docs/contributing/tool-development.md
@@ -8,7 +8,7 @@ Tools are functions that the AI agent can call to interact with your vault and e
 
 - A unique name
 - Parameters it accepts
-- A category (for permissions)
+- A category (UI grouping) and a classification (permission boundary)
 - An execution function
 
 ## Tool Interface

--- a/docs/contributing/tool-development.md
+++ b/docs/contributing/tool-development.md
@@ -18,15 +18,11 @@ All tools must implement the `Tool` interface:
 ```typescript
 interface Tool {
 	name: string; // Unique identifier (e.g., "read_file")
-	displayName: string; // Human-readable name
-	category: ToolCategory; // Permission category
+	displayName?: string; // Human-readable name (optional)
+	category: string; // UI grouping (ToolCategory value)
+	classification: ToolClassification; // Permission tier: READ / WRITE / DESTRUCTIVE / EXTERNAL
 	description: string; // What the tool does
-	parameters: {
-		// JSON Schema for parameters
-		type: 'object';
-		properties: Record<string, any>;
-		required?: string[];
-	};
+	parameters: ToolParameterSchema; // JSON Schema for parameters
 	execute(params: any, context: ToolExecutionContext): Promise<ToolResult>;
 }
 ```
@@ -37,11 +33,14 @@ Tools are grouped into categories for permission control:
 
 ```typescript
 enum ToolCategory {
-	READ_ONLY = 'read_only', // Reading files, searching
-	VAULT_OPERATIONS = 'vault_operations', // Creating, modifying, deleting
-	WEB_OPERATIONS = 'web_operations', // Web search, URL fetching
+	READ_ONLY = 'read_only', // Search, read files, analyze
+	VAULT_OPERATIONS = 'vault_ops', // Create, modify, delete notes
+	EXTERNAL_MCP = 'external_mcp', // MCP server integrations
+	SKILLS = 'skills', // Agent skill management
 }
 ```
+
+`ToolCategory` is a UI-only grouping. The security/permission boundary is `ToolClassification` (from `src/types/tool-policy.ts`): `READ`, `WRITE`, `DESTRUCTIVE`, `EXTERNAL`. Declare the right `classification` on your tool and the policy system handles filtering and confirmation.
 
 ## Creating a Simple Tool
 
@@ -50,11 +49,13 @@ Here's a basic example of a word count tool:
 ```typescript
 import { Tool, ToolResult, ToolExecutionContext } from '../tools/types';
 import { ToolCategory } from '../types/agent';
+import { ToolClassification } from '../types/tool-policy';
 
 export class WordCountTool implements Tool {
 	name = 'word_count';
 	displayName = 'Word Count';
 	category = ToolCategory.READ_ONLY;
+	classification = ToolClassification.READ;
 	description = 'Count words in a file';
 
 	parameters = {
@@ -196,6 +197,7 @@ export class BatchProcessorTool implements Tool {
 	name = 'batch_process';
 	displayName = 'Batch Process Files';
 	category = ToolCategory.READ_ONLY;
+	classification = ToolClassification.READ;
 	description = 'Process multiple files matching a pattern';
 
 	parameters = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1909,9 +1909,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1929,9 +1926,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1949,9 +1943,6 @@
 				"ppc64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1969,9 +1960,6 @@
 				"riscv64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1989,9 +1977,6 @@
 				"riscv64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2009,9 +1994,6 @@
 				"s390x"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2029,9 +2011,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2049,9 +2028,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2264,9 +2240,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2281,9 +2254,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2298,9 +2268,6 @@
 				"ppc64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2315,9 +2282,6 @@
 				"riscv64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2332,9 +2296,6 @@
 				"riscv64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2349,9 +2310,6 @@
 				"s390x"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2366,9 +2324,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2383,9 +2338,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [

--- a/planning/changelog/2026-05-15.md
+++ b/planning/changelog/2026-05-15.md
@@ -1,0 +1,36 @@
+# Daily changelog — May 15, 2026
+
+**Date:** 2026-05-15
+**PRs merged:** 6
+
+---
+
+## Summary
+
+Heavy infrastructure day. The headliner is a reliability fix for MCP servers that makes plugin startup resilient to offline machines and unreachable servers. Two architecture-audit sweeps cleaned up dead backward-compatibility shims and redundant TypeScript suppressions. A massive test expansion brings all non-UI modules to ≥90% coverage. The daily housekeeping PR and a follow-on dead-exports cleanup rounded out the day.
+
+## What shipped
+
+### [#819 Guard MCP against offline machines and unreachable servers](https://github.com/allenhutchison/obsidian-gemini/pull/819)
+
+Adds three layers of timeout protection so an offline machine or dead MCP HTTP server can no longer hang plugin startup, freeze the settings "Test Connection" modal, or stall the agent mid-turn. Each operation now has a bounded ceiling: 10 s for connect + initial tool list, 60 s for a tool call, 15 s for any HTTP fetch, and 5 s for transport cleanup. HTTP servers are skipped immediately when the machine is offline and auto-retried when the `online` event fires. Startup is now fire-and-forget so a slow MCP server never delays plugin load. Addresses [discussion #576](https://github.com/allenhutchison/obsidian-gemini/discussions/576).
+
+### [#821 refactor: remove dead ImageAttachment/saveImageToVault aliases](https://github.com/allenhutchison/obsidian-gemini/pull/821)
+
+Architecture-audit sweep removed two backward-compatibility shims in `src/ui/agent-view/inline-attachment.ts` (`ImageAttachment` type alias and `saveImageToVault` const alias) left over from the `ImageAttachment` → `InlineAttachment` rename. Neither alias had any call sites; `knip` confirmed them unused. AGENTS.md explicitly discourages keeping such shims — deleting them is the right call.
+
+### [#820 refactor: remove redundant @ts-ignore on bundled asset imports](https://github.com/allenhutchison/obsidian-gemini/pull/820)
+
+Architecture-audit sweep removed `@ts-ignore` comments from six source files that import `.json`, `.hbs`, and `.md` assets. The suppressions were dead: `resolveJsonModule` is already enabled and `src/declarations.d.ts` / `src/types/text-imports.d.ts` already declare the non-TS module types. A stale suppression on a clean line masks future real errors on that import, so removing them is a small correctness improvement.
+
+### [#823 chore(daily): 2026-05-15 daily update](https://github.com/allenhutchison/obsidian-gemini/pull/823)
+
+Automated daily housekeeping. Wrote the May 14 changelog (3 PRs: #814, #816, #817). Fixed `<history-folder>` placeholder → `[state-folder]` terminology drift in `docs/guide/scheduled-tasks.md` (3 occurrences) and `docs/guide/lifecycle-hooks.md` (4 occurrences). No unlabeled issues to triage.
+
+### [#818 test: comprehensive coverage expansion for non-UI components](https://github.com/allenhutchison/obsidian-gemini/pull/818)
+
+Adds 700+ new tests across 30+ test files, closing #803. Brings all non-UI modules to ≥90% statement coverage: `src/api` from 45% → 97.87%, `src/tools` from 69% → 98.02%, `src/files` from 0% → 94.62%, `src/history` from 0% → 100%, `src/mcp` from 49% → 90.05%. The monolithic `test/tools/vault-tools.test.ts` was split into 11 focused files under `test/tools/vault/`. Total test count: 2800 passing across 112 files. Zero source code changes.
+
+### [#825 refactor: remove dead exports flagged by knip](https://github.com/allenhutchison/obsidian-gemini/pull/825)
+
+Removes ~15 dead barrel re-exports, unused `export` keywords, one dead function, and one unused enum member flagged by `knip --exports`. Fixes issue #822 (Groups A–C). The main removals: dead re-exports from `src/api/index.ts` and `src/tools/vault/index.ts` that consumers were already bypassing, the deprecated `waitForOAuthCallback` function (zero call sites), the `ToolCategory.SYSTEM` enum member (zero references), and `export` on internal-only symbols in `agent-loop.ts` and `vault-tools-extended.ts`. Also adds `knip` as a devDependency with `knip.json` config. No behavior change.


### PR DESCRIPTION
## Summary

Automated daily housekeeping for 2026-05-16. Covers the May 15 changelog and a contributing-doc drift fix. No unlabeled issues to triage.

## Changes

- **Add `planning/changelog/2026-05-15.md`**: Documents 6 PRs merged on May 15 — #819 (MCP timeout resilience for offline/unreachable servers), #821 (remove dead ImageAttachment/saveImageToVault aliases), #820 (remove redundant @ts-ignore on bundled imports), #823 (daily housekeeping PR), #818 (700+ new tests, ≥90% non-UI coverage), #825 (remove dead exports flagged by knip).
- **Fix `docs/contributing/tool-development.md`**: Conceptual drift — the Tool interface example was missing the required `classification: ToolClassification` field, and the ToolCategory enum values were wrong (`vault_operations` → `vault_ops`, `WEB_OPERATIONS` removed, `EXTERNAL_MCP` + `SKILLS` added to match current code). Also added a note clarifying the two-tier system (ToolCategory for UI grouping vs. ToolClassification for the permission boundary).

## Sub-skill outcomes

| Sub-skill | Outcome |
| --- | --- |
| daily-changelog | wrote `planning/changelog/2026-05-15.md`, 6 PRs: #819, #821, #820, #823, #818, #825 — infrastructure-heavy day |
| audit-docs | conceptual drift fixed in `docs/contributing/tool-development.md` — Tool interface missing `classification` field; ToolCategory enum values wrong |
| triage-issues | 0 unlabeled open issues — no labels applied |

## Screenshots / Screencast

N/A — no UI changes.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A; automated housekeeping
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [ ] I have tested this change on Desktop — N/A; changelog and doc updates only
- [ ] I have verified this change does not break Mobile — N/A; no code changes
- [x] Documentation has been updated (if applicable) — this PR IS the doc update
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (`daily-update` skill)
- [x] I have reviewed and understand all AI-generated code in this PR

---

https://claude.ai/code/session_01Nos4syF6fHJpDoKgUvQwta

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nos4syF6fHJpDoKgUvQwta)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MCP server reliability with timeout handling to prevent hangs on offline or unreachable machines.

* **Documentation**
  * Updated the tool development guide with a revised tool classification system and clearer guidance on UI grouping.

* **Tests**
  * Expanded test coverage with 700+ additional tests, achieving ≥90% coverage for non-UI modules.

* **Chores**
  * Removed unused code, exports, and redundant comments; cleaned up compatibility aliases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/allenhutchison/obsidian-gemini/pull/830?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->