### PR TITLE
refactor(ui): replace CSS !important with explicit specificity

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -17,7 +17,7 @@ If your plugin does not need CSS, delete this file.
 }
 
 .modal.gemini-scribe-rewrite-modal .modal-content {
-	padding: 0 !important;
+	padding: 0;
 	overflow: hidden;
 }
 
@@ -1464,7 +1464,7 @@ If your plugin does not need CSS, delete this file.
 }
 
 .modal-content.gemini-session-modal {
-	overflow-x: hidden !important;
+	overflow-x: hidden;
 	padding: 0;
 	width: 100%;
 	box-sizing: border-box;
@@ -1483,7 +1483,7 @@ If your plugin does not need CSS, delete this file.
 .gemini-session-list {
 	max-height: 400px;
 	overflow-y: auto;
-	overflow-x: hidden !important;
+	overflow-x: hidden;
 	margin: var(--size-4-3) 20px;
 	padding-right: 5px;
 	/* Add some padding for scrollbar */
@@ -3176,190 +3176,6 @@ If your plugin does not need CSS, delete this file.
 	color: var(--text-error);
 }
 
-/* Migration Modal Styles */
-
-.gemini-migration-modal {
-	max-width: 600px;
-}
-
-.gemini-migration-header {
-	margin-bottom: 1rem;
-	color: var(--text-normal);
-}
-
-.gemini-migration-description {
-	margin-bottom: 1.5rem;
-	line-height: 1.6;
-}
-
-.gemini-migration-description p {
-	margin: 0.5rem 0;
-	color: var(--text-normal);
-}
-
-.gemini-migration-info {
-	background-color: var(--background-secondary);
-	border: 1px solid var(--background-modifier-border);
-	border-radius: 8px;
-	padding: 1rem;
-	margin-bottom: 1.5rem;
-}
-
-.gemini-migration-info h3 {
-	margin: 0 0 0.75rem 0;
-	font-size: 1rem;
-	font-weight: 600;
-	color: var(--text-normal);
-}
-
-.gemini-migration-info ul {
-	margin: 0;
-	padding-left: 1.5rem;
-	list-style: none;
-}
-
-.gemini-migration-info li {
-	margin: 0.5rem 0;
-	color: var(--text-normal);
-}
-
-.gemini-migration-warning {
-	background-color: var(--background-modifier-error-hover);
-	border: 1px solid var(--background-modifier-error);
-	border-radius: 8px;
-	padding: 1rem;
-	margin-bottom: 1.5rem;
-}
-
-.gemini-migration-warning p {
-	margin: 0;
-	color: var(--text-normal);
-	font-weight: 500;
-}
-
-.gemini-migration-buttons {
-	display: flex;
-	justify-content: flex-end;
-	gap: 0.75rem;
-	margin-top: 1.5rem;
-}
-
-.gemini-migration-buttons button {
-	padding: 0.5rem 1.5rem;
-	border-radius: 6px;
-	font-weight: 500;
-	cursor: pointer;
-	transition: all 0.2s ease;
-}
-
-.gemini-migration-progress {
-	padding: 2rem;
-	text-align: center;
-}
-
-.gemini-migration-progress p {
-	margin: 1rem 0;
-	color: var(--text-muted);
-}
-
-.gemini-migration-results {
-	margin: 1.5rem 0;
-}
-
-.gemini-migration-stats {
-	background-color: var(--background-secondary);
-	border-radius: 8px;
-	padding: 1rem;
-	margin-bottom: 1rem;
-}
-
-.gemini-migration-stats p {
-	margin: 0.5rem 0;
-	color: var(--text-normal);
-	font-weight: 500;
-}
-
-.gemini-migration-failed {
-	color: var(--text-error) !important;
-}
-
-.gemini-migration-backup {
-	color: var(--text-success) !important;
-}
-
-.gemini-migration-errors {
-	background-color: var(--background-modifier-error-hover);
-	border: 1px solid var(--background-modifier-error);
-	border-radius: 8px;
-	padding: 1rem;
-	margin-top: 1rem;
-}
-
-.gemini-migration-errors h3 {
-	margin: 0 0 0.5rem 0;
-	font-size: 1rem;
-	color: var(--text-error);
-}
-
-.gemini-migration-errors ul {
-	margin: 0;
-	padding-left: 1.5rem;
-	list-style: disc;
-}
-
-.gemini-migration-errors li {
-	margin: 0.25rem 0;
-	color: var(--text-normal);
-	font-size: 0.875rem;
-}
-
-.gemini-migration-next-steps {
-	margin: 1.5rem 0;
-}
-
-.gemini-migration-next-steps h3 {
-	margin: 0 0 0.75rem 0;
-	font-size: 1rem;
-	font-weight: 600;
-	color: var(--text-normal);
-}
-
-.gemini-migration-next-steps ul {
-	margin: 0;
-	padding-left: 1.5rem;
-	list-style: disc;
-}
-
-.gemini-migration-next-steps li {
-	margin: 0.5rem 0;
-	color: var(--text-normal);
-}
-
-.gemini-migration-error {
-	background-color: var(--background-modifier-error-hover);
-	border: 1px solid var(--background-modifier-error);
-	border-radius: 8px;
-	padding: 1rem;
-	margin: 1rem 0;
-}
-
-.gemini-migration-error p {
-	margin: 0 0 0.5rem 0;
-	color: var(--text-normal);
-	font-weight: 500;
-}
-
-.gemini-migration-error code {
-	display: block;
-	background-color: var(--background-primary);
-	border-radius: 4px;
-	padding: 0.5rem;
-	margin-top: 0.5rem;
-	font-size: 0.875rem;
-	color: var(--text-error);
-	word-wrap: break-word;
-}
-
 /* Update Notification Modal Styles */
 
 .gemini-update-notification-modal {
@@ -3969,9 +3785,9 @@ If your plugin does not need CSS, delete this file.
 	font-size: var(--font-ui-small);
 }
 
-.gemini-agent-input-dragover {
-	background-color: var(--background-modifier-hover) !important;
-	border-color: var(--interactive-accent) !important;
+.gemini-agent-input.gemini-agent-input-dragover {
+	background-color: var(--background-modifier-hover);
+	border-color: var(--interactive-accent);
 }
 
 .gemini-agent-clickable-image {
@@ -4138,7 +3954,7 @@ If your plugin does not need CSS, delete this file.
 }
 
 .modal.gemini-scribe-selection-response-modal .modal-content {
-	padding: 0 !important;
+	padding: 0;
 	overflow: hidden;
 	display: flex;
 	flex-direction: column;
@@ -4273,7 +4089,7 @@ If your plugin does not need CSS, delete this file.
 }
 
 .modal.gemini-scribe-ask-question-modal .modal-content {
-	padding: 0 !important;
+	padding: 0;
 	overflow: hidden;
 }
 


### PR DESCRIPTION
## Summary

The Obsidian plugin registry CSS-lint flagged 9 uses of `!important` (warning: "Avoid `!important` — override styles by increasing selector specificity or using CSS variables instead"). Each call site was either competing with Obsidian's default styling or with our own `:focus` styling. Resolved per site by leaning on specificity / source order.

## Audit and fix

| Count | Class(es) | Resolution |
|---:|---|---|
| 5 | `.gemini-migration-*` (entire `Migration Modal Styles` block) | **Dead CSS.** Zero references anywhere in the repo. Block deleted (183 lines). Removes 2 of the 9 `!important` along the way. |
| 3 | `.modal.X .modal-content { padding: 0 !important }` (rewrite, selection-response, ask-question modals) | Selector specificity is `(0,3,0)`; Obsidian default `.modal-content` is `(0,1,0)`. `!important` was unnecessary. |
| 2 | `.modal-content.gemini-session-modal` + `.gemini-session-list` `overflow-x: hidden !important` | First is `(0,2,0)` vs default `(0,1,0)`. Second was a defensive duplicate of `.gemini-session-modal > *` (same specificity, later in source). Both `!important` removed. |
| 2 | `.gemini-agent-input-dragover` `background-color` + `border-color` `!important` | Was competing with `.gemini-agent-input:focus` `(0,2,0)` when dragging onto a focused input. Bumped selector to `.gemini-agent-input.gemini-agent-input-dragover` `(0,2,0)` + later in source. The element always carries both classes (see `agent-view-ui.ts:351`). |

## Net diff

- `styles.css`: **-192 lines, +8 lines.** 0 `!important` remaining (verified with `grep -c '!important' styles.css` → 0).
- No visual change expected — purely a specificity/dead-code refactor.

## Changes

- `styles.css`: delete `Migration Modal Styles` block (lines 3179–3361, all `.gemini-migration-*` rules); drop `!important` from the 4 remaining live call sites; bump `.gemini-agent-input-dragover` to `.gemini-agent-input.gemini-agent-input-dragover`.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A (registry CSS-lint feedback)
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop — build + 2937 tests pass; specificity math verified per call site. Visual verification on next plugin reload in the test vault.
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — pure CSS change, no platform-gated paths
- [x] Documentation has been updated (if applicable) — N/A, no user-visible behavior change
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated modal styling for consistency across components
  * Refined drag-and-drop input styling with more specific selectors
  * Removed legacy migration modal styles

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/allenhutchison/obsidian-gemini/pull/898?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->