### PR TITLE
refactor(agent): drop unused AgentFactory methods (#855)

### DIFF
--- a/src/agent/agent-factory.ts
+++ b/src/agent/agent-factory.ts
@@ -1,58 +1,13 @@
 import type ObsidianGemini from '../main';
 import { ModelApi } from '../api/interfaces/model-api';
 import { ModelClientFactory } from '../api';
-import { SessionManager } from './session-manager';
-import { ToolExecutionEngine } from '../tools/execution-engine';
-import { ToolRegistry } from '../tools/tool-registry';
-import { ChatSession, SessionModelConfig } from '../types/agent';
-import { App } from 'obsidian';
-
-/**
- * Configuration for creating an agent
- */
-export interface AgentConfig {
-	session: ChatSession;
-	toolRegistry: ToolRegistry;
-	executionEngine: ToolExecutionEngine;
-	modelConfig?: SessionModelConfig;
-}
+import { ChatSession } from '../types/agent';
 
 /**
  * Factory for creating agent-related components
  * Centralizes the creation and configuration of agent mode
  */
 export class AgentFactory {
-	/**
-	 * Create a complete agent setup
-	 *
-	 * @param plugin The plugin instance
-	 * @param app The Obsidian app instance
-	 * @returns Agent components
-	 */
-	static createAgent(
-		plugin: ObsidianGemini,
-		_app: App
-	): {
-		sessionManager: SessionManager;
-		toolRegistry: ToolRegistry;
-		executionEngine: ToolExecutionEngine;
-	} {
-		// Create session manager
-		const sessionManager = new SessionManager(plugin);
-
-		// Create tool registry
-		const toolRegistry = new ToolRegistry(plugin);
-
-		// Create execution engine
-		const executionEngine = new ToolExecutionEngine(plugin, toolRegistry);
-
-		return {
-			sessionManager,
-			toolRegistry,
-			executionEngine,
-		};
-	}
-
 	/**
 	 * Create a model API for agent mode with session configuration
 	 *
@@ -61,42 +16,6 @@ export class AgentFactory {
 	 * @returns Configured ModelApi instance
 	 */
 	static createAgentModel(plugin: ObsidianGemini, session: ChatSession): ModelApi {
-		// Use session's model configuration if available
 		return ModelClientFactory.createChatModel(plugin, session.modelConfig);
-	}
-
-	/**
-	 * Create a model API for a specific agent task
-	 *
-	 * @param plugin The plugin instance
-	 * @param config Agent configuration
-	 * @param taskType Optional task type for specialized models
-	 * @returns Configured ModelApi instance
-	 */
-	static createAgentTaskModel(
-		plugin: ObsidianGemini,
-		config: AgentConfig,
-		_taskType?: 'summarize' | 'research' | 'code'
-	): ModelApi {
-		// For now, use the session's model config for all tasks
-		// In the future, we might want different models for different tasks
-		return this.createAgentModel(plugin, config.session);
-	}
-
-	/**
-	 * Initialize agent components for the plugin
-	 *
-	 * @param plugin The plugin instance
-	 */
-	static async initializeAgent(plugin: ObsidianGemini): Promise<void> {
-		// This would be called during plugin load to set up agent infrastructure
-		const { sessionManager, toolRegistry, executionEngine } = this.createAgent(plugin, plugin.app);
-
-		// Store references in the plugin
-		(plugin as any).sessionManager = sessionManager;
-		(plugin as any).toolRegistry = toolRegistry;
-		(plugin as any).executionEngine = executionEngine;
-
-		// Session manager doesn't need initialization
 	}
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,8 +65,6 @@ export { ModelClientFactory, ModelUseCase } from './api/factory';
 
 export { AgentFactory } from './agent/agent-factory';
 
-export type { AgentConfig } from './agent/agent-factory';
-
 // API Configuration Types
 export type { ApiConfig, ModelConfig, RetryConfig, ApiFeatures } from './api/config/model-config';
 

--- a/test/agent/agent-factory.test.ts
+++ b/test/agent/agent-factory.test.ts
@@ -1,14 +1,7 @@
 import { AgentFactory } from '../../src/agent/agent-factory';
-import { SessionManager } from '../../src/agent/session-manager';
-import { ToolRegistry } from '../../src/tools/tool-registry';
-import { ToolExecutionEngine } from '../../src/tools/execution-engine';
 import { ModelClientFactory } from '../../src/api';
 import type { ChatSession, SessionModelConfig } from '../../src/types/agent';
 
-// Mock dependencies at module level
-vi.mock('../../src/agent/session-manager');
-vi.mock('../../src/tools/tool-registry');
-vi.mock('../../src/tools/execution-engine');
 vi.mock('../../src/api', () => ({
 	ModelClientFactory: {
 		createChatModel: vi.fn().mockReturnValue({ generateModelResponse: vi.fn() }),
@@ -62,43 +55,6 @@ describe('AgentFactory', () => {
 		vi.clearAllMocks();
 	});
 
-	describe('createAgent', () => {
-		it('should return sessionManager, toolRegistry, and executionEngine', () => {
-			const plugin = createMockPlugin();
-
-			const result = AgentFactory.createAgent(plugin, plugin.app);
-
-			expect(result).toHaveProperty('sessionManager');
-			expect(result).toHaveProperty('toolRegistry');
-			expect(result).toHaveProperty('executionEngine');
-		});
-
-		it('should create a SessionManager with the plugin', () => {
-			const plugin = createMockPlugin();
-
-			AgentFactory.createAgent(plugin, plugin.app);
-
-			expect(SessionManager).toHaveBeenCalledWith(plugin);
-		});
-
-		it('should create a ToolRegistry with the plugin', () => {
-			const plugin = createMockPlugin();
-
-			AgentFactory.createAgent(plugin, plugin.app);
-
-			expect(ToolRegistry).toHaveBeenCalledWith(plugin);
-		});
-
-		it('should create a ToolExecutionEngine with the plugin and toolRegistry', () => {
-			const plugin = createMockPlugin();
-
-			AgentFactory.createAgent(plugin, plugin.app);
-
-			// ToolExecutionEngine receives the plugin and the ToolRegistry instance
-			expect(ToolExecutionEngine).toHaveBeenCalledWith(plugin, expect.any(Object));
-		});
-	});
-
 	describe('createAgentModel', () => {
 		it('should delegate to ModelClientFactory.createChatModel with session model config', () => {
 			const plugin = createMockPlugin();
@@ -133,55 +89,6 @@ describe('AgentFactory', () => {
 			const result = AgentFactory.createAgentModel(plugin, session);
 
 			expect(result).toBe(mockApi);
-		});
-	});
-
-	describe('createAgentTaskModel', () => {
-		it('should delegate to createAgentModel with the session from config', () => {
-			const plugin = createMockPlugin();
-			const modelConfig: SessionModelConfig = { model: 'gemini-2.5-pro' };
-			const session = createMockSession({ modelConfig });
-			const config = {
-				session,
-				toolRegistry: {} as any,
-				executionEngine: {} as any,
-				modelConfig,
-			};
-
-			AgentFactory.createAgentTaskModel(plugin, config);
-
-			// Should ultimately call createChatModel with the session's modelConfig
-			expect(ModelClientFactory.createChatModel).toHaveBeenCalledWith(plugin, modelConfig);
-		});
-
-		it('should ignore the taskType parameter (currently unused)', () => {
-			const plugin = createMockPlugin();
-			const session = createMockSession();
-			const config = {
-				session,
-				toolRegistry: {} as any,
-				executionEngine: {} as any,
-			};
-
-			// All task types should produce the same result
-			AgentFactory.createAgentTaskModel(plugin, config, 'summarize');
-			AgentFactory.createAgentTaskModel(plugin, config, 'research');
-			AgentFactory.createAgentTaskModel(plugin, config, 'code');
-
-			// All three calls delegate to createChatModel with the same session config
-			expect(ModelClientFactory.createChatModel).toHaveBeenCalledTimes(3);
-		});
-	});
-
-	describe('initializeAgent', () => {
-		it('should store sessionManager, toolRegistry, and executionEngine on the plugin', async () => {
-			const plugin = createMockPlugin();
-
-			await AgentFactory.initializeAgent(plugin);
-
-			expect((plugin as any).sessionManager).toBeDefined();
-			expect((plugin as any).toolRegistry).toBeDefined();
-			expect((plugin as any).executionEngine).toBeDefined();
 		});
 	});
 


### PR DESCRIPTION
## Summary

Address #855 by deleting the three `AgentFactory` static methods that had no production callers and the now-unused `AgentConfig` interface.

The real wiring of `sessionManager` / `toolRegistry` / `toolExecutionEngine` happens in `LifecycleService.initializeReinitializableServices` ([src/services/lifecycle-service.ts:440](src/services/lifecycle-service.ts:440)), so `AgentFactory.createAgent` and `initializeAgent` were parallel never-called copies of that work.

`initializeAgent` also contained a latent bug — it assigned `(plugin as any).executionEngine = executionEngine`, but the field on `main.ts:193` is `toolExecutionEngine`. The `as any` cast hid the typo from the compiler, and the assignment would silently land on a dead property if anything ever called it. Deleting the method removes the trap.

This is the issue's recommended Option A. `AgentFactory.createAgentModel` is the only method with real callers ([src/ui/agent-view/agent-view-send.ts:361](src/ui/agent-view/agent-view-send.ts:361), [src/agent/agent-loop.ts:202](src/agent/agent-loop.ts:202)) and is kept. `AgentFactory` itself remains exported from `src/index.ts` as the home for that method.

Fixes #855

## Changes

- Delete `AgentFactory.createAgent`, `createAgentTaskModel`, and `initializeAgent` from [src/agent/agent-factory.ts](src/agent/agent-factory.ts).
- Delete the `AgentConfig` interface from the same file (only referenced by the deleted `createAgentTaskModel`).
- Remove the `AgentConfig` re-export from [src/index.ts](src/index.ts).
- Drop the now-unused imports (`App`, `SessionManager`, `ToolExecutionEngine`, `ToolRegistry`, `SessionModelConfig`) from [src/agent/agent-factory.ts](src/agent/agent-factory.ts).
- Remove the corresponding `describe` blocks (`createAgent`, `createAgentTaskModel`, `initializeAgent`) and now-unused mocks/imports from [test/agent/agent-factory.test.ts](test/agent/agent-factory.test.ts); keep `createAgentModel` and `error handling`.

Net diff: 177 lines removed, 1 added.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer
- [x] All CI checks pass (\`npm test\`, \`npm run build\`, \`npm run format-check\`)
- [x] I have tested this change on Desktop — verified via \`npm test\` (2939/2939 passing) and \`npm run build\` (clean).
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — pure code deletion of unused methods; no platform-specific behavior touched.
- [x] Documentation has been updated (if applicable) — N/A. No user-facing docs reference the removed methods; \`AGENTS.md\`'s only \`AgentFactory\` mention is the \`AgentLoop\` cycle-break note, which still applies to the remaining \`createAgentModel\`.
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the agent factory public API by removing redundant factory methods and configuration interfaces.
  * Streamlined the remaining factory method to directly return configured models.
  * Updated public exports to reflect the simplified API surface.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/allenhutchison/obsidian-gemini/pull/907?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->