### PR TITLE
refactor(tools): type ToolExecutionContext.plugin as ObsidianGemini

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,13 +124,15 @@ The plugin uses a factory pattern (`ModelClientFactory` in `src/api/factory.ts`)
 - Blocked calls are flagged with `loopDetected: true` on `ToolResult` and emit a `toolLoopDetected` event on the agent bus
 - `AgentLoop` counts those fires per turn and aborts the turn after `AGENT_LOOP_ABORT_THRESHOLD` (currently 3) — the result comes back with `loopAborted: true` and a user-visible notice, which the UI displays but does not persist to session history
 
-11. **YAML Frontmatter**: Agent instructions include guidance for respecting YAML frontmatter when modifying files
+11. **Tool Implementation**: `ToolExecutionContext.plugin` is typed `ObsidianGemini`; no cast is needed in tool implementations — use `context.plugin` directly.
+
+12. **YAML Frontmatter**: Agent instructions include guidance for respecting YAML frontmatter when modifying files
 
 - The AI is trained to place "top of note" content after frontmatter blocks (defined in `prompts/agentToolsPrompt.hbs`)
 - YAML frontmatter must start with `---` on line 1 and end with `---`
 - Content is only placed before frontmatter when explicitly instructed to modify frontmatter
 
-12. **Agent Skills** (`src/services/skill-manager.ts`, `src/tools/skill-tools.ts`): Extensible skill system following the [agentskills.io](https://agentskills.io) specification
+13. **Agent Skills** (`src/services/skill-manager.ts`, `src/tools/skill-tools.ts`): Extensible skill system following the [agentskills.io](https://agentskills.io) specification
 
 - Skills are self-contained packages stored in `[state-folder]/Skills/<skill-name>/SKILL.md`
 - `SkillManager` handles discovery, metadata parsing, content loading, resource reading, creation, and name validation

--- a/src/tools/deep-research-tool.ts
+++ b/src/tools/deep-research-tool.ts
@@ -2,7 +2,6 @@ import { normalizePath } from 'obsidian';
 import { Tool, ToolResult, ToolExecutionContext } from './types';
 import { ToolCategory } from '../types/agent';
 import { ToolClassification } from '../types/tool-policy';
-import type ObsidianGemini from '../main';
 import { ResearchScope } from '../services/deep-research';
 import { formatLocalDate } from '../utils/format-utils';
 import { sanitizeFileName, ensureFolderExists } from '../utils/file-utils';
@@ -79,7 +78,7 @@ export class DeepResearchTool implements Tool {
 		params: { topic: string; scope?: ResearchScope; outputFile?: string; background?: boolean },
 		context: ToolExecutionContext
 	): Promise<ToolResult> {
-		const plugin = context.plugin as ObsidianGemini;
+		const plugin = context.plugin;
 
 		try {
 			// Validate parameters

--- a/src/tools/execution-engine.ts
+++ b/src/tools/execution-engine.ts
@@ -254,7 +254,7 @@ export class ToolExecutionEngine {
 	 * - edit_skill: originalContent = current SKILL.md body, proposedContent = parameters.content
 	 */
 	private async buildDiffContext(tool: Tool, parameters: any): Promise<DiffContext | undefined> {
-		const plugin = this.plugin as ObsidianGemini;
+		const plugin = this.plugin;
 
 		if (tool.name === 'write_file' && parameters.path && parameters.content !== undefined) {
 			const normalizedPath = normalizePath(parameters.path);
@@ -347,7 +347,7 @@ export class ToolExecutionEngine {
 	 * Used for diff context display only.
 	 */
 	private getSkillFilePath(skillName: string): string {
-		const plugin = this.plugin as ObsidianGemini;
+		const plugin = this.plugin;
 		if (plugin.skillManager) {
 			return normalizePath(`${plugin.skillManager.getSkillsFolderPath()}/${skillName}/SKILL.md`);
 		}
@@ -360,9 +360,9 @@ export class ToolExecutionEngine {
 	 */
 	private async safeReadFile(file: TFile): Promise<string> {
 		try {
-			return await (this.plugin as ObsidianGemini).app.vault.read(file);
+			return await this.plugin.app.vault.read(file);
 		} catch (error) {
-			(this.plugin as any).logger?.warn(`Failed to read file for diff context: ${file.path}`, error);
+			this.plugin.logger.warn(`Failed to read file for diff context: ${file.path}`, error);
 			return '';
 		}
 	}

--- a/src/tools/google-search-tool.ts
+++ b/src/tools/google-search-tool.ts
@@ -1,7 +1,6 @@
 import { Tool, ToolResult, ToolExecutionContext } from './types';
 import { ToolCategory } from '../types/agent';
 import { ToolClassification } from '../types/tool-policy';
-import type ObsidianGemini from '../main';
 import { getDefaultModelForRole } from '../models';
 import { createGoogleGenAI } from '../api/providers/gemini/google-genai-factory';
 import { executeWithRetry } from '../utils/retry';
@@ -38,7 +37,7 @@ export class GoogleSearchTool implements Tool {
 	}
 
 	async execute(params: { query: string }, context: ToolExecutionContext): Promise<ToolResult> {
-		const plugin = context.plugin as ObsidianGemini;
+		const plugin = context.plugin;
 
 		try {
 			// Check if API key is available

--- a/src/tools/image-tools.ts
+++ b/src/tools/image-tools.ts
@@ -1,7 +1,6 @@
 import { Tool, ToolResult, ToolExecutionContext } from './types';
 import { ToolCategory } from '../types/agent';
 import { ToolClassification } from '../types/tool-policy';
-import type ObsidianGemini from '../main';
 
 /**
  * Tool to generate images from text prompts using Gemini's image generation API
@@ -56,7 +55,7 @@ export class GenerateImageTool implements Tool {
 	}
 
 	async execute(params: any, context: ToolExecutionContext): Promise<ToolResult> {
-		const plugin = context.plugin as ObsidianGemini;
+		const plugin = context.plugin;
 
 		try {
 			// Get the image generation service

--- a/src/tools/memory-tool.ts
+++ b/src/tools/memory-tool.ts
@@ -1,7 +1,6 @@
 import { Tool, ToolResult, ToolExecutionContext } from './types';
 import { ToolCategory } from '../types/agent';
 import { ToolClassification } from '../types/tool-policy';
-import type ObsidianGemini from '../main';
 
 /**
  * Tool for updating the AGENTS.md memory file
@@ -38,7 +37,7 @@ export class UpdateMemoryTool implements Tool {
 	}
 
 	async execute(params: { content: string }, context: ToolExecutionContext): Promise<ToolResult> {
-		const plugin = context.plugin as ObsidianGemini;
+		const plugin = context.plugin;
 
 		try {
 			// Validate content
@@ -100,7 +99,7 @@ export class ReadMemoryTool implements Tool {
 	}
 
 	async execute(_params: any, context: ToolExecutionContext): Promise<ToolResult> {
-		const plugin = context.plugin as ObsidianGemini;
+		const plugin = context.plugin;
 
 		try {
 			// Get the agents memory service

--- a/src/tools/rag-search-tool.ts
+++ b/src/tools/rag-search-tool.ts
@@ -1,7 +1,6 @@
 import { Tool, ToolResult, ToolExecutionContext } from './types';
 import { ToolCategory } from '../types/agent';
 import { ToolClassification } from '../types/tool-policy';
-import type ObsidianGemini from '../main';
 
 /**
  * Search result from RAG semantic search
@@ -139,7 +138,7 @@ export class RagSearchTool implements Tool {
 		params: { query: string; maxResults?: number; folder?: string; tags?: string[] },
 		context: ToolExecutionContext
 	): Promise<ToolResult> {
-		const plugin = context.plugin as ObsidianGemini;
+		const plugin = context.plugin;
 
 		try {
 			// Validate query

--- a/src/tools/session-recall-tool.ts
+++ b/src/tools/session-recall-tool.ts
@@ -1,4 +1,3 @@
-import type ObsidianGemini from '../main';
 import { Tool, ToolResult, ToolExecutionContext } from './types';
 import { ToolCategory } from '../types/agent';
 import { ToolClassification } from '../types/tool-policy';
@@ -53,7 +52,7 @@ class RecallSessionsTool implements Tool {
 		params: { query?: string; filePath?: string; project?: string; limit?: number },
 		context: ToolExecutionContext
 	): Promise<ToolResult> {
-		const plugin = context.plugin as ObsidianGemini;
+		const plugin = context.plugin;
 		const limit = Math.max(1, Math.min(50, Math.floor(params.limit || 10)));
 
 		try {

--- a/src/tools/skill-tools.ts
+++ b/src/tools/skill-tools.ts
@@ -1,7 +1,6 @@
 import { Tool, ToolResult, ToolExecutionContext } from './types';
 import { ToolCategory } from '../types/agent';
 import { ToolClassification } from '../types/tool-policy';
-import type ObsidianGemini from '../main';
 
 /**
  * Tool for activating (loading) a skill's full instructions or resources
@@ -42,7 +41,7 @@ export class ActivateSkillTool implements Tool {
 	}
 
 	async execute(params: { name: string; resource_path?: string }, context: ToolExecutionContext): Promise<ToolResult> {
-		const plugin = context.plugin as ObsidianGemini;
+		const plugin = context.plugin;
 
 		try {
 			if (!plugin.skillManager) {
@@ -167,7 +166,7 @@ export class CreateSkillTool implements Tool {
 		params: { name: string; description: string; content: string; _userEdited?: boolean },
 		context: ToolExecutionContext
 	): Promise<ToolResult> {
-		const plugin = context.plugin as ObsidianGemini;
+		const plugin = context.plugin;
 
 		try {
 			if (!plugin.skillManager) {
@@ -280,7 +279,7 @@ export class EditSkillTool implements Tool {
 		params: { name: string; description?: string; content?: string; _userEdited?: boolean },
 		context: ToolExecutionContext
 	): Promise<ToolResult> {
-		const plugin = context.plugin as ObsidianGemini;
+		const plugin = context.plugin;
 
 		try {
 			if (!plugin.skillManager) {

--- a/src/tools/types.ts
+++ b/src/tools/types.ts
@@ -1,5 +1,6 @@
 import { ChatSession } from '../types/agent';
 import { ToolClassification } from '../types/tool-policy';
+import type ObsidianGemini from '../main';
 
 // Re-export ToolCall from its canonical definition in model-api
 export type { ToolCall } from '../api/interfaces/model-api';
@@ -27,7 +28,7 @@ export interface ToolResult {
  */
 export interface ToolExecutionContext {
 	session: ChatSession;
-	plugin: any; // Will be typed to ObsidianGemini
+	plugin: ObsidianGemini;
 	/** When set, discovery tools default their search scope to this directory */
 	projectRootPath?: string;
 	/**

--- a/src/tools/vault-tools-extended.ts
+++ b/src/tools/vault-tools-extended.ts
@@ -2,7 +2,6 @@ import { Tool, ToolResult, ToolExecutionContext } from './types';
 import { ToolCategory } from '../types/agent';
 import { ToolClassification } from '../types/tool-policy';
 import { TFile, normalizePath } from 'obsidian';
-import type ObsidianGemini from '../main';
 import { shouldExcludePathForPlugin as shouldExcludePath } from '../utils/file-utils';
 
 /**
@@ -63,7 +62,7 @@ class UpdateFrontmatterTool implements Tool {
 	}
 
 	async execute(params: { path: string; key: string; value: any }, context: ToolExecutionContext): Promise<ToolResult> {
-		const plugin = context.plugin as ObsidianGemini;
+		const plugin = context.plugin;
 		const { path, key, value } = params;
 
 		try {
@@ -184,7 +183,7 @@ class AppendContentTool implements Tool {
 		params: { path: string; content: string; _replaceFullContent?: boolean; _userEdited?: boolean },
 		context: ToolExecutionContext
 	): Promise<ToolResult> {
-		const plugin = context.plugin as ObsidianGemini;
+		const plugin = context.plugin;
 		const { path, content } = params;
 
 		try {

--- a/src/tools/vault/create-folder-tool.ts
+++ b/src/tools/vault/create-folder-tool.ts
@@ -2,7 +2,6 @@ import { Tool, ToolResult, ToolExecutionContext } from '../types';
 import { ToolCategory } from '../../types/agent';
 import { ToolClassification } from '../../types/tool-policy';
 import { TFolder, normalizePath } from 'obsidian';
-import type ObsidianGemini from '../../main';
 import { shouldExcludePathForPlugin as shouldExcludePath, ensureFolderExists } from '../../utils/file-utils';
 
 /**
@@ -40,7 +39,7 @@ export class CreateFolderTool implements Tool {
 	}
 
 	async execute(params: { path: string }, context: ToolExecutionContext): Promise<ToolResult> {
-		const plugin = context.plugin as ObsidianGemini;
+		const plugin = context.plugin;
 
 		try {
 			const normalizedPath = normalizePath(params.path);

--- a/src/tools/vault/delete-file-tool.ts
+++ b/src/tools/vault/delete-file-tool.ts
@@ -2,7 +2,6 @@ import { Tool, ToolResult, ToolExecutionContext } from '../types';
 import { ToolCategory } from '../../types/agent';
 import { ToolClassification } from '../../types/tool-policy';
 import { normalizePath } from 'obsidian';
-import type ObsidianGemini from '../../main';
 import { shouldExcludePathForPlugin as shouldExcludePath } from '../../utils/file-utils';
 import { resolvePathToFileOrFolder } from './utils';
 
@@ -41,7 +40,7 @@ export class DeleteFileTool implements Tool {
 	}
 
 	async execute(params: { path: string }, context: ToolExecutionContext): Promise<ToolResult> {
-		const plugin = context.plugin as ObsidianGemini;
+		const plugin = context.plugin;
 
 		try {
 			const normalizedPath = normalizePath(params.path);

--- a/src/tools/vault/get-workspace-state-tool.ts
+++ b/src/tools/vault/get-workspace-state-tool.ts
@@ -2,7 +2,6 @@ import { Tool, ToolResult, ToolExecutionContext } from '../types';
 import { ToolCategory } from '../../types/agent';
 import { ToolClassification } from '../../types/tool-policy';
 import { MarkdownView } from 'obsidian';
-import type ObsidianGemini from '../../main';
 import { shouldExcludePathForPlugin as shouldExcludePath } from '../../utils/file-utils';
 
 /** Maximum characters of selected text to include in workspace state */
@@ -31,7 +30,7 @@ export class GetWorkspaceStateTool implements Tool {
 	}
 
 	async execute(_params: any, context: ToolExecutionContext): Promise<ToolResult> {
-		const plugin = context.plugin as ObsidianGemini;
+		const plugin = context.plugin;
 
 		try {
 			const activeFile = plugin.app.workspace.getActiveFile();

--- a/src/tools/vault/list-files-tool.ts
+++ b/src/tools/vault/list-files-tool.ts
@@ -2,7 +2,6 @@ import { Tool, ToolResult, ToolExecutionContext } from '../types';
 import { ToolCategory } from '../../types/agent';
 import { ToolClassification } from '../../types/tool-policy';
 import { TFile, TFolder, normalizePath } from 'obsidian';
-import type ObsidianGemini from '../../main';
 import { shouldExcludePathForPlugin as shouldExcludePath } from '../../utils/file-utils';
 
 /**
@@ -40,7 +39,7 @@ export class ListFilesTool implements Tool {
 	}
 
 	async execute(params: { path: string; recursive?: boolean }, context: ToolExecutionContext): Promise<ToolResult> {
-		const plugin = context.plugin as ObsidianGemini;
+		const plugin = context.plugin;
 
 		try {
 			// Default to project root when no path specified and project is active.

--- a/src/tools/vault/move-file-tool.ts
+++ b/src/tools/vault/move-file-tool.ts
@@ -2,7 +2,6 @@ import { Tool, ToolResult, ToolExecutionContext } from '../types';
 import { ToolCategory } from '../../types/agent';
 import { ToolClassification } from '../../types/tool-policy';
 import { normalizePath } from 'obsidian';
-import type ObsidianGemini from '../../main';
 import { shouldExcludePathForPlugin as shouldExcludePath, ensureFolderExists } from '../../utils/file-utils';
 import { resolvePathToFileOrFolder } from './utils';
 
@@ -51,7 +50,7 @@ export class MoveFileTool implements Tool {
 		params: { sourcePath: string; targetPath: string },
 		context: ToolExecutionContext
 	): Promise<ToolResult> {
-		const plugin = context.plugin as ObsidianGemini;
+		const plugin = context.plugin;
 
 		try {
 			const sourceNormalizedPath = normalizePath(params.sourcePath);

--- a/src/tools/vault/read-file-tool.ts
+++ b/src/tools/vault/read-file-tool.ts
@@ -2,7 +2,6 @@ import { Tool, ToolResult, ToolExecutionContext } from '../types';
 import { ToolCategory } from '../../types/agent';
 import { ToolClassification } from '../../types/tool-policy';
 import { TFile, TFolder, normalizePath } from 'obsidian';
-import type ObsidianGemini from '../../main';
 import { shouldExcludePathForPlugin as shouldExcludePath } from '../../utils/file-utils';
 import {
 	classifyFile,
@@ -44,7 +43,7 @@ export class ReadFileTool implements Tool {
 	}
 
 	async execute(params: { path: string }, context: ToolExecutionContext): Promise<ToolResult> {
-		const plugin = context.plugin as ObsidianGemini;
+		const plugin = context.plugin;
 
 		try {
 			const normalizedPath = normalizePath(params.path);

--- a/src/tools/vault/search-file-contents-tool.ts
+++ b/src/tools/vault/search-file-contents-tool.ts
@@ -1,7 +1,6 @@
 import { Tool, ToolResult, ToolExecutionContext } from '../types';
 import { ToolCategory } from '../../types/agent';
 import { ToolClassification } from '../../types/tool-policy';
-import type ObsidianGemini from '../../main';
 import { shouldExcludePathForPlugin as shouldExcludePath } from '../../utils/file-utils';
 
 /**
@@ -58,7 +57,7 @@ export class SearchFileContentsTool implements Tool {
 		},
 		context: ToolExecutionContext
 	): Promise<ToolResult> {
-		const plugin = context.plugin as ObsidianGemini;
+		const plugin = context.plugin;
 
 		try {
 			const caseSensitive = params.caseSensitive ?? false;

--- a/src/tools/vault/search-files-tool.ts
+++ b/src/tools/vault/search-files-tool.ts
@@ -1,7 +1,6 @@
 import { Tool, ToolResult, ToolExecutionContext } from '../types';
 import { ToolCategory } from '../../types/agent';
 import { ToolClassification } from '../../types/tool-policy';
-import type ObsidianGemini from '../../main';
 import { shouldExcludePathForPlugin as shouldExcludePath } from '../../utils/file-utils';
 
 /**
@@ -38,7 +37,7 @@ export class SearchFilesTool implements Tool {
 	}
 
 	async execute(params: { pattern: string; limit?: number }, context: ToolExecutionContext): Promise<ToolResult> {
-		const plugin = context.plugin as ObsidianGemini;
+		const plugin = context.plugin;
 
 		try {
 			const allFiles = plugin.app.vault.getFiles();

--- a/src/tools/vault/write-file-tool.ts
+++ b/src/tools/vault/write-file-tool.ts
@@ -2,7 +2,6 @@ import { Tool, ToolResult, ToolExecutionContext } from '../types';
 import { ToolCategory } from '../../types/agent';
 import { ToolClassification } from '../../types/tool-policy';
 import { TFile, normalizePath } from 'obsidian';
-import type ObsidianGemini from '../../main';
 import { shouldExcludePathForPlugin as shouldExcludePath, ensureFolderExists } from '../../utils/file-utils';
 
 /**
@@ -54,7 +53,7 @@ export class WriteFileTool implements Tool {
 		params: { path: string; content: string; _userEdited?: boolean },
 		context: ToolExecutionContext
 	): Promise<ToolResult> {
-		const plugin = context.plugin as ObsidianGemini;
+		const plugin = context.plugin;
 
 		try {
 			const normalizedPath = normalizePath(params.path);

--- a/src/tools/web-fetch-tool.ts
+++ b/src/tools/web-fetch-tool.ts
@@ -52,7 +52,7 @@ export class WebFetchTool implements Tool {
 	}
 
 	async execute(params: { url: string; query: string }, context: ToolExecutionContext): Promise<ToolResult> {
-		const plugin = context.plugin as ObsidianGemini;
+		const plugin = context.plugin;
 
 		if (!plugin.apiKey) {
 			return {

--- a/test/tools/google-search-tool.test.ts
+++ b/test/tools/google-search-tool.test.ts
@@ -168,7 +168,7 @@ describe('GoogleSearchTool', () => {
 		});
 
 		it('should return error when API key is missing', async () => {
-			mockContext.plugin.apiKey = '';
+			(mockContext.plugin as any).apiKey = '';
 
 			const result = await tool.execute({ query: 'test' }, mockContext);
 
@@ -187,7 +187,7 @@ describe('GoogleSearchTool', () => {
 		});
 
 		it('should use default model when not specified', async () => {
-			mockContext.plugin.settings.chatModelName = undefined;
+			(mockContext.plugin as any).settings.chatModelName = undefined;
 
 			const mockResponse = {
 				candidates: [

--- a/test/tools/rag-search-tool.test.ts
+++ b/test/tools/rag-search-tool.test.ts
@@ -232,8 +232,8 @@ describe('RagSearchTool', () => {
 		});
 
 		it('should return error when RAG service is not ready', async () => {
-			mockContext.plugin.settings.ragIndexing.enabled = true;
-			mockContext.plugin.ragIndexing = {
+			(mockContext.plugin as any).settings.ragIndexing.enabled = true;
+			(mockContext.plugin as any).ragIndexing = {
 				isReady: () => false,
 				getStoreName: () => null,
 				getClient: () => null,
@@ -245,8 +245,8 @@ describe('RagSearchTool', () => {
 		});
 
 		it('should return error when no store is configured', async () => {
-			mockContext.plugin.settings.ragIndexing.enabled = true;
-			mockContext.plugin.ragIndexing = {
+			(mockContext.plugin as any).settings.ragIndexing.enabled = true;
+			(mockContext.plugin as any).ragIndexing = {
 				isReady: () => true,
 				getStoreName: () => null,
 				getClient: () => null,
@@ -258,8 +258,8 @@ describe('RagSearchTool', () => {
 		});
 
 		it('should return error when API client is not available', async () => {
-			mockContext.plugin.settings.ragIndexing.enabled = true;
-			mockContext.plugin.ragIndexing = {
+			(mockContext.plugin as any).settings.ragIndexing.enabled = true;
+			(mockContext.plugin as any).ragIndexing = {
 				isReady: () => true,
 				getStoreName: () => 'test-store',
 				getClient: () => null,
@@ -281,8 +281,8 @@ describe('RagSearchTool', () => {
 				},
 			};
 
-			mockContext.plugin.settings.ragIndexing.enabled = true;
-			mockContext.plugin.ragIndexing = {
+			(mockContext.plugin as any).settings.ragIndexing.enabled = true;
+			(mockContext.plugin as any).ragIndexing = {
 				isReady: () => true,
 				getStoreName: () => 'test-store',
 				getClient: () => mockAi,


### PR DESCRIPTION
## Summary

Replace the `any` placeholder on `ToolExecutionContext.plugin` with the real `ObsidianGemini` type and drop the 22 redundant `as ObsidianGemini` casts that opened every tool body. Also drops three redundant casts plus one wrong `(this.plugin as any).logger` cast in `execution-engine.ts`.

Fixes #856

## Changes

- **`src/tools/types.ts`**: Add `import type ObsidianGemini` and change `plugin: any` to `plugin: ObsidianGemini`. The `import type` is erased at compile time, so no runtime import cycle is introduced.
- **18 tool files** (22 cast sites): Change `const plugin = context.plugin as ObsidianGemini;` to `const plugin = context.plugin;` in:
  - `image-tools.ts`, `vault-tools-extended.ts` (2 sites), `session-recall-tool.ts`, `google-search-tool.ts`, `web-fetch-tool.ts`, `rag-search-tool.ts`, `memory-tool.ts` (2 sites), `skill-tools.ts` (3 sites), `deep-research-tool.ts`
  - `vault/get-workspace-state-tool.ts`, `vault/list-files-tool.ts`, `vault/read-file-tool.ts`, `vault/delete-file-tool.ts`, `vault/move-file-tool.ts`, `vault/search-files-tool.ts`, `vault/create-folder-tool.ts`, `vault/write-file-tool.ts`, `vault/search-file-contents-tool.ts`
- **Cleanup**: Remove the now-unused `import type ObsidianGemini from '../main'` in the 17 tool files where it's no longer referenced. `web-fetch-tool.ts` keeps the import because `fallbackFetch()` takes a `plugin: ObsidianGemini` parameter.
- **`src/tools/execution-engine.ts`**: Drop three `as ObsidianGemini` casts on `this.plugin` (already typed by the constructor signature) at lines 257, 350, 363, and the wrong `(this.plugin as any).logger?` cast at line 365 — `logger` is declared as `public logger!: Logger` on `main.ts:199`, so no cast or optional chaining is needed.
- **`AGENTS.md`**: Add a one-line note under "Important Patterns": `ToolExecutionContext.plugin` is typed `ObsidianGemini`; no cast is needed in tool implementations.

## Verification

- `npx tsc --noEmit` — clean (no errors revealed by the tighter type)
- `npm test` — 2937 tests across 127 files pass
- `npm run build` — succeeds
- `npm run lint` — no new warnings (7 pre-existing warnings unchanged)
- `npm run format-check` — clean
- Build artifacts (`main.js`) unchanged — `import type` and casts are erased at compile time, so the runtime JS is byte-identical

## Screenshots / Screencast

N/A — type-system-only refactor, no user-visible changes.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards)
- [x] Documentation has been updated (if applicable)
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR


---
_Generated by [Claude Code](https://claude.ai/code/session_015WJTEDmZb22rjvYyKen5F6)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved TypeScript type safety throughout the codebase by removing unnecessary type assertions and explicitly typing the plugin context field. This streamlines the internal architecture while maintaining full backward compatibility.

* **Documentation**
  * Updated developer guidelines with clarification on plugin context typing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/allenhutchison/obsidian-gemini/pull/900?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->