### PR TITLE
chore(build): drop inline sourcemap from production bundle

### DIFF
--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -41,7 +41,12 @@ const context = await esbuild.context({
 	format: 'cjs',
 	target: 'es2018',
 	logLevel: 'info',
-	sourcemap: 'inline',
+	// Inline sourcemaps embed the full source of every dep as base64. In dev
+	// (watch mode) they're worth ~5–7× the binary size for the debugger; in
+	// prod the shipped artifact stays minified (line numbers map back to the
+	// repo source). Without this guard, main.js ships at ~11 MB and exceeds
+	// the Obsidian Sync Standard 5 MB threshold.
+	sourcemap: prod ? false : 'inline',
 	treeShaking: true,
 	outfile: 'main.js',
 	minify: prod,


### PR DESCRIPTION
## Summary

`esbuild.config.mjs` had `sourcemap: 'inline'` set unconditionally, which embeds the full source of every bundled dep (@google/genai, MCP SDK, zod, handlebars, ajv, …) as base64 inside `main.js`. Net effect: the shipped bundle is **11 MB**, even though the actual minified code is only **1.9 MB**.

That trips the Obsidian Sync Standard 5 MB ceiling — Sync Standard users currently can't sync the plugin. The plugin registry's release-section warning calls this out directly.

Switch to `prod ? false : 'inline'`: dev (watch mode) keeps inline sourcemaps so the debugger works; production drops them entirely. Production stack traces still map to minified line numbers, and the source is in the repo if anyone needs to dig in.

## Verification

```
Before: 11 MB main.js (10,709,914 bytes)
After:  1.9 MB main.js (1,927,xxx bytes)
```

Build + tests pass locally (`npm run build`, `npm test` = 2937/2937).

## Bundle composition (post-fix, top contributors)

| KB | Module |
|---:|---|
| 858 | our src |
| 363 | zod |
| 279 | @google/genai |
| 103 | ajv |
| 82 | @modelcontextprotocol/sdk |
| 77 | handlebars |
| 116 | everything else combined |

## What this does NOT fix

The registry's other behavior warnings (`fs`, `child_process`, `new Function`, `localStorage`) are real-ish — they're emitted by transitive dep code, not by our source. They survive minification regardless of sourcemap config. Those would need separate work (e.g. excluding stdio transport on mobile, or upstream PRs against the offending deps). Out of scope here.

## Changes

- `esbuild.config.mjs`: gate inline sourcemap on dev mode; comment block explaining the size impact.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A (registry feedback)
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop — build verified at 1.9 MB; plugin loads correctly under both `npm run build` and `npm run dev` paths
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — build-only change, no runtime behavior diff
- [x] Documentation has been updated (if applicable) — N/A, internal build config
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized production builds by disabling sourcemaps in production environments, reducing deployed bundle size. Sourcemaps remain available during development for debugging purposes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/allenhutchison/obsidian-gemini/pull/897?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->