### PR TITLE
feat(evals): judge-eval tool for measuring candidate judges (#871)

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -467,6 +467,21 @@ The extractor **refuses to overwrite** an existing `judge-calibration.json` by d
 evals/calibration/judge-calibration.json   ← committed to git once labelled
 ```
 
+### Measuring a candidate judge against the gold set
+
+Once the calibration set is labelled, you can measure how well any judge model agrees with the human labels:
+
+```bash
+npm run eval:calibrate-judge                          # default judge (env or fallback)
+npm run eval:calibrate-judge -- --model=gemini-2.5-pro
+npm run eval:calibrate-judge -- --calibration=<path>  # use a different calibration file
+npm run eval:calibrate-judge -- --json                # machine-readable summary for diffing runs
+```
+
+For each tuple with a non-null `human_label` and a clean `judge_error`, the tool calls the candidate judge with the same `(criterion, { userMessage, responseText })` shape used at run time. It reports overall agreement, a confusion matrix (false positives = judge YES / human NO, false negatives = judge NO / human YES), and a per-tuple disagreement list with enough context to inspect _why_ the judge flipped.
+
+The candidate must reach the harness's standard judge surface (currently Gemini via `EVAL_JUDGE_API_KEY` or the running plugin's key). A cross-vendor judge needs the provider plumbing tracked in #872 before it can be measured by this tool.
+
 ## Architecture
 
 The harness drives Obsidian via the `obsidian eval` CLI command, installing a temporary event-bus subscriber to capture agent lifecycle events. It does NOT modify plugin internals — all observation is via the existing `agentEventBus` subscriptions.

--- a/evals/calibrate-judge.mjs
+++ b/evals/calibrate-judge.mjs
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+/**
+ * Measure a candidate LLM-as-judge against the human-labelled calibration set
+ * built in #870. Reports overall agreement, a confusion matrix (FP / FN),
+ * and a per-tuple disagreement list. Informs the judge-model decision (#871).
+ *
+ * Usage:
+ *   npm run eval:calibrate-judge                          # default model (env or fallback)
+ *   npm run eval:calibrate-judge -- --model=gemini-2.5-pro
+ *   npm run eval:calibrate-judge -- --calibration=<path>  # alternate calibration file
+ *   npm run eval:calibrate-judge -- --json                # machine-readable summary
+ *
+ * The candidate must reach the harness's standard judge surface (currently
+ * Gemini via `EVAL_JUDGE_API_KEY` or the running plugin's key). A cross-vendor
+ * judge needs the provider plumbing tracked in #872 before it can be measured
+ * by this tool.
+ */
+
+import { readFile } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+import { createJudge } from './lib/judge.mjs';
+import { evaluateJudgeAgainstCalibration } from './lib/judge-eval.mjs';
+
+const EVALS_DIR = resolve(import.meta.dirname);
+
+function parseArgs() {
+	const args = process.argv.slice(2);
+	const get = (name) => {
+		const a = args.find((x) => x.startsWith(`--${name}=`));
+		return a ? a.slice(`--${name}=`.length) : null;
+	};
+	return {
+		model: get('model'),
+		calibrationPath: get('calibration'),
+		json: args.includes('--json'),
+	};
+}
+
+function pct(n) {
+	return `${(n * 100).toFixed(1)}%`;
+}
+
+function printSummary(result, modelId) {
+	console.log(`\n=== Judge agreement on calibration set ===`);
+	console.log(`Judge model:    ${modelId}`);
+	console.log(`Tuples total:   ${result.total}`);
+	console.log(`Evaluated:      ${result.evaluated}`);
+	console.log(`  unlabelled:   ${result.skipped_unlabelled}`);
+	console.log(`  judge-error:  ${result.skipped_judge_error}`);
+	console.log(`  call errors:  ${result.judge_call_errors}`);
+	console.log('');
+	console.log(`Agreement:      ${result.agreed}/${result.evaluated} (${pct(result.accuracy)})`);
+	console.log(`Disagreements:  ${result.disagreed}`);
+	console.log(`  false +:      ${result.false_positives}  (judge YES, human NO)`);
+	console.log(`  false −:      ${result.false_negatives}  (judge NO,  human YES)`);
+
+	if (result.disagreements.length > 0) {
+		console.log('\n=== Per-tuple disagreements ===');
+		for (const d of result.disagreements) {
+			const tag = d.kind === 'false_positive' ? 'FP' : 'FN';
+			console.log(`  ${tag}  ${d.id}  (judge=${d.judge_verdict ? 'YES' : 'NO'}, human=${d.human_label})`);
+		}
+	}
+}
+
+async function main() {
+	const { model, calibrationPath, json } = parseArgs();
+	const calPath = calibrationPath ? resolve(calibrationPath) : join(EVALS_DIR, 'calibration', 'judge-calibration.json');
+
+	let calibration;
+	try {
+		calibration = JSON.parse(await readFile(calPath, 'utf8'));
+	} catch (err) {
+		console.error(`Failed to load calibration set at ${calPath}: ${err.message}`);
+		console.error(`(Run \`npm run eval:calibrate-extract\` against a sweep result to build one.)`);
+		process.exit(1);
+	}
+
+	const judge = await createJudge({ model });
+	if (!judge) {
+		console.error(
+			'No judge available. Set EVAL_JUDGE_API_KEY to a Gemini API key, or have one configured in the running plugin.'
+		);
+		process.exit(1);
+	}
+
+	const result = await evaluateJudgeAgainstCalibration(calibration, judge);
+
+	if (json) {
+		console.log(JSON.stringify({ model: judge.modelId, ...result }, null, 2));
+	} else {
+		printSummary(result, judge.modelId);
+	}
+}
+
+main().catch((err) => {
+	console.error(err.message);
+	process.exit(1);
+});

--- a/evals/lib/judge-eval.mjs
+++ b/evals/lib/judge-eval.mjs
@@ -1,0 +1,108 @@
+/**
+ * Measure how often a candidate LLM-as-judge agrees with the human-labelled
+ * gold set committed in `evals/calibration/judge-calibration.json` (#870).
+ *
+ * The judge under test is the same shape as the harness's runtime judge —
+ * an async function `(criterion, { userMessage, responseText }) => boolean`.
+ * `createJudge()` in `judge.mjs` already returns that shape; this module is
+ * provider-agnostic by construction, so a cross-vendor judge (#872) drops in
+ * without changes here.
+ *
+ * Outputs are designed to inform #871's decision: an overall agreement rate,
+ * a confusion matrix (FP / FN), and a list of the disagreements with enough
+ * context to eyeball *why* the judge flipped.
+ */
+
+/**
+ * @typedef {object} JudgeEvalResult
+ * @property {number} total - All tuples in the calibration file.
+ * @property {number} evaluated - Tuples with a non-null `human_label` and no `judge_error` (i.e., comparable).
+ * @property {number} skipped_unlabelled - Tuples skipped because `human_label === null`.
+ * @property {number} skipped_judge_error - Tuples skipped because the original automated judge errored; their `human_label` may also be null and is not informative against ground truth.
+ * @property {number} judge_call_errors - Tuples where this run's judge call threw or rejected.
+ * @property {number} agreed - Tuples where this judge agrees with the human label.
+ * @property {number} disagreed - Tuples where this judge disagrees with the human label.
+ * @property {number} accuracy - `agreed / evaluated`, or 0 when `evaluated === 0`.
+ * @property {number} false_positives - Judge said YES, human said NO.
+ * @property {number} false_negatives - Judge said NO, human said YES.
+ * @property {Array<{id: string, task_id: string, criterion: string, response: string, human_label: string, judge_verdict: boolean, kind: 'false_positive'|'false_negative'}>} disagreements
+ */
+
+/**
+ * Run `judgeFn` against every comparable tuple in `calibration` and aggregate.
+ *
+ * "Comparable" = `human_label` is YES or NO and the original `judge_error` is
+ * null. Unlabelled tuples are skipped (the gold set may grow over time);
+ * tuples whose automated judge errored are skipped from accuracy because
+ * there's no automated-vs-human pair to compare under the same evaluator
+ * (the failure was an upstream API/auth issue, not a judging decision).
+ *
+ * Judge call failures are surfaced as a separate count rather than failing
+ * the run — a 429 mid-sweep should not poison the agreement rate. The caller
+ * decides whether to retry or accept partial coverage.
+ *
+ * @param {{tuples: Array<object>}} calibration - Parsed `judge-calibration.json`.
+ * @param {(criterion: string, ctx: {userMessage: string, responseText: string}) => Promise<boolean>} judgeFn
+ * @returns {Promise<JudgeEvalResult>}
+ */
+export async function evaluateJudgeAgainstCalibration(calibration, judgeFn) {
+	const tuples = calibration?.tuples || [];
+	const result = {
+		total: tuples.length,
+		evaluated: 0,
+		skipped_unlabelled: 0,
+		skipped_judge_error: 0,
+		judge_call_errors: 0,
+		agreed: 0,
+		disagreed: 0,
+		accuracy: 0,
+		false_positives: 0,
+		false_negatives: 0,
+		disagreements: [],
+	};
+
+	for (const t of tuples) {
+		if (t.human_label !== 'YES' && t.human_label !== 'NO') {
+			result.skipped_unlabelled++;
+			continue;
+		}
+		if (typeof t.judge_error === 'string' && t.judge_error.length > 0) {
+			result.skipped_judge_error++;
+			continue;
+		}
+
+		let verdict;
+		try {
+			verdict = Boolean(await judgeFn(t.criteria, { userMessage: t.user_message, responseText: t.response }));
+		} catch {
+			// A judge call failure here is operational (rate limit, network).
+			// We surface it via the count but don't let it skew agreement; the
+			// reviewer can re-run if needed.
+			result.judge_call_errors++;
+			continue;
+		}
+
+		result.evaluated++;
+		const humanYes = t.human_label === 'YES';
+		if (verdict === humanYes) {
+			result.agreed++;
+		} else {
+			result.disagreed++;
+			const kind = verdict ? 'false_positive' : 'false_negative';
+			if (verdict) result.false_positives++;
+			else result.false_negatives++;
+			result.disagreements.push({
+				id: t.id,
+				task_id: t.task_id,
+				criterion: t.criteria,
+				response: t.response,
+				human_label: t.human_label,
+				judge_verdict: verdict,
+				kind,
+			});
+		}
+	}
+
+	result.accuracy = result.evaluated > 0 ? result.agreed / result.evaluated : 0;
+	return result;
+}

--- a/evals/lib/judge-eval.mjs
+++ b/evals/lib/judge-eval.mjs
@@ -46,7 +46,7 @@
  * @returns {Promise<JudgeEvalResult>}
  */
 export async function evaluateJudgeAgainstCalibration(calibration, judgeFn) {
-	const tuples = calibration?.tuples || [];
+	const tuples = Array.isArray(calibration?.tuples) ? calibration.tuples : [];
 	const result = {
 		total: tuples.length,
 		evaluated: 0,

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
 		"eval:compare": "node evals/lib/compare.mjs",
 		"eval:bless": "node evals/lib/bless.mjs",
 		"eval:calibrate-extract": "node evals/calibrate-extract.mjs",
+		"eval:calibrate-judge": "node evals/calibrate-judge.mjs",
 		"docs:dev": "vitepress dev docs",
 		"docs:build": "vitepress build docs",
 		"docs:preview": "vitepress preview docs"

--- a/test/evals/judge-eval.test.ts
+++ b/test/evals/judge-eval.test.ts
@@ -161,4 +161,14 @@ describe('evaluateJudgeAgainstCalibration — edge cases', () => {
 		);
 		expect(r.total).toBe(0);
 	});
+
+	it('treats a truthy non-array `tuples` as empty (does not throw on for…of)', async () => {
+		// A malformed calibration file could expose `tuples` as a string or an
+		// object — both are truthy but not iterable. Without the Array.isArray
+		// guard the runtime for…of would throw.
+		const judge = vi.fn(async () => true);
+		expect((await evaluateJudgeAgainstCalibration({ tuples: 'oops' } as any, judge)).total).toBe(0);
+		expect((await evaluateJudgeAgainstCalibration({ tuples: { 0: 'tuple' } } as any, judge)).total).toBe(0);
+		expect(judge).not.toHaveBeenCalled();
+	});
 });

--- a/test/evals/judge-eval.test.ts
+++ b/test/evals/judge-eval.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi } from 'vitest';
+import { evaluateJudgeAgainstCalibration } from '../../evals/lib/judge-eval.mjs';
+
+// Compact helper for synthetic calibration tuples — only the fields the
+// evaluator reads (the file schema has more; null defaults mirror the
+// post-#870 file format).
+function tuple(opts: {
+	id?: string;
+	taskId?: string;
+	criteria?: string;
+	response?: string;
+	humanLabel?: 'YES' | 'NO' | null;
+	judgeError?: string | null;
+}) {
+	return {
+		id: opts.id ?? 't::1::0',
+		task_id: opts.taskId ?? 't',
+		user_message: 'um',
+		criteria: opts.criteria ?? 'covers X',
+		response: opts.response ?? 'response',
+		automated_verdict: false,
+		judge_error: opts.judgeError ?? null,
+		human_label: opts.humanLabel ?? null,
+	};
+}
+
+function cal(tuples: any[]) {
+	return { version: 1, tuples };
+}
+
+describe('evaluateJudgeAgainstCalibration — counting basics', () => {
+	it('counts agreement, FP, FN; computes accuracy = agreed / evaluated', async () => {
+		const judge = vi.fn(async (_c: string, ctx: any) => ctx.responseText === 'good');
+		const calibration = cal([
+			tuple({ id: 'a', response: 'good', humanLabel: 'YES' }), // judge YES / human YES → agree
+			tuple({ id: 'b', response: 'bad', humanLabel: 'NO' }), //  judge NO  / human NO  → agree
+			tuple({ id: 'c', response: 'good', humanLabel: 'NO' }), //  judge YES / human NO  → FP
+			tuple({ id: 'd', response: 'bad', humanLabel: 'YES' }), //  judge NO  / human YES → FN
+		]);
+		const r = await evaluateJudgeAgainstCalibration(calibration, judge);
+		expect(r.total).toBe(4);
+		expect(r.evaluated).toBe(4);
+		expect(r.agreed).toBe(2);
+		expect(r.disagreed).toBe(2);
+		expect(r.false_positives).toBe(1);
+		expect(r.false_negatives).toBe(1);
+		expect(r.accuracy).toBeCloseTo(0.5, 5);
+	});
+
+	it('labels each disagreement with kind and original tuple context', async () => {
+		const judge = vi.fn(async () => true); // always YES
+		const r = await evaluateJudgeAgainstCalibration(
+			cal([
+				tuple({ id: 'fp', taskId: 'tx', criteria: 'crit', response: 'r', humanLabel: 'NO' }),
+				tuple({ id: 'agree', humanLabel: 'YES' }),
+			]),
+			judge
+		);
+		expect(r.disagreements).toHaveLength(1);
+		expect(r.disagreements[0]).toMatchObject({
+			id: 'fp',
+			task_id: 'tx',
+			criterion: 'crit',
+			response: 'r',
+			human_label: 'NO',
+			judge_verdict: true,
+			kind: 'false_positive',
+		});
+	});
+
+	it('returns accuracy=0 (not NaN) when nothing is comparable', async () => {
+		const judge = vi.fn(async () => true);
+		const r = await evaluateJudgeAgainstCalibration(cal([tuple({ humanLabel: null })]), judge);
+		expect(r.evaluated).toBe(0);
+		expect(r.accuracy).toBe(0);
+		expect(judge).not.toHaveBeenCalled();
+	});
+});
+
+describe('evaluateJudgeAgainstCalibration — skipping behaviour', () => {
+	it('skips unlabelled tuples (human_label === null)', async () => {
+		const judge = vi.fn(async () => true);
+		const r = await evaluateJudgeAgainstCalibration(
+			cal([tuple({ humanLabel: 'YES' }), tuple({ humanLabel: null }), tuple({ humanLabel: null })]),
+			judge
+		);
+		expect(r.evaluated).toBe(1);
+		expect(r.skipped_unlabelled).toBe(2);
+		expect(judge).toHaveBeenCalledTimes(1);
+	});
+
+	it('skips tuples whose original automated judge errored (no fair comparison)', async () => {
+		const judge = vi.fn(async () => true);
+		const r = await evaluateJudgeAgainstCalibration(
+			cal([
+				tuple({ humanLabel: 'YES' }),
+				tuple({ humanLabel: 'YES', judgeError: 'no judge available' }),
+				tuple({ humanLabel: 'NO', judgeError: '429 rate limit' }),
+			]),
+			judge
+		);
+		expect(r.evaluated).toBe(1);
+		expect(r.skipped_judge_error).toBe(2);
+		expect(judge).toHaveBeenCalledTimes(1);
+	});
+
+	it('treats an empty-string judge_error as no error (defensive)', async () => {
+		const judge = vi.fn(async () => true);
+		const r = await evaluateJudgeAgainstCalibration(cal([tuple({ humanLabel: 'YES', judgeError: '' as any })]), judge);
+		expect(r.evaluated).toBe(1);
+		expect(r.skipped_judge_error).toBe(0);
+	});
+});
+
+describe('evaluateJudgeAgainstCalibration — judge call failures', () => {
+	it('counts judge call errors separately and does not let them skew accuracy', async () => {
+		let calls = 0;
+		const judge = async () => {
+			calls++;
+			if (calls === 2) throw new Error('429 rate limit');
+			return true;
+		};
+		const r = await evaluateJudgeAgainstCalibration(
+			cal([
+				tuple({ id: 'a', humanLabel: 'YES' }), // judge YES → agree
+				tuple({ id: 'b', humanLabel: 'YES' }), // judge throws → counted as error, NOT a disagreement
+				tuple({ id: 'c', humanLabel: 'NO' }), //  judge YES → FP
+			]),
+			judge
+		);
+		expect(r.judge_call_errors).toBe(1);
+		expect(r.evaluated).toBe(2);
+		expect(r.agreed).toBe(1);
+		expect(r.disagreed).toBe(1);
+		expect(r.accuracy).toBeCloseTo(0.5, 5);
+	});
+
+	it('coerces a truthy non-boolean verdict (defensive)', async () => {
+		const judge = vi.fn(async () => 1 as any);
+		const r = await evaluateJudgeAgainstCalibration(cal([tuple({ humanLabel: 'YES' })]), judge);
+		expect(r.agreed).toBe(1);
+		expect(r.disagreed).toBe(0);
+	});
+});
+
+describe('evaluateJudgeAgainstCalibration — edge cases', () => {
+	it('handles an empty calibration', async () => {
+		const r = await evaluateJudgeAgainstCalibration(
+			{ tuples: [] } as any,
+			vi.fn(async () => true)
+		);
+		expect(r.total).toBe(0);
+		expect(r.evaluated).toBe(0);
+		expect(r.accuracy).toBe(0);
+	});
+
+	it('handles a missing tuples array', async () => {
+		const r = await evaluateJudgeAgainstCalibration(
+			{} as any,
+			vi.fn(async () => true)
+		);
+		expect(r.total).toBe(0);
+	});
+});


### PR DESCRIPTION
## Summary

References #871.

Adds the **measurement** half of #871: a tool that runs any candidate LLM-as-judge against the human-labelled calibration set committed in #870 (PR #887), and reports agreement vs. ground truth.

Per the PR-1 / PR-2 split agreed in scoping: **this PR only builds the measurement tool and sanity-checks it.** It does **not** change the harness's runtime judge model. A follow-up PR (based on the numbers this tool produces) will bump `DEFAULT_JUDGE_MODEL` to the winner, and #872 will be needed first if the chosen judge is non-Gemini.

## Changes

- **`evals/lib/judge-eval.mjs`** — pure `evaluateJudgeAgainstCalibration(calibration, judgeFn)`. For each tuple with a non-null `human_label` and a clean `judge_error`, calls `judgeFn(criteria, { userMessage, responseText })`, compares to `human_label`. Returns overall agreement, FP / FN counts, and a per-tuple disagreement list with enough context to inspect why the judge flipped. Per-call judge failures are surfaced as a separate count so a transient 429 mid-run doesn't poison the rate.
- **`evals/calibrate-judge.mjs`** + **`npm run eval:calibrate-judge`** — CLI wrapping the library; `--model=`, `--calibration=<path>`, `--json` (machine-readable summary for diffing runs).
- **`test/evals/judge-eval.test.ts`** — 10 tests covering counting (agreement / FP / FN / accuracy), disagreement labelling, skipping (unlabelled tuples, judge-errored tuples), judge-call-error isolation, and defensive coercion.
- **`evals/README.md`** — usage docs under the existing "Judge calibration" section.

## Sanity-check

Ran against the current judge model to verify the tool reproduces the calibration-labelling headline number:

```
$ npm run eval:calibrate-judge -- --model=gemini-2.5-flash

=== Judge agreement on calibration set ===
Judge model:    gemini-2.5-flash
Tuples total:   90
Evaluated:      90
  unlabelled:   0
  judge-error:  0
  call errors:  0

Agreement:      83/90 (92.2%)
Disagreements:  7
  false +:      1  (judge YES, human NO)
  false −:      6  (judge NO,  human YES)
```

**92.2% exactly matches** the calibration's headline (PR #887). Tool works.

### Bonus signal: judge noise at temp=0

The *specific* disagreeing tuples weren't perfectly stable between the calibration-time judge call and this fresh run:

- `rewrite-section-inplace::1` was FN at calibration time; agreed in this run.
- `sort-recent-projects::3` agreed at calibration time; flipped to FN in this run.

Same overall count (7), two tuples shifted. The current judge has measurable nondeterminism even at `temperature: 0` — worth noting for the #871 decision. A more stable judge would be a real win independent of raw accuracy.

## Testing

- `npm test` — 2936 passing (10 new).
- `npm run build` — clean.
- `npm run format-check` — clean.
- **Live sanity-run** documented above.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop (unit suite + live sanity-run — see "Sanity-check")
- [ ] I have verified this change does not break Mobile — N/A, the eval harness is a desktop-only Node tool
- [x] Documentation has been updated (if applicable)
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI workflow and npm command to evaluate an LLM judge against a human-calibrated dataset, with model override and machine-readable JSON output.

* **Documentation**
  * New guide describing how to run judge calibration, available invocation options, reported metrics (agreement, confusion matrix) and per-case disagreement details.

* **Tests**
  * Added comprehensive tests covering counting, skips, error handling, edge cases, and disagreement reporting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/allenhutchison/obsidian-gemini/pull/889?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->