### PR TITLE
refactor: replace any with SDK types in Gemini client response handling

### DIFF
--- a/src/api/providers/gemini/client.ts
+++ b/src/api/providers/gemini/client.ts
@@ -5,7 +5,14 @@
  * streamlined implementation powered by @google/genai.
  */
 import { createGoogleGenAI } from './google-genai-factory';
-import { GoogleGenAI, Content, Part, GenerateContentParameters, GenerateContentResponse } from '@google/genai';
+import {
+	GoogleGenAI,
+	Content,
+	Part,
+	GenerateContentParameters,
+	GenerateContentResponse,
+	GenerateContentResponseUsageMetadata,
+} from '@google/genai';
 import {
 	ModelApi,
 	BaseModelRequest,
@@ -79,7 +86,7 @@ export class GeminiClient implements ModelApi {
 		let accumulatedRendered = '';
 		let accumulatedThoughts = '';
 		let toolCalls: ToolCall[] | undefined;
-		let lastUsageMetadata: any = undefined;
+		let lastUsageMetadata: GenerateContentResponseUsageMetadata | undefined = undefined;
 
 		const complete = (async (): Promise<ModelResponse> => {
 			const params = await this.buildGenerateContentParams(request);
@@ -145,12 +152,11 @@ export class GeminiClient implements ModelApi {
 					// Capture usageMetadata from chunks (usually present in last chunk)
 					if (chunk.usageMetadata) {
 						lastUsageMetadata = chunk.usageMetadata;
-						const meta = chunk.usageMetadata as any;
 						this.plugin?.logger.debug(
 							`[GeminiClient] Captured usageMetadata from streaming chunk: ` +
-								`prompt=${meta.promptTokenCount}, ` +
-								`total=${meta.totalTokenCount}, ` +
-								`cached=${meta.cachedContentTokenCount ?? 0}`
+								`prompt=${chunk.usageMetadata.promptTokenCount}, ` +
+								`total=${chunk.usageMetadata.totalTokenCount}, ` +
+								`cached=${chunk.usageMetadata.cachedContentTokenCount ?? 0}`
 						);
 					}
 				}
@@ -419,10 +425,10 @@ export class GeminiClient implements ModelApi {
 			...(toolCalls && { toolCalls }),
 			...(response.usageMetadata && {
 				usageMetadata: {
-					promptTokenCount: (response.usageMetadata as any).promptTokenCount,
-					candidatesTokenCount: (response.usageMetadata as any).candidatesTokenCount,
-					totalTokenCount: (response.usageMetadata as any).totalTokenCount,
-					cachedContentTokenCount: (response.usageMetadata as any).cachedContentTokenCount,
+					promptTokenCount: response.usageMetadata.promptTokenCount,
+					candidatesTokenCount: response.usageMetadata.candidatesTokenCount,
+					totalTokenCount: response.usageMetadata.totalTokenCount,
+					cachedContentTokenCount: response.usageMetadata.cachedContentTokenCount,
 				},
 			}),
 		};
@@ -431,7 +437,7 @@ export class GeminiClient implements ModelApi {
 	/**
 	 * Extract text from streaming chunk
 	 */
-	private extractTextFromChunk(chunk: any): string {
+	private extractTextFromChunk(chunk: GenerateContentResponse): string {
 		if (chunk.candidates?.[0]?.content?.parts) {
 			const text = chunk.candidates[0].content.parts
 				.filter((part: Part) => 'text' in part && part.text && !(part as PartWithThought).thought)
@@ -445,7 +451,7 @@ export class GeminiClient implements ModelApi {
 	/**
 	 * Extract thought/reasoning content from streaming chunk
 	 */
-	private extractThoughtFromChunk(chunk: any): string {
+	private extractThoughtFromChunk(chunk: GenerateContentResponse): string {
 		if (chunk.candidates?.[0]?.content?.parts) {
 			const parts = chunk.candidates[0].content.parts;
 			const thoughtParts = parts.filter(
@@ -515,8 +521,8 @@ export class GeminiClient implements ModelApi {
 	/**
 	 * Extract tool calls from streaming chunk
 	 */
-	private extractToolCallsFromChunk(chunk: any): ToolCall[] | undefined {
-		return this.extractToolCallsFromResponse(chunk as GenerateContentResponse);
+	private extractToolCallsFromChunk(chunk: GenerateContentResponse): ToolCall[] | undefined {
+		return this.extractToolCallsFromResponse(chunk);
 	}
 
 	/**
@@ -524,7 +530,7 @@ export class GeminiClient implements ModelApi {
 	 */
 	private extractRenderedFromResponse(response: GenerateContentResponse): string {
 		// Search grounding metadata is in groundingMetadata
-		const metadata = (response as any).candidates?.[0]?.groundingMetadata;
+		const metadata = response.candidates?.[0]?.groundingMetadata;
 		if (!metadata) return '';
 
 		// Extract and format grounding sources
@@ -552,8 +558,8 @@ export class GeminiClient implements ModelApi {
 	/**
 	 * Extract rendered content from streaming chunk
 	 */
-	private extractRenderedFromChunk(chunk: any): string {
-		return this.extractRenderedFromResponse(chunk as GenerateContentResponse);
+	private extractRenderedFromChunk(chunk: GenerateContentResponse): string {
+		return this.extractRenderedFromResponse(chunk);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Architecture-audit nightly sweep flagged: **`any` overuse** in `src/api/providers/gemini/client.ts`.

The `@google/genai` SDK already exports `GenerateContentResponseUsageMetadata`, and the `groundingMetadata` field is properly typed on the SDK's `Candidate` interface. The Gemini client was declaring chunk parameters as `any` and using `as any` casts on `usageMetadata` and `groundingMetadata` accesses even though the SDK supplies the right shapes. Replacing those with the SDK types tightens type safety on the response/chunk path without any behavior change.

## Changes

- `src/api/providers/gemini/client.ts`:
  - Import `GenerateContentResponseUsageMetadata` from `@google/genai`.
  - Type `lastUsageMetadata` as `GenerateContentResponseUsageMetadata | undefined` instead of `any`.
  - Drop the local `meta = chunk.usageMetadata as any` alias in the streaming log; use `chunk.usageMetadata` directly.
  - Drop 4 `(response.usageMetadata as any)` casts in `extractModelResponse`.
  - Type `extractTextFromChunk`, `extractThoughtFromChunk`, `extractToolCallsFromChunk`, `extractRenderedFromChunk` parameters as `GenerateContentResponse` instead of `any`; drop the now-redundant `chunk as GenerateContentResponse` casts at the two call sites.
  - Drop the `(response as any)` cast before `.candidates?.[0]?.groundingMetadata` — `groundingMetadata` is on the SDK `Candidate` type.

Reduces `any` count in the file from 13 → 2 (remaining: `config: any` and `finalContents: any` in `buildGenerateContentParams`, both more involved — left for a follow-up).

Pure typing change, no runtime behavior modified.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A, filed by the architecture-audit skill as a mechanical type-safety cleanup.
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — locally verified (2914 tests pass).
- [x] I have tested this change on Desktop — type-check + build succeed.
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — pure typing change, no platform-specific code touched.
- [x] Documentation has been updated (if applicable) — N/A, no user-facing behavior change.
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (architecture-audit skill)
- [x] I have reviewed and understand all AI-generated code in this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01T1QuHvP15fc8Df7Q8dXc3a)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced type safety and consistency in the Gemini client to improve reliability and stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/allenhutchison/obsidian-gemini/pull/881?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->