### PR TITLE
fix: resolve install:test-vault target by manifest id

### DIFF
--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -24,7 +24,7 @@ This script copies the built artifacts (`main.js`, `manifest.json`, `styles.css`
 npm run install:test-vault
 ```
 
-By default it targets `~/Obsidian/Test Vault/.obsidian/plugins/gemini-scribe`. Override it with the `TEST_VAULT_PLUGIN_DIR` environment variable:
+By default it looks under `~/Obsidian/Test Vault/.obsidian/plugins/` and finds the destination by reading each `manifest.json` — it installs into whichever folder declares the plugin's `id`, regardless of how that folder is named. (If several folders declare the same `id`, all are updated and the duplicates are reported; on a fresh vault the canonical `<id>` folder is created.) Override the destination entirely with the `TEST_VAULT_PLUGIN_DIR` environment variable to point at an exact plugin directory:
 
 ```bash
 TEST_VAULT_PLUGIN_DIR=/path/to/vault/.obsidian/plugins/gemini-scribe npm run install:test-vault

--- a/scripts/install-test-vault.mjs
+++ b/scripts/install-test-vault.mjs
@@ -9,37 +9,112 @@
 // `hot-reload` community plugin (an empty `.hotreload` file in the plugin
 // directory) for live reloads on rebuild.
 //
-// Override the destination with TEST_VAULT_PLUGIN_DIR if your test vault is
-// elsewhere.
+// Target resolution (no TEST_VAULT_PLUGIN_DIR override):
+//   The plugin folder is found by scanning <vault>/.obsidian/plugins/* for a
+//   manifest.json whose `id` matches this plugin — NOT by assuming a folder
+//   name. Obsidian keys plugins by manifest id, and a vault folder may be named
+//   anything (e.g. `obsidian-gemini`). Installing into a hardcoded `gemini-scribe`
+//   folder silently misses a differently-named folder Obsidian actually loads.
+//   If several folders declare the id, all are updated (Obsidian loads only one
+//   and which is not knowable from outside it) and the duplicates are reported.
+//   If none exist yet (fresh vault), the canonical `<id>` folder is created.
+//
+// Override the destination with TEST_VAULT_PLUGIN_DIR (an exact plugin dir) if
+// your test vault is elsewhere — that bypasses the scan.
 
-import { copyFileSync, existsSync, mkdirSync } from 'node:fs';
+import { copyFileSync, existsSync, mkdirSync, readFileSync, readdirSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 
-const DEFAULT_DEST = join(homedir(), 'Obsidian', 'Test Vault', '.obsidian', 'plugins', 'gemini-scribe');
-const dest = process.env.TEST_VAULT_PLUGIN_DIR ?? DEFAULT_DEST;
 const files = ['main.js', 'manifest.json', 'styles.css'];
 
+// Verify build artifacts exist in the current worktree.
 const missing = files.filter((f) => !existsSync(f));
 if (missing.length > 0) {
 	console.error(`Missing build artifacts: ${missing.join(', ')}. Run 'npm run build' first.`);
 	process.exit(1);
 }
 
-if (!existsSync(dirname(dest))) {
-	console.error(
-		`Parent directory not found: ${dirname(dest)}. Check TEST_VAULT_PLUGIN_DIR, or ensure the test vault has been opened in Obsidian at least once.`
-	);
+// Read the id from the artifact we're about to copy, so the script can never
+// drift from the actual plugin id.
+let pluginId;
+try {
+	pluginId = JSON.parse(readFileSync('manifest.json', 'utf8')).id;
+} catch (err) {
+	console.error(`Could not read plugin id from manifest.json: ${err.message}`);
+	process.exit(1);
+}
+if (!pluginId) {
+	console.error('manifest.json has no "id" field.');
 	process.exit(1);
 }
 
-mkdirSync(dest, { recursive: true });
+const destinations = resolveDestinations(pluginId);
 
-for (const file of files) {
-	const target = join(dest, file);
-	copyFileSync(file, target);
-	console.log(`  ${file} → ${target}`);
+for (const dest of destinations) {
+	mkdirSync(dest, { recursive: true });
+	for (const file of files) {
+		copyFileSync(file, join(dest, file));
+	}
+	console.log(`Installed ${files.join(', ')} → ${dest}`);
 }
 
-console.log(`\nInstalled to ${dest}`);
-console.log('Reload the plugin in Obsidian (or use the hot-reload plugin) to pick up changes.');
+console.log('\nReload the plugin in Obsidian (or use the hot-reload plugin) to pick up changes.');
+
+/**
+ * Resolve which plugin folder(s) to install into.
+ * - TEST_VAULT_PLUGIN_DIR, if set, is used verbatim (no scanning).
+ * - Otherwise scan the test vault's plugins directory for folders whose
+ *   manifest.json declares `id`, falling back to the canonical `<id>` folder
+ *   on a fresh vault.
+ */
+function resolveDestinations(id) {
+	const override = process.env.TEST_VAULT_PLUGIN_DIR;
+	if (override) {
+		if (!existsSync(dirname(override))) {
+			console.error(`Parent directory not found: ${dirname(override)}. Check TEST_VAULT_PLUGIN_DIR.`);
+			process.exit(1);
+		}
+		return [override];
+	}
+
+	const pluginsDir = join(homedir(), 'Obsidian', 'Test Vault', '.obsidian', 'plugins');
+	if (!existsSync(pluginsDir)) {
+		console.error(
+			`Test vault plugins directory not found: ${pluginsDir}.\n` +
+				`Set TEST_VAULT_PLUGIN_DIR, or open the test vault in Obsidian at least once.`
+		);
+		process.exit(1);
+	}
+
+	const matches = [];
+	for (const entry of readdirSync(pluginsDir, { withFileTypes: true })) {
+		if (!entry.isDirectory()) continue;
+		const manifestPath = join(pluginsDir, entry.name, 'manifest.json');
+		if (!existsSync(manifestPath)) continue;
+		try {
+			if (JSON.parse(readFileSync(manifestPath, 'utf8')).id === id) {
+				matches.push(join(pluginsDir, entry.name));
+			}
+		} catch {
+			// A folder with an unreadable manifest isn't ours — skip it.
+		}
+	}
+
+	if (matches.length === 0) {
+		// Fresh vault — the plugin has never been installed. Create the
+		// canonical `<id>` folder.
+		return [join(pluginsDir, id)];
+	}
+
+	if (matches.length > 1) {
+		console.warn(
+			`Warning: ${matches.length} folders in the test vault declare id "${id}":\n` +
+				matches.map((m) => `  - ${m}`).join('\n') +
+				`\nObsidian loads only one of them. Installing into all so the running copy is ` +
+				`fresh — but delete the stale folder(s) to avoid confusion.\n`
+		);
+	}
+
+	return matches;
+}


### PR DESCRIPTION
## Summary

`npm run install:test-vault` hardcoded its destination folder name (`gemini-scribe`). Obsidian keys plugins by manifest `id`, not by folder name — so a test vault whose plugin folder is named anything else (e.g. `obsidian-gemini`) was silently missed: the script created/refreshed a `gemini-scribe` folder Obsidian never loads, and a fresh build appeared to "not take". This surfaced during QA of #840, where the first test run silently exercised a stale build.

## Changes

- `scripts/install-test-vault.mjs` — resolve the destination by scanning `<vault>/.obsidian/plugins/*/manifest.json` for the plugin `id` instead of assuming a folder name:
  - Installs into whichever folder declares the `id`, regardless of its name.
  - If several folders declare the `id`, installs into all and warns to delete the duplicates (Obsidian loads only one, and which is not knowable from outside it).
  - Fresh vault with no install yet → creates the canonical `<id>` folder.
  - `TEST_VAULT_PLUGIN_DIR` still overrides with an exact directory (bypasses the scan).
  - The `id` is read from the `manifest.json` being installed, so it cannot drift.
- `docs/contributing/testing.md` — updated Option A to describe id-based resolution.

## Test plan

- [x] `npm run install:test-vault` resolves to the correctly-named folder (`obsidian-gemini`) and does not recreate a stale `gemini-scribe/`
- [x] `TEST_VAULT_PLUGIN_DIR` override still targets an exact directory
- [x] `npm run build` and `npm test` (2835) pass

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: dev-tooling fix, no behavior change to the plugin
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A: build-time dev script, not shipped in the plugin
- [x] Documentation has been updated (if applicable)
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified testing instructions for the test vault installation process.

* **Chores**
  * Updated test vault installation to support flexible destination resolution with improved handling for fresh vaults and multiple instances.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/allenhutchison/obsidian-gemini/pull/843?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->