### PR TITLE
fix: send pure BaseModelRequest from VaultAnalyzer

### DIFF
--- a/src/services/vault-analyzer.ts
+++ b/src/services/vault-analyzer.ts
@@ -77,9 +77,6 @@ export class VaultAnalyzer {
 			const response = await modelApi.generateModelResponse({
 				prompt: analysisPrompt,
 				model: this.plugin.settings.chatModelName,
-				userMessage: '',
-				conversationHistory: [],
-				renderContent: false,
 			});
 			await this.ensureMinimumDelay(stepStart);
 			modal.setStepComplete('analyze');
@@ -133,9 +130,6 @@ export class VaultAnalyzer {
 			const examplePromptsResponse = await modelApi.generateModelResponse({
 				prompt: examplePromptsPrompt,
 				model: this.plugin.settings.chatModelName,
-				userMessage: '',
-				conversationHistory: [],
-				renderContent: false,
 			});
 			await this.ensureMinimumDelay(stepStart);
 			modal.setStepComplete('examples');

--- a/test/services/vault-analyzer.test.ts
+++ b/test/services/vault-analyzer.test.ts
@@ -585,6 +585,25 @@ describe('VaultAnalyzer', () => {
 			expect(mockPlugin.examplePrompts.write).toHaveBeenCalledWith([{ icon: '✨', text: 'Test prompt' }]);
 		});
 
+		it('should send pure BaseModelRequest (no userMessage/conversationHistory)', async () => {
+			// Regression: GeminiClient.buildGenerateContentParams discriminates on
+			// `'userMessage' in request`. Including an (even empty) userMessage or
+			// conversationHistory makes it an ExtendedModelRequest, which discards
+			// `prompt` and sends the chat identity system prompt instead — the model
+			// then replies with a greeting that fails JSON parsing.
+			setupModelMock('{"vaultOverview":"overview"}', '[{"icon":"✨","text":"Test prompt"}]');
+
+			await analyzer.initializeAgentsMemory();
+
+			for (const call of mockModelApi.generateModelResponse.mock.calls) {
+				const request = call[0];
+				expect(request).not.toHaveProperty('userMessage');
+				expect(request).not.toHaveProperty('conversationHistory');
+				expect(typeof request.prompt).toBe('string');
+				expect(request.prompt.length).toBeGreaterThan(0);
+			}
+		});
+
 		it('should set step failed and show Notice when parseAnalysisResponse returns null', async () => {
 			setupModelMock('totally not json!!!', '[{"icon":"✨","text":"Test prompt"}]');
 


### PR DESCRIPTION
## Summary

Fixes the broken "Initialize Vault Context" button in the agent view. Clicking it produced a JSON parse error and never wrote `AGENTS.md`.

**Root cause:** `GeminiClient.buildGenerateContentParams()` decides whether a request is a `BaseModelRequest` or `ExtendedModelRequest` via `'userMessage' in request`. `VaultAnalyzer` passed `userMessage: ''` and `conversationHistory: []` alongside its real `prompt`, so the presence of the `userMessage` key made it an `ExtendedModelRequest` — which discards the `prompt` entirely and sends the chat identity system prompt with empty content. The model replied with a greeting (`"Hi Allen, I'm Gemini Scribe..."`) that failed JSON parsing:

```
[ERROR] Failed to parse analysis response: Unexpected token 'H', "Hi Allen, "... is not valid JSON
```

## Changes

- `src/services/vault-analyzer.ts`: removed `userMessage`, `conversationHistory`, and `renderContent` from both `generateModelResponse` calls so they are pure `BaseModelRequest`s (matching `context-manager.ts`). The analysis `prompt` is now actually sent to the model.
- `test/services/vault-analyzer.test.ts`: added a regression test asserting the request objects carry no `userMessage`/`conversationHistory` and a non-empty `prompt`.

## Follow-up

The underlying `'userMessage' in request` discriminator is fragile — any caller adding an empty `userMessage` silently loses its `prompt`. Tracked separately in #859.

## Testing

- Verified end-to-end in the test vault: clicked "Initialize Vault Context" — no parse errors, `AGENTS.md` created, example prompts generated, button correctly switched to "Update Vault Context".
- `npm test` — 2836 tests pass (including the new regression test).
- `npm run build` and `npm run format-check` pass.

## Screenshots / Screencast

N/A — internal request-shape fix, no UI changes.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: direct bug fix reported by the maintainer; follow-up tracked in #859
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A: no platform-specific code touched
- [x] Documentation has been updated (if applicable) — N/A: restores already-documented behavior, no doc changes needed
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed request parameter handling in vault analyzer memory initialization that was causing downstream processing issues.

* **Tests**
  * Added regression test for request parameter validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/allenhutchison/obsidian-gemini/pull/860?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->