### PR TITLE
fix: make the help skill aware of the configured state folder

### DIFF
--- a/prompts/bundled-skills/gemini-scribe-help/SKILL.md
+++ b/prompts/bundled-skills/gemini-scribe-help/SKILL.md
@@ -14,6 +14,17 @@ You are the built-in help system for the Gemini Scribe Obsidian plugin. When use
 3. Answer based on the loaded reference content
 4. If the question spans multiple topics, load multiple references
 
+## Plugin State Folder
+
+This vault's Gemini Scribe state folder is `<!-- STATE_FOLDER -->`. Advanced features are stored in its subfolders:
+
+- `<!-- STATE_FOLDER -->/Scheduled-Tasks/` — scheduled task definitions
+- `<!-- STATE_FOLDER -->/Skills/` — agent skill packages
+- `<!-- STATE_FOLDER -->/Prompts/` — custom prompt templates
+- `<!-- STATE_FOLDER -->/Hooks/` — lifecycle hook definitions
+
+The reference documents below use the default folder name `gemini-scribe` in their example paths. When a reference shows a path like `gemini-scribe/Scheduled-Tasks/`, use `<!-- STATE_FOLDER -->/Scheduled-Tasks/` instead. Never create a new `gemini-scribe` folder.
+
 ## Available References
 
 <!-- REFERENCES_TABLE -->

--- a/src/services/bundled-skills.ts
+++ b/src/services/bundled-skills.ts
@@ -45,7 +45,9 @@ function parseDescription(md: string): string {
 
 const skills: Map<string, BundledSkill> = new Map();
 
-// Register gemini-scribe-help with auto-generated references table
+// Register gemini-scribe-help with auto-generated references table.
+// The <!-- STATE_FOLDER --> placeholder is intentionally left unresolved here —
+// SkillManager.loadSkill() fills it with the configured state folder at runtime.
 const helpContent = stripFrontmatter(helpSkillMd).replace('<!-- REFERENCES_TABLE -->', () => helpReferencesTable);
 
 skills.set('gemini-scribe-help', {

--- a/src/services/skill-manager.ts
+++ b/src/services/skill-manager.ts
@@ -202,7 +202,14 @@ export class SkillManager {
 
 		if (!(file instanceof TFile)) {
 			// Fall back to bundled skills
-			return BundledSkillRegistry.loadSkill(name);
+			const bundled = BundledSkillRegistry.loadSkill(name);
+			if (bundled !== null && name === HELP_SKILL_NAME) {
+				// Resolve the runtime-only <!-- STATE_FOLDER --> placeholder so the
+				// help skill reflects the user's configured state folder. A function
+				// replacer keeps a `$` in the folder name from acting as a regex token.
+				return bundled.replace(/<!-- STATE_FOLDER -->/g, () => this.plugin.settings.historyFolder);
+			}
+			return bundled;
 		}
 
 		const fullContent = await this.plugin.app.vault.read(file);

--- a/src/services/skill-manager.ts
+++ b/src/services/skill-manager.ts
@@ -205,9 +205,10 @@ export class SkillManager {
 			const bundled = BundledSkillRegistry.loadSkill(name);
 			if (bundled !== null && name === HELP_SKILL_NAME) {
 				// Resolve the runtime-only <!-- STATE_FOLDER --> placeholder so the
-				// help skill reflects the user's configured state folder. A function
-				// replacer keeps a `$` in the folder name from acting as a regex token.
-				return bundled.replace(/<!-- STATE_FOLDER -->/g, () => this.plugin.settings.historyFolder);
+				// help skill reflects the user's configured state folder. split/join
+				// replaces every occurrence without `$`-pattern substitution, so a
+				// folder name containing `$` is inserted verbatim.
+				return bundled.split('<!-- STATE_FOLDER -->').join(this.plugin.settings.historyFolder);
 			}
 			return bundled;
 		}

--- a/test/services/bundled-skills.test.ts
+++ b/test/services/bundled-skills.test.ts
@@ -85,6 +85,14 @@ describe('BundledSkillRegistry', () => {
 			expect(content).toContain('references/settings.md');
 		});
 
+		it('should leave the STATE_FOLDER placeholder unresolved for runtime substitution', () => {
+			const content = BundledSkillRegistry.loadSkill('gemini-scribe-help');
+			expect(content).not.toBeNull();
+			// <!-- STATE_FOLDER --> is intentionally NOT replaced at module-load time;
+			// SkillManager.loadSkill() fills it with the configured folder at runtime.
+			expect(content).toContain('<!-- STATE_FOLDER -->');
+		});
+
 		it('should return body content for obsidian-bases', () => {
 			const content = BundledSkillRegistry.loadSkill('obsidian-bases');
 			expect(content).not.toBeNull();

--- a/test/services/skill-manager.test.ts
+++ b/test/services/skill-manager.test.ts
@@ -13,7 +13,7 @@ vi.mock('../../src/services/bundled-skills', () => ({
 			{ name: 'obsidian-bases', description: 'Create Obsidian Bases' },
 		]),
 		loadSkill: vi.fn().mockImplementation((name: string) => {
-			if (name === 'gemini-scribe-help') return '# Help\n\nInstructions';
+			if (name === 'gemini-scribe-help') return '# Help\n\nState folder: <!-- STATE_FOLDER -->\n\nInstructions';
 			if (name === 'obsidian-bases') return '# Bases\n\nSyntax guide';
 			return null;
 		}),
@@ -115,6 +115,8 @@ describe('SkillManager', () => {
 		mockVault.adapter.exists.mockReset().mockResolvedValue(false);
 		mockVault.adapter.read.mockReset().mockResolvedValue('');
 		mockPlugin.settings.fileLogging = false;
+		// Pin the default state folder so tests that mutate it don't leak.
+		mockPlugin.settings.historyFolder = 'gemini-scribe';
 		manager = new SkillManager(mockPlugin);
 	});
 
@@ -582,7 +584,20 @@ describe('SkillManager', () => {
 
 				const content = await manager.loadSkill('gemini-scribe-help');
 
-				expect(content).toBe('# Help\n\nInstructions');
+				// The help skill's <!-- STATE_FOLDER --> placeholder resolves to the
+				// configured state folder (default 'gemini-scribe').
+				expect(content).toBe('# Help\n\nState folder: gemini-scribe\n\nInstructions');
+				expect(content).not.toContain('<!-- STATE_FOLDER -->');
+			});
+
+			it('should resolve the help skill STATE_FOLDER placeholder to a custom state folder', async () => {
+				mockVault.getAbstractFileByPath.mockReturnValue(null);
+				mockPlugin.settings.historyFolder = 'Resources';
+
+				const content = await manager.loadSkill('gemini-scribe-help');
+
+				expect(content).toBe('# Help\n\nState folder: Resources\n\nInstructions');
+				expect(content).not.toContain('<!-- STATE_FOLDER -->');
 			});
 
 			it('should prefer vault skill over bundled skill', async () => {


### PR DESCRIPTION
## Summary

- The bundled `gemini-scribe-help` skill and its reference docs use the literal default folder name `gemini-scribe` in example paths. When a user has moved the plugin state folder (e.g. to `Resources`), the agent takes those paths at face value and creates a stray `gemini-scribe/` folder at the vault root instead of using the real one.
- Adds a **Plugin State Folder** section to the help skill's `SKILL.md` with a `<!-- STATE_FOLDER -->` placeholder, filled with `settings.historyFolder` by `SkillManager.loadSkill()` when the bundled help skill loads — mirroring the existing `<!-- REFERENCES_TABLE -->` placeholder pattern.
- The section also instructs the agent to substitute the real folder wherever a reference doc shows a `gemini-scribe/...` example path.

Fixes #755

## Implementation notes

- `prompts/bundled-skills/gemini-scribe-help/SKILL.md` — new `## Plugin State Folder` section with `<!-- STATE_FOLDER -->` placeholders.
- `src/services/skill-manager.ts` — `loadSkill()` resolves the placeholder (global regex + function replacer, so a `$` in the folder name isn't treated as a regex token) for the bundled help skill only. A vault override of the help skill bypasses this branch and is left untouched.
- `src/services/bundled-skills.ts` — comment noting the placeholder is intentionally left unresolved at module-load time (no plugin/settings available there).

## Test plan

- [x] `npm run build` — TypeScript check + bundle, clean
- [x] `npm test` — 2764 passed, 5 skipped (113 test files)
- [x] New unit tests: placeholder survives module-load assembly (`bundled-skills.test.ts`); `loadSkill()` resolves it for the default `gemini-scribe` and a custom `Resources` folder (`skill-manager.test.ts`)
- [ ] Manual: set `historyFolder` to a non-default folder, ask the agent to "set up a scheduled task", confirm it uses `<folder>/Scheduled-Tasks/` and does not create a new `gemini-scribe` folder

## Documentation

No `docs/` changes — this is an internal fix to how the bundled help skill is assembled. There is no new setting or user-facing feature, and the docs already use the `[state-folder]/` placeholder convention.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MUEVRcUTQrJFA7D7y3s684)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Help documentation updated to explain the plugin state folder and key subdirectories (Scheduled-Tasks, Skills, Prompts, Hooks) and to use a configurable state-folder placeholder.

* **Bug Fixes**
  * Help content now displays the correct state-folder path based on your configured settings, ensuring accurate references in the help text.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/allenhutchison/obsidian-gemini/pull/832?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->