### PR TITLE
chore(daily): 2026-05-26 daily update

### DIFF
--- a/planning/changelog/2026-05-25.md
+++ b/planning/changelog/2026-05-25.md
@@ -1,0 +1,44 @@
+# Daily changelog — May 25, 2026
+
+**Date:** 2026-05-25
+**PRs merged:** 8
+
+---
+
+## Summary
+
+A day of closure and cleanup in two waves. The morning wrapped up the multi-day eval strike: re-baselined all models on the unified 54-task suite, published the methodology and results table to the public docs, and committed the full project record. The evening shifted to Obsidian plugin registry compliance — three PRs addressed CSS-lint warnings (`:has()`, `!important`) and the most impactful build defect: a bloated 11 MB production bundle that was silently blocking Obsidian Sync Standard users.
+
+## What shipped
+
+### [#891 chore(evals): re-baseline all models on the 54-task suite](https://github.com/allenhutchison/obsidian-gemini/pull/891)
+
+Refreshed every model baseline on the 54-task suite under the `gemini-3.5-flash` judge introduced in #890. Prior to this PR, most baselines were on the old 7-task suite, making cross-model comparisons meaningless. All three sweeps (N=5) ran clean. Notable finding: `gemini-3.1-flash-lite` outperforms `gemini-2.5-flash` by 17 percentage points (74.1% vs 57.4% `solve^5`) despite the name suggesting otherwise. The `:latest`/`-preview` baseline files were replaced with pinned identifiers aligned with the eval-harness policy.
+
+### [#892 chore(daily): 2026-05-25 daily update](https://github.com/allenhutchison/obsidian-gemini/pull/892)
+
+Automated daily housekeeping for May 25, documenting the May 24 changelog (8 PRs — the judge calibration pipeline build-out and two architecture-audit cleanups).
+
+### [#893 docs: publish eval-suite methodology + results table](https://github.com/allenhutchison/obsidian-gemini/pull/893)
+
+New public-facing docs page at `/reference/evals` covering evaluation methodology, the T1–T4 task tiers, `pass^k`/`solve^k` scoring, judge model disclosure (including a same-family bias caveat), and a live results table fed by a VitePress data loader reading the committed baselines at build time. Closes the two long-deferred issues #874 (methodology doc) and #875 (published results table). No harness changes were needed — the baseline files already carried all the required fields.
+
+### [#894 docs(planning): commit eval-strike record as markdown](https://github.com/allenhutchison/obsidian-gemini/pull/894)
+
+Converts the working eval-strike HTML plan into a permanent `planning/eval-strike-plan.md` — phase-by-phase record of all 9 phases, the cross-model results table, surfaced methodology findings, and a critical-path diagram showing every issue resolved. Closes out the eval strike cleanly; the live results table itself stays at `docs/reference/evals` (from #893).
+
+### [#896 refactor(ui): replace CSS :has() modal sizing with explicit modal classes](https://github.com/allenhutchison/obsidian-gemini/pull/896)
+
+The plugin registry CSS-lint flagged 5 uses of `:has()` for modal sizing. Replaced with `this.modalEl.addClass('mod-X')` in each modal's `onOpen()` and flat `.modal.mod-X` selectors. Also deletes the `gemini-tool-confirmation-modal` CSS block, which grep confirmed was dead (no element ever received that class). Also regenerates `src/services/generated-help-references.ts` to pick up the eval-suite docs page added in #893.
+
+### [#895 chore(release): attest build provenance for main.js and styles.css](https://github.com/allenhutchison/obsidian-gemini/pull/895)
+
+Adds `actions/attest-build-provenance@v2` to the release workflow, scoped with `id-token: write` and `attestations: write`, so users can cryptographically verify release assets were built from this repository. Addresses two of the three release-section warnings from the Obsidian registry feedback. Takes effect on the next tag push.
+
+### [#897 chore(build): drop inline sourcemap from production bundle](https://github.com/allenhutchison/obsidian-gemini/pull/897)
+
+`esbuild.config.mjs` had `sourcemap: 'inline'` unconditionally enabled, which embedded the full source of every bundled dependency as base64 inside `main.js`. Result: an 11 MB production bundle when the actual minified code is only 1.9 MB. This tripped the Obsidian Sync Standard 5 MB ceiling, silently blocking Sync Standard users from syncing the plugin. The fix gates inline sourcemaps on dev mode only; production drops them entirely. Dev watch mode is unaffected. The registry's bundle-size warning is now resolved.
+
+### [#898 refactor(ui): replace CSS !important with explicit specificity](https://github.com/allenhutchison/obsidian-gemini/pull/898)
+
+The registry CSS-lint flagged 9 uses of `!important`. Resolved per call site: 5 were in a dead `.gemini-migration-*` block (183 lines deleted, zero source references found), 3 were unnecessary given the actual selector specificity, and the remaining 2 were fixed by bumping `.gemini-agent-input-dragover` to `.gemini-agent-input.gemini-agent-input-dragover` to beat the `:focus` rule when dragging onto a focused input. Net diff: −192 lines, +8 lines. Zero `!important` remaining in `styles.css`.


### PR DESCRIPTION
## Summary

Automated daily housekeeping for 2026-05-26. Covers the May 25 changelog (8 PRs — eval strike closure in the morning, registry compliance sweep in the evening).

## Changes

- **Add `planning/changelog/2026-05-25.md`**: Documents 8 PRs merged on May 25 — eval strike wrap-up (#891 re-baseline, #893 methodology docs, #894 planning record, #892 daily housekeeping) and four registry-compliance PRs that addressed Obsidian plugin registry feedback (#895 build provenance attestation, #896 CSS :has() removal, #897 bundle size 11 MB→1.9 MB fix, #898 CSS !important removal).

## Sub-skill outcomes

- **daily-changelog**: wrote `planning/changelog/2026-05-25.md`, 8 PRs (eval strike closure morning + registry compliance sweep evening — bundle size 11 MB→1.9 MB, CSS :has() and !important cleanup, build provenance attestation)
- **audit-docs**: no drift found — all settings defaults, command IDs, tool names, loop thresholds, schedule formats, folder paths, and model defaults are in sync with the code; no new docs warranted
- **triage-issues**: 0 unlabeled open issues — tracker is clean

## Screenshots / Screencast

N/A — changelog only.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: daily housekeeping
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A: changelog only
- [x] Documentation has been updated (if applicable) — N/A: this PR IS the changelog
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01DZ6tpTuTnEzJKQQEGVgdYV)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Reduced production bundle size by removing inline sourcemaps
  * Optimized stylesheets by removing dead CSS and eliminating unnecessary declarations

* **Bug Fixes**
  * Fixed UI modal sizing to ensure registry compliance

* **Documentation**
  * Published evaluation suite methodology and results

* **Chores**
  * Enhanced release workflow with build provenance attestations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/allenhutchison/obsidian-gemini/pull/899?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->