### PR TITLE
refactor: use Platform.isMobile in mcp-manager

### DIFF
--- a/__mocks__/obsidian.js
+++ b/__mocks__/obsidian.js
@@ -189,6 +189,15 @@ export const Menu = vi.fn().mockImplementation(function () {
 	};
 });
 
+// Mutable Platform flags so individual tests can flip `isMobile` via
+// `(Platform as any).isMobile = true` (with try/finally to restore).
+export const Platform = {
+	isMobile: false,
+	isDesktop: true,
+	isMobileApp: false,
+	isDesktopApp: true,
+};
+
 export class AbstractInputSuggest {
 	constructor() {
 		this.inputEl = null;

--- a/src/mcp/mcp-manager.ts
+++ b/src/mcp/mcp-manager.ts
@@ -15,7 +15,7 @@ import {
 import { withTimeout } from '../utils/timeout';
 import type ObsidianGemini from '../main';
 import { Logger } from '../utils/logger';
-import { Notice } from 'obsidian';
+import { Notice, Platform } from 'obsidian';
 
 /** Marker on MCPServerState.error so the online listener knows which servers to retry. */
 const OFFLINE_ERROR_PREFIX = 'Machine is offline';
@@ -229,7 +229,7 @@ export class MCPManager {
 		const useHttp = isHttpTransport(config);
 
 		// Stdio transport requires process spawning — desktop only
-		if (!useHttp && (this.plugin.app as any).isMobile) {
+		if (!useHttp && Platform.isMobile) {
 			this.logger.warn('MCP: Stdio server connections are not supported on mobile');
 			return;
 		}
@@ -436,7 +436,7 @@ export class MCPManager {
 		const useHttp = isHttpTransport(config);
 
 		// Stdio transport requires process spawning — desktop only
-		if (!useHttp && (this.plugin.app as any).isMobile) {
+		if (!useHttp && Platform.isMobile) {
 			throw new Error('Stdio MCP server connections are not supported on mobile');
 		}
 
@@ -523,7 +523,7 @@ export class MCPManager {
 			// Start the callback server BEFORE connect so it's already listening
 			// when the SDK opens the browser for OAuth authorization.
 			// Desktop-only: mobile won't have http.createServer.
-			if (!(this.plugin.app as any).isMobile) {
+			if (!Platform.isMobile) {
 				try {
 					const { startOAuthCallbackServer } = await import('./mcp-oauth-callback');
 					callbackHandle = await startOAuthCallbackServer();

--- a/test/mcp/mcp-manager.test.ts
+++ b/test/mcp/mcp-manager.test.ts
@@ -1,3 +1,4 @@
+import { Platform } from 'obsidian';
 import { MCPServerConfig, MCPConnectionStatus, MCP_TRANSPORT_STDIO, MCP_TRANSPORT_HTTP } from '../../src/mcp/types';
 import { TimeoutError } from '../../src/utils/timeout';
 import { MCP_CONNECT_TIMEOUT_MS, MCP_LIST_TOOLS_TIMEOUT_MS } from '../../src/mcp/mcp-constants';
@@ -69,11 +70,10 @@ vi.mock('../../src/mcp/mcp-oauth-callback', () => ({
 import { MCPManager } from '../../src/mcp/mcp-manager';
 
 // Mock plugin
-function createMockPlugin(isMobile = false) {
+function createMockPlugin() {
 	const secrets = new Map<string, string>();
 	return {
 		app: {
-			isMobile,
 			secretStorage: {
 				getSecret: vi.fn((id: string) => secrets.get(id) ?? null),
 				setSecret: vi.fn((id: string, value: string) => secrets.set(id, value)),
@@ -177,26 +177,38 @@ describe('MCPManager', () => {
 		});
 
 		it('should block stdio on mobile', async () => {
-			const mobilePlugin = createMockPlugin(true);
-			const mobileManager = new MCPManager(mobilePlugin);
+			const originalIsMobile = Platform.isMobile;
+			try {
+				(Platform as any).isMobile = true;
+				const mobilePlugin = createMockPlugin();
+				const mobileManager = new MCPManager(mobilePlugin);
 
-			await mobileManager.connectServer(createStdioConfig());
+				await mobileManager.connectServer(createStdioConfig());
 
-			expect(MockStdioClientTransport).not.toHaveBeenCalled();
-			expect(mobilePlugin.logger.warn).toHaveBeenCalledWith(
-				expect.stringContaining('Stdio server connections are not supported on mobile')
-			);
+				expect(MockStdioClientTransport).not.toHaveBeenCalled();
+				expect(mobilePlugin.logger.warn).toHaveBeenCalledWith(
+					expect.stringContaining('Stdio server connections are not supported on mobile')
+				);
+			} finally {
+				(Platform as any).isMobile = originalIsMobile;
+			}
 		});
 
 		it('should allow HTTP on mobile', async () => {
-			const mobilePlugin = createMockPlugin(true);
-			const mobileManager = new MCPManager(mobilePlugin);
-			mockListTools.mockResolvedValueOnce({ tools: [] });
+			const originalIsMobile = Platform.isMobile;
+			try {
+				(Platform as any).isMobile = true;
+				const mobilePlugin = createMockPlugin();
+				const mobileManager = new MCPManager(mobilePlugin);
+				mockListTools.mockResolvedValueOnce({ tools: [] });
 
-			await mobileManager.connectServer(createHttpConfig());
+				await mobileManager.connectServer(createHttpConfig());
 
-			expect(MockStreamableHTTPClientTransport).toHaveBeenCalled();
-			expect(mockClientConnect).toHaveBeenCalled();
+				expect(MockStreamableHTTPClientTransport).toHaveBeenCalled();
+				expect(mockClientConnect).toHaveBeenCalled();
+			} finally {
+				(Platform as any).isMobile = originalIsMobile;
+			}
 		});
 
 		it('should register discovered tools', async () => {
@@ -249,23 +261,35 @@ describe('MCPManager', () => {
 		});
 
 		it('should throw for stdio on mobile', async () => {
-			const mobilePlugin = createMockPlugin(true);
-			const mobileManager = new MCPManager(mobilePlugin);
+			const originalIsMobile = Platform.isMobile;
+			try {
+				(Platform as any).isMobile = true;
+				const mobilePlugin = createMockPlugin();
+				const mobileManager = new MCPManager(mobilePlugin);
 
-			await expect(mobileManager.queryToolsForConfig(createStdioConfig())).rejects.toThrow(
-				'Stdio MCP server connections are not supported on mobile'
-			);
+				await expect(mobileManager.queryToolsForConfig(createStdioConfig())).rejects.toThrow(
+					'Stdio MCP server connections are not supported on mobile'
+				);
+			} finally {
+				(Platform as any).isMobile = originalIsMobile;
+			}
 		});
 
 		it('should allow HTTP queries on mobile', async () => {
-			const mobilePlugin = createMockPlugin(true);
-			const mobileManager = new MCPManager(mobilePlugin);
-			mockListTools.mockResolvedValueOnce({ tools: [{ name: 'remote_tool' }] });
+			const originalIsMobile = Platform.isMobile;
+			try {
+				(Platform as any).isMobile = true;
+				const mobilePlugin = createMockPlugin();
+				const mobileManager = new MCPManager(mobilePlugin);
+				mockListTools.mockResolvedValueOnce({ tools: [{ name: 'remote_tool' }] });
 
-			const tools = await mobileManager.queryToolsForConfig(createHttpConfig());
+				const tools = await mobileManager.queryToolsForConfig(createHttpConfig());
 
-			expect(tools).toEqual(['remote_tool']);
-			expect(MockStreamableHTTPClientTransport).toHaveBeenCalled();
+				expect(tools).toEqual(['remote_tool']);
+				expect(MockStreamableHTTPClientTransport).toHaveBeenCalled();
+			} finally {
+				(Platform as any).isMobile = originalIsMobile;
+			}
 		});
 
 		it('should throw when http config has no URL', async () => {


### PR DESCRIPTION
## Summary

Architecture-audit nightly sweep flagged three `(this.plugin.app as any).isMobile` reads in `src/mcp/mcp-manager.ts`. The cast is reaching for an undocumented internal Obsidian property; `Platform.isMobile` is the public documented API and is already the convention used elsewhere in the codebase (`src/main.ts`, `src/ui/agent-view/agent-view.ts`, `src/services/lifecycle-service.ts`, `src/services/hook-manager.ts`).

Replacing the cast removes the three `as any` sites, makes the mobile-detection consistent across the plugin, and stops depending on a non-public field. No behavior change — `Platform.isMobile` reads the same underlying flag.

## Changes

- `src/mcp/mcp-manager.ts` — import `Platform` from obsidian; replace 3 `(this.plugin.app as any).isMobile` reads with `Platform.isMobile`.
- `__mocks__/obsidian.js` — add a mutable `Platform` export to the global obsidian test mock so any test can flip `isMobile` via `(Platform as any).isMobile = true` with try/finally restore. This matches the pattern already in `test/services/hook-manager.test.ts`.
- `test/mcp/mcp-manager.test.ts` — drop the dead `isMobile` parameter from `createMockPlugin` (it's no longer read by the source) and update the four mobile-path tests to mutate `Platform.isMobile` in a try/finally block.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A, opened by the `architecture-audit` nightly sweep as a small mechanical refactor
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop (`npm test` — 2835/2835 passing)
- [x] I have verified this change does not break Mobile — `Platform.isMobile` is the documented mobile-detection API; the test mock exercises the mobile path
- [ ] Documentation has been updated (if applicable) — N/A, pure internal refactor with no user-visible change
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (architecture-audit skill)
- [x] I have reviewed and understand all AI-generated code in this PR

---

_Filed by the `architecture-audit` skill._

---
_Generated by [Claude Code](https://claude.ai/code/session_01UAhy8QuHEwj9B36KxQbXYL)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved mobile platform detection for Model Context Protocol (MCP) connections. Stdio MCP connections are now properly unsupported on mobile devices, and the OAuth callback server is only initialized on non-mobile platforms.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/allenhutchison/obsidian-gemini/pull/853?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->