### PR TITLE
fix(mcp): store stdio server env vars in SecretStorage

### DIFF
--- a/docs/guide/mcp-servers.md
+++ b/docs/guide/mcp-servers.md
@@ -113,7 +113,7 @@ The OAuth callback runs a temporary local server on port 8095. Ensure this port 
 
 Stdio servers can be configured with environment variables. These are useful for passing API keys, paths, or other configuration to the server process.
 
-When adding or editing a stdio server, click **Add Environment Variable** to define key-value pairs:
+When adding or editing a stdio server, enter `KEY=VALUE` pairs (one per line) in the **Environment variables** field:
 
 | Variable        | Example Use Case                               |
 | --------------- | ---------------------------------------------- |
@@ -121,8 +121,8 @@ When adding or editing a stdio server, click **Add Environment Variable** to def
 | `GITHUB_TOKEN`  | Personal access token for GitHub MCP server    |
 | `HOME`          | Override home directory for the server process |
 
-::: warning
-Environment variables may contain sensitive values like API keys. These are stored in your Obsidian plugin settings (`data.json`), not in SecretStorage. Avoid committing your vault's `.obsidian` folder to public repositories.
+::: tip
+Environment variable values often hold sensitive credentials. Gemini Scribe stores them in Obsidian's **SecretStorage** (your operating system's keychain), not in the plugin's `data.json`. Because the keychain is per-device, these values do **not** sync across machines — if you use the same vault on multiple devices, re-enter the environment variables on each one.
 :::
 
 ## Finding Servers

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -424,16 +424,18 @@ MCP (Model Context Protocol) server support allows the agent to use tools from e
 
 Each server configuration includes:
 
-| Field          | Type     | Description                                                                |
-| -------------- | -------- | -------------------------------------------------------------------------- |
-| `name`         | String   | Unique server name                                                         |
-| `transport`    | String   | Transport type: `"stdio"` (local) or `"http"` (remote). Default: `"stdio"` |
-| `command`      | String   | Command to spawn the server (stdio only)                                   |
-| `args`         | String[] | Command arguments (stdio only)                                             |
-| `url`          | String   | Server URL (http only, e.g., `http://localhost:3000/mcp`)                  |
-| `env`          | Object   | Optional environment variables                                             |
-| `enabled`      | Boolean  | Connect on plugin load                                                     |
-| `trustedTools` | String[] | Tools that skip confirmation                                               |
+| Field           | Type     | Description                                                                                    |
+| --------------- | -------- | ---------------------------------------------------------------------------------------------- |
+| `name`          | String   | Unique server name                                                                             |
+| `transport`     | String   | Transport type: `"stdio"` (local) or `"http"` (remote). Default: `"stdio"`                     |
+| `command`       | String   | Command to spawn the server (stdio only)                                                       |
+| `args`          | String[] | Command arguments (stdio only)                                                                 |
+| `url`           | String   | Server URL (http only, e.g., `http://localhost:3000/mcp`)                                      |
+| `envSecretName` | String   | SecretStorage key for the server's env vars (stdio only; values are not stored in `data.json`) |
+| `enabled`       | Boolean  | Connect on plugin load                                                                         |
+| `trustedTools`  | String[] | Tools that skip confirmation                                                                   |
+
+Environment variable **values** are kept in Obsidian's SecretStorage (the OS keychain), not in `data.json`. The config only stores `envSecretName`, a pointer to the keychain entry.
 
 See the [MCP Servers Guide](/guide/mcp-servers) for setup instructions.
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -28,6 +28,7 @@ import { RagIndexingService } from './services/rag-indexing';
 import { SelectionActionService } from './services/selection-action-service';
 import { MCPManager } from './mcp/mcp-manager';
 import { MCPServerConfig } from './mcp/types';
+import { migrateServerEnvToSecretStorage } from './mcp/mcp-secrets';
 import { ContextManager } from './services/context-manager';
 import { SkillManager } from './services/skill-manager';
 import { FolderInitializer } from './services/folder-initializer';
@@ -908,6 +909,18 @@ export default class ObsidianGemini extends Plugin {
 				this.logger?.log('Migrated API key from settings to secure storage');
 			} else {
 				this.logger?.error('API key migration failed: verification mismatch, keeping key in settings');
+			}
+		}
+
+		// One-time migration: move MCP stdio server env vars out of data.json into
+		// SecretStorage. Desktop-only — env feeds stdio servers, which never run on
+		// mobile; migrating on a mobile device first would strip env from the synced
+		// data.json before any desktop copies it into its (non-syncing) keychain.
+		if (!(this.app as { isMobile?: boolean }).isMobile) {
+			const migrated = migrateServerEnvToSecretStorage(this.app, this.settings.mcpServers, this.logger);
+			if (migrated) {
+				await this.saveData(this.settings);
+				this.logger?.log('Migrated MCP server env vars to secure storage');
 			}
 		}
 

--- a/src/mcp/mcp-manager.ts
+++ b/src/mcp/mcp-manager.ts
@@ -5,6 +5,7 @@ import { MCPServerConfig, MCPConnectionStatus, MCPServerState, MCP_TRANSPORT_HTT
 import { MCPToolWrapper } from './mcp-tool-wrapper';
 import { ObsidianOAuthClientProvider, OAUTH_CALLBACK_PORT } from './mcp-oauth-provider';
 import { obsidianFetch } from './mcp-fetch';
+import { resolveServerEnv } from './mcp-secrets';
 import {
 	MCP_CLOSE_TIMEOUT_MS,
 	MCP_CONNECT_TIMEOUT_MS,
@@ -538,7 +539,7 @@ export class MCPManager {
 			transport = new StdioClientTransport({
 				command: config.command,
 				args: config.args,
-				env: buildEnv(config.env),
+				env: buildEnv(resolveServerEnv(this.plugin.app, config)),
 			});
 		}
 

--- a/src/mcp/mcp-secrets.ts
+++ b/src/mcp/mcp-secrets.ts
@@ -40,6 +40,8 @@ export function resolveServerEnv(app: App, config: MCPServerConfig): Record<stri
  * Persist a stdio MCP server's environment variables to SecretStorage, keeping
  * them out of data.json. Mutates `config.envSecretName`, generating a key on
  * first write. An empty or undefined env clears any previously stored secret.
+ * Throws if a non-empty write cannot be verified via read-back, so the caller
+ * never reports success on credentials that did not actually persist.
  */
 export function writeServerEnv(app: App, config: MCPServerConfig, env: Record<string, string> | undefined): void {
 	const hasEnv = !!env && Object.keys(env).length > 0;
@@ -52,7 +54,11 @@ export function writeServerEnv(app: App, config: MCPServerConfig, env: Record<st
 	if (!config.envSecretName) {
 		config.envSecretName = makeEnvSecretName(config.name);
 	}
-	app.secretStorage.setSecret(config.envSecretName, JSON.stringify(env));
+	const blob = JSON.stringify(env);
+	app.secretStorage.setSecret(config.envSecretName, blob);
+	if (app.secretStorage.getSecret(config.envSecretName) !== blob) {
+		throw new Error(`Failed to store environment variables for MCP server "${config.name}" in SecretStorage`);
+	}
 }
 
 /**

--- a/src/mcp/mcp-secrets.ts
+++ b/src/mcp/mcp-secrets.ts
@@ -1,0 +1,111 @@
+import type { App } from 'obsidian';
+import type { Logger } from '../utils/logger';
+import type { MCPServerConfig } from './types';
+import { sanitizeKeySegment } from './mcp-oauth-provider';
+
+/** Prefix for SecretStorage keys holding stdio MCP server environment variables. */
+const SECRET_KEY_ENV_PREFIX = 'mcp-env-';
+
+/**
+ * Generate a SecretStorage key for a server's environment-variable blob. The
+ * random suffix keeps keys unique even when two distinct server names sanitize
+ * to the same segment — it is a key disambiguator, not a security boundary.
+ */
+export function makeEnvSecretName(serverName: string): string {
+	const suffix = Math.random().toString(36).slice(2, 10);
+	return `${SECRET_KEY_ENV_PREFIX}${sanitizeKeySegment(serverName)}-${suffix}`;
+}
+
+/**
+ * Read a stdio MCP server's environment variables from Obsidian's SecretStorage
+ * (OS keychain). Returns undefined when none are stored or the stored blob is
+ * empty or unparseable.
+ */
+export function resolveServerEnv(app: App, config: MCPServerConfig): Record<string, string> | undefined {
+	if (!config.envSecretName) return undefined;
+	const raw = app.secretStorage.getSecret(config.envSecretName);
+	if (!raw) return undefined;
+	try {
+		const parsed = JSON.parse(raw) as Record<string, string>;
+		if (parsed && typeof parsed === 'object' && Object.keys(parsed).length > 0) {
+			return parsed;
+		}
+	} catch {
+		// Corrupt blob — treat as no env rather than failing the connection.
+	}
+	return undefined;
+}
+
+/**
+ * Persist a stdio MCP server's environment variables to SecretStorage, keeping
+ * them out of data.json. Mutates `config.envSecretName`, generating a key on
+ * first write. An empty or undefined env clears any previously stored secret.
+ */
+export function writeServerEnv(app: App, config: MCPServerConfig, env: Record<string, string> | undefined): void {
+	const hasEnv = !!env && Object.keys(env).length > 0;
+	if (!hasEnv) {
+		if (config.envSecretName) {
+			app.secretStorage.setSecret(config.envSecretName, '');
+		}
+		return;
+	}
+	if (!config.envSecretName) {
+		config.envSecretName = makeEnvSecretName(config.name);
+	}
+	app.secretStorage.setSecret(config.envSecretName, JSON.stringify(env));
+}
+
+/**
+ * Clear a server's stored env secret. Called when a server is deleted so its
+ * credentials do not linger in the keychain.
+ */
+export function clearServerEnv(app: App, config: MCPServerConfig): void {
+	if (config.envSecretName) {
+		app.secretStorage.setSecret(config.envSecretName, '');
+	}
+}
+
+/**
+ * One-time migration: move any plaintext `env` objects on MCP server configs
+ * (legacy data.json storage) into SecretStorage. Mutates each migrated config —
+ * sets `envSecretName`, deletes the legacy `env` field. Returns true when at
+ * least one config changed, signalling the caller to persist settings.
+ *
+ * Each migration is verified (the read-back must match) before the plaintext is
+ * dropped; on mismatch the plaintext is kept and an error is logged.
+ */
+export function migrateServerEnvToSecretStorage(
+	app: App,
+	servers: MCPServerConfig[] | undefined,
+	logger?: Logger
+): boolean {
+	if (!Array.isArray(servers)) return false;
+	let changed = false;
+	for (const server of servers) {
+		const legacyEnv = (server as { env?: unknown }).env;
+		if (legacyEnv === undefined) continue;
+
+		const entries =
+			legacyEnv && typeof legacyEnv === 'object' ? Object.entries(legacyEnv as Record<string, string>) : [];
+
+		if (entries.length > 0 && !server.envSecretName) {
+			const secretName = makeEnvSecretName(server.name);
+			const blob = JSON.stringify(legacyEnv);
+			app.secretStorage.setSecret(secretName, blob);
+			if (app.secretStorage.getSecret(secretName) === blob) {
+				server.envSecretName = secretName;
+				delete (server as { env?: unknown }).env;
+				changed = true;
+			} else {
+				logger?.error(
+					`MCP env migration failed for "${server.name}": SecretStorage verification mismatch, keeping plaintext`
+				);
+			}
+		} else {
+			// Empty env, or a secret pointer already exists — drop the stray plaintext field.
+			delete (server as { env?: unknown }).env;
+			changed = true;
+		}
+	}
+	return changed;
+}

--- a/src/mcp/mcp-secrets.ts
+++ b/src/mcp/mcp-secrets.ts
@@ -12,7 +12,7 @@ const SECRET_KEY_ENV_PREFIX = 'mcp-env-';
  * to the same segment — it is a key disambiguator, not a security boundary.
  */
 export function makeEnvSecretName(serverName: string): string {
-	const suffix = Math.random().toString(36).slice(2, 10);
+	const suffix = crypto.randomUUID().slice(0, 8);
 	return `${SECRET_KEY_ENV_PREFIX}${sanitizeKeySegment(serverName)}-${suffix}`;
 }
 

--- a/src/mcp/types.ts
+++ b/src/mcp/types.ts
@@ -24,8 +24,12 @@ export interface MCPServerConfig {
 	/** URL for HTTP transport (e.g., "http://localhost:3000/mcp") */
 	url?: string;
 
-	/** Optional environment variables */
-	env?: Record<string, string>;
+	/**
+	 * SecretStorage key holding this server's environment variables as a JSON
+	 * blob. The values live in the OS keychain, never in data.json. Absent when
+	 * the server has no environment variables configured.
+	 */
+	envSecretName?: string;
 
 	/** Whether to connect on startup */
 	enabled: boolean;

--- a/src/ui/mcp-server-modal.ts
+++ b/src/ui/mcp-server-modal.ts
@@ -285,7 +285,12 @@ export class MCPServerModal extends Modal {
 								return;
 							}
 							// Persist env vars to SecretStorage; sets config.envSecretName.
-							writeServerEnv(this.app, this.config, this.env);
+							try {
+								writeServerEnv(this.app, this.config, this.env);
+							} catch (error) {
+								new Notice(error instanceof Error ? error.message : 'Failed to store environment variables');
+								return;
+							}
 						}
 						await this.onSave(this.config);
 						this.close();

--- a/src/ui/mcp-server-modal.ts
+++ b/src/ui/mcp-server-modal.ts
@@ -2,6 +2,7 @@ import { App, Modal, Setting, Notice } from 'obsidian';
 import { MCPServerConfig, MCP_TRANSPORT_STDIO, MCP_TRANSPORT_HTTP, MCPTransportType } from '../mcp/types';
 import { MCPManager } from '../mcp/mcp-manager';
 import { ObsidianOAuthClientProvider } from '../mcp/mcp-oauth-provider';
+import { resolveServerEnv, writeServerEnv } from '../mcp/mcp-secrets';
 
 /**
  * Modal for adding or editing an MCP server configuration.
@@ -10,6 +11,8 @@ import { ObsidianOAuthClientProvider } from '../mcp/mcp-oauth-provider';
  */
 export class MCPServerModal extends Modal {
 	private config: MCPServerConfig;
+	/** Working copy of the server's env vars. Persisted to SecretStorage on save. */
+	private env: Record<string, string> | undefined;
 	private mcpManager: MCPManager;
 	private onSave: (config: MCPServerConfig) => Promise<void> | void;
 	private isEdit: boolean;
@@ -37,7 +40,6 @@ export class MCPServerModal extends Modal {
 					args: [...config.args],
 					// Legacy field — kept for migration compatibility, no longer used in UI
 					trustedTools: config.trustedTools ? [...config.trustedTools] : [],
-					env: config.env ? { ...config.env } : undefined,
 				}
 			: {
 					name: '',
@@ -45,10 +47,13 @@ export class MCPServerModal extends Modal {
 					command: '',
 					args: [],
 					url: undefined,
-					env: undefined,
 					enabled: true,
 					trustedTools: [],
 				};
+
+		// Env values live in SecretStorage, not on the config object. Load them
+		// into a working copy; writeServerEnv() persists them back on save.
+		this.env = config ? resolveServerEnv(app, config) : undefined;
 
 		if (this.isEdit) {
 			// Pre-populate from the connected server's tool list if available.
@@ -166,12 +171,12 @@ export class MCPServerModal extends Modal {
 			// Environment variables
 			new Setting(contentEl)
 				.setName('Environment variables')
-				.setDesc('Optional KEY=VALUE pairs, one per line')
+				.setDesc('Optional KEY=VALUE pairs, one per line. Values are stored in your OS keychain, not in plaintext.')
 				.addTextArea((text) => {
 					text.inputEl.rows = 2;
 					text.inputEl.cols = 40;
-					const envStr = this.config.env
-						? Object.entries(this.config.env)
+					const envStr = this.env
+						? Object.entries(this.env)
 								.map(([k, v]) => `${k}=${v}`)
 								.join('\n')
 						: '';
@@ -187,7 +192,7 @@ export class MCPServerModal extends Modal {
 									const eqIndex = line.indexOf('=');
 									return [line.substring(0, eqIndex).trim(), line.substring(eqIndex + 1).trim()] as [string, string];
 								});
-							this.config.env = entries.length > 0 ? Object.fromEntries(entries) : undefined;
+							this.env = entries.length > 0 ? Object.fromEntries(entries) : undefined;
 						});
 				});
 		}
@@ -279,6 +284,8 @@ export class MCPServerModal extends Modal {
 								new Notice('Command is required for stdio transport');
 								return;
 							}
+							// Persist env vars to SecretStorage; sets config.envSecretName.
+							writeServerEnv(this.app, this.config, this.env);
 						}
 						await this.onSave(this.config);
 						this.close();

--- a/src/ui/settings-mcp.ts
+++ b/src/ui/settings-mcp.ts
@@ -1,6 +1,7 @@
 import type ObsidianGemini from '../main';
 import { App, Setting, Notice, setIcon } from 'obsidian';
 import { sanitizeKeySegment } from '../mcp/mcp-oauth-provider';
+import { clearServerEnv } from '../mcp/mcp-secrets';
 import { getErrorMessage } from '../utils/error-utils';
 import { createCollapsibleSection } from './settings-helpers';
 import type { SettingsSectionContext } from './settings';
@@ -148,6 +149,8 @@ async function createMCPSettings(
 							if (mcpManager?.isConnected(server.name)) {
 								await mcpManager.disconnectServer(server.name);
 							}
+							// Remove the server's env vars from the keychain.
+							clearServerEnv(app, server);
 							plugin.settings.mcpServers = plugin.settings.mcpServers.filter((s) => s.name !== server.name);
 							await plugin.saveSettings();
 							context.redisplay();

--- a/test/mcp/mcp-manager.test.ts
+++ b/test/mcp/mcp-manager.test.ts
@@ -679,12 +679,11 @@ describe('MCPManager', () => {
 	});
 
 	describe('connectServer - env vars', () => {
-		it('should pass merged env to StdioClientTransport when env is provided', async () => {
+		it('should resolve env from SecretStorage and pass it to StdioClientTransport', async () => {
 			mockListTools.mockResolvedValueOnce({ tools: [] });
 
-			const config = createStdioConfig({
-				env: { MY_VAR: 'hello', ANOTHER: 'world' },
-			});
+			plugin.app.secretStorage.setSecret('mcp-env-test', JSON.stringify({ MY_VAR: 'hello', ANOTHER: 'world' }));
+			const config = createStdioConfig({ envSecretName: 'mcp-env-test' });
 
 			await manager.connectServer(config);
 
@@ -696,6 +695,14 @@ describe('MCPManager', () => {
 					}),
 				})
 			);
+		});
+
+		it('should pass env: undefined when the server has no envSecretName', async () => {
+			mockListTools.mockResolvedValueOnce({ tools: [] });
+
+			await manager.connectServer(createStdioConfig());
+
+			expect(MockStdioClientTransport).toHaveBeenCalledWith(expect.objectContaining({ env: undefined }));
 		});
 	});
 });

--- a/test/mcp/mcp-secrets.test.ts
+++ b/test/mcp/mcp-secrets.test.ts
@@ -1,0 +1,210 @@
+import {
+	makeEnvSecretName,
+	resolveServerEnv,
+	writeServerEnv,
+	clearServerEnv,
+	migrateServerEnvToSecretStorage,
+} from '../../src/mcp/mcp-secrets';
+import { MCPServerConfig, MCP_TRANSPORT_STDIO } from '../../src/mcp/types';
+
+// Mock Obsidian's App with a working SecretStorage backed by a Map.
+function createMockApp() {
+	const secrets = new Map<string, string>();
+	return {
+		secretStorage: {
+			getSecret: vi.fn((id: string) => secrets.get(id) ?? null),
+			setSecret: vi.fn((id: string, value: string) => {
+				if (value === '') {
+					secrets.delete(id);
+				} else {
+					secrets.set(id, value);
+				}
+			}),
+			listSecrets: vi.fn(() => Array.from(secrets.keys())),
+		},
+	} as any;
+}
+
+function makeConfig(overrides?: Partial<MCPServerConfig>): MCPServerConfig {
+	return {
+		name: 'test-server',
+		transport: MCP_TRANSPORT_STDIO,
+		command: 'npx',
+		args: [],
+		enabled: true,
+		trustedTools: [],
+		...overrides,
+	};
+}
+
+/** Attach a legacy plaintext `env` field (removed from the type) for migration tests. */
+function withLegacyEnv(config: MCPServerConfig, env: unknown): MCPServerConfig {
+	(config as { env?: unknown }).env = env;
+	return config;
+}
+
+describe('makeEnvSecretName', () => {
+	it('prefixes the key and includes the sanitized server name', () => {
+		const key = makeEnvSecretName('My Server');
+		expect(key.startsWith('mcp-env-my-server-')).toBe(true);
+	});
+
+	it('produces unique keys for the same name (random suffix)', () => {
+		expect(makeEnvSecretName('foo')).not.toBe(makeEnvSecretName('foo'));
+	});
+});
+
+describe('resolveServerEnv', () => {
+	it('returns undefined when the config has no envSecretName', () => {
+		const app = createMockApp();
+		expect(resolveServerEnv(app, makeConfig())).toBeUndefined();
+	});
+
+	it('returns undefined when the referenced secret does not exist', () => {
+		const app = createMockApp();
+		expect(resolveServerEnv(app, makeConfig({ envSecretName: 'missing' }))).toBeUndefined();
+	});
+
+	it('parses and returns a stored env blob', () => {
+		const app = createMockApp();
+		app.secretStorage.setSecret('k', JSON.stringify({ API_KEY: 'abc', HOME: '/tmp' }));
+		expect(resolveServerEnv(app, makeConfig({ envSecretName: 'k' }))).toEqual({ API_KEY: 'abc', HOME: '/tmp' });
+	});
+
+	it('returns undefined for an empty stored blob', () => {
+		const app = createMockApp();
+		app.secretStorage.setSecret('k', '{}');
+		expect(resolveServerEnv(app, makeConfig({ envSecretName: 'k' }))).toBeUndefined();
+	});
+
+	it('returns undefined for a corrupt (unparseable) blob', () => {
+		const app = createMockApp();
+		app.secretStorage.setSecret('k', 'not-json{');
+		expect(resolveServerEnv(app, makeConfig({ envSecretName: 'k' }))).toBeUndefined();
+	});
+});
+
+describe('writeServerEnv', () => {
+	it('generates an envSecretName and stores the blob on first write', () => {
+		const app = createMockApp();
+		const config = makeConfig();
+		writeServerEnv(app, config, { TOKEN: 'xyz' });
+		expect(config.envSecretName).toMatch(/^mcp-env-test-server-/);
+		expect(resolveServerEnv(app, config)).toEqual({ TOKEN: 'xyz' });
+	});
+
+	it('reuses an existing envSecretName', () => {
+		const app = createMockApp();
+		const config = makeConfig({ envSecretName: 'existing-key' });
+		writeServerEnv(app, config, { TOKEN: 'xyz' });
+		expect(config.envSecretName).toBe('existing-key');
+		expect(app.secretStorage.getSecret('existing-key')).toBe(JSON.stringify({ TOKEN: 'xyz' }));
+	});
+
+	it('clears the stored secret when env is emptied', () => {
+		const app = createMockApp();
+		const config = makeConfig();
+		writeServerEnv(app, config, { TOKEN: 'xyz' });
+		const key = config.envSecretName!;
+		writeServerEnv(app, config, {});
+		expect(app.secretStorage.getSecret(key)).toBeNull();
+	});
+
+	it('is a no-op when env is empty and no secret exists', () => {
+		const app = createMockApp();
+		const config = makeConfig();
+		writeServerEnv(app, config, undefined);
+		expect(config.envSecretName).toBeUndefined();
+		expect(app.secretStorage.setSecret).not.toHaveBeenCalled();
+	});
+
+	it('round-trips through resolveServerEnv', () => {
+		const app = createMockApp();
+		const config = makeConfig();
+		const env = { A: '1', B: '2' };
+		writeServerEnv(app, config, env);
+		expect(resolveServerEnv(app, config)).toEqual(env);
+	});
+});
+
+describe('clearServerEnv', () => {
+	it('removes the stored secret', () => {
+		const app = createMockApp();
+		const config = makeConfig();
+		writeServerEnv(app, config, { TOKEN: 'xyz' });
+		const key = config.envSecretName!;
+		clearServerEnv(app, config);
+		expect(app.secretStorage.getSecret(key)).toBeNull();
+	});
+
+	it('is a no-op when the config has no envSecretName', () => {
+		const app = createMockApp();
+		expect(() => clearServerEnv(app, makeConfig())).not.toThrow();
+		expect(app.secretStorage.setSecret).not.toHaveBeenCalled();
+	});
+});
+
+describe('migrateServerEnvToSecretStorage', () => {
+	it('returns false for an undefined server list', () => {
+		expect(migrateServerEnvToSecretStorage(createMockApp(), undefined)).toBe(false);
+	});
+
+	it('returns false when no server carries a legacy env field', () => {
+		expect(migrateServerEnvToSecretStorage(createMockApp(), [makeConfig()])).toBe(false);
+	});
+
+	it('moves a plaintext env into SecretStorage and drops the legacy field', () => {
+		const app = createMockApp();
+		const server = withLegacyEnv(makeConfig({ name: 'brave' }), { BRAVE_API_KEY: 'secret' });
+
+		const changed = migrateServerEnvToSecretStorage(app, [server]);
+
+		expect(changed).toBe(true);
+		expect((server as { env?: unknown }).env).toBeUndefined();
+		expect(server.envSecretName).toMatch(/^mcp-env-brave-/);
+		expect(resolveServerEnv(app, server)).toEqual({ BRAVE_API_KEY: 'secret' });
+	});
+
+	it('drops a stray empty env field without creating a secret', () => {
+		const app = createMockApp();
+		const server = withLegacyEnv(makeConfig(), {});
+
+		const changed = migrateServerEnvToSecretStorage(app, [server]);
+
+		expect(changed).toBe(true);
+		expect((server as { env?: unknown }).env).toBeUndefined();
+		expect(server.envSecretName).toBeUndefined();
+	});
+
+	it('does not re-migrate a server that already has an envSecretName', () => {
+		const app = createMockApp();
+		const server = withLegacyEnv(makeConfig({ envSecretName: 'already-there' }), { K: 'v' });
+
+		const changed = migrateServerEnvToSecretStorage(app, [server]);
+
+		// The stray plaintext field is dropped, but the existing pointer is untouched.
+		expect(changed).toBe(true);
+		expect((server as { env?: unknown }).env).toBeUndefined();
+		expect(server.envSecretName).toBe('already-there');
+		expect(app.secretStorage.getSecret('already-there')).toBeNull();
+	});
+
+	it('keeps the plaintext and logs an error when verification fails', () => {
+		const secrets = new Map<string, string>();
+		const app = {
+			secretStorage: {
+				getSecret: vi.fn((id: string) => secrets.get(id) ?? null),
+				setSecret: vi.fn(), // write silently fails — read-back will not match
+			},
+		} as any;
+		const logger = { error: vi.fn() } as any;
+		const server = withLegacyEnv(makeConfig({ name: 'flaky' }), { K: 'v' });
+
+		const changed = migrateServerEnvToSecretStorage(app, [server], logger);
+
+		expect(changed).toBe(false);
+		expect((server as { env?: unknown }).env).toEqual({ K: 'v' });
+		expect(server.envSecretName).toBeUndefined();
+		expect(logger.error).toHaveBeenCalled();
+	});
+});

--- a/test/mcp/mcp-secrets.test.ts
+++ b/test/mcp/mcp-secrets.test.ts
@@ -125,6 +125,16 @@ describe('writeServerEnv', () => {
 		writeServerEnv(app, config, env);
 		expect(resolveServerEnv(app, config)).toEqual(env);
 	});
+
+	it('throws when a non-empty write cannot be verified', () => {
+		const app = {
+			secretStorage: {
+				getSecret: vi.fn(() => null),
+				setSecret: vi.fn(), // write silently fails — read-back will not match
+			},
+		} as any;
+		expect(() => writeServerEnv(app, makeConfig(), { TOKEN: 'x' })).toThrow(/SecretStorage/);
+	});
 });
 
 describe('clearServerEnv', () => {


### PR DESCRIPTION
## Summary

MCP stdio server environment variables — for which the docs cite API keys and tokens (`BRAVE_API_KEY`, `GITHUB_TOKEN`) as the canonical use case — were serialized in **plaintext** to `data.json`, while OAuth tokens and the Gemini API key already use Obsidian's `SecretStorage`. This PR closes that inconsistency by migrating stdio `env` to the OS keychain, following the existing `apiKeySecretName` pattern.

Fixes #444

## Changes

- **`MCPServerConfig.env` → `envSecretName`** — the config now stores only a pointer; the values live in `SecretStorage` as a JSON blob. A pointer field (vs. a name-derived key) keeps the migration rename-safe.
- **New `src/mcp/mcp-secrets.ts`** — `resolveServerEnv` / `writeServerEnv` / `clearServerEnv` helpers, plus `migrateServerEnvToSecretStorage`, a one-time **verify-before-delete** migration of legacy plaintext `env` (on read-back mismatch the plaintext is kept and an error is logged).
- **`main.ts loadSettings()`** — runs the migration, **desktop-only**: `env` feeds stdio servers, which never run on mobile, so a mobile device can't strip `env` from a synced `data.json` before a desktop copies it into its own (non-syncing) keychain.
- **`mcp-manager.ts`** — resolves `env` from `SecretStorage` at connect time.
- **`mcp-server-modal.ts`** — loads/saves `env` through `SecretStorage`; the env field description now states values are keychain-stored, not plaintext.
- **`settings-mcp.ts`** — deleting a server clears its env secret so credentials don't linger.
- **Docs** — `docs/guide/mcp-servers.md` and `docs/reference/settings.md` updated (the stale "stored in `data.json`" warning is replaced; adds the per-device, non-syncing caveat).
- **Tests** — new `test/mcp/mcp-secrets.test.ts` (20 tests: resolve/write/clear round-trips, migration verify/empty/already-migrated/mismatch paths); `mcp-manager.test.ts` updated to the new model.

## Screenshots / Screencast

No layout change. The only UI delta is one description string under the stdio **Environment variables** field: now reads "Values are stored in your OS keychain, not in plaintext."

## Verification

- `npm run build` — clean (incl. `tsc -noEmit`)
- `npm test` — **2825 passed** (+21 new); `npm run typecheck:test` — clean
- `npm run lint` and `npm run format-check` — clean
- Manual Obsidian desktop smoke-testing not yet performed — flagged in the checklist below.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer — #444, filed by the maintainer, lists this migration as option 1.
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [ ] I have tested this change on Desktop — verified via the automated suite (build + 2825 tests, 20 new); manual in-Obsidian smoke test still pending.
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — the migration is gated behind `!app.isMobile`; stdio `env` is already desktop-only.
- [x] Documentation has been updated (if applicable)
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR


---
_Generated by [Claude Code](https://claude.ai/code/session_01C2ueyYtUJr9RY8gbwDuY1s)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MCP server environment variables are now stored securely in the OS keychain (SecretStorage) instead of plaintext config.

* **Documentation**
  * Guides updated to explain entering KEY=VALUE lines, that values are stored in the OS keychain, and do not sync across devices (re-enter per machine).
  * Server configuration docs updated to reference secret key names instead of plaintext env.

* **Chores / Migration**
  * Desktop-only one‑time migration moves existing plaintext env to secure storage and clears plaintext.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/allenhutchison/obsidian-gemini/pull/838?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->