### PR TITLE
chore(daily): 2026-05-25 daily update

### DIFF
--- a/planning/changelog/2026-05-24.md
+++ b/planning/changelog/2026-05-24.md
@@ -1,0 +1,44 @@
+# Daily changelog — May 24, 2026
+
+**Date:** 2026-05-24
+**PRs merged:** 8
+
+---
+
+## Summary
+
+Heavy evals infrastructure day. Three feature PRs built out the judge-measurement pipeline from scratch: a human-labelled calibration set, a tool to score candidate judges against it, and the resulting decision to switch the default judge from `gemini-2.5-flash` to `gemini-3.5-flash` (94.4% vs. 92.2% agreement on the gold set). Alongside that, the architecture-audit nightly sweep contributed two mechanical cleanups — tighter SDK typing in the Gemini client and a circular-import break — plus the daily housekeeping PR and a Dependabot dev-dependency sweep.
+
+## What shipped
+
+### [#881 refactor: replace any with SDK types in Gemini client response handling](https://github.com/allenhutchison/obsidian-gemini/pull/881)
+
+The nightly architecture-audit sweep flagged 13 `any` usages in `src/api/providers/gemini/client.ts`. The `@google/genai` SDK already exports the right shapes (`GenerateContentResponseUsageMetadata`, typed `Candidate` with `groundingMetadata`), so this PR imports them and drops the casts — reducing the `any` count from 13 to 2. Pure typing change; no runtime behavior affected. Two stickier `any` usages in `buildGenerateContentParams` are left for a follow-up.
+
+### [#884 chore(deps-dev): bump the dev-dependencies group with 7 updates](https://github.com/allenhutchison/obsidian-gemini/pull/884)
+
+Dependabot bumped seven dev dependencies: `@google/genai` 2.3.0 → 2.6.0 (adds `gemini-3.5-flash`, `budget_exceeded` status, prompt injection detection), `@types/node` 25.8.0 → 25.9.1, `@vitest/coverage-v8` and `@vitest/ui` 4.1.6 → 4.1.7, `knip` 6.14.1 → 6.14.2, `typescript-eslint` 8.59.3 → 8.59.4, and `vitest` 4.1.6 → 4.1.7.
+
+### [#885 refactor: collocate VIEW_TYPE_DIFF with its view to break runtime cycle](https://github.com/allenhutchison/obsidian-gemini/pull/885)
+
+The nightly architecture-audit sweep flagged a circular runtime import: `main.ts → gemini-diff-view.ts → main.ts`. The root cause was `VIEW_TYPE_DIFF` living in `main.ts` instead of beside the view it names. Moving the constant to `gemini-diff-view.ts` lets `agent-view-messages.ts` consolidate its two dynamic imports into one, eliminating the cycle. Pure code-motion refactor; the constant value (`'gemini-diff-view'`) is unchanged.
+
+### [#886 chore(daily): 2026-05-24 daily update](https://github.com/allenhutchison/obsidian-gemini/pull/886)
+
+Automated daily housekeeping: adds `planning/changelog/2026-05-23.md` covering the May 23 run (2 PRs — the daily housekeeping PR #882 and a Dependabot `qs` security bump #883). No doc drift or unlabeled issues found that day.
+
+### [#887 feat(evals): human-labelled judge calibration set (#870)](https://github.com/allenhutchison/obsidian-gemini/pull/887)
+
+Fixes #870. Builds the ground-truth reference needed to measure how often the LLM-as-judge agrees with a human. The PR ships both the extraction tooling (`evals/lib/calibration.mjs`, `evals/calibrate-extract.mjs`, `npm run eval:calibrate-extract`) and the populated gold set (`evals/calibration/judge-calibration.json` — 90 hand-labelled tuples across 30 judge-matcher tasks from a full 54-task × 3-repeat sweep on `gemini-3.1-flash-lite`). Agreement with the current judge (`gemini-2.5-flash`) came out at 83/90 (92%); 7 disagreements skewed toward false negatives, mostly cosmetic-formatting brittleness and a fabrication acceptance. Also adds 12 unit tests and a new "Judge calibration" section in `evals/README.md`.
+
+### [#888 fix(evals): repair rewrite-section-inplace's broken matchers (#714)](https://github.com/allenhutchison/obsidian-gemini/pull/888)
+
+References #714. The `rewrite-section-inplace` eval task had been scoring 0/3 on every recent sweep due to two independent failures uncovered by the calibration pass. First, the judge criterion asked the model to _describe_ the rewrite in its response, but the prompt actually asks the agent to _edit the file_ — so correct behavior was being marked NO. Second, the three `fileMatches` vault assertions used `(?i)` inline flag syntax, which JavaScript's `RegExp` does not support; the regex constructor threw `SyntaxError` on every run, silently swallowed by the runner's `try/catch`. Fix: drop the judge matcher entirely (vault assertions already verify correctness) and replace `(?i)` with the separate `flags` field.
+
+### [#889 feat(evals): judge-eval tool for measuring candidate judges (#871)](https://github.com/allenhutchison/obsidian-gemini/pull/889)
+
+References #871 (PR 1 of 2). Adds the measurement tool for scoring any candidate LLM-as-judge against the human-labelled calibration set. The core is `evals/lib/judge-eval.mjs` (pure `evaluateJudgeAgainstCalibration()`) wrapped by `evals/calibrate-judge.mjs` and `npm run eval:calibrate-judge`. Sanity-checked against the existing `gemini-2.5-flash` judge and reproduced the 83/90 (92.2%) headline number from the calibration labelling. Ten unit tests cover agreement counting, FP/FN classification, skipping of unlabelled or errored tuples, and judge-call-error isolation.
+
+### [#890 feat(evals): switch default judge to gemini-3.5-flash (#871)](https://github.com/allenhutchison/obsidian-gemini/pull/890)
+
+Fixes #871 (PR 2 of 2). Uses the measurement tool from #889 to select the new default judge. Four candidates were scored against the 90-tuple calibration set: `gemini-3.5-flash` won at 94.4% (85/90) with 1 FP / 4 FN, beating `gemini-3.1-flash-lite` (93.3%, but accepted a fabrication — worse FP profile), the current `gemini-2.5-flash` (92.2%), and `gemini-3.1-pro-preview` (95.6%, but a `-preview` id is explicitly barred as a stable baseline reference by the eval-harness skill). `DEFAULT_JUDGE_MODEL` in the harness is bumped to `gemini-3.5-flash`.


### PR DESCRIPTION
## Summary

Automated daily housekeeping for 2026-05-25. Covers the May 24 changelog (8 PRs — heavy evals infrastructure day).

## Changes

- **Add `planning/changelog/2026-05-24.md`**: Documents 8 PRs merged on May 24 — two architecture-audit cleanups (#881, #885), a Dependabot dev-dependency sweep (#884), the daily housekeeping PR (#886), and four evals PRs that built the judge-calibration pipeline end-to-end (#887, #888, #889, #890).

## Sub-skill outcomes

- **daily-changelog**: wrote `planning/changelog/2026-05-24.md`, 8 PRs (evals infrastructure day — judge calibration set, measurement tool, default judge switch to gemini-3.5-flash, plus 2 architecture-audit cleanups, dependabot dev bump, daily housekeeping)
- **audit-docs**: no drift found — all settings names/defaults, command IDs, tool names, loop thresholds, schedule formats, folder paths, model list, and attachment limits are in sync with the code
- **triage-issues**: 0 unlabeled open issues — tracker is clean

## Screenshots / Screencast

N/A — changelog only.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: daily housekeeping
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A: changelog only
- [x] Documentation has been updated (if applicable) — N/A: this PR IS the changelog
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01H5b7yCCoaHwrwQjddfhzXr)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added daily changelog documenting recent improvements and changes.

* **Chores**
  * Internal refactoring and dependency management updates.
  * Evaluation tooling enhancements including judge model optimization and calibration improvements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/allenhutchison/obsidian-gemini/pull/892?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->