### PR TITLE
refactor: dedupe RagVaultScanner teardown + not-found checks

### DIFF
--- a/src/services/rag-vault-scanner.ts
+++ b/src/services/rag-vault-scanner.ts
@@ -7,7 +7,7 @@ import type { RagCache } from './rag-cache';
 import type { RagRateLimiter } from './rag-rate-limiter';
 import { CACHE_VERSION } from './rag-types';
 import type { IndexProgress, IndexResult, FailedFileEntry, RagIndexStatus } from './rag-types';
-import { getErrorMessage, isQuotaExhausted } from '../utils/error-utils';
+import { getErrorMessage, isNotFoundError, isQuotaExhausted } from '../utils/error-utils';
 import { executeWithRetry } from '../utils/retry';
 
 /**
@@ -134,8 +134,7 @@ export class RagVaultScanner {
 			} catch (error) {
 				// Check if it's a 404/not found error vs other errors
 				const errorMessage = error instanceof Error ? error.message : String(error);
-				const isNotFound =
-					errorMessage.includes('404') || errorMessage.includes('not found') || errorMessage.includes('NOT_FOUND');
+				const isNotFound = isNotFoundError(error);
 				// A saved store name can be structurally invalid — e.g. a custom name
 				// entered via an older plugin version that the File Search API rejects
 				// as malformed (the resource ID is server-assigned and cannot be chosen).
@@ -315,11 +314,7 @@ export class RagVaultScanner {
 					);
 					this.plugin.logger.log(`RAG Indexing: Deleted store ${storeName}`);
 				} catch (deleteError) {
-					const errorMessage = deleteError instanceof Error ? deleteError.message : String(deleteError);
-					const isNotFound =
-						errorMessage.includes('404') || errorMessage.includes('not found') || errorMessage.includes('NOT_FOUND');
-
-					if (isNotFound) {
+					if (isNotFoundError(deleteError)) {
 						this.plugin.logger.debug(
 							'RAG Indexing: Store no longer exists, proceeding with fresh creation',
 							deleteError
@@ -557,17 +552,7 @@ export class RagVaultScanner {
 				if (isQuotaExhausted(error)) {
 					this.plugin.logger.error('RAG Indexing: Permanent quota exhaustion detected, stopping');
 					this.rateLimiter.resetTracking();
-					this.callbacks.setStatus('error');
-					this.currentFile = undefined;
-					this.indexingStartTime = undefined;
-					if (this.ragCache.cache) {
-						this.ragCache.cache.indexingInProgress = false;
-						this.ragCache.cache.indexingStartedAt = undefined;
-						this.ragCache.cache.lastIndexedFile = undefined;
-						await this.ragCache.saveCache();
-					}
-					this.callbacks.onUpdateStatusBar();
-					this.callbacks.onNotifyListeners();
+					await this.resetIndexingState('error');
 					new Notice(getErrorMessage(error), 8000);
 					result.duration = Date.now() - startTime;
 					return result;
@@ -577,18 +562,7 @@ export class RagVaultScanner {
 				if (this.rateLimiter.consecutiveCount >= this.rateLimiter.maxRetries) {
 					this.plugin.logger.error(`RAG Indexing: Max rate limit retries (${this.rateLimiter.maxRetries}) exceeded`);
 					this.rateLimiter.resetTracking();
-					this.callbacks.setStatus('error');
-					this.currentFile = undefined;
-					this.indexingStartTime = undefined;
-					// Clear resume flags on explicit failure
-					if (this.ragCache.cache) {
-						this.ragCache.cache.indexingInProgress = false;
-						this.ragCache.cache.indexingStartedAt = undefined;
-						this.ragCache.cache.lastIndexedFile = undefined;
-						await this.ragCache.saveCache();
-					}
-					this.callbacks.onUpdateStatusBar();
-					this.callbacks.onNotifyListeners();
+					await this.resetIndexingState('error');
 					result.duration = Date.now() - startTime;
 					return result;
 				}
@@ -616,21 +590,9 @@ export class RagVaultScanner {
 				return result;
 			}
 
-			this.callbacks.setStatus(this.cancelRequested ? 'idle' : 'error');
-			this.currentFile = undefined;
-			this.indexingStartTime = undefined;
+			const newStatus: RagIndexStatus = this.cancelRequested ? 'idle' : 'error';
 			this.cancelRequested = false;
-
-			// Clear resume flags on cancellation or error.
-			if (this.ragCache.cache) {
-				this.ragCache.cache.indexingInProgress = false;
-				this.ragCache.cache.indexingStartedAt = undefined;
-				this.ragCache.cache.lastIndexedFile = undefined;
-				await this.ragCache.saveCache();
-			}
-
-			this.callbacks.onUpdateStatusBar();
-			this.callbacks.onNotifyListeners();
+			await this.resetIndexingState(newStatus);
 
 			// Don't re-throw if cancelled, just return partial results
 			if (error instanceof Error && error.message === 'Indexing cancelled by user') {
@@ -643,6 +605,25 @@ export class RagVaultScanner {
 
 		result.duration = Date.now() - startTime;
 		return result;
+	}
+
+	/**
+	 * Tear down indexing state on a failed or cancelled run: apply the status,
+	 * clear the in-memory progress fields, and reset the cache resume flags so the
+	 * next run starts clean rather than offering to resume a dead run.
+	 */
+	private async resetIndexingState(status: RagIndexStatus): Promise<void> {
+		this.callbacks.setStatus(status);
+		this.currentFile = undefined;
+		this.indexingStartTime = undefined;
+		if (this.ragCache.cache) {
+			this.ragCache.cache.indexingInProgress = false;
+			this.ragCache.cache.indexingStartedAt = undefined;
+			this.ragCache.cache.lastIndexedFile = undefined;
+			await this.ragCache.saveCache();
+		}
+		this.callbacks.onUpdateStatusBar();
+		this.callbacks.onNotifyListeners();
 	}
 
 	/**

--- a/src/utils/error-utils.ts
+++ b/src/utils/error-utils.ts
@@ -99,6 +99,16 @@ export function isRateLimitError(error: unknown): boolean {
 }
 
 /**
+ * Check if an error represents a "resource not found" failure (HTTP 404 /
+ * NOT_FOUND). Matches on message substrings so it works across the varying
+ * error shapes the Google File Search API and SDK return.
+ */
+export function isNotFoundError(error: unknown): boolean {
+	const message = error instanceof Error ? error.message : String(error);
+	return message.includes('404') || message.includes('not found') || message.includes('NOT_FOUND');
+}
+
+/**
  * Extract a user-friendly error message from various error types
  *
  * Handles errors from Google Gemini API, network errors, and generic errors.

--- a/test/services/rag-vault-scanner.test.ts
+++ b/test/services/rag-vault-scanner.test.ts
@@ -54,6 +54,10 @@ vi.mock('@allenhutchison/gemini-utils', () => ({
 vi.mock('../../src/utils/error-utils', () => ({
 	getErrorMessage: vi.fn((err: any) => (err instanceof Error ? err.message : String(err))),
 	isQuotaExhausted: vi.fn().mockReturnValue(false),
+	isNotFoundError: vi.fn((err: any) => {
+		const msg = err instanceof Error ? err.message : String(err);
+		return msg.includes('404') || msg.includes('not found') || msg.includes('NOT_FOUND');
+	}),
 	extractStatusCode: vi.fn((err: any) => err?.status ?? null),
 }));
 

--- a/test/utils/error-utils.test.ts
+++ b/test/utils/error-utils.test.ts
@@ -1,4 +1,10 @@
-import { getErrorMessage, getShortErrorMessage, isQuotaExhausted, isRateLimitError } from '../../src/utils/error-utils';
+import {
+	getErrorMessage,
+	getShortErrorMessage,
+	isNotFoundError,
+	isQuotaExhausted,
+	isRateLimitError,
+} from '../../src/utils/error-utils';
 
 describe('error-utils', () => {
 	describe('getErrorMessage', () => {
@@ -418,6 +424,30 @@ describe('error-utils', () => {
 		test('returns false for null/undefined', () => {
 			expect(isRateLimitError(null)).toBe(false);
 			expect(isRateLimitError(undefined)).toBe(false);
+		});
+	});
+
+	describe('isNotFoundError', () => {
+		test('detects 404 in message', () => {
+			expect(isNotFoundError(new Error('HTTP 404'))).toBe(true);
+		});
+
+		test('detects "not found" in message', () => {
+			expect(isNotFoundError(new Error('The store could not be located: not found'))).toBe(true);
+		});
+
+		test('detects NOT_FOUND in message', () => {
+			expect(isNotFoundError(new Error('Request failed: NOT_FOUND'))).toBe(true);
+		});
+
+		test('returns false for unrelated errors', () => {
+			expect(isNotFoundError(new Error('Internal server error'))).toBe(false);
+			expect(isNotFoundError(new Error('400 INVALID_ARGUMENT'))).toBe(false);
+		});
+
+		test('handles non-Error values via String()', () => {
+			expect(isNotFoundError('plain 404 string')).toBe(true);
+			expect(isNotFoundError(null)).toBe(false);
 		});
 	});
 


### PR DESCRIPTION
## Summary

Closes #865 — DRY refactor of `RagVaultScanner` (`src/services/rag-vault-scanner.ts`).

- The `_doIndexVault` catch handler repeated the same ~10-line indexing-state teardown **three times** (permanent quota exhaustion, max-retries exceeded, generic error/cancellation). A resume-flag fix had to land in all three or the failure paths would silently drift. Extracted into a private `resetIndexingState(status)` method.
- The duplicated `404 / not found / NOT_FOUND` message check (in `ensureFileSearchStore` and `startFresh`) is now a shared `isNotFoundError()` predicate in `error-utils.ts`, co-located with `isQuotaExhausted` / `isRateLimitError`.

## Changes

- `src/utils/error-utils.ts` — new exported `isNotFoundError(error: unknown): boolean`.
- `src/services/rag-vault-scanner.ts` — new private `resetIndexingState(status)`; the three catch-handler teardown blocks collapsed to call it; both not-found checks now use `isNotFoundError`.
- `test/utils/error-utils.test.ts` — added an `isNotFoundError` unit-test block (5 tests).
- `test/services/rag-vault-scanner.test.ts` — added `isNotFoundError` to the `error-utils` mock so the existing 404-path tests keep exercising the new helper.

## Behavior

Pure refactor — **no behavior change**. The early-`return result` control flow and the recursive rate-limit retry path are untouched. In the generic-error path, `cancelRequested = false` now runs just before the teardown instead of mid-block; this is not observable — nothing reads the flag during teardown, and it is reset at the start of every indexing run regardless.

## Test plan

- [x] `npm test` — 2842 passed (122 files), incl. 5 new `isNotFoundError` tests
- [x] `npm run build` — TypeScript check + bundle clean
- [x] `npm run lint` — 0 errors (7 pre-existing warnings, all in untouched files)
- [x] `npm run format-check` — clean

## Documentation

No documentation changes — internal refactor with no user-facing behavior, settings, or API changes.

https://claude.ai/code/session_01CuHvCNsPcrtwXyApRZr1EX

---
_Generated by [Claude Code](https://claude.ai/code/session_01CuHvCNsPcrtwXyApRZr1EX)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error detection for "not found" scenarios using more reliable pattern matching instead of substring comparison.

* **Tests**
  * Added comprehensive test coverage for detecting "not found" errors across various input types.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/allenhutchison/obsidian-gemini/pull/868?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->