### PR TITLE
chore(daily): 2026-05-27 daily update

### DIFF
--- a/planning/changelog/2026-05-26.md
+++ b/planning/changelog/2026-05-26.md
@@ -1,0 +1,16 @@
+# Daily changelog — May 26, 2026
+
+**Date:** 2026-05-26
+**PRs merged:** 1
+
+---
+
+## Summary
+
+Quiet evening — a single administrative PR merged as the daily housekeeping run landed. The substantive work of the day (eval registry compliance cleanup) had already shipped the day before.
+
+## What shipped
+
+### [#899 chore(daily): 2026-05-26 daily update](https://github.com/allenhutchison/obsidian-gemini/pull/899)
+
+The automated daily-update PR for May 26, covering the May 25 changelog. It documents eight PRs that merged on May 25: the eval-strike closure in the morning (re-baseline on 54-task suite, methodology docs, planning record, daily housekeeping) and the four registry-compliance refactors that landed in the afternoon (#895 build provenance attestation, #896 CSS `:has()` removal, #897 inline sourcemap drop reducing the production bundle from 11 MB to 1.9 MB, #898 CSS `!important` removal). Merged at 5:37 PM PDT.


### PR DESCRIPTION
## Summary

Automated daily housekeeping for 2026-05-27. Covers the May 26 changelog (1 PR — the daily-update housekeeping PR itself).

## Changes

- **Add `planning/changelog/2026-05-26.md`**: Documents the single PR that merged on May 26 Pacific time — PR #899 (the daily-update for May 25), which landed at 5:37 PM PDT after the eval-strike closure and registry-compliance work documented therein.

## Sub-skill outcomes

- **daily-changelog**: wrote `planning/changelog/2026-05-26.md`, 1 PR (daily-update PR #899 — covers May 25 eval-strike closure + registry compliance sweep)
- **audit-docs**: no drift found — all settings defaults, command IDs, tool names, loop thresholds, schedule formats, folder paths, model defaults, and hook defaults are in sync with the code; no new docs warranted
- **triage-issues**: 0 unlabeled open issues — tracker is clean

## Screenshots / Screencast

N/A — changelog only.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: daily housekeeping
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A: changelog only
- [x] Documentation has been updated (if applicable) — N/A: this PR IS the changelog
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01SAwRGWRno4vwv7ou1JBvTk)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added daily changelog entry summarizing merged pull requests and released changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/allenhutchison/obsidian-gemini/pull/902?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->