### PR TITLE
fix: recover from invalid RAG file search store names

### DIFF
--- a/docs/guide/semantic-search.md
+++ b/docs/guide/semantic-search.md
@@ -33,7 +33,7 @@ Initial indexing time depends on vault size. A vault with 1,000 notes typically 
 | Setting                   | Default        | Description                                                                                                                     |
 | ------------------------- | -------------- | ------------------------------------------------------------------------------------------------------------------------------- |
 | **Enable vault indexing** | Off            | Master toggle for the feature                                                                                                   |
-| **Search index name**     | Auto-generated | Google File Search Store identifier (auto-set to `obsidian-{vault-name}`)                                                       |
+| **Search index name**     | Auto-generated | Read-only. The Google File Search store identifier, assigned automatically when indexing starts                                 |
 | **Auto-sync changes**     | On             | Automatically update the index when files change                                                                                |
 | **Include attachments**   | Off            | Index PDFs, Office documents, and other supported file types beyond markdown                                                    |
 | **Exclude folders**       | None           | Folders to skip during indexing (one per line). System folders like `.obsidian` and the plugin state folder are always excluded |

--- a/src/services/rag-vault-scanner.ts
+++ b/src/services/rag-vault-scanner.ts
@@ -136,9 +136,21 @@ export class RagVaultScanner {
 				const errorMessage = error instanceof Error ? error.message : String(error);
 				const isNotFound =
 					errorMessage.includes('404') || errorMessage.includes('not found') || errorMessage.includes('NOT_FOUND');
+				// A saved store name can be structurally invalid — e.g. a custom name
+				// entered via an older plugin version that the File Search API rejects
+				// as malformed (the resource ID is server-assigned and cannot be chosen).
+				// Treat that like "not found": discard the bad name and create a fresh
+				// store instead of failing indexing permanently.
+				const isInvalidName =
+					errorMessage.includes('INVALID_ARGUMENT') || errorMessage.includes('does not match expected format');
 
 				if (isNotFound) {
 					this.plugin.logger.warn('RAG Indexing: Store no longer exists, creating new store');
+				} else if (isInvalidName) {
+					this.plugin.logger.warn(
+						`RAG Indexing: Saved search index name "${existingStoreName}" is invalid, creating a new store`
+					);
+					this.plugin.settings.ragIndexing.fileSearchStoreName = null;
 				} else {
 					// For other errors (network, auth, etc.), log and re-throw
 					this.plugin.logger.error('RAG Indexing: Failed to verify store', error);

--- a/src/ui/settings-rag.ts
+++ b/src/ui/settings-rag.ts
@@ -16,19 +16,10 @@ export async function renderRAGSettings(
 	});
 	// Debounce saveSettings() for text inputs so typing doesn't trigger the plugin
 	// lifecycle on every keystroke. Settings are mutated immediately; only the save is delayed.
-	// The store-name field uses `pendingStoreNameMessage` to queue a confirmation
-	// notice that fires only after the save actually succeeds, so a failed save
-	// doesn't surface a misleading success toast.
-	let pendingStoreNameMessage: string | null = null;
 	const debouncedSave = debounce(
 		async () => {
-			const messageToShow = pendingStoreNameMessage;
-			pendingStoreNameMessage = null;
 			try {
 				await plugin.saveSettings();
-				if (messageToShow) {
-					new Notice(messageToShow);
-				}
 			} catch (error) {
 				plugin.logger.error('Failed to save RAG settings:', error);
 				new Notice(`Failed to save settings: ${getErrorMessage(error)}`);
@@ -157,18 +148,19 @@ export async function renderRAGSettings(
 					})
 			);
 
-		// Store name setting
+		// Store name display. The Google File Search API assigns the store's
+		// resource ID automatically — it cannot be chosen — so this is shown
+		// read-only, and only once a store actually exists.
 		const currentStoreName = plugin.settings.ragIndexing.fileSearchStoreName;
 		const storeNameSetting = new Setting(containerEl)
 			.setName('Search index name')
 			.setDesc(
 				currentStoreName
-					? `Current: ${currentStoreName}. To change, disable indexing and delete the store first.`
-					: 'Will be auto-generated on first index, or enter a custom name.'
+					? 'The Google File Search store identifier, assigned automatically. Delete the index to start over with a new one.'
+					: 'Assigned automatically by Google File Search when indexing starts.'
 			);
 
 		if (currentStoreName) {
-			// Store exists - show read-only with copy button
 			storeNameSetting
 				.addText((text) => {
 					text.inputEl.style.width = '30ch';
@@ -184,26 +176,6 @@ export async function renderRAGSettings(
 							new Notice('Store name copied to clipboard');
 						})
 				);
-		} else {
-			// No store yet - allow editing
-			storeNameSetting.addText((text) => {
-				text.inputEl.style.width = '30ch';
-				text
-					.setPlaceholder('Auto-generated if empty')
-					.setValue('')
-					.onChange((value) => {
-						const trimmedValue = value.trim();
-						const normalizedStoreName = trimmedValue.length > 0 ? trimmedValue : null;
-						plugin.settings.ragIndexing.fileSearchStoreName = normalizedStoreName;
-						// Queue the confirmation notice for the next save completion. Reusing
-						// the section-level debouncedSave keeps all RAG saves on a single 300 ms
-						// queue so rapid edits across fields collapse into one saveSettings call.
-						pendingStoreNameMessage = normalizedStoreName
-							? 'Store name set. Will be used when indexing starts.'
-							: 'Store name cleared.';
-						debouncedSave();
-					});
-			});
 		}
 
 		new Setting(containerEl)

--- a/test/services/rag-vault-scanner.test.ts
+++ b/test/services/rag-vault-scanner.test.ts
@@ -362,6 +362,31 @@ describe('RagVaultScanner', () => {
 			expect(plugin.saveData).toHaveBeenCalled();
 		});
 
+		it('should create a new store when the saved store name is invalid (malformed)', async () => {
+			const mockAi = {
+				fileSearchStores: {
+					get: vi
+						.fn()
+						.mockRejectedValue(
+							new Error('400 INVALID_ARGUMENT: FileSearchStore name does not match expected format or is too long.')
+						),
+					create: vi.fn().mockResolvedValue({ name: 'fileSearchStores/auto-generated-id' }),
+				},
+			};
+			const callbacks = createMockCallbacks({ getAi: vi.fn().mockReturnValue(mockAi) });
+			const plugin = createMockPlugin();
+			// A custom name entered in an older plugin version that Google rejects as malformed.
+			plugin.settings.ragIndexing.fileSearchStoreName = 'Scribe-RAG-index';
+			const { scanner } = createScanner({ plugin, callbacks });
+
+			await scanner.ensureFileSearchStore();
+
+			// The bad name is discarded and a fresh, server-assigned store is created.
+			expect(mockAi.fileSearchStores.create).toHaveBeenCalled();
+			expect(plugin.settings.ragIndexing.fileSearchStoreName).toBe('fileSearchStores/auto-generated-id');
+			expect(plugin.saveData).toHaveBeenCalled();
+		});
+
 		it('should rethrow non-404 errors when verifying existing store', async () => {
 			const mockAi = {
 				fileSearchStores: {


### PR DESCRIPTION
## Summary

Issue #858 reports RAG indexing failing with a store named `Scribe-RAG-index`. The root cause is the **"Search index name"** setting: when no store existed yet, it rendered an *editable* text field ("or enter a custom name"), and whatever the user typed was stored verbatim as `fileSearchStoreName`.

But the Google File Search API assigns store resource IDs **server-side** — `fileSearchStores.create()` only accepts a `displayName`, never a chosen name. So a typed custom name was never used to create anything; it just poisoned settings. On the next run, `ensureFileSearchStore()` saw a truthy stored name, called `fileSearchStores.get({ name })` to verify it, and Google rejected the malformed value with **400 INVALID_ARGUMENT** ("name does not match expected format"). The catch block only treated 404/NOT_FOUND as recoverable, so the 400 was re-thrown and indexing broke permanently.

This PR removes the misleading field and makes the verification step self-heal.

Refs #858

**Scope note:** This fixes the store-name root cause and recovery. It does *not* address the separate, environment-specific `TypeError: Failed to fetch` transport behavior also discussed in the issue thread — the reporter's own DevTools test showed that transport returns a clean HTTP 400, so that remains a separate open question.

## Changes

- **`src/ui/settings-rag.ts`** — Removed the editable custom-name input. "Search index name" is now always read-only (shown with a Copy button once a store exists; description-only before that). Dropped the now-unused `pendingStoreNameMessage` plumbing.
- **`src/services/rag-vault-scanner.ts`** — `ensureFileSearchStore()` now treats a `400 INVALID_ARGUMENT` / malformed-name error from store verification the same as a 404: it discards the bad `fileSearchStoreName` and creates a fresh, server-assigned store. Existing users stuck with a poisoned setting self-heal on the next index.
- **`docs/guide/semantic-search.md`** — Corrected the "Search index name" row to describe it as read-only and auto-assigned.
- **`test/services/rag-vault-scanner.test.ts`** — Added a regression test covering recovery from a malformed saved store name.

## Screenshots / Screencast

No screenshot captured (no live Obsidian instance in this environment). UI change: when no store exists yet, the "Search index name" row now shows a description only instead of an editable text box. When a store exists, behavior is unchanged (read-only value + Copy button).

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer
- [x] All CI checks pass (`npm test` — 2837 passing, `npm run build`, `npm run format-check`)
- [ ] I have tested this change on Desktop
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards)
- [x] Documentation has been updated (if applicable)
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

> Manual Desktop/Mobile testing was not performed in this environment. Verified via the full unit suite, production build, ESLint, and Prettier. The change is platform-agnostic (removes a settings field; adds error-string handling) with no `Platform`-specific code.

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR


---
_Generated by [Claude Code](https://claude.ai/code/session_01BwAsNqHz5EwYD9vAuJXteM)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to clarify that the search index name is automatically assigned by the system and read-only.

* **Bug Fixes**
  * Enhanced error handling for invalid or malformed search index names; the system now automatically clears and recreates them.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/allenhutchison/obsidian-gemini/pull/867?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->