### PR TITLE
chore(daily): 2026-05-28 daily update

### DIFF
--- a/docs/guide/context-system.md
+++ b/docs/guide/context-system.md
@@ -168,7 +168,7 @@ To remove a file from context:
 
 **Technical Limits:**
 
-- Maximum token limit per request (~2M tokens for Gemini 2.5+)
+- Maximum token limit per request (~1M tokens for current Gemini models)
 - Large files count against this limit
 - Agent may not see all content if limit exceeded
 

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -21,11 +21,12 @@ The reference below groups settings by topic for lookup, which doesn't always ma
 - [Model Configuration](#model-configuration) (UI: _General_ — chat/summary/completion/image model selection)
 - [Custom Prompts](#custom-prompts) (UI: _Agent Config_ — advanced)
 - [UI Settings](#ui-settings) (UI: _User Experience_ — streaming, diff view, identity, frontmatter key, session history)
+- [Automation Settings](#automation-settings) (UI: _Automation_ — scheduled task catch-up, lifecycle hooks toggle)
 - [Context Management](#context-management) (UI: _Agent Config_ — advanced)
 - [Developer Settings](#developer-settings) (UI: split across _Agent Config_, _Tool Permissions_, _MCP Servers_, _Debug_)
 - [Session-Level Settings](#session-level-settings)
 
-UI sections without a dedicated topic in this reference: _Automation_ (covered in the [Scheduled Tasks](/guide/scheduled-tasks) and [Lifecycle Hooks](/guide/lifecycle-hooks) guides) and _Vault Search Index_ (covered in [Semantic Search](/guide/semantic-search)).
+UI sections without a dedicated topic in this reference: _Vault Search Index_ (covered in [Semantic Search](/guide/semantic-search)). The _Automation_ section's task and hook management UI is covered in the [Scheduled Tasks](/guide/scheduled-tasks) and [Lifecycle Hooks](/guide/lifecycle-hooks) guides; the two persistent settings (`autoRunCatchUp`, `hooksEnabled`) are documented in [Automation Settings](#automation-settings) below.
 
 ## Basic Settings
 
@@ -169,6 +170,18 @@ See the [Custom Prompts Guide](/guide/custom-prompts) for detailed instructions.
 - **Description**: Enable streaming responses in the chat interface for a more interactive experience
 - **Note**: When disabled, full responses are displayed at once
 
+### Expanded Settings Sections
+
+- **Setting**: `expandedSettingsSections`
+- **Type**: `string[]`
+- **Default**: `[]`
+- **Description**: Internal list of section ids that are currently expanded in the settings tab. Updated automatically when you toggle a section. Known ids: `ui`, `automation`, `rag`, `tool-permissions`, `mcp-servers`, `agent-config`, `debug`. (General is always open; it has no id and ignores this setting.)
+- **Note**: Edit `data.json` directly to pre-expand sections (for example, on a new install) or restore a custom layout after migrating vaults.
+
+## Automation Settings
+
+These settings appear in the **Automation** section of the plugin settings (UI: _Automation_). Task and hook management controls (creating, editing, and running tasks/hooks) are covered in the [Scheduled Tasks](/guide/scheduled-tasks) and [Lifecycle Hooks](/guide/lifecycle-hooks) guides.
+
 ### Auto-run missed scheduled tasks on startup
 
 - **Setting**: `autoRunCatchUp`
@@ -186,14 +199,6 @@ See the [Custom Prompts Guide](/guide/custom-prompts) for detailed instructions.
 - **Description**: Subscribe to vault events (file created/modified/deleted/renamed) and dispatch them to hook definitions in `[state-folder]/Hooks/`. Each matching event fires a headless agent run with debounce, rate-limit, and loop-prevention guards.
 - **Why opt-in**: Vault events fire continuously; an unintentionally-broad hook can drain API quota quickly. The default is off so users opt in deliberately.
 - **See also**: [Lifecycle Hooks](/guide/lifecycle-hooks)
-
-### Expanded Settings Sections
-
-- **Setting**: `expandedSettingsSections`
-- **Type**: `string[]`
-- **Default**: `[]`
-- **Description**: Internal list of section ids that are currently expanded in the settings tab. Updated automatically when you toggle a section. Known ids: `ui`, `automation`, `rag`, `tool-permissions`, `mcp-servers`, `agent-config`, `debug`. (General is always open; it has no id and ignores this setting.)
-- **Note**: Edit `data.json` directly to pre-expand sections (for example, on a new install) or restore a custom layout after migrating vaults.
 
 ## Context Management
 

--- a/planning/changelog/2026-05-27.md
+++ b/planning/changelog/2026-05-27.md
@@ -1,0 +1,20 @@
+# Daily changelog — May 27, 2026
+
+**Date:** 2026-05-27
+**PRs merged:** 2
+
+---
+
+## Summary
+
+A light refactor day with one substantive improvement. The daily housekeeping PR landed in the morning, followed by a type-safety cleanup in the afternoon that removed 22 redundant casts across the tool layer — a clean-up that had been accumulating since the plugin context type was left as `any`.
+
+## What shipped
+
+### [#902 chore(daily): 2026-05-27 daily update](https://github.com/allenhutchison/obsidian-gemini/pull/902)
+
+Automated daily housekeeping for May 27, covering the May 26 changelog. The May 26 day was quiet — a single administrative PR (the daily-update for May 25 documenting eight PRs including the eval-strike closure and the four registry-compliance refactors). Merged at 11:46 AM PDT.
+
+### [#900 refactor(tools): type ToolExecutionContext.plugin as ObsidianGemini](https://github.com/allenhutchison/obsidian-gemini/pull/900)
+
+Replaced the `any` placeholder on `ToolExecutionContext.plugin` with the concrete `ObsidianGemini` type, eliminating 22 redundant `as ObsidianGemini` casts that appeared at the top of every tool body. Also cleaned up three additional casts in `execution-engine.ts` and fixed a wrong `(this.plugin as any).logger` cast — `logger` is publicly declared on `main.ts` and needs neither a cast nor optional chaining. The `AGENTS.md` contributor handbook was updated with a one-liner noting that no cast is needed when accessing `context.plugin` in tool implementations. Fixes #856. TypeScript check, tests (2937 across 127 files), build, lint, and format-check all pass; the runtime JS is byte-identical since `import type` and casts are erased at compile time. Merged at 5:10 PM PDT.


### PR DESCRIPTION
## Summary

Automated daily housekeeping for 2026-05-28. Covers the May 27 changelog (2 PRs) and fixes 2 doc drift items found by the audit.

## Changes

- **Add `planning/changelog/2026-05-27.md`**: Documents the two PRs that merged on May 27 PDT — PR #902 (daily housekeeping covering May 26) and PR #900 (ToolExecutionContext.plugin type-safety refactor, eliminating 22 redundant casts across the tool layer).
- **Fix `docs/guide/context-system.md` line 171**: The context window size claim was wrong — changed "~2M tokens for Gemini 2.5+" to "~1M tokens for current Gemini models". The plugin's `context-manager.ts` uses `DEFAULT_INPUT_TOKEN_LIMIT = 1_000_000` as the assumed limit; the 2M figure was a user-facing overstatement.
- **Fix `docs/reference/settings.md`**: `autoRunCatchUp` and `hooksEnabled` were documented inside the `## UI Settings` section but actually appear in the plugin's **Automation** settings panel. Added a dedicated `## Automation Settings` section, updated the Table of Contents entry, and moved the `expandedSettingsSections` entry to its correct position within UI Settings.

## Sub-skill outcomes

- **daily-changelog**: wrote `planning/changelog/2026-05-27.md`, 2 PRs (daily-housekeeping #902 + ToolExecutionContext type-safety refactor #900)
- **audit-docs**: fixed 2 drift items — `context-system.md` (2M→1M token limit claim), `settings.md` (Automation settings misplaced under UI Settings; added dedicated section + ToC entry)
- **triage-issues**: 0 unlabeled open issues — tracker is clean

## Screenshots / Screencast

N/A — changelog and doc fixes only.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: daily housekeeping
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A: changelog and docs only
- [x] Documentation has been updated (if applicable) — this PR IS the documentation update
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01P86dxicg64C84nYxxKv25q)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated context token limits guidance to align with current Gemini model specifications
  * Reorganized settings reference documentation with improved structure and clearer section hierarchy
  * Enhanced documentation of expandable settings sections including configuration options and pre-expansion capabilities
  * Added May 27, 2026 changelog entry documenting recent system updates

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/allenhutchison/obsidian-gemini/pull/905?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->