### PR TITLE
chore(daily): 2026-05-20 daily update

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,25 +7,26 @@ Gemini Scribe is an Obsidian plugin that integrates Google's Gemini AI models, p
 > - **Google Gemini (cloud)** — requires a Gemini API key (free tier available at [Google AI Studio](https://aistudio.google.com/apikey)).
 > - **Ollama (local)** — runs locally with no API key; install [Ollama](https://ollama.com), pull a model, and select it in settings. See [docs/guide/ollama-setup.md](docs/guide/ollama-setup.md) for the feature-parity table.
 
-## What's New in v4.8.0
+## What's New in v4.9.0
 
-**✨ Gemini Scribe 4.8 - Scheduled & Background Tasks, Ollama, Activity Modal**
+**🪝 Gemini Scribe 4.9 - Lifecycle Hooks, Stable Prefix Caching, Custom Endpoint**
+
+- **🪝 Lifecycle hooks** - Trigger headless AI agent runs in response to vault events (file created, modified, deleted, renamed). Create and manage hooks from the **Open Hook Manager** command. See the [Lifecycle Hooks guide](docs/guide/lifecycle-hooks.md).
+- **⚡ Stable prefix caching** - The agent's system instruction is now byte-stable across turns and tool follow-ups, restoring Gemini's implicit prefix cache so long sessions stop reprocessing history each turn.
+- **🌐 Custom API endpoint** - New setting to route all Gemini API calls through a proxy or alternate endpoint, covering every SDK call site.
+- **📐 Collapsible settings sections** - Settings page reorganized into foldable sections for a cleaner UI.
+- **🔐 MCP hardening** - Stdio server environment variables now live in Obsidian's encrypted SecretStorage; offline or unreachable MCP servers no longer block plugin load.
+- **🛡️ Unified tool-policy** - Sessions, Projects, Scheduled Tasks, and Hooks now share one policy model so per-feature permissions behave consistently.
+- **📦 Two-phase context compaction** - Long conversations truncate older tool-result payloads first, summarize second, for cleaner handling near the token limit.
+
+**Previous Updates (v4.8.0):**
 
 - **⏰ Scheduled tasks** - Run agent tasks on a cron, time-of-day, or day-of-week schedule with full management UI. See the [Scheduled Tasks guide](docs/guide/scheduled-tasks.md).
 - **🌙 Missed-run catch-up** - Tasks that should have run while Obsidian was closed surface on startup for review.
 - **🛰️ Background tasks** - Deep research and image generation now run in the background with output consolidated under `[state-folder]/Background-Tasks/`. See the [Background Tasks guide](docs/guide/background-tasks.md).
-- **📊 Unified activity modal** - Background Tasks and RAG status share a single tabbed view.
 - **🦙 Ollama provider** - Point the plugin at a local Ollama server for offline, local-model chat. See the [Ollama Setup guide](docs/guide/ollama-setup.md).
 - **🛑 Runaway-loop abort** - Repeated tool-loop detections within a turn now abort the turn with a clear notice instead of churning.
 - **🛠️ Headless agent loop** - AgentLoop extracted from the agent view so scheduled and background runners share the same execution engine.
-
-**Previous Updates (v4.7.0):**
-
-- **📂 Projects** - Scope agent sessions to a folder with custom instructions, permission overrides, and skill filters. See the [Projects guide](docs/guide/projects.md).
-- **🧠 Session recall** - The agent can search past conversations for relevant context via the `recall_sessions` tool.
-- **📦 Bundled skills** - Built-in help and Obsidian-knowledge skills, auto-generated from the docs site at build time.
-- **📄 Binary file awareness in tools** - `read_file` can return images, audio, video, and PDFs directly to the model when encountered during tool execution.
-- **🏗️ Layered prompt architecture** - System prompts refactored into composable Handlebars sections.
 
 ## Features
 

--- a/planning/changelog/2026-05-19.md
+++ b/planning/changelog/2026-05-19.md
@@ -1,0 +1,28 @@
+# Daily changelog — May 19, 2026
+
+**Date:** 2026-05-19
+**PRs merged:** 4
+
+---
+
+## Summary
+
+A light housekeeping day: the headline change is a behavior-preserving refactor that eliminates a DRY violation in the lifecycle service's RAG teardown logic. Two daily-update PRs landed (clearing the queue from the morning batch), and an automated workflow refreshed the available Gemini model list from Google's API.
+
+## What shipped
+
+### [#847 refactor: extract disposeRagIndexing helper in LifecycleService](https://github.com/allenhutchison/obsidian-gemini/pull/847)
+
+The architecture-audit nightly sweep flagged a verbatim three-way duplication of the RAG indexing teardown sequence inside `initializeRagIndexing()` — the Ollama-provider branch, the re-init cleanup, and the RAG-disabled cleanup all repeated the same import-unregister-destroy-null block. This PR collapses them into a single private `disposeRagIndexing()` helper with no behavior change. The intentionally different teardown order in `onUnload()` (null-first, per-step try/catch) is left untouched.
+
+### [#848 chore(daily): 2026-05-18 daily update](https://github.com/allenhutchison/obsidian-gemini/pull/848)
+
+Daily housekeeping for 2026-05-18. Added `planning/changelog/2026-05-17.md` documenting the five PRs that landed on May 17 — the headline being the system-prompt prefix caching stabilization (#840) that moves per-turn context out of `systemInstruction` for up to 75% lower input token cost. No doc drift and no unlabeled issues on that run.
+
+### [#849 chore(daily): 2026-05-19 daily update](https://github.com/allenhutchison/obsidian-gemini/pull/849)
+
+Daily housekeeping covering May 18 (a quiet day, zero PRs merged). Also fixed two stale command labels in `README.md`'s Rewrite section: the right-click label ("Rewrite with Gemini" → "Gemini Scribe: Rewrite Text...") and the command palette label ("Rewrite selected text with AI" → "Rewrite text with AI"), both now matching the strings in `main.ts`.
+
+### [#851 chore: Update available Gemini models](https://github.com/allenhutchison/obsidian-gemini/pull/851)
+
+Automated model list refresh triggered by the GitHub Actions workflow detecting new models from Google's API. Requires maintainer review to curate labels, assign `defaultForRoles`, prune models not suitable for users, and verify `supportsImageGeneration` flags before the list goes live.


### PR DESCRIPTION
## Summary

Automated daily housekeeping for 2026-05-20. Covers the May 19 changelog (4 PRs) and a README drift fix updating "What's New" to v4.9.0.

## Changes

- **Add `planning/changelog/2026-05-19.md`**: Documents 4 PRs merged on May 19 — `disposeRagIndexing` helper refactor eliminating a 3-way DRY violation in LifecycleService (#847), the May 18 daily update (#848), the May 19 daily update (#849), and an automated Gemini model list refresh (#851).

- **Fix `README.md`**: "What's New" section was showing v4.8.0 as the current release; updated to v4.9.0 with the full highlight list (lifecycle hooks, stable prefix caching, custom API endpoint, collapsible settings, MCP hardening, unified tool-policy, two-phase context compaction). Previous updates block updated to show v4.8.0.

## Sub-skill outcomes

- **daily-changelog**: wrote `planning/changelog/2026-05-19.md`, 4 PRs (lifecycle refactor, 2 daily updates, automated model list refresh)
- **audit-docs**: updated `README.md` "What's New" from v4.8.0 → v4.9.0; no other drift found in `docs/guide/`, `docs/reference/`, or `AGENTS.md`
- **triage-issues**: no unlabeled open issues — tracker is clean

## Screenshots / Screencast

N/A — no UI changes.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: daily housekeeping
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A: docs and changelog only
- [x] Documentation has been updated (if applicable)
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_0143ph5kMnxB6aDCZeDha2yV)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated "What's New" section with v4.9.0 release features including lifecycle hooks, stable prefix caching, custom API endpoints, collapsible settings, MCP hardening, unified tool-policy, and context compaction.
  * Added daily changelog entry documenting recent releases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/allenhutchison/obsidian-gemini/pull/854?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->