### PR TITLE
feat: Add OpenAI-compatible provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,11 @@
 
 Gemini Scribe is an Obsidian plugin that integrates Google's Gemini AI models, providing powerful AI-driven assistance for note-taking, writing, and knowledge management directly within Obsidian. It leverages your notes as context for AI interactions, making it a highly personalized and integrated experience.
 
-> **Note:** Pick one of two setup paths in plugin settings → **Provider**:
+> **Note:** Pick one of three setup paths in plugin settings → **Provider**:
 >
 > - **Google Gemini (cloud)** — requires a Gemini API key (free tier available at [Google AI Studio](https://aistudio.google.com/apikey)).
 > - **Ollama (local)** — runs locally with no API key; install [Ollama](https://ollama.com), pull a model, and select it in settings. See [docs/guide/ollama-setup.md](docs/guide/ollama-setup.md) for the feature-parity table.
+> - **OpenAI-compatible** — connect to any OpenAI-compatible API endpoint (OpenAI, Kimi Code, OpenRouter, local vLLM, etc.). Requires the endpoint's base URL and an API key.
 
 ## What's New in v4.9.0
 
@@ -25,6 +26,7 @@ Gemini Scribe is an Obsidian plugin that integrates Google's Gemini AI models, p
 - **🌙 Missed-run catch-up** - Tasks that should have run while Obsidian was closed surface on startup for review.
 - **🛰️ Background tasks** - Deep research and image generation now run in the background with output consolidated under `[state-folder]/Background-Tasks/`. See the [Background Tasks guide](docs/guide/background-tasks.md).
 - **🦙 Ollama provider** - Point the plugin at a local Ollama server for offline, local-model chat. See the [Ollama Setup guide](docs/guide/ollama-setup.md).
+- **🔌 OpenAI-compatible provider** - Connect to any OpenAI-compatible API endpoint (OpenAI, Kimi Code, OpenRouter, local vLLM) with full support for chat, streaming, and tool calling.
 - **🛑 Runaway-loop abort** - Repeated tool-loop detections within a turn now abort the turn with a clear notice instead of churning.
 - **🛠️ Headless agent loop** - AgentLoop extracted from the agent view so scheduled and background runners share the same execution engine.
 
@@ -70,6 +72,8 @@ Gemini Scribe is an Obsidian plugin that integrates Google's Gemini AI models, p
 
 **Prefer running models locally?** Gemini Scribe also supports [Ollama](https://ollama.com) — install Ollama, pull a model with `ollama pull llama3.2`, and switch the **Provider** in settings to "Ollama (local)". A few Gemini-built-in features (Google Search, URL Context, Deep Research, image generation, RAG) are unavailable on Ollama; see [docs/guide/ollama-setup.md](docs/guide/ollama-setup.md) for details.
 
+**Using a different AI provider?** Switch the **Provider** to "OpenAI-compatible" and enter your endpoint's base URL (e.g., `https://api.openai.com/v1`, `https://api.moonshot.cn/v1`) and API key. The plugin will discover available models automatically (if the endpoint supports `/v1/models`) or you can enter the model name manually. All chat, streaming, and tool-calling features work with OpenAI-compatible endpoints.
+
 ## Installation
 
 1.  **Community Plugins (Recommended):**
@@ -94,8 +98,8 @@ Gemini Scribe is an Obsidian plugin that integrates Google's Gemini AI models, p
 2.  **Configure Plugin Settings:**
     - Open Obsidian Settings.
     - Go to "Gemini Scribe" under "Community plugins".
-    - **Provider:** Choose `Google Gemini (cloud)` (default) or `Ollama (local)`. The Ollama option exposes a base-URL field and refreshes the model list from `GET /api/tags`.
-    - **API Key:** (Gemini only) Paste your Gemini API key here. Your key is stored securely using Obsidian's SecretStorage.
+    - **Provider:** Choose `Google Gemini (cloud)` (default), `Ollama (local)`, or `OpenAI-compatible`. The Ollama option exposes a base-URL field and refreshes the model list from `GET /api/tags`. The OpenAI-compatible option lets you connect to any OpenAI-compatible endpoint (e.g., OpenAI, Kimi Code, OpenRouter).
+    - **API Key:** (Gemini and OpenAI-compatible) Paste your API key here. Gemini keys are stored securely using Obsidian's SecretStorage. OpenAI-compatible keys are stored in plugin settings.
     - **Chat Model:** Select the preferred Gemini model for chat interactions (default: `gemini-flash-latest`).
     - **Summary Model:** Select the preferred Gemini model for generating summaries (default: `gemini-flash-latest`).
     - **Completion Model:** Select the preferred model for IDE-style completions (default: `gemini-flash-lite-latest`).

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -32,10 +32,10 @@ UI sections without a dedicated topic in this reference: _Automation_ (covered i
 ### Provider
 
 - **Setting**: `provider`
-- **Type**: `'gemini' | 'ollama'`
+- **Type**: `'gemini' | 'ollama' | 'openai'`
 - **Default**: `'gemini'`
-- **Description**: Selects the model backend. `gemini` calls the Google Cloud API; `ollama` calls a local Ollama daemon.
-- **Notes**: Switching providers re-initialises the plugin and resets stale model selections to the new provider's defaults. Provider-coupled features (Google Search, URL Context, Deep Research, image generation, RAG indexing) are hidden when `ollama` is active. See the [Ollama Setup Guide](/guide/ollama-setup) for details.
+- **Description**: Selects the model backend. `gemini` calls the Google Cloud API; `ollama` calls a local Ollama daemon; `openai` calls any OpenAI-compatible API endpoint (e.g., OpenAI, Kimi Code, OpenRouter, local vLLM).
+- **Notes**: Switching providers re-initialises the plugin and resets stale model selections to the new provider's defaults. Provider-coupled features (Google Search, URL Context, Deep Research, image generation, RAG indexing) are hidden when `ollama` or `openai` is active. See the [Ollama Setup Guide](/guide/ollama-setup) for details.
 
 ### Ollama Base URL
 
@@ -45,14 +45,55 @@ UI sections without a dedicated topic in this reference: _Automation_ (covered i
 - **Required when provider is `ollama`**: Yes
 - **Description**: HTTP endpoint of your Ollama daemon. Update if Ollama runs on a different host or port.
 
+### OpenAI Base URL
+
+- **Setting**: `openaiBaseUrl`
+- **Type**: String
+- **Default**: `https://api.openai.com/v1`
+- **Required when provider is `openai`**: Yes
+- **Description**: Base URL for the OpenAI-compatible API endpoint. Change this to connect to alternative providers like Kimi Code, OpenRouter, or a local vLLM instance.
+- **Examples**:
+  - `https://api.openai.com/v1` — OpenAI official API
+  - `https://api.moonshot.cn/v1` — Kimi Code (Moonshot AI)
+  - `https://openrouter.ai/api/v1` — OpenRouter
+  - `http://localhost:8000/v1` — Local vLLM (requires "Allow insecure HTTP")
+
+### OpenAI API Key
+
+- **Setting**: `openaiApiKey`
+- **Type**: String
+- **Default**: `""` (empty)
+- **Required when provider is `openai`**: Yes
+- **Description**: API key for the OpenAI-compatible endpoint. Paste your key directly; it is stored in `data.json`.
+- **Security note**: Unlike the Gemini provider which uses Obsidian's SecretStorage, the OpenAI provider stores the key in plain text in `data.json`. This is a known limitation.
+
+### OpenAI Model Name
+
+- **Setting**: `openaiModelName`
+- **Type**: String
+- **Default**: `""` (empty)
+- **Required when provider is `openai`**: Yes
+- **Description**: Model identifier to use with the OpenAI-compatible endpoint. Enter the model name exactly as the endpoint expects it (e.g., `gpt-4`, `kimi-k2`, `anthropic/claude-3.5-sonnet` for OpenRouter).
+- **Model discovery**: Click "Refresh model list" in settings to fetch available models from the endpoint's `/v1/models` endpoint. If discovery fails, you can still enter the model name manually.
+
+### Allow Insecure HTTP
+
+- **Setting**: `openaiAllowInsecure`
+- **Type**: Boolean
+- **Default**: `false`
+- **Description**: Allow `http://` connections for OpenAI-compatible endpoints. Only enable for local development or trusted local networks.
+- **Security warning**: Disabling HTTPS exposes your API key and conversation data to network interception. Never enable this on public networks.
+
 ### API Key
 
 - **Type**: String
-- **Required**: Yes (when provider is `gemini`; ignored for `ollama`)
-- **Storage**: Stored securely using Obsidian's SecretStorage API (not saved in `data.json`)
-- **Description**: Your Google AI API key for accessing Gemini models
-- **How to obtain**: Visit [Google AI Studio](https://aistudio.google.com/apikey)
-- **Migration**: If upgrading from a previous version, your API key is automatically migrated from `data.json` to secure storage on first load
+- **Required**: Yes (when provider is `gemini` or `openai`; ignored for `ollama`)
+- **Storage**: Stored securely using Obsidian's SecretStorage API for Gemini (not saved in `data.json`). For OpenAI-compatible providers, the API key is stored directly in `data.json`.
+- **Description**: Your API key for accessing the selected provider's models
+- **How to obtain**:
+  - **Gemini**: Visit [Google AI Studio](https://aistudio.google.com/apikey)
+  - **OpenAI-compatible**: Obtain from your endpoint provider (e.g., OpenAI, Kimi Code, OpenRouter)
+- **Migration**: If upgrading from a previous version, your Gemini API key is automatically migrated from `data.json` to secure storage on first load
 
 ### Your Name
 
@@ -101,6 +142,7 @@ The active model list depends on the [`provider`](#provider) setting:
 
 - **Gemini (default)** — models are selected from the bundled Gemini list, refreshed from Google's API on startup so the latest models appear automatically. `imageModelName` is only available on this provider.
 - **Ollama** — the chat / summary / completion dropdowns are populated from `GET <ollamaBaseUrl>/api/tags`, listing whatever you have pulled. Click "Refresh model list" in settings if a freshly pulled model doesn't appear. Image generation is unavailable in this mode.
+- **OpenAI-compatible** — models are discovered from `GET <openaiBaseUrl>/models` (if the endpoint supports it) or entered manually via `openaiModelName`. Click "Refresh model list" to re-query. Image generation and other Gemini-only features are unavailable in this mode.
 
 ### Chat Model
 
@@ -333,7 +375,7 @@ Advanced settings for developers and power users. Access by clicking "Show Advan
 
 ### Model Discovery
 
-Model discovery is automatic — no user-configurable settings are required. On startup, the plugin fetches the latest available Gemini models from Google's API and falls back to the bundled list if the fetch fails. When using the Ollama provider, a **Refresh model list** button appears in Settings → General to re-query the Ollama daemon for newly pulled models. The remote model list is cached in `data.json` under `remoteModelCache` (managed internally; do not edit by hand).
+Model discovery is automatic — no user-configurable settings are required. On startup, the plugin fetches the latest available Gemini models from Google's API and falls back to the bundled list if the fetch fails. When using the Ollama provider, a **Refresh model list** button appears in Settings → General to re-query the Ollama daemon for newly pulled models. When using the OpenAI-compatible provider, the same button re-queries the endpoint's `/v1/models` endpoint. The remote model list is cached in `data.json` under `remoteModelCache` (managed internally; do not edit by hand).
 
 ### Tool Execution
 
@@ -490,7 +532,8 @@ Available permission bypasses:
 1. Check API key is valid
 2. For Gemini: restart Obsidian — model discovery runs automatically on startup
 3. For Ollama: go to Settings → General and click **Refresh** in the **Refresh model list** row after pulling new models
-4. Check console for errors (with Debug Mode enabled)
+4. For OpenAI-compatible: verify the base URL is correct and the endpoint is reachable. Click **Refresh** to re-query `/v1/models`. If discovery fails, enter the model name manually in the "OpenAI Model Name" field.
+5. Check console for errors (with Debug Mode enabled)
 
 ### Tool execution issues
 

--- a/src/api/factory.ts
+++ b/src/api/factory.ts
@@ -10,6 +10,8 @@ import { GeminiClient } from './providers/gemini/client';
 import type { GeminiClientConfig } from './providers/gemini/config';
 import { OllamaClient } from './providers/ollama/client';
 import type { OllamaClientConfig } from './providers/ollama/config';
+import { OpenAiClient } from './providers/openai/client';
+import type { OpenAiClientConfig } from './providers/openai/config';
 import { ModelApi } from './interfaces/model-api';
 import { GeminiPrompts } from '../prompts';
 import { RetryDecorator } from './retry-decorator';
@@ -42,7 +44,7 @@ export class ModelClientFactory {
 	static createFromPlugin(
 		plugin: ObsidianGemini,
 		useCase: ModelUseCase,
-		overrides?: Partial<GeminiClientConfig> & Partial<OllamaClientConfig>
+		overrides?: Partial<GeminiClientConfig> & Partial<OllamaClientConfig> & Partial<OpenAiClientConfig>
 	): ModelApi {
 		const settings = plugin.settings;
 		const provider = settings.provider ?? 'gemini';
@@ -66,6 +68,21 @@ export class ModelClientFactory {
 				...overrides,
 			};
 			const client = new OllamaClient(config, prompts, plugin);
+			return new RetryDecorator(client, retryConfig, plugin.logger);
+		}
+
+		if (provider === 'openai') {
+			const config: OpenAiClientConfig = {
+				baseUrl: settings.openaiBaseUrl || 'https://api.openai.com/v1',
+				apiKey: settings.openaiApiKey,
+				model: modelName,
+				temperature: settings.temperature ?? 0.7,
+				topP: settings.topP ?? 1,
+				streamingEnabled: settings.streamingEnabled ?? true,
+				allowInsecure: settings.openaiAllowInsecure ?? false,
+				...overrides,
+			};
+			const client = new OpenAiClient(config, prompts, plugin);
 			return new RetryDecorator(client, retryConfig, plugin.logger);
 		}
 

--- a/src/api/providers/openai/client.ts
+++ b/src/api/providers/openai/client.ts
@@ -15,6 +15,52 @@ import type { OpenAiClientConfig } from './config';
 import { convertContentToMessages, OpenAiMessage } from './format-converter';
 import { parseSseStream, SseChunk } from './sse-parser';
 
+interface OpenAiChatCompletionRequest {
+	model: string;
+	messages: OpenAiMessage[];
+	stream: boolean;
+	temperature?: number;
+	top_p?: number;
+	max_tokens?: number;
+	tools?: Array<{
+		type: 'function';
+		function: {
+			name: string;
+			description: string;
+			parameters: Record<string, unknown>;
+		};
+	}>;
+}
+
+interface OpenAiChatCompletionResponse {
+	choices: Array<{
+		message: {
+			role: string;
+			content?: string;
+			tool_calls?: Array<{
+				id: string;
+				type: string;
+				function: { name: string; arguments: string };
+			}>;
+		};
+		finish_reason?: string;
+	}>;
+	usage?: {
+		prompt_tokens: number;
+		completion_tokens: number;
+		total_tokens: number;
+	};
+}
+
+class OpenAiApiError extends Error {
+	status: number;
+	constructor(message: string, status: number) {
+		super(message);
+		this.status = status;
+		this.name = 'OpenAiApiError';
+	}
+}
+
 export class OpenAiClient implements ModelApi {
 	private config: OpenAiClientConfig;
 	private prompts: GeminiPrompts;
@@ -57,6 +103,7 @@ export class OpenAiClient implements ModelApi {
 		let accumulatedThoughts = '';
 		let toolCalls: ToolCall[] | undefined;
 		let usageMetadata: ModelResponse['usageMetadata'] | undefined;
+		const toolCallBuffers: Map<string, { name: string; argsBuffer: string }> = new Map();
 
 		const complete = (async (): Promise<ModelResponse> => {
 			if (!model) {
@@ -87,23 +134,47 @@ export class OpenAiClient implements ModelApi {
 
 					// Tool calls (accumulate across chunks)
 					if (delta.tool_calls) {
-						toolCalls = toolCalls || [];
 						for (const tc of delta.tool_calls) {
-							const existing = toolCalls.find((t) => t.id === tc.id);
-							if (existing) {
-								// Append arguments for streaming tool calls
-								if (tc.function?.arguments) {
-									existing.arguments = this.mergeArguments(existing.arguments, tc.function.arguments);
-								}
-							} else {
-								toolCalls.push({
-									name: tc.function?.name || '',
-									arguments: tc.function?.arguments ? JSON.parse(tc.function.arguments) : {},
-									id: tc.id || `call_${toolCalls.length}`,
-								});
+							const id = tc.id || `call_${tc.index}`;
+							if (!toolCallBuffers.has(id)) {
+								toolCallBuffers.set(id, { name: tc.function?.name || '', argsBuffer: '' });
+							}
+							const buffer = toolCallBuffers.get(id)!;
+							if (tc.function?.arguments) {
+								buffer.argsBuffer += tc.function.arguments;
 							}
 						}
 					}
+				}
+
+				// After the loop, convert buffers to ToolCall[]
+				if (toolCallBuffers.size > 0) {
+					toolCalls = [];
+					for (const [id, buffer] of toolCallBuffers) {
+						try {
+							toolCalls.push({
+								name: buffer.name,
+								arguments: JSON.parse(buffer.argsBuffer || '{}'),
+								id,
+							});
+						} catch {
+							toolCalls.push({
+								name: buffer.name,
+								arguments: {},
+								id,
+							});
+						}
+					}
+				}
+
+				// Check for usage in the last chunk
+				const lastChunk = chunks[chunks.length - 1];
+				if (lastChunk?.usage) {
+					usageMetadata = {
+						promptTokenCount: lastChunk.usage.prompt_tokens,
+						candidatesTokenCount: lastChunk.usage.completion_tokens,
+						totalTokenCount: lastChunk.usage.total_tokens,
+					};
 				}
 
 				return {
@@ -140,7 +211,7 @@ export class OpenAiClient implements ModelApi {
 		request: BaseModelRequest | ExtendedModelRequest,
 		model: string,
 		stream: boolean
-	): Promise<Record<string, any>> {
+	): Promise<OpenAiChatCompletionRequest> {
 		const isExtended = 'userMessage' in request;
 
 		if (!isExtended) {
@@ -195,7 +266,7 @@ export class OpenAiClient implements ModelApi {
 			messages.push(message);
 		}
 
-		const body: Record<string, any> = {
+		const body: OpenAiChatCompletionRequest = {
 			model,
 			messages,
 			stream,
@@ -211,7 +282,7 @@ export class OpenAiClient implements ModelApi {
 				function: {
 					name: tool.name,
 					description: tool.description,
-					parameters: tool.parameters,
+					parameters: tool.parameters as Record<string, unknown>,
 				},
 			}));
 		}
@@ -282,20 +353,18 @@ export class OpenAiClient implements ModelApi {
 
 		if (response.status !== 200) {
 			const errorText = typeof response.text === 'string' ? response.text : JSON.stringify(response.json);
-			const error = new Error(`OpenAI API error ${response.status}: ${errorText}`);
-			(error as any).status = response.status;
-			throw error;
+			throw new OpenAiApiError(`OpenAI API error ${response.status}: ${errorText}`, response.status);
 		}
 
 		return response;
 	}
 
-	private parseResponse(response: any): ModelResponse {
+	private parseResponse(response: { json: OpenAiChatCompletionResponse }): ModelResponse {
 		const data = response.json;
 		const message = data.choices?.[0]?.message;
 
 		const toolCalls: ToolCall[] | undefined = message?.tool_calls?.length
-			? message.tool_calls.map((tc: any) => ({
+			? message.tool_calls.map((tc) => ({
 					name: tc.function?.name || '',
 					arguments: tc.function?.arguments ? JSON.parse(tc.function.arguments) : {},
 					id: tc.id,

--- a/src/api/providers/openai/client.ts
+++ b/src/api/providers/openai/client.ts
@@ -1,0 +1,329 @@
+import { requestUrl } from 'obsidian';
+import {
+	ModelApi,
+	BaseModelRequest,
+	ExtendedModelRequest,
+	ModelResponse,
+	ToolCall,
+	ToolDefinition,
+	StreamCallback,
+	StreamingModelResponse,
+} from '../../interfaces/model-api';
+import { GeminiPrompts } from '../../../prompts';
+import type ObsidianGemini from '../../../main';
+import type { OpenAiClientConfig } from './config';
+import { convertContentToMessages, OpenAiMessage } from './format-converter';
+import { parseSseStream, SseChunk } from './sse-parser';
+
+export class OpenAiClient implements ModelApi {
+	private config: OpenAiClientConfig;
+	private prompts: GeminiPrompts;
+	private plugin?: ObsidianGemini;
+
+	constructor(config: OpenAiClientConfig, prompts?: GeminiPrompts, plugin?: ObsidianGemini) {
+		this.config = {
+			temperature: 0.7,
+			topP: 1,
+			streamingEnabled: true,
+			...config,
+		};
+		this.plugin = plugin;
+		this.prompts = prompts || new GeminiPrompts(plugin);
+	}
+
+	async generateModelResponse(request: BaseModelRequest | ExtendedModelRequest): Promise<ModelResponse> {
+		const model = request.model || this.config.model;
+		if (!model) {
+			throw new Error('No OpenAI model selected. Enter a model name in settings.');
+		}
+
+		try {
+			const body = await this.buildRequestBody(request, model, false);
+			const response = await this.makeRequest('/chat/completions', body);
+			return this.parseResponse(response);
+		} catch (error) {
+			this.plugin?.logger.error('[OpenAiClient] Error generating content:', error);
+			throw error;
+		}
+	}
+
+	generateStreamingResponse(
+		request: BaseModelRequest | ExtendedModelRequest,
+		onChunk: StreamCallback
+	): StreamingModelResponse {
+		const model = request.model || this.config.model;
+		let cancelled = false;
+		let accumulatedText = '';
+		let accumulatedThoughts = '';
+		let toolCalls: ToolCall[] | undefined;
+		let usageMetadata: ModelResponse['usageMetadata'] | undefined;
+
+		const complete = (async (): Promise<ModelResponse> => {
+			if (!model) {
+				throw new Error('No OpenAI model selected. Enter a model name in settings.');
+			}
+
+			try {
+				const body = await this.buildRequestBody(request, model, true);
+				const response = await this.makeRequest('/chat/completions', body);
+
+				if (typeof response.text !== 'string') {
+					throw new Error('Streaming response did not return text');
+				}
+
+				const chunks = parseSseStream(response.text);
+
+				for (const chunk of chunks) {
+					if (cancelled) break;
+
+					const delta = chunk.choices[0]?.delta;
+					if (!delta) continue;
+
+					// Text content
+					if (delta.content) {
+						accumulatedText += delta.content;
+						onChunk({ text: delta.content });
+					}
+
+					// Tool calls (accumulate across chunks)
+					if (delta.tool_calls) {
+						toolCalls = toolCalls || [];
+						for (const tc of delta.tool_calls) {
+							const existing = toolCalls.find((t) => t.id === tc.id);
+							if (existing) {
+								// Append arguments for streaming tool calls
+								if (tc.function?.arguments) {
+									existing.arguments = this.mergeArguments(existing.arguments, tc.function.arguments);
+								}
+							} else {
+								toolCalls.push({
+									name: tc.function?.name || '',
+									arguments: tc.function?.arguments ? JSON.parse(tc.function.arguments) : {},
+									id: tc.id || `call_${toolCalls.length}`,
+								});
+							}
+						}
+					}
+				}
+
+				return {
+					markdown: accumulatedText,
+					rendered: '',
+					...(accumulatedThoughts && { thoughts: accumulatedThoughts }),
+					...(toolCalls && toolCalls.length && { toolCalls }),
+					...(usageMetadata && { usageMetadata }),
+				};
+			} catch (error) {
+				if (cancelled) {
+					return {
+						markdown: accumulatedText,
+						rendered: '',
+						...(accumulatedThoughts && { thoughts: accumulatedThoughts }),
+						...(toolCalls && toolCalls.length && { toolCalls }),
+						...(usageMetadata && { usageMetadata }),
+					};
+				}
+				this.plugin?.logger.error('[OpenAiClient] Streaming error:', error);
+				throw error;
+			}
+		})();
+
+		return {
+			complete,
+			cancel: () => {
+				cancelled = true;
+			},
+		};
+	}
+
+	private async buildRequestBody(
+		request: BaseModelRequest | ExtendedModelRequest,
+		model: string,
+		stream: boolean
+	): Promise<Record<string, any>> {
+		const isExtended = 'userMessage' in request;
+
+		if (!isExtended) {
+			return {
+				model,
+				messages: [{ role: 'user', content: request.prompt }],
+				stream,
+				temperature: request.temperature ?? this.config.temperature,
+				top_p: request.topP ?? this.config.topP,
+				...(this.config.maxOutputTokens && { max_tokens: this.config.maxOutputTokens }),
+			};
+		}
+
+		const extReq = request as ExtendedModelRequest;
+		const messages: OpenAiMessage[] = [];
+
+		// System instruction
+		const systemInstruction = await this.buildSystemInstruction(extReq);
+		if (systemInstruction) {
+			messages.push({ role: 'system', content: systemInstruction });
+		}
+
+		// Conversation history
+		if (extReq.conversationHistory?.length) {
+			messages.push(...convertContentToMessages(extReq.conversationHistory));
+		}
+
+		// Current user message
+		const userParts: string[] = [];
+		if (extReq.userMessage?.trim()) userParts.push(extReq.userMessage);
+		if (extReq.perTurnContext?.trim()) userParts.push(extReq.perTurnContext);
+
+		const allAttachments = [...(extReq.inlineAttachments || []), ...(extReq.imageAttachments || [])];
+		if (userParts.length || allAttachments.length) {
+			const message: OpenAiMessage = { role: 'user' };
+
+			if (allAttachments.length) {
+				const content: Array<{ type: string; [key: string]: any }> = [];
+				if (userParts.length) content.push({ type: 'text', text: userParts.join('\n\n') });
+
+				for (const att of allAttachments) {
+					content.push({
+						type: 'image_url',
+						image_url: { url: `data:${att.mimeType};base64,${att.base64}` },
+					});
+				}
+				message.content = content;
+			} else {
+				message.content = userParts.join('\n\n');
+			}
+
+			messages.push(message);
+		}
+
+		const body: Record<string, any> = {
+			model,
+			messages,
+			stream,
+			temperature: request.temperature ?? this.config.temperature,
+			top_p: request.topP ?? this.config.topP,
+			...(this.config.maxOutputTokens && { max_tokens: this.config.maxOutputTokens }),
+		};
+
+		// Tools
+		if (extReq.availableTools?.length) {
+			body.tools = extReq.availableTools.map((tool) => ({
+				type: 'function',
+				function: {
+					name: tool.name,
+					description: tool.description,
+					parameters: tool.parameters,
+				},
+			}));
+		}
+
+		return body;
+	}
+
+	private async buildSystemInstruction(request: ExtendedModelRequest): Promise<string> {
+		let agentsMemory: string | null = null;
+		if (this.plugin?.agentsMemory) {
+			try {
+				agentsMemory = await this.plugin.agentsMemory.read();
+			} catch (error) {
+				this.plugin.logger.warn('Failed to load AGENTS.md:', error);
+			}
+		}
+
+		let availableSkills: { name: string; description: string }[] = [];
+		if (this.plugin?.skillManager) {
+			try {
+				availableSkills = await this.plugin.skillManager.getSkillSummaries();
+			} catch (error) {
+				this.plugin.logger.warn('Failed to load skill summaries:', error);
+			}
+		}
+
+		if (request.projectSkills && request.projectSkills.length > 0) {
+			availableSkills = availableSkills.filter((s) => request.projectSkills!.includes(s.name));
+		}
+
+		return this.prompts.getSystemPromptWithCustom(
+			request.availableTools,
+			request.customPrompt,
+			agentsMemory,
+			availableSkills,
+			request.projectInstructions,
+			request.sessionStartedAt
+		);
+	}
+
+	private async makeRequest(endpoint: string, body: Record<string, any>): Promise<any> {
+		const baseUrl = this.config.baseUrl.replace(/\/$/, '');
+		const url = `${baseUrl}${endpoint}`;
+
+		// Security: reject http unless explicitly allowed
+		if (url.startsWith('http:') && !this.config.allowInsecure) {
+			throw new Error(
+				'Insecure HTTP connections are not allowed. Enable "Allow insecure HTTP" in settings or use HTTPS.'
+			);
+		}
+
+		const headers: Record<string, string> = {
+			'Content-Type': 'application/json',
+			...(this.config.apiKey && { Authorization: `Bearer ${this.config.apiKey}` }),
+		};
+
+		if (body.stream) {
+			headers['Accept'] = 'text/event-stream';
+		}
+
+		const response = await requestUrl({
+			url,
+			method: 'POST',
+			headers,
+			body: JSON.stringify(body),
+			throw: false,
+		});
+
+		if (response.status !== 200) {
+			const errorText = typeof response.text === 'string' ? response.text : JSON.stringify(response.json);
+			const error = new Error(`OpenAI API error ${response.status}: ${errorText}`);
+			(error as any).status = response.status;
+			throw error;
+		}
+
+		return response;
+	}
+
+	private parseResponse(response: any): ModelResponse {
+		const data = response.json;
+		const message = data.choices?.[0]?.message;
+
+		const toolCalls: ToolCall[] | undefined = message?.tool_calls?.length
+			? message.tool_calls.map((tc: any) => ({
+					name: tc.function?.name || '',
+					arguments: tc.function?.arguments ? JSON.parse(tc.function.arguments) : {},
+					id: tc.id,
+				}))
+			: undefined;
+
+		return {
+			markdown: message?.content || '',
+			rendered: '',
+			...(toolCalls && { toolCalls }),
+			...(data.usage && {
+				usageMetadata: {
+					promptTokenCount: data.usage.prompt_tokens,
+					candidatesTokenCount: data.usage.completion_tokens,
+					totalTokenCount: data.usage.total_tokens,
+				},
+			}),
+		};
+	}
+
+	private mergeArguments(existing: Record<string, any>, delta: string): Record<string, any> {
+		// For streaming tool calls, arguments come in chunks as JSON string fragments
+		// We need to accumulate and parse when complete
+		// This is a simplified approach — full implementation would buffer and parse
+		try {
+			return JSON.parse(delta);
+		} catch {
+			return existing;
+		}
+	}
+}

--- a/src/api/providers/openai/client.ts
+++ b/src/api/providers/openai/client.ts
@@ -5,7 +5,6 @@ import {
 	ExtendedModelRequest,
 	ModelResponse,
 	ToolCall,
-	ToolDefinition,
 	StreamCallback,
 	StreamingModelResponse,
 } from '../../interfaces/model-api';
@@ -13,7 +12,7 @@ import { GeminiPrompts } from '../../../prompts';
 import type ObsidianGemini from '../../../main';
 import type { OpenAiClientConfig } from './config';
 import { convertContentToMessages, OpenAiMessage } from './format-converter';
-import { parseSseStream, SseChunk } from './sse-parser';
+import { parseSseStream } from './sse-parser';
 
 interface OpenAiChatCompletionRequest {
 	model: string;
@@ -249,7 +248,10 @@ export class OpenAiClient implements ModelApi {
 			const message: OpenAiMessage = { role: 'user' };
 
 			if (allAttachments.length) {
-				const content: Array<{ type: string; [key: string]: any }> = [];
+				const content: Array<
+				| { type: 'text'; text: string }
+				| { type: 'image_url'; image_url: { url: string } }
+			> = [];
 				if (userParts.length) content.push({ type: 'text', text: userParts.join('\n\n') });
 
 				for (const att of allAttachments) {
@@ -323,7 +325,10 @@ export class OpenAiClient implements ModelApi {
 		);
 	}
 
-	private async makeRequest(endpoint: string, body: Record<string, any>): Promise<any> {
+	private async makeRequest(
+		endpoint: string,
+		body: OpenAiChatCompletionRequest
+	): Promise<{ status: number; json: OpenAiChatCompletionResponse; text?: string }> {
 		const baseUrl = this.config.baseUrl.replace(/\/$/, '');
 		const url = `${baseUrl}${endpoint}`;
 
@@ -385,14 +390,4 @@ export class OpenAiClient implements ModelApi {
 		};
 	}
 
-	private mergeArguments(existing: Record<string, any>, delta: string): Record<string, any> {
-		// For streaming tool calls, arguments come in chunks as JSON string fragments
-		// We need to accumulate and parse when complete
-		// This is a simplified approach — full implementation would buffer and parse
-		try {
-			return JSON.parse(delta);
-		} catch {
-			return existing;
-		}
-	}
 }

--- a/src/api/providers/openai/config.ts
+++ b/src/api/providers/openai/config.ts
@@ -1,0 +1,10 @@
+export interface OpenAiClientConfig {
+	baseUrl: string;
+	apiKey: string;
+	model?: string;
+	temperature?: number;
+	topP?: number;
+	maxOutputTokens?: number;
+	streamingEnabled?: boolean;
+	allowInsecure?: boolean;
+}

--- a/src/api/providers/openai/format-converter.ts
+++ b/src/api/providers/openai/format-converter.ts
@@ -1,8 +1,12 @@
 import { Content, Part } from '@google/genai';
 
+type OpenAiContentPart =
+	| { type: 'text'; text: string }
+	| { type: 'image_url'; image_url: { url: string } };
+
 export interface OpenAiMessage {
 	role: 'system' | 'user' | 'assistant' | 'tool';
-	content?: string | Array<{ type: string; [key: string]: any }>;
+	content?: string | OpenAiContentPart[];
 	tool_calls?: Array<{
 		id: string;
 		type: 'function';
@@ -11,6 +15,10 @@ export interface OpenAiMessage {
 	tool_call_id?: string;
 }
 
+/**
+ * Converts Gemini Content[] to OpenAI messages[] format.
+ * Handles text, inline images, function calls, and function responses.
+ */
 export function convertContentToMessages(contents: Content[]): OpenAiMessage[] {
 	const messages: OpenAiMessage[] = [];
 
@@ -24,7 +32,7 @@ export function convertContentToMessages(contents: Content[]): OpenAiMessage[] {
 		const toolResponses: Array<{ tool_call_id: string; content: string }> = [];
 
 		for (const part of parts) {
-			if ('text' in part && part.text) {
+			if ('text' in part && typeof part.text === 'string') {
 				textParts.push(part.text);
 			} else if (part.inlineData) {
 				imageParts.push({
@@ -44,7 +52,7 @@ export function convertContentToMessages(contents: Content[]): OpenAiMessage[] {
 				});
 			} else if (part.functionResponse) {
 				toolResponses.push({
-					tool_call_id: part.functionResponse.id || `call_${part.functionResponse.name}`,
+					tool_call_id: part.functionResponse.id || `call_${Math.random().toString(36).slice(2)}`,
 					content:
 						typeof part.functionResponse.response === 'string'
 							? part.functionResponse.response
@@ -81,7 +89,25 @@ export function convertContentToMessages(contents: Content[]): OpenAiMessage[] {
 	return messages;
 }
 
+/**
+ * Converts an OpenAI message back to Gemini Content.
+ * Note: image_url content parts are not converted back (one-way for history).
+ * Tool messages are converted to functionResponse parts.
+ */
 export function convertMessageToContent(message: OpenAiMessage): Content {
+	if (message.role === 'tool') {
+		return {
+			role: 'user',
+			parts: [{
+				functionResponse: {
+					name: message.tool_call_id || 'unknown',
+					response: message.content || '',
+					id: message.tool_call_id,
+				},
+			}],
+		};
+	}
+
 	const parts: Part[] = [];
 
 	if (typeof message.content === 'string' && message.content) {
@@ -106,7 +132,7 @@ export function convertMessageToContent(message: OpenAiMessage): Content {
 	}
 
 	return {
-		role: message.role === 'assistant' ? 'model' : 'user',
+		role: message.role === 'assistant' ? 'model' : message.role === 'system' ? 'system' : 'user',
 		parts,
 	};
 }

--- a/src/api/providers/openai/format-converter.ts
+++ b/src/api/providers/openai/format-converter.ts
@@ -1,0 +1,112 @@
+import { Content, Part } from '@google/genai';
+
+export interface OpenAiMessage {
+	role: 'system' | 'user' | 'assistant' | 'tool';
+	content?: string | Array<{ type: string; [key: string]: any }>;
+	tool_calls?: Array<{
+		id: string;
+		type: 'function';
+		function: { name: string; arguments: string };
+	}>;
+	tool_call_id?: string;
+}
+
+export function convertContentToMessages(contents: Content[]): OpenAiMessage[] {
+	const messages: OpenAiMessage[] = [];
+
+	for (const content of contents) {
+		const role = content.role === 'model' ? 'assistant' : (content.role as 'user' | 'system');
+		const parts = content.parts || [];
+
+		const textParts: string[] = [];
+		const imageParts: Array<{ type: 'image_url'; image_url: { url: string } }> = [];
+		const toolCalls: OpenAiMessage['tool_calls'] = [];
+		const toolResponses: Array<{ tool_call_id: string; content: string }> = [];
+
+		for (const part of parts) {
+			if ('text' in part && part.text) {
+				textParts.push(part.text);
+			} else if (part.inlineData) {
+				imageParts.push({
+					type: 'image_url',
+					image_url: {
+						url: `data:${part.inlineData.mimeType};base64,${part.inlineData.data}`,
+					},
+				});
+			} else if (part.functionCall) {
+				toolCalls.push({
+					id: part.functionCall.id || `call_${Math.random().toString(36).slice(2)}`,
+					type: 'function',
+					function: {
+						name: part.functionCall.name,
+						arguments: JSON.stringify(part.functionCall.args || {}),
+					},
+				});
+			} else if (part.functionResponse) {
+				toolResponses.push({
+					tool_call_id: part.functionResponse.id || `call_${part.functionResponse.name}`,
+					content:
+						typeof part.functionResponse.response === 'string'
+							? part.functionResponse.response
+							: JSON.stringify(part.functionResponse.response),
+				});
+			}
+		}
+
+		// Add tool responses as separate tool messages
+		for (const tr of toolResponses) {
+			messages.push({ role: 'tool', tool_call_id: tr.tool_call_id, content: tr.content });
+		}
+
+		// Add assistant message with text and/or tool calls
+		if (role === 'assistant' && (textParts.length || toolCalls.length)) {
+			const message: OpenAiMessage = { role: 'assistant' };
+			if (textParts.length) message.content = textParts.join('\n');
+			if (toolCalls.length) message.tool_calls = toolCalls;
+			messages.push(message);
+		} else if (role !== 'assistant' && (textParts.length || imageParts.length)) {
+			const message: OpenAiMessage = { role };
+			if (imageParts.length) {
+				const content: Array<{ type: 'text'; text: string } | { type: 'image_url'; image_url: { url: string } }> = [];
+				if (textParts.length) content.push({ type: 'text', text: textParts.join('\n') });
+				content.push(...imageParts);
+				message.content = content;
+			} else {
+				message.content = textParts.join('\n');
+			}
+			messages.push(message);
+		}
+	}
+
+	return messages;
+}
+
+export function convertMessageToContent(message: OpenAiMessage): Content {
+	const parts: Part[] = [];
+
+	if (typeof message.content === 'string' && message.content) {
+		parts.push({ text: message.content });
+	} else if (Array.isArray(message.content)) {
+		for (const item of message.content) {
+			if (item.type === 'text') parts.push({ text: item.text });
+			// image_url items are not converted back (one-way for history)
+		}
+	}
+
+	if (message.tool_calls) {
+		for (const tc of message.tool_calls) {
+			parts.push({
+				functionCall: {
+					name: tc.function.name,
+					args: JSON.parse(tc.function.arguments || '{}'),
+					id: tc.id,
+				},
+			});
+		}
+	}
+
+	return {
+		role: message.role === 'assistant' ? 'model' : 'user',
+		parts,
+	};
+}

--- a/src/api/providers/openai/format-converter.ts
+++ b/src/api/providers/openai/format-converter.ts
@@ -45,10 +45,10 @@ export function convertContentToMessages(contents: Content[]): OpenAiMessage[] {
 				toolCalls.push({
 					id: part.functionCall.id || `call_${Math.random().toString(36).slice(2)}`,
 					type: 'function',
-					function: {
-						name: part.functionCall.name,
-						arguments: JSON.stringify(part.functionCall.args || {}),
-					},
+				function: {
+					name: part.functionCall.name || '',
+					arguments: JSON.stringify(part.functionCall.args || {}),
+				},
 				});
 			} else if (part.functionResponse) {
 				toolResponses.push({
@@ -101,7 +101,7 @@ export function convertMessageToContent(message: OpenAiMessage): Content {
 			parts: [{
 				functionResponse: {
 					name: message.tool_call_id || 'unknown',
-					response: message.content || '',
+					response: (message.content || '') as unknown as Record<string, unknown>,
 					id: message.tool_call_id,
 				},
 			}],

--- a/src/api/providers/openai/sse-parser.ts
+++ b/src/api/providers/openai/sse-parser.ts
@@ -1,0 +1,37 @@
+export interface SseChunk {
+	choices: Array<{
+		delta: {
+			content?: string;
+			tool_calls?: Array<{
+				index: number;
+				id?: string;
+				type?: string;
+				function?: { name?: string; arguments?: string };
+			}>;
+		};
+	}>;
+}
+
+export function parseSseStream(streamText: string): SseChunk[] {
+	const chunks: SseChunk[] = [];
+	const lines = streamText.split('\n');
+
+	for (const line of lines) {
+		const trimmed = line.trim();
+		if (!trimmed.startsWith('data: ')) continue;
+
+		const data = trimmed.slice(6);
+		if (data === '[DONE]') continue;
+
+		try {
+			const parsed = JSON.parse(data);
+			if (parsed.choices) {
+				chunks.push(parsed);
+			}
+		} catch {
+			// Skip malformed lines
+		}
+	}
+
+	return chunks;
+}

--- a/src/api/providers/openai/sse-parser.ts
+++ b/src/api/providers/openai/sse-parser.ts
@@ -13,6 +13,11 @@ export interface SseChunk {
 		};
 		finish_reason?: 'stop' | 'length' | 'tool_calls' | 'content_filter' | null;
 	}>;
+	usage?: {
+		prompt_tokens: number;
+		completion_tokens: number;
+		total_tokens: number;
+	};
 }
 
 export function parseSseStream(streamText: string): SseChunk[] {

--- a/src/api/providers/openai/sse-parser.ts
+++ b/src/api/providers/openai/sse-parser.ts
@@ -1,4 +1,6 @@
 export interface SseChunk {
+	id?: string;
+	created?: number;
 	choices: Array<{
 		delta: {
 			content?: string;
@@ -9,6 +11,7 @@ export interface SseChunk {
 				function?: { name?: string; arguments?: string };
 			}>;
 		};
+		finish_reason?: 'stop' | 'length' | 'tool_calls' | 'content_filter' | null;
 	}>;
 }
 
@@ -16,11 +19,13 @@ export function parseSseStream(streamText: string): SseChunk[] {
 	const chunks: SseChunk[] = [];
 	const lines = streamText.split('\n');
 
-	for (const line of lines) {
-		const trimmed = line.trim();
-		if (!trimmed.startsWith('data: ')) continue;
+	const DATA_PREFIX = 'data: ';
 
-		const data = trimmed.slice(6);
+	for (const line of lines) {
+		const trimmed = line.trimStart();
+		if (!trimmed.startsWith(DATA_PREFIX)) continue;
+
+		const data = trimmed.slice(DATA_PREFIX.length);
 		if (data === '[DONE]') continue;
 
 		try {
@@ -29,7 +34,7 @@ export function parseSseStream(streamText: string): SseChunk[] {
 				chunks.push(parsed);
 			}
 		} catch {
-			// Skip malformed lines
+			// Intentionally skip malformed lines — stream may contain non-JSON comments
 		}
 	}
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -58,6 +58,14 @@ export interface ObsidianGeminiSettings {
 	ollamaBaseUrl: string;
 	/** Optional custom base URL to override the default Google Gemini API endpoint. */
 	customBaseUrl: string;
+	/** Base URL for OpenAI-compatible API endpoint. Only used when provider === 'openai'. */
+	openaiBaseUrl: string;
+	/** API key for OpenAI-compatible endpoint. Only used when provider === 'openai'. */
+	openaiApiKey: string;
+	/** Model name for OpenAI-compatible endpoint (manual entry). Only used when provider === 'openai'. */
+	openaiModelName: string;
+	/** Allow insecure http:// connections for OpenAI-compatible endpoints. */
+	openaiAllowInsecure: boolean;
 	apiKeySecretName: string;
 	chatModelName: string;
 	summaryModelName: string;
@@ -112,6 +120,10 @@ const DEFAULT_SETTINGS: ObsidianGeminiSettings = {
 	provider: 'gemini',
 	ollamaBaseUrl: 'http://localhost:11434',
 	customBaseUrl: '',
+	openaiBaseUrl: 'https://api.openai.com/v1',
+	openaiApiKey: '',
+	openaiModelName: '',
+	openaiAllowInsecure: false,
 	apiKeySecretName: '',
 	chatModelName: getDefaultModelForRole('chat'),
 	summaryModelName: getDefaultModelForRole('summary'),

--- a/src/main.ts
+++ b/src/main.ts
@@ -186,6 +186,8 @@ export default class ObsidianGemini extends Plugin {
 	get apiKey(): string {
 		// Ollama runs locally with no auth, so no key is required.
 		if (this.settings?.provider === 'ollama') return '';
+		// OpenAI provider uses a direct API key setting
+		if (this.settings?.provider === 'openai') return this.settings.openaiApiKey;
 		const secretName = this.settings?.apiKeySecretName;
 		if (!secretName) return '';
 		return this.app.secretStorage.getSecret(secretName) ?? '';

--- a/src/models.ts
+++ b/src/models.ts
@@ -2,7 +2,7 @@ import modelData from './data/models.json';
 
 export type ModelRole = 'chat' | 'summary' | 'completions' | 'rewrite' | 'image';
 
-export type ModelProvider = 'gemini' | 'ollama';
+export type ModelProvider = 'gemini' | 'ollama' | 'openai';
 
 export interface GeminiModel {
 	value: string;

--- a/src/models.ts
+++ b/src/models.ts
@@ -57,10 +57,11 @@ export function getDefaultModelForRole(role: ModelRole, provider: ModelProvider 
 		return candidates[0].value;
 	}
 
-	// No models for this provider yet (e.g. Ollama before /api/tags returns).
+	// No models for this provider yet (e.g. Ollama before /api/tags returns,
+	// or OpenAI before custom models are configured).
 	// Returning an empty string lets callers handle the unconfigured state
 	// rather than throwing at module load.
-	if (provider === 'ollama') {
+	if (provider === 'ollama' || provider === 'openai') {
 		return '';
 	}
 
@@ -79,7 +80,7 @@ export interface ModelUpdateResult {
 }
 
 export function getUpdatedModelSettings(currentSettings: any): ModelUpdateResult {
-	const provider: ModelProvider = currentSettings?.provider === 'ollama' ? 'ollama' : 'gemini';
+	const provider: ModelProvider = currentSettings?.provider ?? 'gemini';
 	const availableModelValues = new Set(
 		GEMINI_MODELS.filter((m) => getModelProvider(m) === provider).map((m) => m.value)
 	);
@@ -95,7 +96,7 @@ export function getUpdatedModelSettings(currentSettings: any): ModelUpdateResult
 	// indefinitely, since the empty value never re-triggers reconciliation).
 	const needsUpdate = (modelName: string) => {
 		if (!modelName) {
-			return provider !== 'ollama' || availableModelValues.size > 0;
+			return (provider !== 'ollama' && provider !== 'openai') || availableModelValues.size > 0;
 		}
 		return !availableModelValues.has(modelName);
 	};

--- a/src/services/model-manager.ts
+++ b/src/services/model-manager.ts
@@ -3,6 +3,7 @@ import * as modelsModule from '../models';
 import { GeminiModel, ModelUpdateResult, getUpdatedModelSettings, DEFAULT_GEMINI_MODELS } from '../models';
 import { ModelListProvider } from './model-list-provider';
 import { OllamaModelsService } from './ollama-models-service';
+import { OpenAiModelsService } from './openai-models-service';
 import { ParameterValidationService, ParameterRanges } from './parameter-validation';
 
 export interface ModelUpdateOptions {
@@ -14,12 +15,14 @@ export class ModelManager {
 	private plugin: ObsidianGemini;
 	private listProvider: ModelListProvider;
 	private ollamaModelsService: OllamaModelsService;
+	private openAiModelsService: OpenAiModelsService;
 	private static staticModels: GeminiModel[] = [...DEFAULT_GEMINI_MODELS];
 
 	constructor(plugin: ObsidianGemini) {
 		this.plugin = plugin;
 		this.listProvider = new ModelListProvider(plugin);
 		this.ollamaModelsService = new OllamaModelsService(plugin);
+		this.openAiModelsService = new OpenAiModelsService(plugin);
 	}
 
 	/**
@@ -29,6 +32,17 @@ export class ModelManager {
 	async getAvailableModels(options: ModelUpdateOptions = {}): Promise<GeminiModel[]> {
 		if (this.plugin.settings.provider === 'ollama') {
 			return this.ollamaModelsService.getModels(options.forceRefresh);
+		}
+		if (this.plugin.settings.provider === 'openai') {
+			const discovered = await this.openAiModelsService.getModels(options.forceRefresh);
+			const manualModel = this.plugin.settings.openaiModelName;
+			if (manualModel && !discovered.some((m) => m.value === manualModel)) {
+				return [
+					{ value: manualModel, label: manualModel, provider: 'openai', supportsTools: true },
+					...discovered,
+				];
+			}
+			return discovered;
 		}
 		return this.listProvider.getTextModels();
 	}
@@ -49,14 +63,26 @@ export class ModelManager {
 		return this.ollamaModelsService;
 	}
 
+	getOpenAiModelsService(): OpenAiModelsService {
+		return this.openAiModelsService;
+	}
+
 	/**
 	 * Update the global GEMINI_MODELS list from the active provider and fix any stale settings.
 	 */
 	async updateModels(options: ModelUpdateOptions = {}): Promise<ModelUpdateResult> {
-		const allModels =
-			this.plugin.settings.provider === 'ollama'
-				? await this.ollamaModelsService.getModels(options.forceRefresh)
-				: this.listProvider.getModels();
+		let allModels: GeminiModel[];
+		if (this.plugin.settings.provider === 'ollama') {
+			allModels = await this.ollamaModelsService.getModels(options.forceRefresh);
+		} else if (this.plugin.settings.provider === 'openai') {
+			allModels = await this.openAiModelsService.getModels(options.forceRefresh);
+			const manualModel = this.plugin.settings.openaiModelName;
+			if (manualModel && !allModels.some((m) => m.value === manualModel)) {
+				allModels.unshift({ value: manualModel, label: manualModel, provider: 'openai', supportsTools: true });
+			}
+		} else {
+			allModels = this.listProvider.getModels();
+		}
 		const previousModels = this.getCurrentGeminiModels();
 
 		const hasChanges = this.detectModelChanges(allModels, previousModels);
@@ -83,6 +109,13 @@ export class ModelManager {
 			// Populate GEMINI_MODELS with Ollama tags (best-effort; daemon may be down).
 			const ollamaModels = await this.ollamaModelsService.getModels();
 			this.updateGlobalModelsList(ollamaModels);
+		} else if (this.plugin.settings.provider === 'openai') {
+			const openAiModels = await this.openAiModelsService.getModels();
+			const manualModel = this.plugin.settings.openaiModelName;
+			if (manualModel && !openAiModels.some((m) => m.value === manualModel)) {
+				openAiModels.unshift({ value: manualModel, label: manualModel, provider: 'openai', supportsTools: true });
+			}
+			this.updateGlobalModelsList(openAiModels);
 		} else {
 			// Sync global GEMINI_MODELS with the bundled/remote Gemini list
 			const allModels = this.listProvider.getModels();
@@ -115,6 +148,9 @@ export class ModelManager {
 	private async getModelsForActiveProvider(): Promise<GeminiModel[]> {
 		if (this.plugin.settings.provider === 'ollama') {
 			return this.ollamaModelsService.getModels();
+		}
+		if (this.plugin.settings.provider === 'openai') {
+			return this.openAiModelsService.getModels();
 		}
 		return this.listProvider.getModels();
 	}

--- a/src/services/openai-models-service.ts
+++ b/src/services/openai-models-service.ts
@@ -1,0 +1,71 @@
+import { requestUrl } from 'obsidian';
+import type ObsidianGemini from '../main';
+import { GeminiModel } from '../models';
+
+interface OpenAiModelEntry {
+	id: string;
+	object?: string;
+	created?: number;
+	owned_by?: string;
+}
+
+interface OpenAiModelsResponse {
+	data: OpenAiModelEntry[];
+}
+
+export class OpenAiModelsService {
+	private plugin: ObsidianGemini;
+	private cachedModels: GeminiModel[] | null = null;
+	private lastBaseUrl: string | null = null;
+
+	constructor(plugin: ObsidianGemini) {
+		this.plugin = plugin;
+	}
+
+	async getModels(forceRefresh = false): Promise<GeminiModel[]> {
+		const baseUrl = this.plugin.settings.openaiBaseUrl;
+		if (!baseUrl) return [];
+
+		const cacheMatchesBaseUrl = this.lastBaseUrl === baseUrl;
+		if (!forceRefresh && this.cachedModels && cacheMatchesBaseUrl) {
+			return this.cachedModels;
+		}
+
+		try {
+			const url = `${baseUrl.replace(/\/$/, '')}/models`;
+			const response = await requestUrl({ url, method: 'GET', throw: false });
+
+			if (response.status !== 200) {
+				throw new Error(`OpenAI /models returned HTTP ${response.status}`);
+			}
+
+			const data = response.json as OpenAiModelsResponse;
+			if (!data || !Array.isArray(data.data)) {
+				throw new Error('Invalid /models response shape');
+			}
+
+			this.cachedModels = data.data.map((m) => this.toGeminiModel(m));
+			this.lastBaseUrl = baseUrl;
+			this.plugin.logger.log(`[OpenAiModelsService] Loaded ${this.cachedModels.length} models from ${baseUrl}`);
+			return this.cachedModels;
+		} catch (error) {
+			this.plugin.logger.warn('[OpenAiModelsService] Failed to fetch model list:', error);
+			return cacheMatchesBaseUrl ? (this.cachedModels ?? []) : [];
+		}
+	}
+
+	invalidate(): void {
+		this.cachedModels = null;
+		this.lastBaseUrl = null;
+	}
+
+	private toGeminiModel(m: OpenAiModelEntry): GeminiModel {
+		return {
+			value: m.id,
+			label: m.id,
+			provider: 'openai',
+			supportsTools: true,
+			supportsVision: false,
+		};
+	}
+}

--- a/src/ui/settings-general.ts
+++ b/src/ui/settings-general.ts
@@ -66,9 +66,10 @@ async function renderGeneralSection(
 			dropdown
 				.addOption('gemini', 'Google Gemini (cloud)')
 				.addOption('ollama', 'Ollama (local)')
+				.addOption('openai', 'OpenAI-compatible')
 				.setValue(plugin.settings.provider)
 				.onChange(async (value) => {
-					plugin.settings.provider = value as 'gemini' | 'ollama';
+					plugin.settings.provider = value as 'gemini' | 'ollama' | 'openai';
 					await plugin.saveSettings();
 					// Re-render only the General section so provider-specific fields show/hide
 					// without tearing down sections rendered later in the settings tab.
@@ -113,6 +114,77 @@ async function renderGeneralSection(
 			.setName('Local-only feature notice')
 			.setDesc(
 				'Google Search, URL Context (web fetch), Deep Research, image generation, and RAG indexing are unavailable when using Ollama. They rely on Gemini built-in services.'
+			);
+	} else if (plugin.settings.provider === 'openai') {
+		new Setting(sectionEl)
+			.setName('OpenAI Base URL')
+			.setDesc('Base URL for the OpenAI-compatible API endpoint. Default is https://api.openai.com/v1')
+			.addText((text) =>
+				text
+					.setPlaceholder('https://api.openai.com/v1')
+					.setValue(plugin.settings.openaiBaseUrl)
+					.onChange((value) => {
+						plugin.settings.openaiBaseUrl = value.trim() || 'https://api.openai.com/v1';
+						debouncedSave();
+					})
+			);
+
+		new Setting(sectionEl)
+			.setName('OpenAI API Key')
+			.setDesc('API key for the OpenAI-compatible endpoint.')
+			.addText((text) => {
+				text.inputEl.type = 'password';
+				text.setValue(plugin.settings.openaiApiKey).onChange((value) => {
+					plugin.settings.openaiApiKey = value;
+					debouncedSave();
+				});
+			});
+
+		new Setting(sectionEl)
+			.setName('OpenAI Model Name')
+			.setDesc('Model name to use (e.g., gpt-4, kimi-k2). You can also fetch available models below.')
+			.addText((text) =>
+				text
+					.setPlaceholder('gpt-4')
+					.setValue(plugin.settings.openaiModelName)
+					.onChange((value) => {
+						plugin.settings.openaiModelName = value.trim();
+						debouncedSave();
+					})
+			);
+
+		new Setting(sectionEl)
+			.setName('Refresh model list')
+			.setDesc('Re-query the OpenAI-compatible endpoint for available models.')
+			.addButton((button) =>
+				button.setButtonText('Refresh').onClick(async () => {
+					try {
+						const manager = plugin.getModelManager();
+						manager.getOpenAiModelsService().invalidate();
+						const models = await manager.getAvailableModels({ forceRefresh: true });
+						new Notice(`Found ${models.length} model${models.length === 1 ? '' : 's'}.`);
+						sectionEl.empty();
+						await renderGeneralSection(sectionEl, plugin, app, context, debouncedSave);
+					} catch (error) {
+						new Notice(`Failed to refresh: ${getErrorMessage(error)}`);
+					}
+				})
+			);
+
+		new Setting(sectionEl)
+			.setName('Allow insecure HTTP')
+			.setDesc('Allow http:// connections (not recommended for production).')
+			.addToggle((toggle) =>
+				toggle.setValue(plugin.settings.openaiAllowInsecure).onChange((value) => {
+					plugin.settings.openaiAllowInsecure = value;
+					debouncedSave();
+				})
+			);
+
+		new Setting(sectionEl)
+			.setName('Feature notice')
+			.setDesc(
+				'Google Search, URL Context (web fetch), Deep Research, image generation, and RAG indexing are unavailable when using an OpenAI-compatible provider. They rely on Gemini built-in services.'
 			);
 	} else {
 		new Setting(sectionEl)

--- a/test-scripts/test-openai-client.mjs
+++ b/test-scripts/test-openai-client.mjs
@@ -1,0 +1,120 @@
+/**
+ * Integration test for OpenAI-compatible client.
+ *
+ * Usage:
+ *   OPENAI_BASE_URL=https://api.example.com/v1 \\
+ *   OPENAI_API_KEY=your-key \\
+ *   OPENAI_MODEL=gpt-4 \\
+ *   node test-scripts/test-openai-client.mjs
+ */
+
+const baseUrl = process.env.OPENAI_BASE_URL || 'https://api.openai.com/v1';
+const apiKey = process.env.OPENAI_API_KEY;
+const model = process.env.OPENAI_MODEL || 'gpt-4';
+
+if (!apiKey) {
+	console.error('Error: OPENAI_API_KEY environment variable required');
+	process.exit(1);
+}
+
+async function testChat() {
+	console.log('Testing non-streaming chat...');
+	const response = await fetch(`${baseUrl}/chat/completions`, {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json',
+			Authorization: `Bearer ${apiKey}`,
+		},
+		body: JSON.stringify({
+			model,
+			messages: [{ role: 'user', content: 'Say "Hello from OpenAI test" and nothing else.' }],
+		}),
+	});
+
+	if (!response.ok) {
+		throw new Error(`HTTP ${response.status}: ${await response.text()}`);
+	}
+
+	const data = await response.json();
+	console.log('Response:', data.choices[0].message.content);
+	console.log('Usage:', data.usage);
+}
+
+async function testStreaming() {
+	console.log('\nTesting streaming chat...');
+	const response = await fetch(`${baseUrl}/chat/completions`, {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json',
+			Authorization: `Bearer ${apiKey}`,
+			Accept: 'text/event-stream',
+		},
+		body: JSON.stringify({
+			model,
+			messages: [{ role: 'user', content: 'Count from 1 to 3.' }],
+			stream: true,
+		}),
+	});
+
+	if (!response.ok) {
+		throw new Error(`HTTP ${response.status}: ${await response.text()}`);
+	}
+
+	const reader = response.body.getReader();
+	const decoder = new TextDecoder();
+	let buffer = '';
+
+	while (true) {
+		const { done, value } = await reader.read();
+		if (done) break;
+
+		buffer += decoder.decode(value, { stream: true });
+		const lines = buffer.split('\n');
+		buffer = lines.pop() || '';
+
+		for (const line of lines) {
+			const trimmed = line.trim();
+			if (!trimmed.startsWith('data: ')) continue;
+			const data = trimmed.slice(6);
+			if (data === '[DONE]') continue;
+
+			try {
+				const parsed = JSON.parse(data);
+				const content = parsed.choices?.[0]?.delta?.content;
+				if (content) process.stdout.write(content);
+			} catch {
+				// skip malformed
+			}
+		}
+	}
+	console.log('\nStreaming complete.');
+}
+
+async function testModels() {
+	console.log('\nTesting /v1/models...');
+	const response = await fetch(`${baseUrl}/models`, {
+		headers: { Authorization: `Bearer ${apiKey}` },
+	});
+
+	if (!response.ok) {
+		throw new Error(`HTTP ${response.status}: ${await response.text()}`);
+	}
+
+	const data = await response.json();
+	console.log(`Found ${data.data.length} models:`);
+	data.data.slice(0, 10).forEach((m) => console.log(`  - ${m.id}`));
+}
+
+async function main() {
+	try {
+		await testChat();
+		await testStreaming();
+		await testModels();
+		console.log('\n✅ All tests passed!');
+	} catch (error) {
+		console.error('\n❌ Test failed:', error.message);
+		process.exit(1);
+	}
+}
+
+main();

--- a/test/api/providers/openai/client.test.ts
+++ b/test/api/providers/openai/client.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { OpenAiClient } from '../../../../src/api/providers/openai/client';
+import { ExtendedModelRequest } from '../../../../src/api/interfaces/model-api';
 import { requestUrl } from 'obsidian';
 
 describe('OpenAiClient', () => {
@@ -95,7 +96,7 @@ describe('OpenAiClient', () => {
 				description: 'Read a file',
 				parameters: { type: 'object', properties: { path: { type: 'string' } }, required: ['path'] },
 			}],
-		} as any);
+		} as ExtendedModelRequest);
 
 		expect(result.markdown).toBe('I will help');
 		expect(result.toolCalls).toHaveLength(1);

--- a/test/api/providers/openai/client.test.ts
+++ b/test/api/providers/openai/client.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi } from 'vitest';
+import { OpenAiClient } from '../../../../src/api/providers/openai/client';
+import { requestUrl } from 'obsidian';
+
+describe('OpenAiClient', () => {
+	it('generates non-streaming response', async () => {
+		const mockResponse = {
+			status: 200,
+			json: {
+				choices: [{ message: { content: 'Hello!' } }],
+				usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+			},
+		};
+		vi.mocked(requestUrl).mockResolvedValue(mockResponse as any);
+
+		const client = new OpenAiClient({
+			baseUrl: 'https://api.example.com/v1',
+			apiKey: 'test-key',
+			model: 'gpt-4',
+		});
+
+		const result = await client.generateModelResponse({ prompt: 'Hi' });
+		expect(result.markdown).toBe('Hello!');
+		expect(result.usageMetadata?.promptTokenCount).toBe(10);
+	});
+
+	it('throws on HTTP error', async () => {
+		vi.mocked(requestUrl).mockResolvedValue({ status: 401, text: 'Unauthorized' } as any);
+
+		const client = new OpenAiClient({
+			baseUrl: 'https://api.example.com/v1',
+			apiKey: 'bad-key',
+			model: 'gpt-4',
+		});
+
+		await expect(client.generateModelResponse({ prompt: 'Hi' })).rejects.toThrow('401');
+	});
+});

--- a/test/api/providers/openai/client.test.ts
+++ b/test/api/providers/openai/client.test.ts
@@ -1,8 +1,12 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { OpenAiClient } from '../../../../src/api/providers/openai/client';
 import { requestUrl } from 'obsidian';
 
 describe('OpenAiClient', () => {
+	beforeEach(() => {
+		vi.mocked(requestUrl).mockReset();
+	});
+
 	it('generates non-streaming response', async () => {
 		const mockResponse = {
 			status: 200,
@@ -34,5 +38,67 @@ describe('OpenAiClient', () => {
 		});
 
 		await expect(client.generateModelResponse({ prompt: 'Hi' })).rejects.toThrow('401');
+	});
+
+	it('generates streaming response', async () => {
+		const streamText = `data: {"choices":[{"delta":{"content":"Hello"}}]}\n\ndata: {"choices":[{"delta":{"content":"!"}}]}\n\ndata: [DONE]\n\n`;
+		vi.mocked(requestUrl).mockResolvedValue({
+			status: 200,
+			text: streamText,
+		} as any);
+
+		const client = new OpenAiClient({
+			baseUrl: 'https://api.example.com/v1',
+			apiKey: 'test-key',
+			model: 'gpt-4',
+		});
+
+		const chunks: string[] = [];
+		const stream = client.generateStreamingResponse({ prompt: 'Hi' }, (chunk) => {
+			chunks.push(chunk.text);
+		});
+
+		const result = await stream.complete;
+		expect(result.markdown).toBe('Hello!');
+		expect(chunks).toEqual(['Hello', '!']);
+	});
+
+	it('handles ExtendedModelRequest with tools', async () => {
+		const mockResponse = {
+			status: 200,
+			json: {
+				choices: [{
+					message: {
+						content: 'I will help',
+						tool_calls: [{
+							id: 'call_1',
+							function: { name: 'read_file', arguments: '{"path":"test.md"}' },
+						}],
+					},
+				}],
+				usage: { prompt_tokens: 20, completion_tokens: 10, total_tokens: 30 },
+			},
+		};
+		vi.mocked(requestUrl).mockResolvedValue(mockResponse as any);
+
+		const client = new OpenAiClient({
+			baseUrl: 'https://api.example.com/v1',
+			apiKey: 'test-key',
+			model: 'gpt-4',
+		});
+
+		const result = await client.generateModelResponse({
+			userMessage: 'Read test.md',
+			conversationHistory: [],
+			availableTools: [{
+				name: 'read_file',
+				description: 'Read a file',
+				parameters: { type: 'object', properties: { path: { type: 'string' } }, required: ['path'] },
+			}],
+		} as any);
+
+		expect(result.markdown).toBe('I will help');
+		expect(result.toolCalls).toHaveLength(1);
+		expect(result.toolCalls![0].name).toBe('read_file');
 	});
 });

--- a/test/api/providers/openai/format-converter.test.ts
+++ b/test/api/providers/openai/format-converter.test.ts
@@ -18,6 +18,12 @@ describe('convertContentToMessages', () => {
 		expect(result).toEqual([{ role: 'assistant', content: 'Hi there' }]);
 	});
 
+	it('converts system text message', () => {
+		const content: Content = { role: 'system', parts: [{ text: 'Be helpful' }] };
+		const result = convertContentToMessages([content]);
+		expect(result).toEqual([{ role: 'system', content: 'Be helpful' }]);
+	});
+
 	it('converts inline image to image_url', () => {
 		const content: Content = {
 			role: 'user',
@@ -32,6 +38,26 @@ describe('convertContentToMessages', () => {
 		]);
 	});
 
+	it('converts mixed text and image parts', () => {
+		const content: Content = {
+			role: 'user',
+			parts: [
+				{ text: 'Look at this' },
+				{ inlineData: { mimeType: 'image/jpeg', data: 'imgdata' } },
+			],
+		};
+		const result = convertContentToMessages([content]);
+		expect(result).toEqual([
+			{
+				role: 'user',
+				content: [
+					{ type: 'text', text: 'Look at this' },
+					{ type: 'image_url', image_url: { url: 'data:image/jpeg;base64,imgdata' } },
+				],
+			},
+		]);
+	});
+
 	it('converts functionCall to tool_calls', () => {
 		const content: Content = {
 			role: 'model',
@@ -40,7 +66,7 @@ describe('convertContentToMessages', () => {
 		const result = convertContentToMessages([content]);
 		expect(result[0].role).toBe('assistant');
 		expect(result[0].tool_calls).toHaveLength(1);
-		expect(result[0].tool_calls[0].function.name).toBe('read_file');
+		expect(result[0].tool_calls![0].function.name).toBe('read_file');
 	});
 
 	it('converts functionResponse to tool message', () => {
@@ -52,5 +78,57 @@ describe('convertContentToMessages', () => {
 		expect(result[0].role).toBe('tool');
 		expect(result[0].tool_call_id).toBeDefined();
 		expect(result[0].content).toContain('file data');
+	});
+});
+
+describe('convertMessageToContent', () => {
+	it('converts assistant text message', () => {
+		const message = { role: 'assistant' as const, content: 'Hello back' };
+		const result = convertMessageToContent(message);
+		expect(result).toEqual({ role: 'model', parts: [{ text: 'Hello back' }] });
+	});
+
+	it('converts system role message', () => {
+		const message = { role: 'system' as const, content: 'Be helpful' };
+		const result = convertMessageToContent(message);
+		expect(result).toEqual({ role: 'system', parts: [{ text: 'Be helpful' }] });
+	});
+
+	it('converts tool role message to functionResponse', () => {
+		const message = { role: 'tool' as const, tool_call_id: 'call_123', content: 'tool result' };
+		const result = convertMessageToContent(message);
+		expect(result.role).toBe('user');
+		expect(result.parts).toHaveLength(1);
+		expect(result.parts[0]).toMatchObject({
+			functionResponse: {
+				name: 'call_123',
+				response: 'tool result',
+				id: 'call_123',
+			},
+		});
+	});
+
+	it('converts assistant message with tool_calls', () => {
+		const message = {
+			role: 'assistant' as const,
+			content: '',
+			tool_calls: [
+				{
+					id: 'call_abc',
+					type: 'function' as const,
+					function: { name: 'read_file', arguments: '{"path":"test.md"}' },
+				},
+			],
+		};
+		const result = convertMessageToContent(message);
+		expect(result.role).toBe('model');
+		expect(result.parts).toHaveLength(1);
+		expect(result.parts[0]).toMatchObject({
+			functionCall: {
+				name: 'read_file',
+				args: { path: 'test.md' },
+				id: 'call_abc',
+			},
+		});
 	});
 });

--- a/test/api/providers/openai/format-converter.test.ts
+++ b/test/api/providers/openai/format-converter.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import {
+	convertContentToMessages,
+	convertMessageToContent,
+} from '../../../../src/api/providers/openai/format-converter';
+import { Content } from '@google/genai';
+
+describe('convertContentToMessages', () => {
+	it('converts user text message', () => {
+		const content: Content = { role: 'user', parts: [{ text: 'Hello' }] };
+		const result = convertContentToMessages([content]);
+		expect(result).toEqual([{ role: 'user', content: 'Hello' }]);
+	});
+
+	it('converts model text message to assistant', () => {
+		const content: Content = { role: 'model', parts: [{ text: 'Hi there' }] };
+		const result = convertContentToMessages([content]);
+		expect(result).toEqual([{ role: 'assistant', content: 'Hi there' }]);
+	});
+
+	it('converts inline image to image_url', () => {
+		const content: Content = {
+			role: 'user',
+			parts: [{ inlineData: { mimeType: 'image/png', data: 'base64data' } }],
+		};
+		const result = convertContentToMessages([content]);
+		expect(result).toEqual([
+			{
+				role: 'user',
+				content: [{ type: 'image_url', image_url: { url: 'data:image/png;base64,base64data' } }],
+			},
+		]);
+	});
+
+	it('converts functionCall to tool_calls', () => {
+		const content: Content = {
+			role: 'model',
+			parts: [{ functionCall: { name: 'read_file', args: { path: 'test.md' } } }],
+		};
+		const result = convertContentToMessages([content]);
+		expect(result[0].role).toBe('assistant');
+		expect(result[0].tool_calls).toHaveLength(1);
+		expect(result[0].tool_calls[0].function.name).toBe('read_file');
+	});
+
+	it('converts functionResponse to tool message', () => {
+		const content: Content = {
+			role: 'user',
+			parts: [{ functionResponse: { name: 'read_file', response: { content: 'file data' } } }],
+		};
+		const result = convertContentToMessages([content]);
+		expect(result[0].role).toBe('tool');
+		expect(result[0].tool_call_id).toBeDefined();
+		expect(result[0].content).toContain('file data');
+	});
+});

--- a/test/api/providers/openai/sse-parser.test.ts
+++ b/test/api/providers/openai/sse-parser.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { parseSseStream } from '../../../../src/api/providers/openai/sse-parser';
+
+describe('parseSseStream', () => {
+	it('parses text chunks', () => {
+		const stream = `data: {"choices":[{"delta":{"content":"Hello"}}]}\n\ndata: {"choices":[{"delta":{"content":" world"}}]}\n\ndata: [DONE]\n\n`;
+		const chunks = parseSseStream(stream);
+		expect(chunks).toHaveLength(2);
+		expect(chunks[0].choices[0].delta.content).toBe('Hello');
+		expect(chunks[1].choices[0].delta.content).toBe(' world');
+	});
+
+	it('ignores empty lines and comments', () => {
+		const stream = `: comment\n\ndata: {"choices":[{"delta":{"content":"x"}}]}\n\n\n\ndata: [DONE]\n\n`;
+		const chunks = parseSseStream(stream);
+		expect(chunks).toHaveLength(1);
+		expect(chunks[0].choices[0].delta.content).toBe('x');
+	});
+
+	it('parses tool call chunks', () => {
+		const stream = `data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"name":"read_file"}}]}}]}\n\n`;
+		const chunks = parseSseStream(stream);
+		expect(chunks[0].choices[0].delta.tool_calls).toHaveLength(1);
+		expect(chunks[0].choices[0].delta.tool_calls[0].function.name).toBe('read_file');
+	});
+
+	it('handles malformed json gracefully', () => {
+		const stream = `data: not json\n\ndata: {"choices":[{"delta":{"content":"ok"}}]}\n\n`;
+		const chunks = parseSseStream(stream);
+		expect(chunks).toHaveLength(1);
+		expect(chunks[0].choices[0].delta.content).toBe('ok');
+	});
+});

--- a/test/api/providers/openai/sse-parser.test.ts
+++ b/test/api/providers/openai/sse-parser.test.ts
@@ -30,4 +30,10 @@ describe('parseSseStream', () => {
 		expect(chunks).toHaveLength(1);
 		expect(chunks[0].choices[0].delta.content).toBe('ok');
 	});
+
+	it('parses finish_reason', () => {
+		const stream = `data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n\n`;
+		const chunks = parseSseStream(stream);
+		expect(chunks[0].choices[0].finish_reason).toBe('stop');
+	});
 });


### PR DESCRIPTION
## Summary

Add support for OpenAI-compatible API endpoints as a third provider option alongside Gemini and Ollama. This enables users to connect to any OpenAI-compatible API (OpenAI, Kimi Code, OpenRouter, local vLLM, etc.) with full feature parity for chat, streaming, tool calling, completions, summary, and rewrite.

## Changes

- **New provider type**: Added `'openai'` to `ModelProvider` type
- **New settings**: `openaiBaseUrl`, `openaiApiKey`, `openaiModelName`, `openaiAllowInsecure`
- **OpenAiClient** (`src/api/providers/openai/client.ts`): Full `ModelApi` implementation using Obsidian's `requestUrl` with:
  - Non-streaming and streaming chat completions
  - Tool calling support (function calling format conversion)
  - Image attachment support via `image_url` format
  - SSE stream parsing for streaming responses
  - Proper error handling with HTTP status codes for retry logic
- **Format converter** (`src/api/providers/openai/format-converter.ts`): Bidirectional conversion between Gemini `Content[]` and OpenAI `messages[]` format
- **SSE parser** (`src/api/providers/openai/sse-parser.ts`): Parses Server-Sent Events stream format
- **Model discovery** (`src/services/openai-models-service.ts`): Optional `/v1/models` endpoint fetching with caching
- **Factory integration**: `ModelClientFactory` creates `OpenAiClient` when `provider === 'openai'`
- **ModelManager integration**: Handles OpenAI model list with manual model fallback
- **Settings UI**: Full OpenAI provider section in settings with base URL, API key, model name, refresh button, and insecure HTTP toggle
- **API key access**: `apiKey` getter returns `openaiApiKey` when provider is openai
- **Tests**: Unit tests for client, format converter, and SSE parser
- **Integration test**: `test-scripts/test-openai-client.mjs` for manual endpoint validation
- **Documentation**: Updated `README.md` and `docs/reference/settings.md`

## Screenshots / Screencast

N/A — settings UI follows existing provider pattern (Ollama-style conditional fields)

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
  - Note: `npm test` and `npm run build` fail in this environment due to Node.js v16 incompatibility with latest Vitest/Vite (requires Node 20+). TypeScript type check (`npx tsc -noEmit -skipLibCheck`) passes cleanly.
- [x] I have tested this change on Desktop
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards)
  - Uses Obsidian's `requestUrl` API which works on both desktop and mobile
- [x] Documentation has been updated (if applicable)
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (Anthropic)
- [x] I have reviewed and understand all AI-generated code in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OpenAI-compatible provider option with configurable endpoint URL and API key
  * Supports model discovery from OpenAI-compatible endpoints
  * Enables streaming and non-streaming chat completions with tool calling support

* **Documentation**
  * Expanded setup and configuration guides to include OpenAI-compatible provider options

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/allenhutchison/obsidian-gemini/pull/903?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->