### PR TITLE
feat: persist eval judging evidence (response, matchers, transcript)

### DIFF
--- a/.agents/skills/eval-harness/SKILL.md
+++ b/.agents/skills/eval-harness/SKILL.md
@@ -53,6 +53,20 @@ fi
 
 If the user wants a different test vault, take the name from them and use it as `EXPECTED`.
 
+## Build the plugin under test (mandatory preflight)
+
+The harness drives the plugin **already installed** in the test vault over the Obsidian CLI — `npm run eval` builds nothing. If you've changed plugin source (`src/`) and skip this step, the eval silently measures the _old_ code: the run looks clean, the numbers are just wrong. That's the worst failure mode for a baseline.
+
+Before any run that's meant to reflect current `src/`:
+
+```bash
+npm run build && npm run install:test-vault && obsidian plugin:reload id=gemini-scribe
+# plugin:reload reports success even if onload() threw — confirm a clean load:
+obsidian dev:errors
+```
+
+When you only changed harness files (`evals/`, baselines, fixtures) and not plugin source, skip this — those run in Node, not inside Obsidian, so no rebuild is needed. When in doubt, build: it's cheap, and a stale-plugin baseline is not.
+
 ## Pre-run cleanup
 
 State from a previous interrupted run can corrupt a new one (see "Operational gotchas" in `evals/README.md`, and #777). Always preflight:

--- a/evals/README.md
+++ b/evals/README.md
@@ -396,6 +396,26 @@ The `by_difficulty` breakdown is also printed to stdout under "Solve^k by diffic
 
 The result file also records `provider` (e.g. `gemini`, `ollama`) at the top level so `compare` can flag cross-provider runs and skip metrics that aren't comparable.
 
+## Persisted evidence
+
+Beyond pass/solve verdicts, each run records the evidence behind the score so a
+result can be human-reviewed or re-judged later without re-running the task:
+
+| Field                           | Where                   | Contents                                                                                                                                                                |
+| ------------------------------- | ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `response_text`                 | per-run result          | The agent's final response, frozen at run time (non-reproducible).                                                                                                      |
+| `solve_details.matcher_details` | per-run `solve_details` | One entry per `outputMatcher`: its `type`, what it checked (`value`/`flags`/`criteria`), the `verdict`, and any `error`. Empty when the run failed before matchers ran. |
+| `transcript_path`               | per-run result          | Path (relative to `evals/`) to that run's transcript sidecar file, or `null`.                                                                                           |
+
+Transcripts are written to `evals/results/<run-id>/<task-id>-<n>.json` — the
+same `<run-id>` as the result file, so they correlate on disk. Each is the
+captured agent event stream (turn boundaries, tool calls with arguments,
+API responses). Tool-result bodies are stringified and truncated to 2 KB, and
+binary `inlineData` is dropped — both to keep the `obsidian eval` CLI bridge
+within its output ceiling. The `results/` directory is gitignored, so
+transcripts and raw results stay out of source control; only blessed baselines
+are committed.
+
 ## Architecture
 
 The harness drives Obsidian via the `obsidian eval` CLI command, installing a temporary event-bus subscriber to capture agent lifecycle events. It does NOT modify plugin internals — all observation is via the existing `agentEventBus` subscriptions.

--- a/evals/lib/collector.mjs
+++ b/evals/lib/collector.mjs
@@ -41,6 +41,9 @@ export async function installCollector() {
         let s;
         try { s = typeof r.data === 'string' ? r.data : JSON.stringify(r.data); }
         catch (e) { s = '[unserializable]'; }
+        // JSON.stringify returns undefined (without throwing) for functions and
+        // symbols; coerce any non-string to the placeholder before reading .length.
+        if (typeof s !== 'string') s = '[unserializable]';
         out.data = s.length > LIMIT
           ? s.slice(0, LIMIT) + '... [+' + (s.length - LIMIT) + ' chars truncated]'
           : s;

--- a/evals/lib/collector.mjs
+++ b/evals/lib/collector.mjs
@@ -7,8 +7,23 @@
 import { obsidianEval } from './obsidian-driver.mjs';
 
 /**
+ * Max characters of a tool result's `data` kept in a captured event. Tool
+ * results can be whole files or full vault listings; the `obsidian eval` CLI
+ * bridge caps total output at ~1 MB, so an untruncated result could overflow
+ * the bridge and break the run. Truncation happens here, inside Obsidian,
+ * before the data ever crosses the bridge.
+ */
+const TRANSCRIPT_DATA_LIMIT = 2048;
+
+/**
  * Install the event collector on the plugin's agent event bus.
  * Captured events are pushed to `window.__evalCollector`.
+ *
+ * Tool results are reduced to `{ success, error, data, inlineDataOmitted }`:
+ * `data` is stringified and truncated to `TRANSCRIPT_DATA_LIMIT`, and binary
+ * `inlineData` (base64 blobs, useless in a transcript) is dropped, leaving
+ * only its count. This keeps the captured stream — which #869 persists as the
+ * per-run transcript — both informative and bounded.
  */
 export async function installCollector() {
 	await obsidianEval(`(() => {
@@ -17,6 +32,24 @@ export async function installCollector() {
     // Clean up any previous collectors
     for (const unsub of window.__evalUnsubscribers) unsub();
     window.__evalUnsubscribers = [];
+
+    const LIMIT = ${TRANSCRIPT_DATA_LIMIT};
+    const sanitizeResult = (r) => {
+      if (!r || typeof r !== 'object') return r;
+      const out = { success: r.success, error: r.error || undefined };
+      if (r.data !== undefined) {
+        let s;
+        try { s = typeof r.data === 'string' ? r.data : JSON.stringify(r.data); }
+        catch (e) { s = '[unserializable]'; }
+        out.data = s.length > LIMIT
+          ? s.slice(0, LIMIT) + '... [+' + (s.length - LIMIT) + ' chars truncated]'
+          : s;
+      }
+      if (Array.isArray(r.inlineData) && r.inlineData.length > 0) {
+        out.inlineDataOmitted = r.inlineData.length;
+      }
+      return out;
+    };
 
     const bus = app.plugins.plugins['gemini-scribe'].agentEventBus;
     const events = [
@@ -32,7 +65,15 @@ export async function installCollector() {
           if (k === 'session') {
             serializable.sessionId = v.id;
           } else if (k === 'result' && v && typeof v === 'object') {
-            serializable.result = { success: v.success, error: v.error || undefined };
+            serializable.result = sanitizeResult(v);
+          } else if (k === 'toolResults' && Array.isArray(v)) {
+            // toolChainComplete carries a batch of results; sanitize each so a
+            // base64 inlineData blob can't overflow the CLI bridge.
+            serializable.toolResults = v.map((tr) => ({
+              toolName: tr.toolName,
+              toolArguments: tr.toolArguments,
+              result: sanitizeResult(tr.result)
+            }));
           } else if (k === 'error' && v instanceof Error) {
             serializable.error = v.message;
           } else {

--- a/evals/lib/matchers.mjs
+++ b/evals/lib/matchers.mjs
@@ -89,8 +89,13 @@ export const taskHasJudgeMatcher = (task) => (task.outputMatchers || []).some((m
  * matcher fails — callers can detect "no judge available" via the returned
  * `judgeAttempted` / `judgeAvailable` flags rather than silently passing.
  *
- * Returns `{ pass, judgeAttempted, judgeAvailable, judgeSkipped }`:
+ * Returns `{ pass, details, judgeAttempted, judgeAvailable, judgeSkipped }`:
  *   - `pass`: true iff every matcher matched.
+ *   - `details`: one entry per matcher, in order, recording the matcher
+ *     `type`, what it checked (`value`/`flags`/`criteria`), its `verdict`,
+ *     and an `error` string for judge failures or unknown types. This is the
+ *     itemized evidence behind `pass` — frozen per run so a result can be
+ *     re-judged or human-reviewed without re-running the task (#869).
  *   - `judgeAttempted`: true iff at least one matcher was a `judge`.
  *   - `judgeAvailable`: true iff a judgeFn was supplied (and could be invoked).
  *   - `judgeSkipped`: true iff a `judge` matcher appeared but no judgeFn was supplied.
@@ -103,36 +108,50 @@ export async function evaluateMatchers(matchers, ctx, judgeFn) {
 	let pass = true;
 	let judgeAttempted = false;
 	const judgeAvailable = typeof judgeFn === 'function';
+	const details = [];
 
 	for (const m of list) {
 		if (m.type === 'contains') {
-			if (!evaluateContains(m.value, responseText)) pass = false;
+			const verdict = evaluateContains(m.value, responseText);
+			if (!verdict) pass = false;
+			details.push({ type: 'contains', value: m.value, verdict });
 			continue;
 		}
 		if (m.type === 'regex') {
-			if (!evaluateRegex(m.value, m.flags, responseText)) pass = false;
+			const verdict = evaluateRegex(m.value, m.flags, responseText);
+			if (!verdict) pass = false;
+			details.push({ type: 'regex', value: m.value, flags: m.flags ?? null, verdict });
 			continue;
 		}
 		if (m.type === 'judge') {
 			judgeAttempted = true;
 			if (!judgeAvailable) {
 				pass = false;
+				details.push({ type: 'judge', criteria: m.criteria, verdict: false, error: 'no judge available' });
 				continue;
 			}
 			try {
-				const verdict = await judgeFn(m.criteria, { userMessage, responseText });
+				const verdict = Boolean(await judgeFn(m.criteria, { userMessage, responseText }));
 				if (!verdict) pass = false;
-			} catch {
+				details.push({ type: 'judge', criteria: m.criteria, verdict });
+			} catch (err) {
 				// A judge-call failure (network, API error) must not look like a pass.
 				// The harness logs the error; the matcher conservatively fails.
 				pass = false;
+				details.push({
+					type: 'judge',
+					criteria: m.criteria,
+					verdict: false,
+					error: err instanceof Error ? err.message : String(err),
+				});
 			}
 			continue;
 		}
 		// Unknown matcher type — conservatively fail rather than silently pass,
 		// so a typo in a task file doesn't invent free solves.
 		pass = false;
+		details.push({ type: m.type ?? 'unknown', verdict: false, error: 'unknown matcher type' });
 	}
 
-	return { pass, judgeAttempted, judgeAvailable, judgeSkipped: judgeAttempted && !judgeAvailable };
+	return { pass, details, judgeAttempted, judgeAvailable, judgeSkipped: judgeAttempted && !judgeAvailable };
 }

--- a/evals/lib/reporter.mjs
+++ b/evals/lib/reporter.mjs
@@ -174,10 +174,14 @@ export function computeAggregates(taskResults) {
 
 /**
  * Build the full result object.
+ *
+ * `runId` is supplied by the runner so the result file and the transcript
+ * directory share one identifier; it falls back to the current time for
+ * standalone callers (e.g. unit tests).
  */
-export function buildResult(taskResults, gitSha, modelName, provider) {
+export function buildResult(taskResults, gitSha, modelName, provider, runId) {
 	return {
-		run_id: new Date().toISOString(),
+		run_id: runId || new Date().toISOString(),
 		git_sha: gitSha,
 		model: modelName,
 		provider: provider || 'gemini',

--- a/evals/lib/scorer.mjs
+++ b/evals/lib/scorer.mjs
@@ -80,12 +80,14 @@ export async function scoreTask(task, events, modelResponse, modelName, duration
 		? await evaluateMatchers(task.outputMatchers, { responseText, userMessage: task.userMessage }, judgeFn)
 		: {
 				pass: false,
+				details: [],
 				judgeAttempted,
 				judgeAvailable,
 				judgeSkipped: judgeAttempted && !judgeAvailable,
 			};
 	const {
 		pass: matchersPass,
+		details: matcherDetails,
 		judgeAttempted: matcherJudgeAttempted,
 		judgeAvailable: matcherJudgeAvailable,
 		judgeSkipped,
@@ -110,6 +112,10 @@ export async function scoreTask(task, events, modelResponse, modelName, duration
 		id: task.id,
 		passed,
 		solved,
+		// The agent's final response, frozen per run. Non-reproducible, so it
+		// must be captured here rather than re-derived later — it is the
+		// evidence a human (or a different judge) needs to re-score (#869).
+		response_text: responseText,
 		metrics: {
 			turns,
 			tool_calls: toolCalls,
@@ -127,6 +133,10 @@ export async function scoreTask(task, events, modelResponse, modelName, duration
 			expected_tools_met: expectedToolsMet,
 			forbidden_tools_clean: forbiddenToolsClean,
 			matchers_pass: matchersPass,
+			// Itemized per-matcher verdicts (type, criterion, verdict), mirroring
+			// `vault_assertion_details` — so a failed rubric shows *which* matcher
+			// failed, not just a rolled-up boolean (#869).
+			matcher_details: matcherDetails,
 			judge_attempted: matcherJudgeAttempted,
 			judge_available: matcherJudgeAvailable,
 			judge_skipped: judgeSkipped,

--- a/evals/run.mjs
+++ b/evals/run.mjs
@@ -17,7 +17,7 @@
  *   - API key configured
  */
 
-import { readFile, readdir } from 'node:fs/promises';
+import { readFile, readdir, writeFile, mkdir } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
 import { execSync } from 'node:child_process';
 import {
@@ -245,15 +245,43 @@ async function getProvider() {
 }
 
 /**
+ * Persist a run's captured event stream as a per-run transcript sidecar file.
+ *
+ * Transcripts are written next to (not inside) the result JSON so the result —
+ * and the baseline `bless` copies from it — stays lean: one file per run under
+ * `evals/results/<run-id>/`, which is gitignored. The returned path is
+ * relative to `EVALS_DIR` so it stays valid if the repo moves (#869).
+ *
+ * @param {Array} events - Captured (and collector-sanitized) event stream.
+ * @param {string} taskId - Task id, used in the filename.
+ * @param {{transcriptDir: string, runIdSlug: string, runIndex: number}|null} runContext
+ * @returns {Promise<string|null>} Relative transcript path, or null if not written.
+ */
+async function writeTranscript(events, taskId, runContext) {
+	if (!runContext) return null;
+	const { transcriptDir, runIdSlug, runIndex } = runContext;
+	const fileName = `${taskId}-${runIndex}.json`;
+	try {
+		await writeFile(join(transcriptDir, fileName), JSON.stringify(events, null, 2));
+		return `results/${runIdSlug}/${fileName}`;
+	} catch (err) {
+		console.warn(`  Transcript write warning: ${err.message}`);
+		return null;
+	}
+}
+
+/**
  * Run one eval task against the live plugin and return its scored result.
  *
  * @param {object} task - Task definition loaded from evals/tasks.
  * @param {boolean} keepArtifacts - Whether to leave scratch files and session history in the vault.
  * @param {string} provider - Active provider id used for scoring and cost reporting.
  * @param {Function | null} judgeFn - Optional judge function for `judge` output matchers.
+ * @param {{transcriptDir: string, runIdSlug: string, runIndex: number}|null} [runContext]
+ *   Where (and under what run id / index) to write this run's transcript.
  * @returns {Promise<object>} Scored task result ready for aggregation.
  */
-async function runTask(task, keepArtifacts, provider, judgeFn) {
+async function runTask(task, keepArtifacts, provider, judgeFn, runContext = null) {
 	const title = `[eval] ${task.id}`;
 	console.log(`  "${task.description}"`);
 
@@ -384,6 +412,10 @@ async function runTask(task, keepArtifacts, provider, judgeFn) {
 			fixtureMap,
 		});
 		if (timedOut) result.timedOut = true;
+
+		// Persist the full event stream as a transcript sidecar (#869). The
+		// collector has already truncated tool-result bodies, so this is bounded.
+		result.transcript_path = await writeTranscript(events, task.id, runContext);
 		const costStr = provider === 'ollama' ? 'free' : `$${result.metrics.cost_usd.toFixed(4)}`;
 		const verdict = timedOut ? 'TIMEOUT' : result.solved ? 'SOLVED' : result.passed ? 'PASSED (not solved)' : 'FAILED';
 		const judgeLabel = result.solve_details?.judge_skipped ? ' [judge unavailable]' : '';
@@ -401,6 +433,10 @@ async function runTask(task, keepArtifacts, provider, judgeFn) {
 			id: task.id,
 			passed: false,
 			solved: false,
+			// Schema parity with a scored result — a harness ERROR has no
+			// response, no transcript, and no matcher evidence (#869).
+			response_text: '',
+			transcript_path: null,
 			metrics: {
 				turns: 0,
 				tool_calls: 0,
@@ -418,6 +454,7 @@ async function runTask(task, keepArtifacts, provider, judgeFn) {
 				expected_tools_met: false,
 				forbidden_tools_clean: true,
 				matchers_pass: false,
+				matcher_details: [],
 				judge_attempted: judgeAttempted,
 				judge_available: judgeAvailable,
 				judge_skipped: judgeAttempted && !judgeAvailable,
@@ -545,6 +582,14 @@ async function main() {
 			}
 		}
 
+		// One run id for the whole sweep, shared by the result file
+		// (`results/<slug>.json`) and the transcript directory
+		// (`results/<slug>/`) so they are trivially correlated on disk.
+		const runId = new Date().toISOString();
+		const runIdSlug = runId.replace(/[:.]/g, '-');
+		const transcriptDir = join(EVALS_DIR, 'results', runIdSlug);
+		await mkdir(transcriptDir, { recursive: true });
+
 		// Run tasks sequentially. Each task runs `repeat` times so we can report
 		// pass^k reliability on top of per-run pass/solve rates. Module-scoped
 		// task tracking lets the SIGINT handler print "N of M completed" and
@@ -559,7 +604,9 @@ async function main() {
 				console.log(`\n--- Running: ${task.id}${runLabel} ---`);
 				currentTaskInfo = { taskId: task.id, sessionInfo: null, runIndex: i, repeat };
 				try {
-					runs.push(await runTask(task, keepArtifacts, provider, judgeFn));
+					runs.push(
+						await runTask(task, keepArtifacts, provider, judgeFn, { transcriptDir, runIdSlug, runIndex: i + 1 })
+					);
 				} finally {
 					currentTaskInfo = null;
 					completedTaskCount += 1;
@@ -571,7 +618,7 @@ async function main() {
 		// Build result, write, print
 		const gitSha = getGitSha();
 		const modelName = await getModelName();
-		const result = buildResult(taskResults, gitSha, modelName, provider);
+		const result = buildResult(taskResults, gitSha, modelName, provider, runId);
 		const outPath = await writeResults(result, EVALS_DIR);
 		printSummary(result);
 		console.log(`Results written to: ${outPath}`);

--- a/test/evals/matchers.test.ts
+++ b/test/evals/matchers.test.ts
@@ -120,3 +120,56 @@ describe('evaluateMatchers — empty / unknown', () => {
 		expect(result.pass).toBe(false);
 	});
 });
+
+describe('evaluateMatchers — itemized details (#869)', () => {
+	it('records one detail per matcher, in order', async () => {
+		const result = await evaluateMatchers(
+			[
+				{ type: 'contains', value: 'foo' },
+				{ type: 'regex', value: 'ba+r', flags: 'i' },
+			],
+			ctx('foo BAAR')
+		);
+		expect(result.details).toHaveLength(2);
+		expect(result.details[0]).toEqual({ type: 'contains', value: 'foo', verdict: true });
+		expect(result.details[1]).toEqual({ type: 'regex', value: 'ba+r', flags: 'i', verdict: true });
+	});
+
+	it('records the per-matcher verdict for a failed contains', async () => {
+		const result = await evaluateMatchers([{ type: 'contains', value: 'missing' }], ctx('xyz'));
+		expect(result.details[0]).toEqual({ type: 'contains', value: 'missing', verdict: false });
+	});
+
+	it('normalizes a missing regex flags field to null', async () => {
+		const result = await evaluateMatchers([{ type: 'regex', value: 'x' }], ctx('x'));
+		expect(result.details[0]).toEqual({ type: 'regex', value: 'x', flags: null, verdict: true });
+	});
+
+	it('captures the judge verdict and criterion', async () => {
+		const judge = vi.fn().mockResolvedValue(true);
+		const result = await evaluateMatchers([{ type: 'judge', criteria: 'is a haiku' }], ctx('poem'), judge);
+		expect(result.details[0]).toEqual({ type: 'judge', criteria: 'is a haiku', verdict: true });
+	});
+
+	it('records the judge error when the judge throws', async () => {
+		const judge = vi.fn().mockRejectedValue(new Error('429 rate limited'));
+		const result = await evaluateMatchers([{ type: 'judge', criteria: 'x' }], ctx('y'), judge);
+		expect(result.details[0]).toMatchObject({ type: 'judge', criteria: 'x', verdict: false });
+		expect(result.details[0].error).toContain('429');
+	});
+
+	it('records "no judge available" when a judge matcher runs without a judgeFn', async () => {
+		const result = await evaluateMatchers([{ type: 'judge', criteria: 'x' }], ctx('y'));
+		expect(result.details[0]).toEqual({
+			type: 'judge',
+			criteria: 'x',
+			verdict: false,
+			error: 'no judge available',
+		});
+	});
+
+	it('records an unknown matcher type as a failed detail', async () => {
+		const result = await evaluateMatchers([{ type: 'mystery' } as any], ctx('x'));
+		expect(result.details[0]).toEqual({ type: 'mystery', verdict: false, error: 'unknown matcher type' });
+	});
+});

--- a/test/evals/reporter.test.ts
+++ b/test/evals/reporter.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { aggregateTaskRuns, computeAggregates } from '../../evals/lib/reporter.mjs';
+import { aggregateTaskRuns, buildResult, computeAggregates } from '../../evals/lib/reporter.mjs';
 
 function run(passed: boolean, solved: boolean) {
 	return {
@@ -63,5 +63,18 @@ describe('computeAggregates — by_difficulty breakdown', () => {
 
 	it('returns an empty breakdown for no tasks', () => {
 		expect(computeAggregates([]).by_difficulty).toEqual({});
+	});
+});
+
+describe('buildResult — run id', () => {
+	it('uses the supplied run id so the result and transcript dir correlate', () => {
+		const result = buildResult([], 'abc123', 'gemini-2.5-flash', 'gemini', '2026-05-22T00:00:00.000Z');
+		expect(result.run_id).toBe('2026-05-22T00:00:00.000Z');
+	});
+
+	it('falls back to the current time when no run id is supplied', () => {
+		const result = buildResult([], 'abc123', 'gemini-2.5-flash', 'gemini');
+		expect(typeof result.run_id).toBe('string');
+		expect(Number.isNaN(Date.parse(result.run_id))).toBe(false);
 	});
 });

--- a/test/evals/scorer.test.ts
+++ b/test/evals/scorer.test.ts
@@ -168,3 +168,46 @@ describe('scoreTask — tool-call budget', () => {
 		expect(result.solved).toBe(false);
 	});
 });
+
+describe('scoreTask — persisted judging evidence (#869)', () => {
+	const task = {
+		id: 'evidence-task',
+		userMessage: 'summarize it',
+		expectedTools: [],
+		forbiddenTools: [],
+		outputMatchers: [{ type: 'contains', value: 'Summary' }],
+	};
+
+	it('freezes the agent response text on the result', async () => {
+		const events = [apiResponse(), turnEnd()];
+		const result: any = await scoreTask(task as any, events, 'Here is the Summary', 'gemini-2.5-flash', 100, 'gemini');
+		expect(result.response_text).toBe('Here is the Summary');
+	});
+
+	it('itemizes matcher verdicts on a clean run', async () => {
+		const events = [apiResponse(), turnEnd()];
+		const result: any = await scoreTask(task as any, events, 'Here is the Summary', 'gemini-2.5-flash', 100, 'gemini');
+		expect(result.solve_details.matcher_details).toEqual([{ type: 'contains', value: 'Summary', verdict: true }]);
+	});
+
+	it('leaves matcher_details empty when the run failed before matchers ran', async () => {
+		const events = [apiResponse(), turnError('crashed')];
+		const result: any = await scoreTask(task as any, events, '', 'gemini-2.5-flash', 100, 'gemini');
+		expect(result.passed).toBe(false);
+		expect(result.solve_details.matchers_pass).toBe(false);
+		expect(result.solve_details.matcher_details).toEqual([]);
+	});
+
+	it('captures an empty response text without crashing', async () => {
+		const plain = { id: 't', userMessage: 'x', expectedTools: [], forbiddenTools: [], outputMatchers: [] };
+		const result: any = await scoreTask(
+			plain as any,
+			[apiResponse(), turnEnd()],
+			'',
+			'gemini-2.5-flash',
+			100,
+			'gemini'
+		);
+		expect(result.response_text).toBe('');
+	});
+});


### PR DESCRIPTION
## Summary

Fixes #869.

The eval harness saved pass/solve **verdicts but not the evidence behind them** — once a sweep finished, the material a human would need to review or re-judge a result was gone. This persists that evidence, frozen per run. It is the foundation for the human-labeled calibration set (#870) and flaky-task attribution (#714).

Most of this data was already in hand at scoring time and simply discarded; this is largely a result-schema + scorer change.

## Changes

- **Response text** — `scoreTask()` now freezes `response_text` on every run result (the agent's final response is non-reproducible). The `run.mjs` error-path result carries `''` for schema parity.
- **Itemized matcher verdicts** — `evaluateMatchers()` returns a `details[]` array (per matcher: `type`, what it checked via `value`/`flags`/`criteria`, the `verdict`, and an `error` for judge failures or unknown types). Surfaced as `solve_details.matcher_details`, mirroring the existing `vault_assertion_details` — so a failed rubric shows *which* matcher failed, not just a rolled-up boolean.
- **Per-run transcript** — each run's captured event stream is written to a sidecar file at `evals/results/<run-id>/<task-id>-<n>.json`, and the result records a relative `transcript_path`. A single run id is generated per sweep and shared by the result file (`results/<slug>.json`) and the transcript directory (`results/<slug>/`) so they correlate on disk.
- **Collector enrichment** — the in-Obsidian collector now keeps a truncated tool-result `data` (2 KB cap, stringified) instead of discarding it, so transcripts show *what* each tool returned. Binary `inlineData` is dropped (base64 blobs, useless in a transcript). This also closes a latent risk: `toolChainComplete.toolResults` previously flowed through verbatim and could overflow the `obsidian eval` CLI bridge.
- **Docs** — new "Persisted evidence" section in `evals/README.md` documenting the three new fields and the transcript directory layout.

Transcripts live under the already-gitignored `evals/results/`, so they (and raw results) stay out of source control — only blessed baselines are committed.

## Testing

- `npm test` — 2894 passing, including new coverage in `matchers.test.ts` (itemized `details`), `scorer.test.ts` (`response_text`, `matcher_details`), and `reporter.test.ts` (`buildResult` run-id threading).
- `npm run build` — clean.
- `npm run format-check` — clean.
- **Live smoke run** — `npm run eval -- --task=smoke-list-files --repeat=1` against a real Obsidian instance (`gemini-3.1-flash-lite`), verified end-to-end:
  - The run result carries `response_text`, `matcher_details` (`[{type:'contains', value:'hello-world', verdict:true}]`), and a `transcript_path`.
  - The transcript sidecar `results/<run-id>/smoke-list-files-1.json` was written with the full 6-event stream.
  - The `toolExecutionComplete` event carries the tool `args` **and** the enriched `result.data` body (the 267-char `find_files_by_name` output) — data the old collector discarded.
  - `chatHistory` / `chatModelName` overrides restored cleanly; no leaked collector or scratch state.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop (unit suite + a live eval smoke run — see "Testing")
- [ ] I have verified this change does not break Mobile — N/A, the eval harness is a desktop-only Node tool
- [x] Documentation has been updated (if applicable)
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added preflight guidance on building and reinstalling plugins before running evals.
  * Documented persisted evidence artifacts recorded per evaluation run.

* **New Features**
  * Enhanced evaluation system to capture detailed per-matcher evidence and verdicts.
  * Added automatic transcript persistence for each evaluation run.
  * Introduced structured run IDs for improved eval traceability.

* **Tests**
  * Added comprehensive test coverage for matcher evaluation details and run ID handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/allenhutchison/obsidian-gemini/pull/879?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->