### PR TITLE
test: fix flaky detectMissedRuns "no state entry" test

### DIFF
--- a/test/services/scheduled-task-manager.test.ts
+++ b/test/services/scheduled-task-manager.test.ts
@@ -1379,10 +1379,21 @@ describe('ScheduledTaskManager', () => {
 		it('excludes tasks with no state entry', async () => {
 			const manager = await makeManagerWithMissedRuns(
 				[{ slug: 'no-state', schedule: 'daily', runIfMissed: true }],
-				{} // State was not seeded for this slug — but discoverTasks will add it.
-				// However, the seeded nextRunAt is 'now' which is not in the past, so it should not be missed.
+				{} // No persisted state — discoverTasks() seeds nextRunAt to "now" (due immediately).
 			);
-			expect(manager.detectMissedRuns()).toHaveLength(0);
+
+			// detectMissedRuns() uses a strict `<` comparison, so a task due exactly
+			// at `now` is not a missed run. Pin the clock to the discovery-seeded
+			// nextRunAt so wall-clock drift between discovery and detection can't
+			// flakily flip the result to 1.
+			const seededNextRunAt = manager.getState()['no-state'].nextRunAt;
+			vi.useFakeTimers();
+			vi.setSystemTime(new Date(seededNextRunAt));
+			try {
+				expect(manager.detectMissedRuns()).toHaveLength(0);
+			} finally {
+				vi.useRealTimers();
+			}
 		});
 	});
 


### PR DESCRIPTION
## Summary

Fixes a flaky test in `test/services/scheduled-task-manager.test.ts` — `detectMissedRuns — edge cases > excludes tasks with no state entry`. It failed CI on an unrelated PR (#862) and passes/fails depending on wall-clock timing.

**Root cause:** the test seeds a task with no persisted state. During `initialize()`, `discoverTasks()` seeds its `nextRunAt` to `new Date()` — the wall-clock instant of discovery ("due immediately"). `detectMissedRuns()` then runs a few milliseconds later and compares `nextRunAt` against a fresh `new Date()`. By then the seeded "now" has drifted into the past, so the task is flagged as a missed run (length 1 instead of the expected 0). The test only passed when both `new Date()` calls happened to land in the same millisecond — a race it loses on slower CI runners.

**Fix:** pin the clock to the discovery-seeded `nextRunAt` (via `vi.useFakeTimers()` + `vi.setSystemTime()`) before calling `detectMissedRuns()`. Since `detectMissedRuns()` uses a strict `<` comparison, a task due exactly at `now` is correctly not counted — deterministically. The test now meaningfully exercises that strict-boundary behavior. Test-only change; no product code touched.

Verified deterministic across repeated runs of the suite.

## Changes

- `test/services/scheduled-task-manager.test.ts`: freeze the clock at the seeded `nextRunAt` for the "no state entry" case; replace the inaccurate inline comment.

## Note

In real usage, a brand-new `runIfMissed: true` task *will* surface in the catch-up modal on the next startup, since `discoverTasks()` seeds it as due-now and `detectMissedRuns()` then sees it as past-due. That is existing product behavior and out of scope here — flagging it in case it warrants a separate UX discussion.

## Screenshots / Screencast

N/A — test-only change.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: flaky-test fix surfaced by CI on #862
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — verified locally, plus 5 repeated runs of the affected suite
- [x] I have tested this change on Desktop — N/A for a test-only change
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A: test-only
- [x] Documentation has been updated (if applicable) — N/A: no user-facing change
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR