### PR TITLE
refactor(prompts): extract shared system-instruction assembly (#901)

### DIFF
--- a/src/api/providers/gemini/client.ts
+++ b/src/api/providers/gemini/client.ts
@@ -207,43 +207,9 @@ export class GeminiClient implements ModelApi {
 		// Build system instruction
 		let systemInstruction = '';
 		if (isExtended) {
-			const extReq = request as ExtendedModelRequest;
-
-			// Load AGENTS.md memory if available
-			let agentsMemory: string | null = null;
-			if (this.plugin?.agentsMemory) {
-				try {
-					agentsMemory = await this.plugin.agentsMemory.read();
-				} catch (error) {
-					this.plugin.logger.warn('Failed to load AGENTS.md:', error);
-				}
-			}
-
-			// Load available skill summaries for system prompt injection
-			let availableSkills: { name: string; description: string }[] = [];
-			if (this.plugin?.skillManager) {
-				try {
-					availableSkills = await this.plugin.skillManager.getSkillSummaries();
-				} catch (error) {
-					this.plugin.logger.warn('Failed to load skill summaries:', error);
-				}
-			}
-
-			// Filter skills to project scope if active
-			if (extReq.projectSkills && extReq.projectSkills.length > 0) {
-				availableSkills = availableSkills.filter((s) => extReq.projectSkills!.includes(s.name));
-			}
-
 			// Build layered system prompt: identity → vault context → project →
 			// agent rules → tool catalog → custom instructions → per-turn context
-			systemInstruction = this.prompts.getSystemPromptWithCustom(
-				extReq.availableTools,
-				extReq.customPrompt,
-				agentsMemory,
-				availableSkills,
-				extReq.projectInstructions,
-				extReq.sessionStartedAt
-			);
+			systemInstruction = await this.prompts.buildExtendedSystemInstruction(request as ExtendedModelRequest);
 		} else {
 			// For BaseModelRequest, prompt is the full input
 			systemInstruction = request.prompt || '';

--- a/src/api/providers/ollama/client.ts
+++ b/src/api/providers/ollama/client.ts
@@ -287,36 +287,7 @@ export class OllamaClient implements ModelApi {
 	}
 
 	private async buildSystemInstruction(request: ExtendedModelRequest): Promise<string> {
-		let agentsMemory: string | null = null;
-		if (this.plugin?.agentsMemory) {
-			try {
-				agentsMemory = await this.plugin.agentsMemory.read();
-			} catch (error) {
-				this.plugin.logger.warn('Failed to load AGENTS.md:', error);
-			}
-		}
-
-		let availableSkills: { name: string; description: string }[] = [];
-		if (this.plugin?.skillManager) {
-			try {
-				availableSkills = await this.plugin.skillManager.getSkillSummaries();
-			} catch (error) {
-				this.plugin.logger.warn('Failed to load skill summaries:', error);
-			}
-		}
-
-		if (request.projectSkills && request.projectSkills.length > 0) {
-			availableSkills = availableSkills.filter((s) => request.projectSkills!.includes(s.name));
-		}
-
-		return this.prompts.getSystemPromptWithCustom(
-			request.availableTools,
-			request.customPrompt,
-			agentsMemory,
-			availableSkills,
-			request.projectInstructions,
-			request.sessionStartedAt
-		);
+		return this.prompts.buildExtendedSystemInstruction(request);
 	}
 
 	private convertHistoryEntry(entry: any): Message[] | null {

--- a/src/prompts/gemini-prompts.ts
+++ b/src/prompts/gemini-prompts.ts
@@ -1,7 +1,7 @@
 import * as Handlebars from 'handlebars';
 import { getLanguage } from 'obsidian';
 import { CustomPrompt } from './types';
-import { ToolDefinition } from '../api/interfaces/model-api';
+import { ExtendedModelRequest, ToolDefinition } from '../api/interfaces/model-api';
 import type ObsidianGemini from '../main';
 
 import systemPromptContent from '../../prompts/systemPrompt.hbs';
@@ -175,5 +175,51 @@ export class GeminiPrompts {
 			toolCatalogSection,
 			additionalInstructions,
 		});
+	}
+
+	/**
+	 * Assemble the system instruction for an extended (agent-style) request.
+	 *
+	 * Loads AGENTS.md memory and skill summaries off the plugin, filters skills
+	 * to the project scope when active, and renders the layered system prompt
+	 * via `getSystemPromptWithCustom`. Errors loading memory or skills are
+	 * swallowed (logged via `plugin.logger.warn`) and the prompt continues with
+	 * an empty value — this preserves the contract that the system instruction
+	 * is always renderable.
+	 *
+	 * Provider clients call this once per request to keep the system-instruction
+	 * assembly identical across Gemini and Ollama (#901).
+	 */
+	async buildExtendedSystemInstruction(request: ExtendedModelRequest): Promise<string> {
+		let agentsMemory: string | null = null;
+		if (this.plugin?.agentsMemory) {
+			try {
+				agentsMemory = await this.plugin.agentsMemory.read();
+			} catch (error) {
+				this.plugin.logger.warn('Failed to load AGENTS.md:', error);
+			}
+		}
+
+		let availableSkills: { name: string; description: string }[] = [];
+		if (this.plugin?.skillManager) {
+			try {
+				availableSkills = await this.plugin.skillManager.getSkillSummaries();
+			} catch (error) {
+				this.plugin.logger.warn('Failed to load skill summaries:', error);
+			}
+		}
+
+		if (request.projectSkills && request.projectSkills.length > 0) {
+			availableSkills = availableSkills.filter((s) => request.projectSkills!.includes(s.name));
+		}
+
+		return this.getSystemPromptWithCustom(
+			request.availableTools,
+			request.customPrompt,
+			agentsMemory,
+			availableSkills,
+			request.projectInstructions,
+			request.sessionStartedAt
+		);
 	}
 }

--- a/test/prompts/gemini-prompts.test.ts
+++ b/test/prompts/gemini-prompts.test.ts
@@ -243,7 +243,14 @@ describe('GeminiPrompts', () => {
 			mockPlugin.skillManager = { getSkillSummaries: vi.fn().mockResolvedValue([]) };
 			const spy = vi.spyOn(geminiPrompts, 'getSystemPromptWithCustom');
 
-			const customPrompt = { content: 'custom', overrideSystemPrompt: false };
+			const customPrompt = {
+				name: 'custom',
+				description: 'test',
+				version: 1,
+				overrideSystemPrompt: false,
+				tags: [],
+				content: 'custom',
+			};
 			await geminiPrompts.buildExtendedSystemInstruction({
 				...baseRequest,
 				customPrompt,

--- a/test/prompts/gemini-prompts.test.ts
+++ b/test/prompts/gemini-prompts.test.ts
@@ -1,5 +1,6 @@
 import { GeminiPrompts } from '../../src/prompts/gemini-prompts';
 import type ObsidianGemini from '../../src/main';
+import type { ExtendedModelRequest } from '../../src/api/interfaces/model-api';
 import { getLanguage } from 'obsidian';
 
 describe('GeminiPrompts', () => {
@@ -111,6 +112,146 @@ describe('GeminiPrompts', () => {
 			const prompt = geminiPrompts.getSystemPromptWithCustom(...baseArgs, '2026-04-12T14:23:45.123-07:00');
 			expect(prompt).not.toContain("Today's date is:");
 			expect(prompt).not.toContain('The current time is:');
+		});
+	});
+
+	describe('buildExtendedSystemInstruction', () => {
+		const baseRequest: ExtendedModelRequest = {
+			model: 'gemini-test',
+			prompt: '',
+			conversationHistory: [],
+			userMessage: 'hi',
+		};
+
+		it('loads AGENTS.md memory and skill summaries and feeds them into the system prompt', async () => {
+			mockPlugin.agentsMemory = { read: vi.fn().mockResolvedValue('AGENTS body') };
+			mockPlugin.skillManager = {
+				getSkillSummaries: vi.fn().mockResolvedValue([{ name: 'echo', description: 'echoes things' }]),
+			};
+
+			const spy = vi.spyOn(geminiPrompts, 'getSystemPromptWithCustom');
+			await geminiPrompts.buildExtendedSystemInstruction({
+				...baseRequest,
+				availableTools: [{ name: 't', description: 'd', parameters: { type: 'object', properties: {} } }],
+			});
+
+			expect(mockPlugin.agentsMemory.read).toHaveBeenCalledTimes(1);
+			expect(mockPlugin.skillManager.getSkillSummaries).toHaveBeenCalledTimes(1);
+			expect(spy).toHaveBeenCalledWith(
+				expect.any(Array),
+				undefined,
+				'AGENTS body',
+				[{ name: 'echo', description: 'echoes things' }],
+				undefined,
+				undefined
+			);
+		});
+
+		it('renders the prompt with empty memory when plugin is undefined', async () => {
+			const orphan = new GeminiPrompts(undefined);
+			const spy = vi.spyOn(orphan, 'getSystemPromptWithCustom');
+			const result = await orphan.buildExtendedSystemInstruction(baseRequest);
+			expect(typeof result).toBe('string');
+			expect(spy).toHaveBeenCalledWith(undefined, undefined, null, [], undefined, undefined);
+		});
+
+		it('falls back to empty memory when plugin has no agentsMemory', async () => {
+			mockPlugin.agentsMemory = undefined;
+			mockPlugin.skillManager = { getSkillSummaries: vi.fn().mockResolvedValue([]) };
+			const spy = vi.spyOn(geminiPrompts, 'getSystemPromptWithCustom');
+			await geminiPrompts.buildExtendedSystemInstruction(baseRequest);
+			expect(spy).toHaveBeenCalledWith(undefined, undefined, null, [], undefined, undefined);
+		});
+
+		it('swallows agentsMemory.read() rejection and logs a warning', async () => {
+			const err = new Error('read fail');
+			mockPlugin.agentsMemory = { read: vi.fn().mockRejectedValue(err) };
+			mockPlugin.skillManager = { getSkillSummaries: vi.fn().mockResolvedValue([]) };
+			const spy = vi.spyOn(geminiPrompts, 'getSystemPromptWithCustom');
+
+			await geminiPrompts.buildExtendedSystemInstruction(baseRequest);
+
+			expect(mockPlugin.logger.warn).toHaveBeenCalledWith('Failed to load AGENTS.md:', err);
+			expect(spy).toHaveBeenCalledWith(undefined, undefined, null, [], undefined, undefined);
+		});
+
+		it('falls back to no skills when plugin has no skillManager', async () => {
+			mockPlugin.agentsMemory = { read: vi.fn().mockResolvedValue('') };
+			mockPlugin.skillManager = undefined;
+			const spy = vi.spyOn(geminiPrompts, 'getSystemPromptWithCustom');
+			await geminiPrompts.buildExtendedSystemInstruction(baseRequest);
+			expect(spy).toHaveBeenCalledWith(undefined, undefined, '', [], undefined, undefined);
+		});
+
+		it('swallows getSkillSummaries() rejection and logs a warning', async () => {
+			const err = new Error('skills fail');
+			mockPlugin.agentsMemory = { read: vi.fn().mockResolvedValue('') };
+			mockPlugin.skillManager = { getSkillSummaries: vi.fn().mockRejectedValue(err) };
+			const spy = vi.spyOn(geminiPrompts, 'getSystemPromptWithCustom');
+
+			await geminiPrompts.buildExtendedSystemInstruction(baseRequest);
+
+			expect(mockPlugin.logger.warn).toHaveBeenCalledWith('Failed to load skill summaries:', err);
+			expect(spy).toHaveBeenCalledWith(undefined, undefined, '', [], undefined, undefined);
+		});
+
+		it('filters skills down to projectSkills when the list is non-empty', async () => {
+			mockPlugin.agentsMemory = { read: vi.fn().mockResolvedValue('') };
+			mockPlugin.skillManager = {
+				getSkillSummaries: vi.fn().mockResolvedValue([
+					{ name: 'echo', description: 'a' },
+					{ name: 'hello', description: 'b' },
+					{ name: 'world', description: 'c' },
+				]),
+			};
+			const spy = vi.spyOn(geminiPrompts, 'getSystemPromptWithCustom');
+
+			await geminiPrompts.buildExtendedSystemInstruction({
+				...baseRequest,
+				projectSkills: ['echo', 'world'],
+			});
+
+			expect(spy).toHaveBeenCalledWith(
+				undefined,
+				undefined,
+				'',
+				[
+					{ name: 'echo', description: 'a' },
+					{ name: 'world', description: 'c' },
+				],
+				undefined,
+				undefined
+			);
+		});
+
+		it('does not filter skills when projectSkills is an empty array', async () => {
+			mockPlugin.agentsMemory = { read: vi.fn().mockResolvedValue('') };
+			const allSkills = [
+				{ name: 'echo', description: 'a' },
+				{ name: 'hello', description: 'b' },
+			];
+			mockPlugin.skillManager = { getSkillSummaries: vi.fn().mockResolvedValue(allSkills) };
+			const spy = vi.spyOn(geminiPrompts, 'getSystemPromptWithCustom');
+
+			await geminiPrompts.buildExtendedSystemInstruction({ ...baseRequest, projectSkills: [] });
+
+			expect(spy).toHaveBeenCalledWith(undefined, undefined, '', allSkills, undefined, undefined);
+		});
+
+		it('forwards request fields (customPrompt, projectInstructions, sessionStartedAt) verbatim', async () => {
+			mockPlugin.agentsMemory = { read: vi.fn().mockResolvedValue('') };
+			mockPlugin.skillManager = { getSkillSummaries: vi.fn().mockResolvedValue([]) };
+			const spy = vi.spyOn(geminiPrompts, 'getSystemPromptWithCustom');
+
+			const customPrompt = { content: 'custom', overrideSystemPrompt: false };
+			await geminiPrompts.buildExtendedSystemInstruction({
+				...baseRequest,
+				customPrompt,
+				projectInstructions: 'be helpful',
+				sessionStartedAt: '2026-05-28T10:00:00Z',
+			});
+
+			expect(spy).toHaveBeenCalledWith(undefined, customPrompt, '', [], 'be helpful', '2026-05-28T10:00:00Z');
 		});
 	});
 });


### PR DESCRIPTION
## Summary

Both `GeminiClient.buildGenerateContentParams()` and `OllamaClient.buildSystemInstruction()` independently ran the same six-step recipe to assemble the system instruction (load AGENTS.md, swallow errors, load skill summaries, swallow errors, filter by `projectSkills`, call `GeminiPrompts.getSystemPromptWithCustom()` with the same six positional arguments). Every new layer had to land in both files in lockstep.

Both clients already share a `GeminiPrompts` instance, so this PR adds `GeminiPrompts.buildExtendedSystemInstruction(request)` next to `getSystemPromptWithCustom` and collapses both client sites to a one-line call. The error-swallow contract (`logger.warn`, continue with empty value) is preserved.

Fixes #901

## Changes

- Add `GeminiPrompts.buildExtendedSystemInstruction(request: ExtendedModelRequest): Promise<string>` in `src/prompts/gemini-prompts.ts` — owns the six-step assembly that was duplicated across providers.
- `GeminiClient.buildGenerateContentParams()` in `src/api/providers/gemini/client.ts`: replace the 35-line inline block with `await this.prompts.buildExtendedSystemInstruction(request as ExtendedModelRequest)`.
- `OllamaClient.buildSystemInstruction()` in `src/api/providers/ollama/client.ts`: delegates to the helper (the method stays — its callers live inside the file).
- Add eight unit tests under `test/prompts/gemini-prompts.test.ts` covering: missing plugin, missing `agentsMemory`, `agentsMemory.read()` rejection, missing `skillManager`, `getSkillSummaries()` rejection, `projectSkills` filter active, `projectSkills` filter empty, full forwarding of `customPrompt`/`projectInstructions`/`sessionStartedAt`.
- Picked Option B from the issue (method on `GeminiPrompts`) rather than a free function. The class already owns `getSystemPromptWithCustom` and already carries `plugin` as a constructor field, so a method avoids invented parameters.
- Pure code motion — no behaviour change. Existing provider tests (`test/api/providers/gemini/client.test.ts`, `test/api/providers/ollama/client.test.ts`) stay green without modification.

## Screenshots / Screencast

N/A — internal refactor, no user-visible change.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — no platform-specific code paths touched
- [x] Documentation has been updated (if applicable) — N/A, internal refactor with no docs references to the affected methods
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR


---
_Generated by [Claude Code](https://claude.ai/code/session_01QhuQQGgQbxAZwbB7s65VPh)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized system instruction building logic for improved code maintainability and centralized functionality.

* **Tests**
  * Added comprehensive test coverage for system instruction building to ensure reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/allenhutchison/obsidian-gemini/pull/904?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->