### PR TITLE
refactor: extract disposeRagIndexing helper in LifecycleService

### DIFF
--- a/src/services/lifecycle-service.ts
+++ b/src/services/lifecycle-service.ts
@@ -267,28 +267,13 @@ export class LifecycleService {
 
 		// RAG uses Gemini's File Search Store cloud API — not available on Ollama in Phase 1.
 		if (plugin.settings.provider === 'ollama') {
-			if (plugin.ragIndexing) {
-				const { getRagTools } = await import('../tools/rag-search-tool');
-				for (const tool of getRagTools()) {
-					plugin.toolRegistry?.unregisterTool(tool.name);
-				}
-				await plugin.ragIndexing.destroy();
-				plugin.ragIndexing = null;
-			}
+			await this.disposeRagIndexing();
 			return;
 		}
 
 		if (plugin.settings.ragIndexing.enabled) {
 			// Clean up existing instance if re-initializing
-			if (plugin.ragIndexing) {
-				const { getRagTools } = await import('../tools/rag-search-tool');
-				const ragTools = getRagTools();
-				for (const tool of ragTools) {
-					plugin.toolRegistry?.unregisterTool(tool.name);
-				}
-				await plugin.ragIndexing.destroy();
-				plugin.ragIndexing = null;
-			}
+			await this.disposeRagIndexing();
 
 			try {
 				plugin.ragIndexing = new RagIndexingService(plugin);
@@ -347,14 +332,24 @@ export class LifecycleService {
 			}
 		} else if (plugin.ragIndexing) {
 			// RAG was disabled - clean up
-			const { getRagTools } = await import('../tools/rag-search-tool');
-			const ragTools = getRagTools();
-			for (const tool of ragTools) {
-				plugin.toolRegistry?.unregisterTool(tool.name);
-			}
-			await plugin.ragIndexing.destroy();
-			plugin.ragIndexing = null;
+			await this.disposeRagIndexing();
 		}
+	}
+
+	/**
+	 * Unregister RAG search tools and tear down the indexing service.
+	 * No-op when RAG indexing was never initialized.
+	 */
+	private async disposeRagIndexing(): Promise<void> {
+		const plugin = this.plugin;
+		if (!plugin.ragIndexing) return;
+
+		const { getRagTools } = await import('../tools/rag-search-tool');
+		for (const tool of getRagTools()) {
+			plugin.toolRegistry?.unregisterTool(tool.name);
+		}
+		await plugin.ragIndexing.destroy();
+		plugin.ragIndexing = null;
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Architecture-audit nightly sweep flagged: **DRY violation** in `src/services/lifecycle-service.ts`.

The RAG-indexing teardown sequence — dynamically import `getRagTools`, unregister each RAG search tool, `await ragIndexing.destroy()`, null the reference — was duplicated verbatim in three places inside `initializeRagIndexing()` (the Ollama-provider branch, the re-init cleanup, and the RAG-disabled cleanup). This collapses the three copies into a single private `disposeRagIndexing()` helper. The helper's guard/sequence matches the existing blocks exactly, so behavior is unchanged. `onUnload()` has a deliberately different teardown order (null-first, per-step try/catch) and is intentionally left untouched.

## Changes

- `src/services/lifecycle-service.ts` — add private `disposeRagIndexing()`; replace the three duplicated teardown blocks in `initializeRagIndexing()` with calls to it.

## Screenshots / Screencast

N/A — internal refactor, no user-facing or UI change.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: mechanical, behavior-preserving refactor opened by the automated `architecture-audit` sweep.
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A: no platform-specific code paths touched; pure code motion.
- [x] Documentation has been updated (if applicable) — N/A: internal refactor with no behavior change.
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR


---
_Generated by [Claude Code](https://claude.ai/code/session_01NC8Xrdt2vceV5qzSM485rx)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved RAG indexing initialization when using the Ollama provider.

* **Refactor**
  * Consolidated RAG service cleanup logic to eliminate duplication and enhance stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/allenhutchison/obsidian-gemini/pull/847?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->