### PR TITLE
PR-based release flow with full-version release titles

### DIFF
--- a/.agents/skills/release-process/SKILL.md
+++ b/.agents/skills/release-process/SKILL.md
@@ -1,12 +1,14 @@
 ---
 name: release-process
 description: >-
-  Full release workflow for obsidian-gemini: update release notes, run checks,
-  bump version with npm, create a GitHub release, and verify. Use this skill
-  when preparing a new plugin release.
+  The single release workflow for obsidian-gemini, used for both interactive
+  (human) and scheduled (agent) runs. Checks whether a release is warranted,
+  drafts release notes, bumps the version on a release branch, and opens a
+  "Release X.Y.Z" PR; merging that PR tags the commit and builds a draft GitHub
+  release. Use this skill whenever preparing a plugin release.
 metadata:
   author: obsidian-gemini
-  version: '1.0'
+  version: '2.0'
 compatibility: Specific to the obsidian-gemini repository.
 ---
 
@@ -18,74 +20,138 @@ Use this skill when:
 
 - You need to create a new release of the plugin
 - The user asks to bump the version, publish, or ship a release
+- A scheduled task runs the weekly release check
 - You need to understand the release workflow or version management
+
+This is the **single release process** — the steps are identical whether a
+human runs them interactively or a scheduled agent runs them. The only
+difference is who reviews and merges the release PR (step 7).
 
 ## Release steps
 
-Follow these steps in order to create a new release:
+### 1. Check whether a release is warranted (release gate)
 
-### 1. Update Release Notes (`src/release-notes.json`)
-
-- Add a new entry at the top of the JSON object for the new version
-- Include a title, highlights (array of bullet points), and details
-- Follow the emoji pattern used in existing releases
-- This file is the single source of truth for both the in-app modal and the docs site changelog
-
-### 2. Run Tests and Build
+List the commits since the last release:
 
 ```bash
-npm test        # Ensure all tests pass
-npm run build   # Verify production build succeeds
+git fetch --tags origin
+git log "$(git describe --tags --abbrev=0)"..HEAD --oneline
 ```
 
-### 3. Commit Release Notes
+Categorize them by conventional-commit prefix:
+
+- **Warrants a release:** `feat:`, `fix:`, `perf:` (or a `revert:` of one)
+- **Does NOT, on its own:** `chore:`, `docs:`, `test:`, `ci:`, `style:`,
+  `refactor:`, `build:`
+
+If there is no `feat:`, `fix:`, or `perf:` commit, **stop** — there is nothing
+to ship. A scheduled run must respect this and exit quietly. A human may
+override with explicit judgement (e.g. shipping a refactor-only release).
+
+### 2. Pick the version bump
+
+Derive the new `X.Y.Z` from those commits, semver-style:
+
+- **major** — any commit with a `!` (e.g. `feat!:`) or a `BREAKING CHANGE:` footer
+- **minor** — at least one `feat:` and no breaking change
+- **patch** — only `fix:` / `perf:` changes
+
+### 3. Draft the release notes (`src/release-notes.json`)
+
+Add a new entry at the **top** of the JSON object, keyed by the new `X.Y.Z`:
+
+- `title` — **must contain the full three-part version** (`X.Y.Z`). Never
+  abbreviate a `.0` minor release: write `Gemini Scribe 4.10.0`, not `4.10`.
+  The GitHub release name is taken verbatim from this field, and the Obsidian
+  community score card requires the full version string in the release name.
+- `highlights` — array of short bullet points; follow the emoji pattern of
+  existing entries.
+- `details` — a paragraph summarizing the release.
+
+This file is the single source of truth for the in-app "what's new" modal, the
+docs-site changelog, and the GitHub release title and body. On a scheduled run,
+synthesize the entry from that period's `planning/changelog/YYYY-MM-DD.md`
+files (produced by the `daily-changelog` skill).
+
+### 4. Create the release branch and bump the version
 
 ```bash
-git add src/release-notes.json
-git commit -m "Add release notes for version X.Y.Z"
+git checkout main && git pull origin main
+git checkout -b "auto/release-X.Y.Z"
+node version-bump.mjs X.Y.Z
 ```
 
-### 4. Bump Version (Choose appropriate semantic version)
+`node version-bump.mjs X.Y.Z` updates `package.json`, `manifest.json`, and
+`versions.json` together, with no git side-effects. Do **not** use
+`npm version` — it tags and pushes immediately, which the PR-based flow must
+not do.
+
+### 5. Verify
 
 ```bash
-npm version patch  # Bug fixes (4.1.0 -> 4.1.1)
-npm version minor  # New features (4.1.0 -> 4.2.0)
-npm version major  # Breaking changes (4.1.0 -> 5.0.0)
+npm test
+npm run build
 ```
 
-The `npm version` command automatically:
+Both must pass. Abort the release if either fails.
 
-- Updates `package.json` version
-- Runs `version-bump.mjs` to update `manifest.json` and `versions.json`
-- Creates a git commit with the version change
-- Creates a git tag (e.g., `4.1.1`)
-- Pushes the commit and tag to GitHub (via `postversion` script)
+### 6. Commit and push the release branch
 
-### 5. Update GitHub Release
+```bash
+git add src/release-notes.json package.json manifest.json versions.json
+git commit -m "Release X.Y.Z"
+git push -u origin "auto/release-X.Y.Z"
+```
 
-A GitHub Actions runner automatically creates a draft release when a tag is pushed. After the tag is pushed:
+### 7. Open the "Release X.Y.Z" PR
 
-- Go to https://github.com/allenhutchison/obsidian-gemini/releases
-- Find the auto-generated release for the new tag
-- Update the release notes body with content from `src/release-notes.json`, formatted as Markdown
-- Mark the release as **"Set as the latest release"**
-- Publish the release (if still in draft)
+Open a pull request from `auto/release-X.Y.Z` into `main`, titled
+`Release X.Y.Z`, with the release notes in the body.
 
-### 6. Verify Release
+- **Human run:** review the diff and merge the PR.
+- **Scheduled agent run:** stop here — report the PR link and let a human
+  review and merge it. Do not merge it yourself.
 
-- Check that the release appears on GitHub and is marked as "Latest"
-- Verify the tag matches the version
-- Test installation in a test vault (if needed)
+The release notes are compiled into the plugin at build time, so the PR is the
+checkpoint where they are reviewed **before** they ship.
+
+### 8. Automated tag and draft release (no action needed)
+
+When the `auto/release-*` PR is merged, `.github/workflows/release.yml`
+automatically: verifies the release title contains the full version, creates
+and pushes the `X.Y.Z` tag, builds the plugin, and creates a **draft** GitHub
+release — titled and described from `src/release-notes.json`, with `main.js`,
+`manifest.json`, and `styles.css` attached.
+
+### 9. Publish the release
+
+- Open the draft release at https://github.com/allenhutchison/obsidian-gemini/releases
+- Confirm the title contains the full `X.Y.Z` and the body reads well
+- Mark it **"Set as the latest release"** and publish
 
 ## Important rules
 
-- Do NOT manually edit version numbers in `package.json`, `manifest.json`, or `versions.json`. Always use the `npm version` commands.
-- Always update release notes BEFORE running `npm version`.
-- Ensure you're on the master branch and it's up to date before releasing.
+- The GitHub release **title** must contain the full `X.Y.Z` version string
+  (Obsidian community score-card requirement). Never abbreviate `X.Y.0` as `X.Y`.
+- Do NOT hand-edit version numbers in `package.json`, `manifest.json`, or
+  `versions.json` — always use `node version-bump.mjs X.Y.Z`.
+- Do NOT use `npm version` for releases; it tags and pushes immediately.
+- Every release goes through an `auto/release-*` PR — there is no
+  direct-to-`main` release path.
+- Always branch from an up-to-date `main`.
 
 ## Build system context
 
 - Uses esbuild for fast bundling with TypeScript
 - Custom text file loader for `.txt` and `.hbs` templates
 - Source maps inline in dev, tree shaking in production
-- Generated artifacts (`main.js`, `manifest.json`, `versions.json`) stay in the repo root for Obsidian
+- Generated artifacts (`main.js`, `manifest.json`, `versions.json`) stay in the
+  repo root for Obsidian
+
+## Manual release escape hatch
+
+If the PR flow is unavailable, a release can be triggered manually: bump the
+version on `main` with `node version-bump.mjs X.Y.Z` (with a matching
+`src/release-notes.json` entry), then run the **Release Obsidian Gemini plugin**
+workflow via _workflow_dispatch_, supplying the version. It performs the same
+tag + build + draft-release steps.

--- a/.agents/skills/release-process/SKILL.md
+++ b/.agents/skills/release-process/SKILL.md
@@ -76,7 +76,7 @@ files (produced by the `daily-changelog` skill).
 ### 4. Create the release branch and bump the version
 
 ```bash
-git checkout main && git pull origin main
+git checkout master && git pull origin master
 git checkout -b "auto/release-X.Y.Z"
 node version-bump.mjs X.Y.Z
 ```
@@ -105,7 +105,7 @@ git push -u origin "auto/release-X.Y.Z"
 
 ### 7. Open the "Release X.Y.Z" PR
 
-Open a pull request from `auto/release-X.Y.Z` into `main`, titled
+Open a pull request from `auto/release-X.Y.Z` into `master`, titled
 `Release X.Y.Z`, with the release notes in the body.
 
 - **Human run:** review the diff and merge the PR.
@@ -137,8 +137,8 @@ release — titled and described from `src/release-notes.json`, with `main.js`,
   `versions.json` — always use `node version-bump.mjs X.Y.Z`.
 - Do NOT use `npm version` for releases; it tags and pushes immediately.
 - Every release goes through an `auto/release-*` PR — there is no
-  direct-to-`main` release path.
-- Always branch from an up-to-date `main`.
+  direct-to-`master` release path.
+- Always branch from an up-to-date `master`.
 
 ## Build system context
 
@@ -151,7 +151,7 @@ release — titled and described from `src/release-notes.json`, with `main.js`,
 ## Manual release escape hatch
 
 If the PR flow is unavailable, a release can be triggered manually: bump the
-version on `main` with `node version-bump.mjs X.Y.Z` (with a matching
+version on `master` with `node version-bump.mjs X.Y.Z` (with a matching
 `src/release-notes.json` entry), then run the **Release Obsidian Gemini plugin**
 workflow via _workflow_dispatch_, supplying the version. It performs the same
 tag + build + draft-release steps.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,55 +1,107 @@
+# Releases the plugin when an `auto/release-*` PR is merged (see the
+# release-process skill), or via a manual workflow_dispatch. Creates the tag,
+# builds, and publishes a draft GitHub release titled from src/release-notes.json.
 name: Release Obsidian Gemini plugin
 
 on:
-  push:
-    tags:
-      - '*'
+  pull_request:
+    types: [closed]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to release, e.g. 4.10.0 (version files on main must already be bumped)'
+        required: true
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
-  test:
+  release:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.pull_request.merged == true &&
+       startsWith(github.event.pull_request.head.ref, 'auto/release-'))
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
     steps:
       - uses: actions/checkout@v6
-      - name: Use Node.js
-        uses: actions/setup-node@v6
         with:
-          node-version: '24.x'
-      - name: Install dependencies
-        run: npm install
-      - name: Run tests
-        run: npm test
-
-  build:
-    needs: test
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-
-    steps:
-      - uses: actions/checkout@v6
+          ref: ${{ github.event.pull_request.merge_commit_sha || github.ref }}
 
       - name: Use Node.js
         uses: actions/setup-node@v6
         with:
           node-version: '24.x'
 
-      - name: Build plugin
+      - name: Resolve version
+        id: version
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          if [ "$EVENT_NAME" = 'workflow_dispatch' ]; then
+            version="$INPUT_VERSION"
+          else
+            version="$(node -p "require('./package.json').version")"
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve release title
+        id: title
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          title="$(node -p "require('./src/release-notes.json')[process.env.VERSION]?.title || ''")"
+          echo "title=$title" >> "$GITHUB_OUTPUT"
+
+      - name: Verify release title contains the full version
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          TITLE: ${{ steps.title.outputs.title }}
+        run: |
+          if [ -z "$TITLE" ]; then
+            echo "::error::No src/release-notes.json entry for version $VERSION"
+            exit 1
+          fi
+          case "$TITLE" in
+            *"$VERSION"*) echo "Release title OK: $TITLE" ;;
+            *) echo "::error::Release title '$TITLE' must contain the full version '$VERSION'"; exit 1 ;;
+          esac
+
+      - name: Install dependencies and test
         run: |
           npm install
-          npm run build
+          npm test
 
-      - name: Create release
+      - name: Build plugin
+        run: npm run build
+
+      - name: Create and push tag
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          git tag "$VERSION"
+          git push origin "$VERSION"
+
+      - name: Write release notes body
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          node -e "
+            const note = require('./src/release-notes.json')[process.env.VERSION];
+            const parts = [];
+            if (note.details) parts.push(note.details, '');
+            parts.push(...note.highlights.map((h) => '- ' + h));
+            require('fs').writeFileSync('RELEASE_BODY.md', parts.join('\n') + '\n');
+          "
+
+      - name: Create draft release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.version.outputs.version }}
+          TITLE: ${{ steps.title.outputs.title }}
         run: |
-          tag="${GITHUB_REF#refs/tags/}"
-
-          gh release create "$tag" \
-            --title="$tag" \
+          gh release create "$VERSION" \
+            --title="$TITLE" \
+            --notes-file RELEASE_BODY.md \
             --draft \
             main.js manifest.json styles.css

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -297,7 +297,7 @@ This keeps technical planning centralized and accessible for all contributors.
 For creating pull requests, use the **create-pr** skill which enforces the PR template and runs all pre-flight checks.
 
 - Write concise, imperative commit subjects (`Fix agent session cleanup`, `Improve prompt builder`); reference issues/PRs with `#123`
-- Commit generated artifacts (`main.js`, `manifest.json`, `versions.json`) alongside source changes; use `npm run version` for releases
+- Commit generated artifacts (`manifest.json`, `versions.json`) alongside source changes; releases go through a `Release X.Y.Z` PR — see the **release-process** skill
 - **MANDATORY**: Include documentation updates in the same PR/commit as code changes (see Documentation Maintenance section)
 - PRs should explain motivation, highlight user-visible impact, list automated/manual tests, and attach screenshots or vault clips for UI tweaks
 - Flag reviewers who own the affected area and mention required follow-up or rollout notes

--- a/src/release-notes.json
+++ b/src/release-notes.json
@@ -7,7 +7,7 @@
 		"details": "This patch fixes the \"Initialize Vault Context\" / \"Update Vault Context\" button in the agent view. The request sent to the model was shaped so that the analysis prompt was discarded, causing the model to return a conversational reply that failed to parse and never produced an AGENTS.md file. The request is now built correctly and the feature works again."
 	},
 	"4.9.0": {
-		"title": "🪝 Gemini Scribe 4.9 - Lifecycle Hooks, Stable Prefix Caching, Custom Endpoint",
+		"title": "🪝 Gemini Scribe 4.9.0 - Lifecycle Hooks, Stable Prefix Caching, Custom Endpoint",
 		"highlights": [
 			"🪝 Lifecycle hooks engine — define hooks that fire on Obsidian events and run summarize/rewrite/command/agent actions, with full management UI and a settings toggle",
 			"⚡ Prompt-prefix caching stabilized — the agent's system instruction is now byte-stable across turns and tool follow-ups, restoring Gemini's implicit prefix cache so long sessions stop reprocessing history each turn (closes #763)",
@@ -23,7 +23,7 @@
 		"details": "This release introduces a lifecycle-hooks engine — define hooks that fire on Obsidian events (note modify, command palette, etc.) and run summarize/rewrite/command/agent actions with a dedicated management UI. Agent prompt-prefix caching has been stabilized (closes #763): the system instruction is now byte-stable across turns and tool follow-ups, restoring Gemini's implicit prefix cache so long chat or coding sessions no longer reprocess history each turn. A custom API endpoint setting lets you point Gemini Scribe at a proxy or alternate Gemini-compatible host. MCP servers are now resilient on offline machines and store stdio env vars in Obsidian's encrypted SecretStorage. Tool-policy is unified across Sessions, Projects, Scheduled Tasks, and Hooks. The settings UI gains collapsible sections, and new agent sidebar actions are registered as Obsidian commands. Under the hood: per-provider packages under src/api/providers/ (GeminiClientFactory → ModelClientFactory; breaking for SDK consumers, OllamaClient now in the public barrel), two-phase context compaction, tool-result payload truncation in older history, retry/backoff applied to non-chat direct SDK calls, and substantial eval-harness maturity work (baseline-compare, LLM-judge fallback, per-task timeouts, clean interrupt) plus broader test coverage."
 	},
 	"4.8.0": {
-		"title": "✨ Gemini Scribe 4.8 - Scheduled & Background Tasks, Ollama, Activity Modal",
+		"title": "✨ Gemini Scribe 4.8.0 - Scheduled & Background Tasks, Ollama, Activity Modal",
 		"highlights": [
 			"⏰ Scheduled tasks — run agent tasks on a cron, time-of-day, or day-of-week schedule with full management UI",
 			"🌙 Missed-run catch-up — tasks that should have run while Obsidian was closed surface on startup for review",
@@ -38,7 +38,7 @@
 		"details": "This release introduces scheduled tasks: define agent tasks with cron, time-of-day, or day-of-week schedules and manage them with a dedicated UI. If Obsidian was closed when a run was due, a catch-up modal surfaces missed runs on startup. Long-running operations like deep research and image generation now run as background tasks, with all their output consolidated under [state-folder]/Background-Tasks/, and a unified activity modal gives you a single place to monitor background work alongside RAG indexing status. Ollama joins as a provider option for fully local chat. The runaway-loop detector now escalates to a per-turn abort with a user-visible notice. Under the hood, AgentLoop has been extracted so scheduled and background runners share the same engine as the UI, and a new eval harness with multi-hop, loop-trap, and pass^k reliability checks helps verify agent-loop changes. Includes mobile fixes for iOS layout and the catch-up modal, plus a migration of the test runner from ts-jest to Vitest."
 	},
 	"4.7.0": {
-		"title": "✨ Gemini Scribe 4.7 - Projects, Session Memory & File Shelf",
+		"title": "✨ Gemini Scribe 4.7.0 - Projects, Session Memory & File Shelf",
 		"highlights": [
 			"📂 Projects — scope agent sessions to a folder with custom instructions and tool/skill overrides",
 			"🧠 Session recall — the agent can search past conversations for relevant context",
@@ -52,7 +52,7 @@
 		"details": "This release introduces Projects, letting you scope agent sessions to a folder with custom instructions, permission overrides, and skill filters. Session recall gives the agent memory across conversations — it can search past sessions for relevant context. The new file context shelf replaces the old context panel with a compact drag-and-drop bar that auto-expands folder contents. Write and edit tool calls now show a diff review view so you can inspect changes before they're applied. Bundled skills ship built-in help and Obsidian knowledge that are auto-generated from the docs site at build time. Agent tools can now read binary files (images, audio, PDFs) encountered during tool execution. The prompt system has been refactored into layered Handlebars templates for better maintainability. Under the hood, a new event bus architecture decouples lifecycle hooks, and strict TypeScript checks improve code reliability."
 	},
 	"4.6.0": {
-		"title": "✨ Gemini Scribe 4.6 - Context Management & Tool Permissions",
+		"title": "✨ Gemini Scribe 4.6.0 - Context Management & Tool Permissions",
 		"highlights": [
 			"🧠 Automatic context compaction — long conversations are summarized to stay within model limits",
 			"📊 Live token usage display with cached/uncached breakdown (opt-in in settings)",

--- a/version-bump.mjs
+++ b/version-bump.mjs
@@ -1,6 +1,20 @@
 import { readFileSync, writeFileSync } from 'fs';
 
-const targetVersion = process.env.npm_package_version;
+// Target version: CLI arg (PR-based release flow) or npm_package_version (`npm version`).
+const argVersion = process.argv[2];
+const targetVersion = argVersion ?? process.env.npm_package_version;
+
+if (!targetVersion) {
+	console.error('No target version. Usage: node version-bump.mjs <version>');
+	process.exit(1);
+}
+
+// With a CLI arg, npm has not bumped package.json — do it here.
+if (argVersion) {
+	const pkg = JSON.parse(readFileSync('package.json', 'utf8'));
+	pkg.version = targetVersion;
+	writeFileSync('package.json', JSON.stringify(pkg, null, '\t') + '\n');
+}
 
 // read minAppVersion from manifest.json and bump version to target version
 let manifest = JSON.parse(readFileSync('manifest.json', 'utf8'));


### PR DESCRIPTION
## Summary

Reworks the release process into a single PR-based flow that works identically whether a human or a scheduled agent runs it, and fixes the Obsidian community score-card requirement that the release **title** carry the full `X.Y.Z` version.

Releases now: gate on whether anything is shippable → draft release notes → bump the version on an `auto/release-*` branch → open a `Release X.Y.Z` PR. Merging that PR triggers `release.yml`, which tags, builds, and creates a draft GitHub release in one job. This makes a weekly scheduled release agent possible — it runs the same `release-process` skill and stops at the PR for human review.

## Changes

- **`.agents/skills/release-process/SKILL.md`** — rewritten as the single human/agent release process: release gate, semver decision, notes drafting, branch + bump, verify, open PR. Adds the full-version-title rule.
- **`.github/workflows/release.yml`** — re-triggers on a merged `auto/release-*` PR (or manual `workflow_dispatch`); tag + build + draft release in one job with `GITHUB_TOKEN` only (no PAT). Fails the release if the title omits the full version.
- **`version-bump.mjs`** — `node version-bump.mjs X.Y.Z` bumps all three version files with no git side-effects (the PR flow must not tag/push).
- **`src/release-notes.json`** — corrected the four abbreviated minor titles (`4.6.0`–`4.9.0`, e.g. `4.9` → `4.9.0`).
- **`AGENTS.md`** — release guidance points at the PR flow; dropped the stale claim that `main.js` is committed (it is gitignored).

## Follow-ups (not in this PR)

- **Re-title 4 existing GitHub releases** — `4.6.0`–`4.9.0` are still named `4.6`–`4.9` on GitHub. No release-edit API was available in this environment; please update them to match the corrected `release-notes.json` titles:
  - `4.9.0` → `🪝 Gemini Scribe 4.9.0 - Lifecycle Hooks, Stable Prefix Caching, Custom Endpoint`
  - `4.8.0` → `✨ Gemini Scribe 4.8.0 - Scheduled & Background Tasks, Ollama, Activity Modal`
  - `4.7.0` → `✨ Gemini Scribe 4.7.0 - Projects, Session Memory & File Shelf`
  - `4.6.0` → `✨ Gemini Scribe 4.6.0 - Context Management & Tool Permissions`
- **Schedule the weekly run** — a local weekly-Tuesday task that runs the `release-process` skill (configured on your machine).

## Docs updated

- `.agents/skills/release-process/SKILL.md`
- `AGENTS.md`

## Test plan

- [x] `npm test` — 2836 tests pass
- [x] `npm run build` — production build succeeds
- [x] `node version-bump.mjs X.Y.Z` verified in a temp dir (bumps all three version files, reads `minAppVersion` correctly)
- [ ] First real release exercises the merged-PR trigger in `release.yml`

https://claude.ai/code/session_01NDf7CjfjVQxBQ2zRGrrPwk

---
_Generated by [Claude Code](https://claude.ai/code/session_01NDf7CjfjVQxBQ2zRGrrPwk)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release-process guidelines with a unified workflow for automated and manual releases.
  * Added release gates and validation rules (requires full version numbers in release titles).

* **Chores**
  * Refactored release workflow to use PR-based process with automated testing and artifact handling.
  * Updated version bump tooling to support flexible version input.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/allenhutchison/obsidian-gemini/pull/878?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->