### PR TITLE
refactor: triage and clean up unused type exports

### DIFF
--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -18,6 +18,7 @@ import {
  * view, headless task runners) can render or react without the loop knowing
  * anything about its caller. All hooks are optional; an absent hook is a no-op.
  */
+// knip:keep — Intentional public API for UI and headless extension hooks
 export interface AgentLoopHooks {
 	/**
 	 * Fired once at the start of each tool-execution batch (every iteration of

--- a/src/api/config/model-config.ts
+++ b/src/api/config/model-config.ts
@@ -38,12 +38,3 @@ export interface ApiConfig {
 	retryConfig?: RetryConfig;
 	features?: ApiFeatures;
 }
-
-/**
- * Session-specific model configuration overrides
- */
-export interface SessionModelConfig {
-	model?: string;
-	temperature?: number;
-	topP?: number;
-}

--- a/src/api/interfaces/model-api.ts
+++ b/src/api/interfaces/model-api.ts
@@ -62,9 +62,6 @@ export interface InlineDataPart {
 	mimeType: string;
 }
 
-/** Backward-compatible alias */
-export type ImagePart = InlineDataPart;
-
 /**
  * Represents an extended model request with conversation history and a user message.
  *
@@ -119,6 +116,7 @@ export interface ToolDefinition {
 /**
  * Streaming chunk data passed to callback
  */
+// knip:keep — Intentional public API structurally consumed by StreamCallback
 export interface StreamChunk {
 	/** Text content chunk */
 	text: string;

--- a/src/mcp/mcp-oauth-callback.ts
+++ b/src/mcp/mcp-oauth-callback.ts
@@ -18,6 +18,7 @@ const CALLBACK_TIMEOUT_MS = 120_000;
 /**
  * Result of an OAuth callback. Contains either a code or an error.
  */
+// knip:keep — Intentional public API structurally returned by startOAuthCallbackServer()
 export interface OAuthCallbackResult {
 	code: string;
 }

--- a/src/services/background-task-manager.ts
+++ b/src/services/background-task-manager.ts
@@ -3,6 +3,7 @@ import type ObsidianGemini from '../main';
 import type { AgentEventBus } from '../agent/agent-event-bus';
 import { getErrorMessage } from '../utils/error-utils';
 
+// knip:keep — Intentional public API structurally consumed by BackgroundTask.status
 export type BackgroundTaskStatus = 'pending' | 'running' | 'complete' | 'failed' | 'cancelled';
 
 export interface BackgroundTask {

--- a/src/services/rag-indexing.ts
+++ b/src/services/rag-indexing.ts
@@ -19,18 +19,6 @@ import type {
 	ProgressListener,
 } from './rag-types';
 
-// Re-export all types for backwards compatibility
-export type {
-	IndexedFileEntry,
-	RagIndexCache,
-	IndexProgress,
-	IndexResult,
-	FailedFileEntry,
-	RagIndexStatus,
-	RagProgressInfo,
-	ProgressListener,
-} from './rag-types';
-
 /**
  * Service for managing RAG indexing of vault files to Google's File Search API.
  *

--- a/src/services/rag-types.ts
+++ b/src/services/rag-types.ts
@@ -1,6 +1,7 @@
 /**
  * Represents a file that has been indexed in the File Search Store
  */
+// knip:keep — Intentional public API structurally consumed by RagIndexCache.files
 export interface IndexedFileEntry {
 	resourceName: string; // Gemini file resource name
 	contentHash: string; // SHA-256 hash for reliable change detection

--- a/src/ui/rag-progress-modal.ts
+++ b/src/ui/rag-progress-modal.ts
@@ -1,5 +1,5 @@
 import { App, Modal, Setting, setIcon } from 'obsidian';
-import type { RagProgressInfo, ProgressListener } from '../services/rag-indexing';
+import type { RagProgressInfo, ProgressListener } from '../services/rag-types';
 
 /**
  * Modal showing live progress during RAG indexing operations

--- a/src/ui/rag-status-modal.ts
+++ b/src/ui/rag-status-modal.ts
@@ -1,5 +1,5 @@
 import { App, Modal, Notice, Setting, setIcon } from 'obsidian';
-import type { RagIndexStatus, FailedFileEntry } from '../services/rag-indexing';
+import type { RagIndexStatus, FailedFileEntry } from '../services/rag-types';
 
 /**
  * Detailed status information for the modal

--- a/test/services/rag-indexing.test.ts
+++ b/test/services/rag-indexing.test.ts
@@ -16,7 +16,8 @@ vi.mock('obsidian', () => {
 	};
 });
 
-import { RagIndexingService, RagIndexCache } from '../../src/services/rag-indexing';
+import { RagIndexingService } from '../../src/services/rag-indexing';
+import type { RagIndexCache } from '../../src/services/rag-types';
 import { TFile } from 'obsidian';
 
 // Mock GoogleGenAI


### PR DESCRIPTION
## Summary

Triage and resolve all 8 remaining unused exported types flagged by `knip --exports`. Fixes #824.

Provides a clean, highly-maintainable type exports layout: keeping and annotating intentional public interfaces with descriptive comments while completely removing duplicate code.

## Changes

- **`src/agent/agent-loop.ts`**: Kept `AgentLoopHooks` and added `// knip:keep` inline annotation (intentional extension hook).
- **`src/api/config/model-config.ts`**: Deleted redundant unused duplicate `SessionModelConfig` definition.
- **`src/api/interfaces/model-api.ts`**: Deleted legacy unused `ImagePart` type alias. Added `// knip:keep` inline annotation to `StreamChunk` (structurally required by `StreamCallback`).
- **`src/mcp/mcp-oauth-callback.ts`**: Kept `OAuthCallbackResult` and added `// knip:keep` inline annotation (structurally returned by `startOAuthCallbackServer()`).
- **`src/services/background-task-manager.ts`**: Kept `BackgroundTaskStatus` and added `// knip:keep` inline annotation (structurally required by `BackgroundTask.status`).
- **`src/services/rag-indexing.ts`**: Removed legacy unused internal duplicate barrel re-export block (`export type { ... } from './rag-types'`).
- **`src/services/rag-types.ts`**: Kept `IndexedFileEntry` and added `// knip:keep` inline annotation (structurally consumed inside `RagIndexCache.files`).
- **`test/services/rag-indexing.test.ts`**, **`src/ui/rag-progress-modal.ts`**, and **`src/ui/rag-status-modal.ts`**: Refactored type imports to point directly to `rag-types` instead of importing RAG types from the service barrel.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A: type refactoring only, zero runtime behavior change
- [x] Documentation has been updated (if applicable) — N/A: internal type cleanup only, no user-facing settings or feature changes
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Google Antigravity
- [x] I have reviewed and understand all AI-generated code in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactoring**
  * Reorganized type exports and imports for improved API clarity
  * Removed `ImagePart` type alias; use `InlineDataPart` directly for inline attachments
  * Removed `SessionModelConfig` interface from public API
  * Consolidated RAG-related type imports to source from their definition module

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/allenhutchison/obsidian-gemini/pull/837?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->