### PR TITLE
chore(daily): 2026-05-23 daily update

### DIFF
--- a/docs/guide/custom-prompts.md
+++ b/docs/guide/custom-prompts.md
@@ -40,15 +40,6 @@ If you're unsure whether you need a custom prompt or a [skill](/guide/agent-skil
 
 ## Getting Started
 
-### Enable Custom Prompts
-
-1. Open Obsidian Settings
-2. Navigate to Gemini Scribe settings
-3. Find the "Custom Prompts" section
-4. Toggle "Enable Custom Prompts" to ON
-
-**Note**: Custom prompts are disabled by default. You must enable them to use this feature.
-
 ### Locate the Prompts Folder
 
 Custom prompts are stored in: `[Your Plugin State Folder]/Prompts/`

--- a/planning/changelog/2026-05-22.md
+++ b/planning/changelog/2026-05-22.md
@@ -1,0 +1,52 @@
+# Daily changelog — May 22, 2026
+
+**Date:** 2026-05-22
+**PRs merged:** 7
+
+---
+
+## Summary
+
+A heavy eval-infrastructure day. The centerpiece is the long-awaited major eval suite expansion (#846) finally merging after landing in review on May 18 — state-based scoring, difficulty tiers, and a broad new task catalog. Two follow-on eval harness PRs (#879, #880) shipped the same evening, rounding out evidence persistence and cross-provider run support. In parallel, a meaningful user-facing RAG bug fix (#867) landed mid-day, along with two clean DRY refactors (#868, #877) and the routine daily-update housekeeping (#866).
+
+## What shipped
+
+### [#866 chore(daily): 2026-05-22 daily update](https://github.com/allenhutchison/obsidian-gemini/pull/866)
+
+Automated daily housekeeping covering the May 21 changelog and two doc drift fixes: removed the stale `History/` folder from the state-folder structure diagram in `docs/reference/settings.md` (that folder was a v3.x artifact not created by v4.x), and corrected `docs/guide/custom-prompts.md` to reference `Agent-Sessions/` instead of the legacy `History/` path.
+
+### [#867 fix: recover from invalid RAG file search store names](https://github.com/allenhutchison/obsidian-gemini/pull/867)
+
+Fixes #858. The "Search index name" settings field was previously editable, letting users type a custom name that the Google File Search API would never accept — store resource IDs are assigned server-side, not chosen by the client. The typed name was stored verbatim, then caused a permanent `400 INVALID_ARGUMENT` error on every subsequent index attempt because the code only treated `404 NOT_FOUND` as recoverable.
+
+The fix removes the editable input entirely (the field is now read-only, showing only a Copy button once a store exists), and teaches `ensureFileSearchStore()` to treat a `400` malformed-name response the same as a `404`: discard the poisoned `fileSearchStoreName` and create a fresh server-assigned store. Existing users with a bad stored name self-heal on the next index run.
+
+### [#868 refactor: dedupe RagVaultScanner teardown + not-found checks](https://github.com/allenhutchison/obsidian-gemini/pull/868)
+
+Closes #865. Pure DRY refactor — no behavior change. The three catch-handler teardown blocks in `_doIndexVault` (quota exhaustion, max-retries exceeded, generic error/cancellation) each repeated the same ~10-line teardown sequence, so a bug fix had to land in all three or paths would drift. Extracted into a private `resetIndexingState(status)` method. Separately, the duplicated `404 / NOT_FOUND` string check in two methods is now a shared `isNotFoundError()` predicate in `error-utils.ts`, alongside `isQuotaExhausted` and `isRateLimitError`.
+
+### [#846 Expand the eval suite: state-based scoring, difficulty tiers, and a broad task catalog](https://github.com/allenhutchison/obsidian-gemini/pull/846)
+
+A major upgrade to the agent eval harness and task catalog, created May 18 and merged after review. The harness previously saturated near 100% solve on its 8 original tasks, making it useless for ranking model classes.
+
+Harness enhancements: **`vaultAssertions`** adds post-run state-based scoring (`fileExists`, `fileAbsent`, `fileContains`, `fileLacks`, `fileMatches`, `frontmatterEquals`, `fileUnchanged`) so write/edit/delete tasks verify actual vault state rather than response text alone. **Difficulty tiers** (T1–T4) with per-tier `solve^k` breakdown in the reporter. **`toolCallBudget`** — an optional efficiency gate on the `solved` verdict. **`setup`** — seeding files outside `eval-scratch/` for tasks requiring pre-existing vault content (cleaned up post-run).
+
+Task catalog: broad expansion across T2–T4 covering retrieval, multi-hop reasoning, cross-note aggregation and arithmetic, conflicting-source resolution, synthesis, write/edit/delete (state-verified), long-context fidelity, negative-space/ambiguity/refusal, prompt-injection safety, and feature-specific paths (memory, skills, session recall, context shelf). All task corpora are fully fictional for leak-resistance.
+
+### [#879 feat: persist eval judging evidence (response, matchers, transcript)](https://github.com/allenhutchison/obsidian-gemini/pull/879)
+
+Fixes #869. The eval harness saved pass/solve verdicts but discarded the evidence behind them — the response text, per-matcher details, and the event transcript. Once a sweep finished, the material needed to review or re-judge a result was gone.
+
+Three new persisted artifacts: **response text** is frozen on every run result. **Matcher details** — `evaluateMatchers()` now returns a `details[]` array with per-matcher type, value, verdict, and error, surfaced as `solve_details.matcher_details`. **Per-run transcripts** are written to `evals/results/<run-id>/<task-id>-<n>.json` sidecars, with the result recording a relative `transcript_path`. The in-Obsidian collector is also enriched to keep truncated tool-result data (2 KB cap) instead of discarding it, so transcripts show what each tool actually returned.
+
+### [#877 refactor: extract JsonSidecarStateStore + definition-file helpers](https://github.com/allenhutchison/obsidian-gemini/pull/877)
+
+Closes #864. `hook-manager.ts` and `scheduled-task-manager.ts` were written in parallel and hand-rolled identical JSON sidecar state I/O and definition-file parsing logic. Extracted into a shared `src/services/feature-definition.ts` with `JsonSidecarStateStore<T>` (load/save), `extractMarkdownBody`, `resolveFeatureToolPolicy`, `migrateLegacyEnabledTools`, and `purgeOrphanState`. Pure code-motion — net −28 lines across the two managers, no behavior change. Covered by 16 new tests in `test/services/feature-definition.test.ts`.
+
+No shared base class was introduced; composition via the helpers covers the duplication without an inheritance layer.
+
+### [#880 feat(evals): add --provider= override for cross-provider runs](https://github.com/allenhutchison/obsidian-gemini/pull/880)
+
+Fixes #845. `npm run eval -- --model=<id>` overrode `chatModelName` but not `settings.provider`, so running against an Ollama model from a Gemini-default setup still required a manual UI toggle in Obsidian settings. That blocked unattended automation (scheduled/CI evals) and cross-provider model sweeps.
+
+Added `--provider=gemini|ollama` with fast validation on bad values. The flag mirrors the existing `chatModelName` override/restore pattern: `originalProvider` and `providerWasOverridden` state, a `restoreProvider()` helper, and wiring into both teardown paths (SIGINT/SIGTERM via `handleInterrupt` and the final `finally` in `main()`) so an interrupted run never leaves the plugin stuck on the wrong provider.


### PR DESCRIPTION
## Summary

Automated daily housekeeping for 2026-05-23. Covers the May 22 changelog (7 PRs) and one conceptual doc drift fix found by audit-docs.

## Changes

- **Add `planning/changelog/2026-05-22.md`**: Documents 7 PRs merged on May 22 — heavy eval-infrastructure day (eval suite expansion, evidence persistence, cross-provider runs) plus a meaningful RAG bug fix and two DRY refactors.
- **`docs/guide/custom-prompts.md`**: Removed the "Enable Custom Prompts" getting-started step that described a non-existent toggle. The custom prompts feature is always available — no opt-in toggle exists in settings.

## Sub-skill outcomes

- **daily-changelog**: wrote `planning/changelog/2026-05-22.md`, 7 PRs (eval suite expansion #846, RAG invalid-store-name fix #867, RagVaultScanner DRY refactor #868, eval evidence persistence #879, feature-definition helpers refactor #877, cross-provider eval runs #880, daily-update housekeeping #866)
- **audit-docs**: removed stale "Enable Custom Prompts" toggle from `docs/guide/custom-prompts.md` — conceptual drift; the setting does not exist in the codebase and the feature is always on
- **triage-issues**: no unlabeled open issues — tracker is clean

## Screenshots / Screencast

N/A — changelog and docs only.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: daily housekeeping
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A: docs and changelog only
- [x] Documentation has been updated (if applicable) — N/A: this PR IS the doc update
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01SNidYZ17XQvvUg7VWCNhQP)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified the custom prompts guide by removing redundant setup instructions.

* **New Features**
  * Enhanced evaluation harness with expanded task support and evidence persistence.
  * Introduced cross-provider evaluation runs for multi-platform testing capabilities.
  * Improved artifact storage including response details and transcripts.

* **Bug Fixes**
  * Fixed RAG file search store recovery to ensure proper index restoration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/allenhutchison/obsidian-gemini/pull/882?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->