### PR TITLE
fix(error-utils): drop overly broad 'service' substring match

### DIFF
--- a/src/utils/error-utils.ts
+++ b/src/utils/error-utils.ts
@@ -208,7 +208,12 @@ export function getErrorMessage(error: unknown): string {
 		}
 
 		// Service unavailable
-		if (messageLower.includes('unavailable') || messageLower.includes('service')) {
+		// Note: only match on "unavailable" — the bare substring "service" appears
+		// in non-outage errors like SERVICE_DISABLED (a configuration/permission
+		// problem) and would otherwise mislead users to chase a Google outage
+		// that isn't happening. Genuine 503s are still covered by the HTTP
+		// status-code path in getHttpErrorMessage.
+		if (messageLower.includes('unavailable')) {
 			return 'The model API is temporarily unavailable. Please try again later.';
 		}
 

--- a/test/utils/error-utils.test.ts
+++ b/test/utils/error-utils.test.ts
@@ -209,6 +209,27 @@ describe('error-utils', () => {
 				expect(getErrorMessage(error)).toBe('The model API is temporarily unavailable. Please try again later.');
 			});
 
+			test('SERVICE_DISABLED 403 is not reported as a temporary outage', () => {
+				// Regression for #861: the bare "service" substring used to map this
+				// configuration error onto the outage message. With a 403 status the
+				// HTTP path should surface the access-forbidden copy instead.
+				const error = {
+					status: 403,
+					message: 'SERVICE_DISABLED: Generative Language API has not been used in project xyz',
+				};
+				expect(getErrorMessage(error)).toBe(
+					'Access forbidden: The model provider denied access to this model or feature.'
+				);
+			});
+
+			test('Service-account error message is not reported as a temporary outage', () => {
+				// Another #861 regression — message contains "service" but is not an
+				// outage. Without an unavailable signal or HTTP status we should fall
+				// through to the generic message-prefixed copy.
+				const error = new Error('service account credentials are missing required scope');
+				expect(getErrorMessage(error)).toBe('API error: service account credentials are missing required scope');
+			});
+
 			test('Safety filter error', () => {
 				const error = new Error('Content blocked by safety filters');
 				expect(getErrorMessage(error)).toBe('Content was blocked by safety filters. Please rephrase your request.');


### PR DESCRIPTION
## Summary

Fixes #861. The `Service unavailable` branch in `getErrorMessage()` was matching the bare substring `service`, which incorrectly mapped configuration/permission errors like `SERVICE_DISABLED` and `service account ...` onto the `The model API is temporarily unavailable. Please try again later.` outage message — sending users to chase a Google outage that wasn't happening.

Only match on `unavailable` now. Genuine 503s remain covered by the HTTP status-code path in `getHttpErrorMessage` (`case 503`), so no real-outage coverage is lost.

## Changes

- `src/utils/error-utils.ts`: drop the bare `'service'` substring from the unavailable branch; add a short comment explaining why.
- `test/utils/error-utils.test.ts`: add two regression tests — a 403 `SERVICE_DISABLED` (maps to the access-forbidden copy via the HTTP path) and a `service account ...` credential error (falls through to the generic `API error: …` copy).

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer (#861)
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop — Vitest suite (2948 tests) passes locally
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — pure error-message mapping, no platform-specific code
- [x] Documentation has been updated (if applicable) — N/A, no user-facing docs reference these internal error strings (`grep -r 'temporarily unavailable\|SERVICE_DISABLED\|Service unavailable' docs/ README.md` returned no matches)
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error message detection to prevent false service outage alerts. The system previously misidentified certain errors as temporary outages. It now correctly distinguishes between actual unavailability and other error types, such as permission or configuration issues, ensuring users receive accurate error information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/allenhutchison/obsidian-gemini/pull/906?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->