### PR TITLE
docs: fix dead link to Testing Guide in contributing.md

### DIFF
--- a/docs/contributing/contributing.md
+++ b/docs/contributing/contributing.md
@@ -101,7 +101,7 @@ This project uses [CodeRabbit](https://coderabbit.ai/) for automated code review
 - Tests live in the `test/` directory, mirroring the `src/` structure.
 - Run `npm test` and ensure all tests pass before pushing.
 
-For detailed instructions on testing your changes on desktop and mobile, including symlink setup, smoke test checklists, and CI checks, see the [Testing Guide](docs/contributing/testing.md).
+For detailed instructions on testing your changes on desktop and mobile, including symlink setup, smoke test checklists, and CI checks, see the [Testing Guide](testing.md).
 
 ## Coding Standards
 


### PR DESCRIPTION
## Summary

The "Deploy Documentation" workflow on `master` is failing on a dead link, which blocks the docs site from deploying. See the failed run: https://github.com/allenhutchison/obsidian-gemini/actions/runs/26259501836

`docs/contributing/contributing.md` linked to the Testing Guide as `docs/contributing/testing.md` — a repo-root-style path. VitePress resolves markdown links relative to the file's own directory, so it looked for `docs/contributing/docs/contributing/testing.md`. The target `testing.md` is in the same folder, so the link is now just `testing.md`.

Introduced 9 days ago in #760.

## Changes

- `docs/contributing/contributing.md`: fix the Testing Guide link path (`docs/contributing/testing.md` → `testing.md`)

## Screenshots / Screencast

N/A — docs link fix.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: trivial CI-unblocking dead-link fix
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — verified `npm run docs:build` passes locally with no dead links
- [x] I have tested this change on Desktop — N/A for a docs link, verified via `npm run docs:build`
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A: docs-only
- [x] Documentation has been updated (if applicable) — this PR is the documentation fix
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contributing guide with corrected documentation references.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/allenhutchison/obsidian-gemini/pull/862?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->