### PR TITLE
feat: stabilize system prompt prefix caching (#763)

### DIFF
--- a/prompts/systemPrompt.hbs
+++ b/prompts/systemPrompt.hbs
@@ -60,9 +60,3 @@ or a web search.
 
 {{{additionalInstructions}}}
 {{/if}}
-{{#if perTurnContext}}
-
-## Turn Context
-
-{{{perTurnContext}}}
-{{/if}}

--- a/src/agent/agent-loop-helpers.ts
+++ b/src/agent/agent-loop-helpers.ts
@@ -158,10 +158,19 @@ export function buildFunctionResponseParts(toolResults: ToolCallResultPair[]): P
 export function buildToolHistoryTurns(args: {
 	conversationHistory: Content[];
 	userMessage: string;
+	perTurnContext?: string;
 	toolCalls: ToolCall[];
 	toolResults: ToolCallResultPair[];
 }): Content[] {
-	const { conversationHistory, userMessage, toolCalls, toolResults } = args;
+	const { conversationHistory, userMessage, perTurnContext, toolCalls, toolResults } = args;
+
+	const userParts: Part[] = [];
+	if (userMessage && userMessage.trim()) {
+		userParts.push({ text: userMessage });
+	}
+	if (perTurnContext && perTurnContext.trim()) {
+		userParts.push({ text: perTurnContext });
+	}
 
 	const updated: Content[] = [
 		...conversationHistory,
@@ -169,10 +178,10 @@ export function buildToolHistoryTurns(args: {
 		{ role: 'user', parts: buildFunctionResponseParts(toolResults) },
 	];
 
-	if (userMessage && userMessage.trim()) {
+	if (userParts.length > 0) {
 		updated.splice(conversationHistory.length, 0, {
 			role: 'user',
-			parts: [{ text: userMessage }],
+			parts: userParts,
 		});
 	}
 

--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -179,6 +179,11 @@ export class AgentLoop {
 		let currentToolCalls = initialResponse.toolCalls ?? [];
 		let conversationHistory = initialHistory;
 		let userMessage = initialUserMessage;
+		// `perTurnContext` is a first-iteration input, like `userMessage`:
+		// `buildToolHistoryTurns` splices it into the user turn once, after which
+		// it lives in `conversationHistory`. Re-passing it on later iterations
+		// would splice the (potentially large) context payload in again each time.
+		let perTurnContext = perTurn?.perTurnContext;
 		let iterations = 0;
 		// Turn-scoped count of tool-loop-detector fires. Incremented per blocked
 		// call (each `ToolResult` with `loopDetected: true`). Once it reaches
@@ -236,7 +241,7 @@ export class AgentLoop {
 				const updatedHistory = buildToolHistoryTurns({
 					conversationHistory,
 					userMessage,
-					perTurnContext: perTurn?.perTurnContext,
+					perTurnContext,
 					toolCalls: currentToolCalls,
 					toolResults,
 				});
@@ -262,7 +267,7 @@ export class AgentLoop {
 			const updatedHistory = buildToolHistoryTurns({
 				conversationHistory,
 				userMessage,
-				perTurnContext: perTurn?.perTurnContext,
+				perTurnContext,
 				toolCalls: currentToolCalls,
 				toolResults,
 			});
@@ -301,7 +306,10 @@ export class AgentLoop {
 				}
 				currentToolCalls = followUpResponse.toolCalls;
 				conversationHistory = updatedHistory;
+				// Both are now embedded in `updatedHistory`; clearing them stops the
+				// next iteration from splicing a duplicate user/context turn.
 				userMessage = ''; // Empty on follow-up — tool results are already in history
+				perTurnContext = undefined;
 				continue;
 			}
 

--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -236,6 +236,7 @@ export class AgentLoop {
 				const updatedHistory = buildToolHistoryTurns({
 					conversationHistory,
 					userMessage,
+					perTurnContext: perTurn?.perTurnContext,
 					toolCalls: currentToolCalls,
 					toolResults,
 				});
@@ -261,6 +262,7 @@ export class AgentLoop {
 			const updatedHistory = buildToolHistoryTurns({
 				conversationHistory,
 				userMessage,
+				perTurnContext: perTurn?.perTurnContext,
 				toolCalls: currentToolCalls,
 				toolResults,
 			});

--- a/src/api/providers/gemini/client.ts
+++ b/src/api/providers/gemini/client.ts
@@ -236,7 +236,6 @@ export class GeminiClient implements ModelApi {
 				agentsMemory,
 				availableSkills,
 				extReq.projectInstructions,
-				extReq.perTurnContext ?? extReq.prompt,
 				extReq.sessionStartedAt
 			);
 		} else {
@@ -352,6 +351,11 @@ export class GeminiClient implements ModelApi {
 		// Add text content if present
 		if (extReq.userMessage && extReq.userMessage.trim()) {
 			userParts.push({ text: extReq.userMessage });
+		}
+
+		// Add per-turn files and context if present
+		if (extReq.perTurnContext && extReq.perTurnContext.trim()) {
+			userParts.push({ text: extReq.perTurnContext });
 		}
 
 		// Add inline data attachments (images, audio, video, PDF)

--- a/src/api/providers/ollama/client.ts
+++ b/src/api/providers/ollama/client.ts
@@ -247,6 +247,9 @@ export class OllamaClient implements ModelApi {
 		if (request.userMessage && request.userMessage.trim()) {
 			userParts.push(request.userMessage);
 		}
+		if (request.perTurnContext && request.perTurnContext.trim()) {
+			userParts.push(request.perTurnContext);
+		}
 		const allAttachments: InlineDataPart[] = [
 			...(request.inlineAttachments || []),
 			...(request.imageAttachments || []),
@@ -312,7 +315,6 @@ export class OllamaClient implements ModelApi {
 			agentsMemory,
 			availableSkills,
 			request.projectInstructions,
-			request.perTurnContext ?? request.prompt,
 			request.sessionStartedAt
 		);
 	}

--- a/src/prompts/gemini-prompts.ts
+++ b/src/prompts/gemini-prompts.ts
@@ -132,7 +132,6 @@ export class GeminiPrompts {
 		agentsMemory?: string | null,
 		availableSkills?: { name: string; description: string }[],
 		projectInstructions?: string,
-		perTurnContext?: string,
 		sessionStartedAt?: string
 	): string {
 		// If custom prompt with override is provided, return only that
@@ -175,7 +174,6 @@ export class GeminiPrompts {
 			agentRulesSection,
 			toolCatalogSection,
 			additionalInstructions,
-			perTurnContext: perTurnContext || '',
 		});
 	}
 }

--- a/src/ui/agent-view/agent-view-tool-followup.ts
+++ b/src/ui/agent-view/agent-view-tool-followup.ts
@@ -47,7 +47,6 @@ export function buildFollowUpRequest(params: FollowUpRequestParams): ExtendedMod
 		projectRootPath,
 		featureToolPolicy,
 		headless,
-		perTurnContext,
 		projectInstructions,
 		projectSkills,
 		sessionStartedAt,
@@ -68,17 +67,20 @@ export function buildFollowUpRequest(params: FollowUpRequestParams): ExtendedMod
 
 	const modelConfig = currentSession?.modelConfig || {};
 
+	// `perTurnContext` is deliberately omitted: `buildToolHistoryTurns` already
+	// spliced it into the user turn of `updatedHistory`. Passing it here too
+	// would make `buildContents` append it a second time, duplicating the
+	// (potentially large) context payload on every tool iteration.
 	return {
 		userMessage: '', // Empty since tool results are already in conversation history
 		conversationHistory: updatedHistory,
 		model: modelConfig.model || plugin.settings.chatModelName,
 		temperature: modelConfig.temperature ?? plugin.settings.temperature,
 		topP: modelConfig.topP ?? plugin.settings.topP,
-		prompt: '', // Unused in agent pipeline — perTurnContext carries context instead
+		prompt: '', // Unused in agent pipeline — context lives in conversationHistory
 		customPrompt,
 		projectInstructions,
 		projectSkills,
-		perTurnContext,
 		sessionStartedAt,
 		renderContent: false,
 		availableTools, // Include tools so model can chain calls
@@ -90,29 +92,22 @@ export function buildFollowUpRequest(params: FollowUpRequestParams): ExtendedMod
  * Does not include tools — just asks the model to summarize what it did.
  */
 export function buildRetryRequest(params: RetryRequestParams): ExtendedModelRequest {
-	const {
-		plugin,
-		currentSession,
-		updatedHistory,
-		customPrompt,
-		perTurnContext,
-		projectInstructions,
-		projectSkills,
-		sessionStartedAt,
-	} = params;
+	const { plugin, currentSession, updatedHistory, customPrompt, projectInstructions, projectSkills, sessionStartedAt } =
+		params;
 	const modelConfig = currentSession?.modelConfig || {};
 
+	// `perTurnContext` is deliberately omitted — see `buildFollowUpRequest`:
+	// it is already embedded in `updatedHistory` via `buildToolHistoryTurns`.
 	return {
 		userMessage: 'Please summarize what you just did with the tools.',
 		conversationHistory: updatedHistory,
 		model: modelConfig.model || plugin.settings.chatModelName,
 		temperature: modelConfig.temperature ?? plugin.settings.temperature,
 		topP: modelConfig.topP ?? plugin.settings.topP,
-		prompt: '', // Unused in agent pipeline — perTurnContext carries context instead
+		prompt: '', // Unused in agent pipeline — context lives in conversationHistory
 		customPrompt,
 		projectInstructions,
 		projectSkills,
-		perTurnContext,
 		sessionStartedAt,
 		renderContent: false,
 	};

--- a/test/agent/agent-loop-helpers.test.ts
+++ b/test/agent/agent-loop-helpers.test.ts
@@ -370,6 +370,42 @@ describe('buildToolHistoryTurns', () => {
 		expect(updated[4].role).toBe('user');
 	});
 
+	test('merges userMessage and perTurnContext into a single spliced user turn', () => {
+		const updated = buildToolHistoryTurns({
+			conversationHistory: sampleHistory,
+			userMessage: 'user query text',
+			perTurnContext: 'context files content...',
+			toolCalls: [sampleToolCall],
+			toolResults: [sampleResult],
+		});
+
+		expect(updated).toHaveLength(5); // 2 prior + user combined + model + user response
+		expect(updated[2]).toEqual({
+			role: 'user',
+			parts: [{ text: 'user query text' }, { text: 'context files content...' }],
+		});
+		expect(updated[3].role).toBe('model');
+		expect(updated[4].role).toBe('user');
+	});
+
+	test('splices user turn with only perTurnContext when userMessage is empty', () => {
+		const updated = buildToolHistoryTurns({
+			conversationHistory: sampleHistory,
+			userMessage: '',
+			perTurnContext: 'only context files...',
+			toolCalls: [sampleToolCall],
+			toolResults: [sampleResult],
+		});
+
+		expect(updated).toHaveLength(5);
+		expect(updated[2]).toEqual({
+			role: 'user',
+			parts: [{ text: 'only context files...' }],
+		});
+		expect(updated[3].role).toBe('model');
+		expect(updated[4].role).toBe('user');
+	});
+
 	test('treats whitespace-only userMessage as empty (no splice)', () => {
 		const updated = buildToolHistoryTurns({
 			conversationHistory: sampleHistory,

--- a/test/agent/agent-loop.test.ts
+++ b/test/agent/agent-loop.test.ts
@@ -1,7 +1,7 @@
 import type { Mock } from 'vitest';
 import { AgentLoop } from '../../src/agent/agent-loop';
 import type { ToolCall, ModelResponse, ModelApi } from '../../src/api/interfaces/model-api';
-import type { IConfirmationProvider, ToolResult } from '../../src/tools/types';
+import type { IConfirmationProvider } from '../../src/tools/types';
 
 // None of these tests exercise the confirmation UI branch (enabledTools/requireConfirmation
 // are empty, so no tool requires confirmation) — the loop only needs *some* provider to
@@ -738,15 +738,21 @@ describe('AgentLoop', () => {
 	});
 
 	describe('per-turn context propagation', () => {
-		// The system prompt is rebuilt on each model call inside the loop. Per-turn
-		// fields (perTurnContext, projectInstructions, projectSkills, sessionStartedAt)
-		// must be threaded onto every follow-up request so the system prompt stays
-		// byte-stable across initial + follow-ups. Without this:
-		//   1. Context-file content the user dragged in disappears once a tool fires,
-		//      forcing the model to re-read via tools.
-		//   2. Gemini implicit prefix cache misses on every follow-up because the
-		//      system-prompt prefix changes shape mid-turn.
-		test('follow-up request carries the same perTurn context the initial call had', async () => {
+		// Count text parts across a request's conversationHistory that exactly
+		// equal `text` — used to assert the per-turn context appears once, not
+		// duplicated.
+		const countContext = (history: any[], text: string): number =>
+			(history ?? []).flatMap((c: any) => c.parts ?? []).filter((p: any) => p?.text === text).length;
+
+		// `buildToolHistoryTurns` splices `perTurnContext` into the user turn of
+		// the history it builds, so it reaches the model via `conversationHistory`.
+		// It must NOT also ride on the follow-up/retry request: `buildContents`
+		// would then append a second copy, duplicating the (potentially large)
+		// context payload on every tool iteration — the opposite of the caching
+		// win this design exists for. Session-static fields (projectInstructions,
+		// projectSkills, sessionStartedAt) still thread onto every request because
+		// they feed the byte-stable system prompt.
+		test('follow-up request keeps per-turn context in history, not duplicated on the request', async () => {
 			const plugin = buildPlugin();
 			const session = buildSession();
 			const api = makeScriptedModelApi([textResponse('done')]);
@@ -773,13 +779,17 @@ describe('AgentLoop', () => {
 
 			expect(api.generateModelResponse).toHaveBeenCalledTimes(1);
 			const followUpRequest = (api.generateModelResponse as Mock).mock.calls[0][0];
-			expect(followUpRequest.perTurnContext).toBe('CONTEXT FILES: foo.md\n<rendered contents>');
+			// Not on the request — otherwise buildContents appends a second copy.
+			expect(followUpRequest.perTurnContext).toBeUndefined();
+			// Still reaches the model, exactly once, via conversation history.
+			expect(countContext(followUpRequest.conversationHistory, 'CONTEXT FILES: foo.md\n<rendered contents>')).toBe(1);
+			// Session-static fields still thread through.
 			expect(followUpRequest.projectInstructions).toBe('be concise');
 			expect(followUpRequest.projectSkills).toEqual(['code-review']);
 			expect(followUpRequest.sessionStartedAt).toBe('2026-05-09T10:00:00');
 		});
 
-		test('retry request (empty-response path) also carries perTurn context', async () => {
+		test('retry request (empty-response path) keeps per-turn context in history, not on the request', async () => {
 			const plugin = buildPlugin();
 			const session = buildSession();
 			// First follow-up returns empty → triggers retry path.
@@ -806,11 +816,12 @@ describe('AgentLoop', () => {
 			expect(result.retried).toBe(true);
 			expect(api.generateModelResponse).toHaveBeenCalledTimes(2);
 			const retryRequest = (api.generateModelResponse as Mock).mock.calls[1][0];
-			expect(retryRequest.perTurnContext).toBe('CTX');
+			expect(retryRequest.perTurnContext).toBeUndefined();
+			expect(countContext(retryRequest.conversationHistory, 'CTX')).toBe(1);
 			expect(retryRequest.sessionStartedAt).toBe('2026-05-09T10:00:00');
 		});
 
-		test('multi-iteration: every follow-up carries perTurn context, not just the first', async () => {
+		test('multi-iteration: per-turn context stays in history exactly once across all follow-ups', async () => {
 			const plugin = buildPlugin();
 			const session = buildSession();
 			const api = makeScriptedModelApi([
@@ -835,8 +846,12 @@ describe('AgentLoop', () => {
 
 			const calls = (api.generateModelResponse as Mock).mock.calls;
 			expect(calls).toHaveLength(2);
-			expect(calls[0][0].perTurnContext).toBe('CTX');
-			expect(calls[1][0].perTurnContext).toBe('CTX');
+			// Never on the request, and never accumulating across iterations:
+			// exactly one copy lives in each follow-up's conversation history.
+			expect(calls[0][0].perTurnContext).toBeUndefined();
+			expect(calls[1][0].perTurnContext).toBeUndefined();
+			expect(countContext(calls[0][0].conversationHistory, 'CTX')).toBe(1);
+			expect(countContext(calls[1][0].conversationHistory, 'CTX')).toBe(1);
 		});
 	});
 

--- a/test/api/providers/gemini/client.test.ts
+++ b/test/api/providers/gemini/client.test.ts
@@ -246,7 +246,7 @@ describe('GeminiClient', () => {
 			(mockPlugin as any).settings = { userName: 'Tester', ragIndexing: { enabled: false } };
 		});
 
-		test('embeds perTurnContext under "## Turn Context" in systemInstruction', async () => {
+		test('transmits perTurnContext directly as a user message content part', async () => {
 			const renderedContext =
 				'CONTEXT FILES: places.md\n\n==============================\nFile Label: Context File\nFile Name: places.md\n==============================\n\nMachu Picchu, Petra, the Great Wall.';
 
@@ -263,18 +263,24 @@ describe('GeminiClient', () => {
 
 			expect(generateContentMock).toHaveBeenCalledTimes(1);
 			const params = (generateContentMock as Mock).mock.calls[0][0];
+
+			// System instruction should be static (no perTurnContext!)
 			expect(params.config.systemInstruction).toBeTruthy();
-			expect(params.config.systemInstruction).toContain('## Turn Context');
-			expect(params.config.systemInstruction).toContain('Machu Picchu, Petra, the Great Wall.');
+			expect(params.config.systemInstruction).not.toContain('## Turn Context');
+			expect(params.config.systemInstruction).not.toContain('Machu Picchu, Petra, the Great Wall.');
 			expect(params.config.systemInstruction).toContain('always cite paths');
 			expect(params.config.systemInstruction).toContain('2026-05-09T10:00:00');
+
+			// User contents must contain perTurnContext as a part
+			expect(params.contents).toBeDefined();
+			const userTurn = params.contents.find((turn: any) => turn.role === 'user');
+			expect(userTurn).toBeDefined();
+			expect(userTurn.parts).toHaveLength(2); // Text query + context files
+			expect(userTurn.parts[0].text).toBe('list the places');
+			expect(userTurn.parts[1].text).toBe(renderedContext);
 		});
 
-		test('omits "## Turn Context" section when perTurnContext is empty', async () => {
-			// Without a per-turn context (e.g. a chat with no chip files), the
-			// section should not appear in the system instruction. This guards
-			// against accidentally always-injecting an empty heading that would
-			// shift the prefix bytes Gemini's implicit cache keys on.
+		test('omits perTurnContext when it is empty', async () => {
 			await client.generateModelResponse({
 				prompt: '',
 				userMessage: 'just chat',
@@ -283,7 +289,12 @@ describe('GeminiClient', () => {
 
 			expect(generateContentMock).toHaveBeenCalledTimes(1);
 			const params = (generateContentMock as Mock).mock.calls[0][0];
-			expect(params.config.systemInstruction).not.toContain('## Turn Context');
+
+			// Should only have the userMessage text part
+			const userTurn = params.contents.find((turn: any) => turn.role === 'user');
+			expect(userTurn).toBeDefined();
+			expect(userTurn.parts).toHaveLength(1);
+			expect(userTurn.parts[0].text).toBe('just chat');
 		});
 	});
 

--- a/test/api/providers/ollama/client.test.ts
+++ b/test/api/providers/ollama/client.test.ts
@@ -194,7 +194,7 @@ describe('OllamaClient', () => {
 		// dropped/@-mentioned files without a redundant `read_file` tool call.
 		// This test asserts the wiring on the initial request — see
 		// agent-loop.test.ts for the follow-up propagation guarantee.
-		it('embeds perTurnContext into the system message under "## Turn Context"', async () => {
+		it('transmits perTurnContext directly inside the user message', async () => {
 			ollamaCalls.chat.mockResolvedValue({
 				message: { role: 'assistant', content: 'ok' },
 				prompt_eval_count: 1,
@@ -215,12 +215,20 @@ describe('OllamaClient', () => {
 			});
 
 			const args = ollamaCalls.chat.mock.calls[0][0];
+
+			// System message should be static (no perTurnContext!)
 			const systemMessage = args.messages.find((m: any) => m.role === 'system');
 			expect(systemMessage).toBeDefined();
-			expect(systemMessage.content).toContain('## Turn Context');
-			expect(systemMessage.content).toContain('The quick brown fox jumps over the lazy dog.');
+			expect(systemMessage.content).not.toContain('## Turn Context');
+			expect(systemMessage.content).not.toContain('The quick brown fox jumps over the lazy dog.');
 			expect(systemMessage.content).toContain('always cite file paths');
 			expect(systemMessage.content).toContain('2026-05-09T10:00:00');
+
+			// User message must contain both query and perTurnContext joined
+			const userMessage = args.messages[args.messages.length - 1];
+			expect(userMessage.role).toBe('user');
+			expect(userMessage.content).toContain('what does the file say');
+			expect(userMessage.content).toContain(renderedContext);
 		});
 
 		it('rejects non-image attachments with a clear error', async () => {

--- a/test/prompts/gemini-prompts.test.ts
+++ b/test/prompts/gemini-prompts.test.ts
@@ -84,7 +84,6 @@ describe('GeminiPrompts', () => {
 			null, // agentsMemory
 			undefined, // availableSkills
 			undefined, // projectInstructions
-			undefined, // perTurnContext
 		] as const;
 
 		it('returns byte-identical output across calls with the same sessionStartedAt', () => {

--- a/test/ui/agent-view/agent-view-tool-followup.test.ts
+++ b/test/ui/agent-view/agent-view-tool-followup.test.ts
@@ -1,0 +1,77 @@
+import { describe, test, expect, vi } from 'vitest';
+import type { Content } from '@google/genai';
+import { buildFollowUpRequest, buildRetryRequest } from '../../../src/ui/agent-view/agent-view-tool-followup';
+import { buildToolHistoryTurns, type ToolCallResultPair } from '../../../src/agent/agent-loop-helpers';
+import type { ToolCall } from '../../../src/api/interfaces/model-api';
+
+const PER_TURN_CONTEXT = 'CONTEXT FILES: probe note content with unique facts';
+
+function makePlugin() {
+	return {
+		settings: { chatModelName: 'gemini-3-flash-preview', temperature: 0.7, topP: 0.95 },
+		toolRegistry: {
+			getEnabledTools: vi.fn().mockReturnValue([{ name: 'read_file' }]),
+			getAutoApprovedTools: vi.fn().mockReturnValue([{ name: 'read_file' }]),
+		},
+	} as any;
+}
+
+const currentSession = { modelConfig: {} } as any;
+
+// Count text parts across a Content[] that exactly equal the per-turn context.
+function countContextOccurrences(history: Content[]): number {
+	return history.flatMap((c) => c.parts ?? []).filter((p) => 'text' in p && p.text === PER_TURN_CONTEXT).length;
+}
+
+describe('buildFollowUpRequest / buildRetryRequest — perTurnContext is not duplicated', () => {
+	const conversationHistory: Content[] = [{ role: 'user', parts: [{ text: 'prior turn' }] }];
+	const toolCall: ToolCall = { name: 'read_file', arguments: { path: 'a.md' } };
+	const toolResult: ToolCallResultPair = {
+		toolName: 'read_file',
+		toolArguments: { path: 'a.md' },
+		result: { success: true, data: { content: 'x' } } as any,
+	};
+
+	// buildToolHistoryTurns splices perTurnContext into the user turn — so the
+	// follow-up/retry requests must NOT carry it again, or buildContents would
+	// append a second copy.
+	const updatedHistory = buildToolHistoryTurns({
+		conversationHistory,
+		userMessage: 'user query',
+		perTurnContext: PER_TURN_CONTEXT,
+		toolCalls: [toolCall],
+		toolResults: [toolResult],
+	});
+
+	test('buildToolHistoryTurns already embeds the context exactly once', () => {
+		expect(countContextOccurrences(updatedHistory)).toBe(1);
+	});
+
+	test('buildFollowUpRequest omits perTurnContext and preserves it in history', () => {
+		const request = buildFollowUpRequest({
+			plugin: makePlugin(),
+			currentSession,
+			updatedHistory,
+			perTurnContext: PER_TURN_CONTEXT,
+		});
+
+		// Omitted from the request so buildContents cannot re-append it.
+		expect(request.perTurnContext).toBeUndefined();
+		// Still reaches the model — once — via conversation history.
+		expect(request.conversationHistory).toBe(updatedHistory);
+		expect(countContextOccurrences(request.conversationHistory as Content[])).toBe(1);
+	});
+
+	test('buildRetryRequest omits perTurnContext and preserves it in history', () => {
+		const request = buildRetryRequest({
+			plugin: makePlugin(),
+			currentSession,
+			updatedHistory,
+			perTurnContext: PER_TURN_CONTEXT,
+		});
+
+		expect(request.perTurnContext).toBeUndefined();
+		expect(request.conversationHistory).toBe(updatedHistory);
+		expect(countContextOccurrences(request.conversationHistory as Content[])).toBe(1);
+	});
+});


### PR DESCRIPTION
## Summary

Apply the established `turnPreamble` design pattern to stabilize Gemini's prompt prefix caching across agent turns, resolving the quadratic prompt parsing costs encountered in long chat or coding sessions.

Fixes #763

## Changes

- **Prompt Caching Optimization**: Refactored dynamic `perTurnContext` (carrying context-chip files and attachments metadata) out of `systemInstruction` and appended it directly to the user's conversation message parts.
- **Clean Prompt Signature**: Removed the `perTurnContext` block from `prompts/systemPrompt.hbs` and its rendering inside `gemini-prompts.ts`'s `getSystemPromptWithCustom`.
- **Static `systemInstruction` Guarantee**: Updated `GeminiClient` and `OllamaClient` to construct completely static system prompts throughout the session, guaranteeing a **100% prefix cache hit rate on the system instruction** across turns (~75% off input token cost!).
- **Correctness & Tool Follow-up Continuity**: Upgraded `buildToolHistoryTurns` in `agent-loop-helpers.ts` to accept optional `perTurnContext` and merge it alongside the user message text inside the spliced `user` history turn. This ensures that files context is preserved in history and remains fully visible to the model across subsequent tool calling iterations.
- **Test Alignment & Coverage**:
  - Updated `test/agent/agent-loop-helpers.test.ts` with comprehensive tests verifying combined user parts splicing.
  - Updated `gemini-prompts.test.ts` to match the getSystemPromptWithCustom signature.
  - Refactored provider tests in `gemini/client.test.ts` and `ollama/client.test.ts` to assert turn-specific file context resides inside the user message content instead of the system prompt.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop
- [ ] I have verified this change does not break Mobile (not applicable - purely internal provider and prompt wiring changes)
- [ ] Documentation has been updated (not applicable - purely internal caching refactoring and prompt wiring optimizations with no user-facing settings or behavior changes)
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Google Antigravity
- [x] I have reviewed and understand all AI-generated code in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Per-turn context is no longer embedded in system prompts; it's sent as user message content to AI providers to ensure consistent handling across requests.
  * Agent loop and tool-history logic updated to include per-turn context exactly once per turn, preventing duplication across follow-up iterations.

* **Tests**
  * Added and updated tests to verify single-instance context embedding and that follow-up/retry requests omit duplicated context.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/allenhutchison/obsidian-gemini/pull/840?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->