### PR TITLE
feat(evals): add --provider= override for cross-provider runs

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -69,6 +69,16 @@ done
 
 Caveat: while the harness is running, the live agent view is using the override too. That's the same disruption already implied by the harness driving the agent — just don't try to use the agent view in another window mid-run.
 
+### Cross-provider runs
+
+`--model=` only sets `chatModelName`. To run against a different provider (e.g. an Ollama model from a Gemini-default setup), also pass `--provider=`:
+
+```bash
+npm run eval -- --model=gemma4:latest --provider=ollama
+```
+
+Valid values are `gemini` and `ollama`. The override mirrors `--model=`: it's applied to `plugin.settings.provider` in memory at the start of the run, restored on exit (including SIGINT/SIGTERM), and never persisted to disk. Without it, an Ollama sweep needs a manual **Settings → Gemini Scribe → provider** toggle in the UI — which blocks unattended automation. The judge (always Gemini) is independent; set `EVAL_JUDGE_API_KEY` if the plugin has no Gemini key configured.
+
 ## Comparing against a baseline
 
 `npm run eval` automatically compares each run against the blessed baseline for the active `(provider, model)` and prints a regressions-only summary at the end:

--- a/evals/run.mjs
+++ b/evals/run.mjs
@@ -70,11 +70,21 @@ function parseArgs() {
 	if (model !== null && model.length === 0) {
 		throw new Error('--model requires a non-empty value');
 	}
+	// Optional `--provider=` override. Mirrors `--model=` and is required for
+	// hands-free cross-provider sweeps (e.g. an Ollama run from a Gemini-default
+	// setup); see #845. Validated against the two real providers — invalid
+	// values fail fast rather than silently routing to a missing client.
+	const providerArg = args.find((a) => a.startsWith('--provider='));
+	const providerOverride = providerArg ? providerArg.slice('--provider='.length) : null;
+	if (providerOverride !== null && providerOverride !== 'gemini' && providerOverride !== 'ollama') {
+		throw new Error(`--provider must be "gemini" or "ollama", got "${providerOverride}"`);
+	}
 	return {
 		taskFilter: args.find((a) => a.startsWith('--task='))?.split('=')[1] || null,
 		keepArtifacts: args.includes('--keep-artifacts'),
 		repeat,
 		model,
+		providerOverride,
 	};
 }
 
@@ -89,6 +99,8 @@ function parseArgs() {
 //     the run stopped.
 let originalChatModel = null;
 let modelWasOverridden = false;
+let originalProvider = null;
+let providerWasOverridden = false;
 let originalChatHistory = null;
 let chatHistoryWasForced = false;
 let currentTaskInfo = null; // { taskId, sessionInfo, runIndex, repeat } when a task is mid-flight
@@ -104,6 +116,16 @@ async function restoreChatModel() {
 		console.error(`Failed to restore chatModelName: ${err.message}`);
 	}
 	modelWasOverridden = false;
+}
+
+async function restoreProvider() {
+	if (!providerWasOverridden) return;
+	try {
+		await setSetting('provider', originalProvider);
+	} catch (err) {
+		console.error(`Failed to restore provider: ${err.message}`);
+	}
+	providerWasOverridden = false;
 }
 
 async function restoreChatHistory() {
@@ -156,6 +178,7 @@ async function handleInterrupt(signal, exitCode) {
 			console.warn(`  collector cleanup warning: ${err.message}`);
 		}
 		await restoreChatModel();
+		await restoreProvider();
 		await restoreChatHistory();
 		process.exit(exitCode);
 	}
@@ -518,7 +541,7 @@ async function maybeCompareToBaseline(result) {
  * aggregate results, and restore any temporary model override.
  */
 async function main() {
-	const { taskFilter, keepArtifacts, repeat, model } = parseArgs();
+	const { taskFilter, keepArtifacts, repeat, model, providerOverride } = parseArgs();
 	console.log('=== Gemini Scribe Eval Harness ===');
 
 	// Verify prerequisites
@@ -538,6 +561,17 @@ async function main() {
 		await setSetting('chatModelName', model);
 		modelWasOverridden = true;
 		console.log(`Overriding chatModelName: ${originalChatModel ?? '(unset)'} → ${model}`);
+	}
+
+	// Apply the provider override BEFORE getProvider() resolves below, so the
+	// resolved value (used for scoring + cost) reflects the override. Required
+	// for hands-free cross-provider sweeps; without it, an Ollama run from a
+	// Gemini-default setup needed a manual UI toggle (#845).
+	if (providerOverride) {
+		originalProvider = await getSetting('provider');
+		await setSetting('provider', providerOverride);
+		providerWasOverridden = true;
+		console.log(`Overriding provider: ${originalProvider ?? '(unset)'} → ${providerOverride}`);
 	}
 
 	// The scorer reads the model's response out of the session history file
@@ -628,6 +662,7 @@ async function main() {
 		await maybeCompareToBaseline(result);
 	} finally {
 		await restoreChatModel();
+		await restoreProvider();
 		await restoreChatHistory();
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #845.

`npm run eval -- --model=<id>` overrides `chatModelName` but not `settings.provider`, so running against an Ollama model from a Gemini-default setup still requires a manual **Settings → Gemini Scribe → provider** toggle in the UI. That blocks unattended automation (scheduled / CI evals) and any cross-provider sweep.

This mirrors the existing `chatModelName` override/restore pattern for `settings.provider`.

## Changes

- **`parseArgs()`** — extract `--provider=`, validate against the two real providers (`gemini` / `ollama`); invalid values throw fast rather than silently routing to a missing client.
- **Module state** — `originalProvider` / `providerWasOverridden`, mirroring the `chatModel` counterparts.
- **`restoreProvider()`** — symmetrical with `restoreChatModel()`.
- **Wired into both teardown paths** — `handleInterrupt` (SIGINT / SIGTERM) and the final `finally` in `main()`, so an interrupted run never leaves the user's plugin stuck on the wrong provider.
- **Applied before `getProvider()`** — so the resolved `provider` (used for scoring + cost) reflects the override.
- **Docs** — new "Cross-provider runs" subsection in `evals/README.md` under "Model overrides", with the canonical example and a pointer to `EVAL_JUDGE_API_KEY` for the judge.

Out of scope for this PR: the optional model→provider inference the issue mentions as a "could layer on" convenience. Explicit `--provider=` satisfies the acceptance criteria; inference can layer on later if useful.

## Testing

- `npm test` — 2894 passing.
- `npm run build` — clean.
- `npm run format-check` — clean.
- **Live Ollama smoke run** — `npm run eval -- --task=smoke-list-files --repeat=1 --model=gemma4:latest --provider=ollama` against a real Obsidian + Ollama setup. Captured originals before the run: `chatModelName=gemini-3.1-flash-lite`, `provider=gemini`. Verified end-to-end:
  - Both overrides logged at start: `Overriding chatModelName: gemini-3.1-flash-lite → gemma4:latest` and `Overriding provider: gemini → ollama`.
  - Task **SOLVED** in 2 turns, 1 tool call, $0 (free / Ollama). Result file correctly stamped `provider: ollama`, `model: gemma4:latest`.
  - After the run, **both settings restored to their originals** (`chatModelName=gemini-3.1-flash-lite`, `provider=gemini`). `chatHistory` also restored. No stragglers, no leaked collector/scratch state.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop (unit suite + live Ollama smoke run — see "Testing")
- [ ] I have verified this change does not break Mobile — N/A, the eval harness is a desktop-only Node tool
- [x] Documentation has been updated (if applicable)
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR