### PR TITLE
chore(daily): 2026-05-21 daily update

### DIFF
--- a/planning/changelog/2026-05-20.md
+++ b/planning/changelog/2026-05-20.md
@@ -1,0 +1,20 @@
+# Daily changelog — May 20, 2026
+
+**Date:** 2026-05-20
+**PRs merged:** 2
+
+---
+
+## Summary
+
+A light housekeeping day: the May 20 daily update PR landed the prior day's changelog and a README refresh, followed immediately by a small architecture-audit cleanup replacing internal Obsidian property casts with the public `Platform.isMobile` API.
+
+## What shipped
+
+### [#854 chore(daily): 2026-05-20 daily update](https://github.com/allenhutchison/obsidian-gemini/pull/854)
+
+Automated daily housekeeping covering May 19. Wrote `planning/changelog/2026-05-19.md` (4 PRs: the `disposeRagIndexing` refactor, two daily-update PRs, and an automated model-list refresh). Also fixed the README "What's New" section, which was still showing v4.8.0 as the current release — updated to v4.9.0 with its full highlight list (lifecycle hooks, stable prefix caching, custom API endpoint, collapsible settings, MCP hardening, unified tool-policy, two-phase context compaction).
+
+### [#853 refactor: use Platform.isMobile in mcp-manager](https://github.com/allenhutchison/obsidian-gemini/pull/853)
+
+Architecture-audit sweep flagged three `(this.plugin.app as any).isMobile` reads in `src/mcp/mcp-manager.ts`. Replaced all three with `Platform.isMobile`, which is the documented Obsidian API and already the convention used across the rest of the plugin (`main.ts`, `agent-view.ts`, `lifecycle-service.ts`, `hook-manager.ts`). Removes the `as any` casts and aligns mobile detection to the public API. No behavior change. The test mock was updated to expose a mutable `Platform` export so mobile-path tests can flip `isMobile` via `try/finally`, matching the pattern in `hook-manager.test.ts`. Filed by the `architecture-audit` nightly skill.


### PR DESCRIPTION
## Summary

Automated daily housekeeping for 2026-05-21. Covers the May 20 changelog (2 PRs).

## Changes

- **Add `planning/changelog/2026-05-20.md`**: Documents 2 PRs merged on May 20 — the daily update PR (#854, documenting May 19 activity and fixing README "What's New" to v4.9.0) and an architecture-audit refactor replacing `(this.plugin.app as any).isMobile` with `Platform.isMobile` across `mcp-manager.ts` (#853).

## Sub-skill outcomes

- **daily-changelog**: wrote `planning/changelog/2026-05-20.md`, 2 PRs (daily update housekeeping, Platform.isMobile refactor)
- **audit-docs**: no drift found in `docs/guide/`, `docs/reference/`, `README.md`, or `AGENTS.md` — all settings names, defaults, command palette IDs, tool names, and schedule formats match the code
- **triage-issues**: no unlabeled open issues — tracker is clean

## Screenshots / Screencast

N/A — changelog and docs only.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: daily housekeeping
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A: docs and changelog only
- [x] Documentation has been updated (if applicable) — N/A: this PR IS the doc update
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_012f3YYqJgy6YZaUVQHYvHhP)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added May 20, 2026 changelog entry documenting recent pull requests and merged changes
  * Updated "What's New" section in README with the latest release version highlights

* **Chores**
  * Completed daily housekeeping maintenance tasks performed for May 19

* **Refactor**
  * Strengthened mobile platform detection implementation by adopting standardized public APIs for improved code reliability and robustness

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/allenhutchison/obsidian-gemini/pull/857?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->