### PR TITLE
fix(evals): repair rewrite-section-inplace's broken matchers (#714)

### DIFF
--- a/evals/tasks/rewrite-section-inplace.json
+++ b/evals/tasks/rewrite-section-inplace.json
@@ -7,12 +7,7 @@
 	"fixture": "rewrite-section",
 	"expectedTools": ["read_file"],
 	"forbiddenTools": ["delete_file"],
-	"outputMatchers": [
-		{
-			"type": "judge",
-			"criteria": "The response indicates the Equipment Pickup section was rewritten to be shorter and clearer than the original run-on sentence, while preserving the key facts (gear cage, Marcy, items issued, barcode responsibility)."
-		}
-	],
+	"outputMatchers": [],
 	"vaultAssertions": [
 		{
 			"type": "fileContains",
@@ -25,9 +20,9 @@
 				"## Overview"
 			]
 		},
-		{ "type": "fileMatches", "path": "eval-scratch/onboarding-guide.md", "value": "(?i)gear cage" },
-		{ "type": "fileMatches", "path": "eval-scratch/onboarding-guide.md", "value": "(?i)marcy" },
-		{ "type": "fileMatches", "path": "eval-scratch/onboarding-guide.md", "value": "(?i)barcode" },
+		{ "type": "fileMatches", "path": "eval-scratch/onboarding-guide.md", "value": "gear cage", "flags": "i" },
+		{ "type": "fileMatches", "path": "eval-scratch/onboarding-guide.md", "value": "marcy", "flags": "i" },
+		{ "type": "fileMatches", "path": "eval-scratch/onboarding-guide.md", "value": "barcode", "flags": "i" },
 		{
 			"type": "fileLacks",
 			"path": "eval-scratch/onboarding-guide.md",


### PR DESCRIPTION
## Summary

References #714.

The `rewrite-section-inplace` task has been **0/3-solved on every recent sweep**, but it's not a model regression. The #870 calibration labelling exposed two independent failures, both unrelated to model behaviour.

## What was broken

### 1. The judge criterion demanded something the prompt didn't

The criterion said the response must "describe the rewrite … while preserving the key facts (gear cage, Marcy, items issued, barcode responsibility)." The prompt asks the agent to **edit the file**, not to repeat its contents in chat. So a perfectly correct response ("I rewrote the section as requested.") was marked NO by the judge.

All 3 calibration tuples for this task **disagreed with the automated judge** — auto NO, human YES (3/3 of this task's disagreements in the gold set). File verification belongs in the vault assertions, not in a response-text judge.

### 2. The three `fileMatches` regexes used invalid syntax

The vault assertions for `gear cage`, `marcy`, `barcode` used the inline flag form:

```json
{ "type": "fileMatches", ..., "value": "(?i)gear cage" }
```

JavaScript's `RegExp` does **not** support inline group flags. `new RegExp("(?i)gear cage")` throws `SyntaxError: Invalid group`. The vault-assertion runner has a `try/catch` that swallows the throw and returns `false` — so these three assertions had been **silently failing on every run**, masked by the (also-broken) judge matcher saying NO.

This is documented in `evals/README.md`:

> JS regex syntax does NOT support inline flags like `(?i)` — pass `flags` explicitly as a separate field.

Only this one task used `(?i)`; the rest of the suite is clean (`grep -l '"(?i)' evals/tasks/*.json`).

## Changes

- **Drop the judge matcher** — `outputMatchers: []`. Existing vault assertions (`fileContains`, `fileMatches`, `fileLacks`, `fileUnchanged`) already verify the rewrite happened, the rambling sentence is gone, the key facts persist, and sibling files weren't touched.
- **Fix the regex syntax** — three `fileMatches` lines switched from `"(?i)gear cage"` to `"value": "gear cage", "flags": "i"`. Validated by parsing with `new RegExp(value, flags)`.

The 4th key fact from the prompt ("items issued") isn't asserted because the original fixture doesn't use the word "issued" — the agent paraphrases. A regex check would be too brittle. The existing 3 fact regexes (gear cage / Marcy / barcode) plus the `fileLacks` (no original run-on) plus the `fileContains` (other sections intact) are the real correctness gate.

## Testing

- `npm test` — 2926 passing.
- `npm run build` — clean.
- `npm run format-check` — clean.
- **Live smoke run** — `npm run eval -- --task=rewrite-section-inplace --repeat=3` on `gemini-3.5-flash`:

  ```
  pass^3 rate:     100%  (mean 100%)
  solve^3 rate:    100%  (mean 100%)
  Flaky tasks:    0
  ```

  Was **0/3** before this PR; now **3/3**. Confirmed each run's vault assertions all pass (`vault_assertions_pass: true`).

This addresses one concrete chunk of #714 ("investigate flaky tasks"): the failure was real-but-not-the-model — a matcher / criterion bug. Other tasks flagged in the most recent sweep (`skill-activate-apply`, `sort-recent-projects`, `decision-brief`) are **judge-model brittleness** on cosmetic formatting; those belong to #871's judge-model decision, not here.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop (unit suite + live 3-repeat smoke run — see "Testing")
- [ ] I have verified this change does not break Mobile — N/A, the eval harness is a desktop-only Node tool
- [x] Documentation has been updated (if applicable) — no doc change needed; the `README`'s regex-syntax warning already covers what this PR aligns to
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  - Updated evaluation task assertions and file matching patterns to use an improved validation format for enhanced consistency and maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/allenhutchison/obsidian-gemini/pull/888?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->