### PR TITLE
refactor(ui): replace CSS :has() modal sizing with explicit modal classes

### DIFF
--- a/src/services/generated-help-references.ts
+++ b/src/services/generated-help-references.ts
@@ -26,6 +26,7 @@ import refSelectionPrompts from '../../docs/guide/selection-prompts.md';
 import refSemanticSearch from '../../docs/guide/semantic-search.md';
 import refSummarization from '../../docs/guide/summarization.md';
 import refAdvancedSettings from '../../docs/reference/advanced-settings.md';
+import refEvals from '../../docs/reference/evals.md';
 import refLoopDetection from '../../docs/reference/loop-detection.md';
 import refSettings from '../../docs/reference/settings.md';
 
@@ -49,6 +50,7 @@ export const helpResources = new Map<string, string>([
 	['references/semantic-search.md', refSemanticSearch],
 	['references/summarization.md', refSummarization],
 	['references/advanced-settings.md', refAdvancedSettings],
+	['references/evals.md', refEvals],
 	['references/loop-detection.md', refLoopDetection],
 	['references/settings.md', refSettings],
 ]);
@@ -74,5 +76,6 @@ export const helpReferencesTable = `| Reference | Topic |
 | \`references/semantic-search.md\` | Semantic Vault Search |
 | \`references/summarization.md\` | Document Summarization Guide |
 | \`references/advanced-settings.md\` | Advanced Settings Guide |
+| \`references/evals.md\` | Eval Suite |
 | \`references/loop-detection.md\` | Tool Loop Detection |
 | \`references/settings.md\` | Settings Reference |`;

--- a/src/ui/agent-view/project-picker-modal.ts
+++ b/src/ui/agent-view/project-picker-modal.ts
@@ -31,6 +31,7 @@ export class ProjectPickerModal extends Modal {
 		const { contentEl } = this;
 		contentEl.empty();
 		contentEl.addClass('gemini-session-modal');
+		this.modalEl.addClass('mod-gemini-session-modal');
 
 		contentEl.createEl('h2', { text: 'Switch Project' });
 

--- a/src/ui/agent-view/session-list-modal.ts
+++ b/src/ui/agent-view/session-list-modal.ts
@@ -38,6 +38,7 @@ export class SessionListModal extends Modal {
 		const { contentEl } = this;
 		contentEl.empty();
 		contentEl.addClass('gemini-session-modal');
+		this.modalEl.addClass('mod-gemini-session-modal');
 
 		// Title
 		contentEl.createEl('h2', { text: 'Agent Sessions' });

--- a/src/ui/background-tasks-modal.ts
+++ b/src/ui/background-tasks-modal.ts
@@ -105,6 +105,7 @@ export class BackgroundTasksModal extends Modal {
 		const { contentEl } = this;
 		contentEl.empty();
 		contentEl.addClass('gemini-activity-modal');
+		this.modalEl.addClass('mod-gemini-activity-modal');
 
 		// Outer tab bar
 		const tabBar = contentEl.createDiv({ cls: 'gemini-activity-tab-bar' });

--- a/src/ui/rag-progress-modal.ts
+++ b/src/ui/rag-progress-modal.ts
@@ -59,6 +59,7 @@ export class RagProgressModal extends Modal {
 		const { contentEl } = this;
 		contentEl.empty();
 		contentEl.addClass('rag-progress-modal');
+		this.modalEl.addClass('mod-rag-progress-modal');
 
 		// Subscribe to progress updates
 		this.ragService.addProgressListener(this.progressListener);

--- a/src/ui/rag-status-modal.ts
+++ b/src/ui/rag-status-modal.ts
@@ -50,6 +50,7 @@ export class RagStatusModal extends Modal {
 		const { contentEl } = this;
 		contentEl.empty();
 		contentEl.addClass('rag-status-modal');
+		this.modalEl.addClass('mod-rag-status-modal');
 
 		// Header with icon
 		const headerEl = contentEl.createDiv({ cls: 'rag-status-header' });

--- a/styles.css
+++ b/styles.css
@@ -525,15 +525,6 @@ If your plugin does not need CSS, delete this file.
 }
 
 /* Tool Confirmation Modal - Enhanced */
-.gemini-tool-confirmation-modal {
-	max-width: 600px;
-}
-
-.modal.modal-container:has(.gemini-tool-confirmation-modal) {
-	width: 600px;
-	max-width: 90vw;
-}
-
 /* Modal Header */
 .gemini-tool-modal-header {
 	display: flex;
@@ -1467,7 +1458,7 @@ If your plugin does not need CSS, delete this file.
 }
 
 /* Session Modal Styles */
-.modal.modal-container:has(.gemini-session-modal) {
+.modal.mod-gemini-session-modal {
 	width: 600px;
 	max-width: 90vw;
 }
@@ -3614,7 +3605,7 @@ If your plugin does not need CSS, delete this file.
 
 /* ==================== RAG Status Modal Tabs ==================== */
 
-.modal.modal-container:has(.rag-status-modal) {
+.modal.mod-rag-status-modal {
 	width: 600px;
 	max-width: 90vw;
 }
@@ -3852,7 +3843,7 @@ If your plugin does not need CSS, delete this file.
 
 /* ==================== RAG Progress Modal ==================== */
 
-.modal.modal-container:has(.rag-progress-modal) {
+.modal.mod-rag-progress-modal {
 	width: 450px;
 	max-width: 90vw;
 }
@@ -4415,7 +4406,7 @@ If your plugin does not need CSS, delete this file.
 
 /* ── Unified Activity Modal (Background Tasks + RAG) ──────────────────────── */
 
-.modal.modal-container:has(.gemini-activity-modal) {
+.modal.mod-gemini-activity-modal {
 	width: 600px;
 	max-width: 90vw;
 }


### PR DESCRIPTION
## Summary

The Obsidian plugin registry CSS-lint flagged 5 uses of `:has()` for modal sizing (registry feedback: "Avoid `:has` — it can cause significant performance issues due to broad selector invalidation"). Each call site was a `.modal.modal-container:has(.X)` selector setting `width` on the modal based on a child content class.

Replaces the pattern with `this.modalEl.addClass('mod-X')` in each modal's `onOpen()` plus a flat `.modal.mod-X` selector. The existing `contentEl.addClass()` calls stay — those drive other in-modal rules that target the content element.

Also drops the `gemini-tool-confirmation-modal` rule block, which was dead CSS (no element ever received that class — grep confirms zero source references).

## Changes

- `src/ui/rag-status-modal.ts`, `src/ui/rag-progress-modal.ts`, `src/ui/background-tasks-modal.ts`, `src/ui/agent-view/project-picker-modal.ts`, `src/ui/agent-view/session-list-modal.ts` — add `this.modalEl.addClass('mod-X')` alongside existing `contentEl.addClass()`.
- `styles.css` — 4 selectors moved from `.modal.modal-container:has(.X)` to `.modal.mod-X`; the `gemini-tool-confirmation-modal` block (2 dead rules) deleted.
- `src/services/generated-help-references.ts` — incidental: caught up the auto-generated file with the eval-suite reference that #893 added without committing the regen.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A (registry CSS-lint feedback)
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop — build + tests pass; visual verification of modal sizes happens on next reload in the test vault
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — pure CSS/class change, no platform-gated paths
- [x] Documentation has been updated (if applicable) — N/A, no user-visible behavior change
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Eval Suite documentation reference to the help system.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/allenhutchison/obsidian-gemini/pull/896?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->