### PR TITLE
feat(models): add in-app refresh for the remote Gemini model list

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Gemini Scribe is an Obsidian plugin that integrates Google's Gemini AI models, p
     - **Advanced Settings:** (Click "Show Advanced Settings" to reveal)
       - **Temperature:** Control AI creativity and randomness (0-2.0, automatically adjusted based on available models).
       - **Top P:** Control response diversity and focus (0-1.0).
-      - **Model Discovery:** Gemini models are automatically fetched on startup; Ollama users can click **Refresh model list** after pulling new models.
+      - **Model Discovery:** Gemini models are automatically fetched on startup (cached for 24h); click **Refresh model list** in General settings or run the "Gemini Scribe: Refresh model list" command to fetch a newly-published model immediately. Ollama users can click the same **Refresh model list** button after pulling new models.
       - **API Configuration:** Configure retry behavior and backoff delays.
       - **Tool Execution:** Control whether to stop agent execution on tool errors.
       - **Tool Loop Detection:** Prevent infinite tool execution loops.

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -100,7 +100,7 @@ UI sections without a dedicated topic in this reference: _Vault Search Index_ (c
 
 The active model list depends on the [`provider`](#provider) setting:
 
-- **Gemini (default)** — models are selected from the bundled Gemini list, refreshed from Google's API on startup so the latest models appear automatically. `imageModelName` is only available on this provider.
+- **Gemini (default)** — models are loaded from the bundled list and auto-refreshed from GitHub on startup (cached for 24h). `imageModelName` is only available on this provider. Click **Refresh model list** in Settings → General — or run the **Gemini Scribe: Refresh model list** command — to fetch the latest list immediately (bypasses the cache).
 - **Ollama** — the chat / summary / completion dropdowns are populated from `GET <ollamaBaseUrl>/api/tags`, listing whatever you have pulled. Click "Refresh model list" in settings if a freshly pulled model doesn't appear. Image generation is unavailable in this mode.
 
 ### Chat Model
@@ -338,7 +338,9 @@ Advanced settings for developers and power users. Access by clicking "Show Advan
 
 ### Model Discovery
 
-Model discovery is automatic — no user-configurable settings are required. On startup, the plugin fetches the latest available Gemini models from Google's API and falls back to the bundled list if the fetch fails. When using the Ollama provider, a **Refresh model list** button appears in Settings → General to re-query the Ollama daemon for newly pulled models. The remote model list is cached in `data.json` under `remoteModelCache` (managed internally; do not edit by hand).
+Model discovery is automatic — no user-configurable settings are required. On startup, the plugin fetches the latest available Gemini models from GitHub and falls back to the bundled list if the fetch fails. The remote list is cached in `data.json` under `remoteModelCache` for 24 hours; subsequent reloads within that window are no-ops.
+
+To pick up a newly-published model without waiting for the cache to expire, click **Refresh model list** in Settings → General, or run the **Gemini Scribe: Refresh model list** command (`gemini-scribe-refresh-model-list`). Both honor the same skip conditions as the auto-fetch — they no-op when the provider is Ollama or the host reports offline, and surface the outcome via a `Notice`. When the Ollama provider is active, the same row appears but re-queries the Ollama daemon for newly pulled models instead.
 
 ### Tool Execution
 
@@ -493,7 +495,7 @@ Available permission bypasses:
 ### Models not appearing
 
 1. Check API key is valid
-2. For Gemini: restart Obsidian — model discovery runs automatically on startup
+2. For Gemini: click **Refresh** in the **Refresh model list** row (Settings → General), or run the **Gemini Scribe: Refresh model list** command. The auto-fetch runs at most once every 24 hours, so a freshly published model won't appear until the cache expires unless you force a refresh.
 3. For Ollama: go to Settings → General and click **Refresh** in the **Refresh model list** row after pulling new models
 4. Check console for errors (with Debug Mode enabled)
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,6 @@
 import { Plugin, WorkspaceLeaf, Editor, MarkdownView, MarkdownFileInfo, Platform } from 'obsidian';
 import ObsidianGeminiSettingTab from './ui/settings';
+import { refreshGeminiModelList } from './ui/settings-general';
 import { AgentView, VIEW_TYPE_AGENT } from './ui/agent-view/agent-view';
 import { GeminiDiffView, VIEW_TYPE_DIFF } from './ui/agent-view/gemini-diff-view';
 import { GeminiSummary } from './summary';
@@ -355,6 +356,16 @@ export default class ObsidianGemini extends Plugin {
 			callback: () => {
 				if (!this.checkInitialized()) return;
 				this.activateAgentView();
+			},
+		});
+
+		// Refresh remote Gemini model list (bypass 24h cache)
+		this.addCommand({
+			id: 'gemini-scribe-refresh-model-list',
+			name: 'Refresh model list',
+			callback: async () => {
+				if (!this.checkInitialized()) return;
+				await refreshGeminiModelList(this);
 			},
 		});
 

--- a/src/services/model-list-provider.ts
+++ b/src/services/model-list-provider.ts
@@ -13,6 +13,14 @@ interface ModelListJson {
 const REMOTE_URL = 'https://raw.githubusercontent.com/allenhutchison/obsidian-gemini/master/src/data/models.json';
 const CACHE_DURATION = 24 * 60 * 60 * 1000; // 24 hours
 
+export type RefreshSkippedReason = 'provider' | 'offline';
+
+export interface RefreshResult {
+	fetched: boolean;
+	modelCount: number;
+	skippedReason?: RefreshSkippedReason;
+}
+
 export class ModelListProvider {
 	private plugin: ObsidianGemini;
 	private bundledModels: GeminiModel[];
@@ -74,6 +82,31 @@ export class ModelListProvider {
 		this.fetchRemoteModels().catch((error) => {
 			this.plugin.logger.warn('[ModelListProvider] Remote fetch failed:', error);
 		});
+	}
+
+	/**
+	 * User-triggered refresh that bypasses the 24h cache. Resolves with a result
+	 * the caller can surface as a `Notice`. Honors the same provider/offline gates
+	 * as `startRemoteFetch()` — when those skip, the cache timestamp is left alone
+	 * (resetting it would force the next auto-fetch to run even though the user's
+	 * conditions blocked this one). Rejects on network/schema errors so the caller
+	 * can show the message.
+	 */
+	async refresh(): Promise<RefreshResult> {
+		const provider = this.plugin.settings?.provider ?? 'gemini';
+		if (provider !== 'gemini') {
+			this.plugin.logger.debug(`[ModelListProvider] refresh skipped (provider=${provider})`);
+			return { fetched: false, modelCount: this.getModels().length, skippedReason: 'provider' };
+		}
+
+		if (typeof navigator !== 'undefined' && navigator.onLine === false) {
+			this.plugin.logger.debug('[ModelListProvider] refresh skipped (navigator reports offline)');
+			return { fetched: false, modelCount: this.getModels().length, skippedReason: 'offline' };
+		}
+
+		this.cacheTimestamp = 0;
+		await this.fetchRemoteModels();
+		return { fetched: true, modelCount: this.getModels().length };
 	}
 
 	/**

--- a/src/services/model-manager.ts
+++ b/src/services/model-manager.ts
@@ -1,7 +1,7 @@
 import type ObsidianGemini from '../main';
 import * as modelsModule from '../models';
 import { GeminiModel, ModelUpdateResult, getUpdatedModelSettings, DEFAULT_GEMINI_MODELS } from '../models';
-import { ModelListProvider } from './model-list-provider';
+import { ModelListProvider, RefreshResult } from './model-list-provider';
 import { OllamaModelsService } from './ollama-models-service';
 import { ParameterValidationService, ParameterRanges } from './parameter-validation';
 
@@ -98,6 +98,20 @@ export class ModelManager {
 	 */
 	getListProvider(): ModelListProvider {
 		return this.listProvider;
+	}
+
+	/**
+	 * Force-refresh the remote Gemini model list (bypassing the 24h cache) and
+	 * sync the global model array so any open dropdowns see the new entries.
+	 * Provider/offline gates are enforced by `ModelListProvider.refresh()`; on a
+	 * skip we leave the global list untouched.
+	 */
+	async refreshRemoteModels(): Promise<RefreshResult> {
+		const result = await this.listProvider.refresh();
+		if (result.fetched) {
+			this.updateGlobalModelsList(this.listProvider.getModels());
+		}
+		return result;
 	}
 
 	/**

--- a/src/ui/settings-general.ts
+++ b/src/ui/settings-general.ts
@@ -126,6 +126,20 @@ async function renderGeneralSection(
 					await plugin.saveSettings();
 				})
 			);
+
+		new Setting(sectionEl)
+			.setName('Refresh model list')
+			.setDesc(
+				'Fetch the latest Gemini model list from GitHub now, bypassing the 24h cache. Use this after a new model is published.'
+			)
+			.addButton((button) =>
+				button.setButtonText('Refresh').onClick(async () => {
+					await refreshGeminiModelList(plugin, async () => {
+						sectionEl.empty();
+						await renderGeneralSection(sectionEl, plugin, app, context, debouncedSave);
+					});
+				})
+			);
 	}
 
 	await selectModelSetting(
@@ -184,4 +198,27 @@ async function renderGeneralSection(
 				context.redisplay();
 			})
 		);
+}
+
+/**
+ * Trigger a Gemini model-list refresh and surface the outcome via `Notice`.
+ * Shared between the settings button and the command-palette entry so both
+ * paths report the same skip/error/success messages.
+ */
+export async function refreshGeminiModelList(
+	plugin: ObsidianGemini,
+	onSuccess?: () => void | Promise<void>
+): Promise<void> {
+	try {
+		const result = await plugin.getModelManager().refreshRemoteModels();
+		if (result.fetched) {
+			new Notice(`Model list updated: ${result.modelCount} model${result.modelCount === 1 ? '' : 's'}.`);
+			if (onSuccess) await onSuccess();
+			return;
+		}
+		const reasonMessage = result.skippedReason === 'offline' ? 'Skipped: offline' : 'Skipped: provider is not Gemini';
+		new Notice(reasonMessage);
+	} catch (error) {
+		new Notice(`Failed to refresh model list: ${getErrorMessage(error)}`);
+	}
 }

--- a/src/ui/settings-general.ts
+++ b/src/ui/settings-general.ts
@@ -219,6 +219,7 @@ export async function refreshGeminiModelList(
 		const reasonMessage = result.skippedReason === 'offline' ? 'Skipped: offline' : 'Skipped: provider is not Gemini';
 		new Notice(reasonMessage);
 	} catch (error) {
+		plugin.logger.error('Failed to refresh Gemini model list:', error);
 		new Notice(`Failed to refresh model list: ${getErrorMessage(error)}`);
 	}
 }

--- a/test/services/model-list-provider.test.ts
+++ b/test/services/model-list-provider.test.ts
@@ -237,6 +237,93 @@ describe('ModelListProvider.getMaxTemperature', () => {
 	});
 });
 
+describe('ModelListProvider.refresh', () => {
+	let originalDescriptor: PropertyDescriptor | undefined;
+
+	beforeEach(() => {
+		mockedRequestUrl.mockReset();
+		originalDescriptor = Object.getOwnPropertyDescriptor(window.navigator, 'onLine');
+	});
+
+	afterEach(() => {
+		if (originalDescriptor) {
+			Object.defineProperty(window.navigator, 'onLine', originalDescriptor);
+		} else {
+			delete (window.navigator as { onLine?: boolean }).onLine;
+		}
+	});
+
+	const setOnline = (value: boolean) => {
+		Object.defineProperty(window.navigator, 'onLine', {
+			configurable: true,
+			get: () => value,
+		});
+	};
+
+	it('returns provider skip reason when active provider is not gemini', async () => {
+		const plugin = buildPlugin({ provider: 'ollama' });
+		setOnline(true);
+
+		const provider = new ModelListProvider(plugin);
+		const result = await provider.refresh();
+
+		expect(result.fetched).toBe(false);
+		expect(result.skippedReason).toBe('provider');
+		expect(result.modelCount).toBeGreaterThan(0);
+		expect(mockedRequestUrl).not.toHaveBeenCalled();
+	});
+
+	it('returns offline skip reason when navigator reports offline', async () => {
+		const plugin = buildPlugin();
+		setOnline(false);
+
+		const provider = new ModelListProvider(plugin);
+		const result = await provider.refresh();
+
+		expect(result.fetched).toBe(false);
+		expect(result.skippedReason).toBe('offline');
+		expect(mockedRequestUrl).not.toHaveBeenCalled();
+	});
+
+	it('bypasses the 24h cache and fetches on success', async () => {
+		const plugin = buildPlugin();
+		setOnline(true);
+		plugin.settings.remoteModelCache = {
+			models: [{ value: 'stale-cached', label: 'Stale' }],
+			timestamp: Date.now(), // fresh cache that startRemoteFetch() would normally skip
+		};
+		mockedRequestUrl.mockResolvedValue({
+			status: 200,
+			json: {
+				version: 1,
+				lastUpdated: '2026-05-28',
+				models: [
+					{ value: 'fresh-1', label: 'Fresh 1' },
+					{ value: 'fresh-2', label: 'Fresh 2' },
+				],
+			},
+		});
+
+		const provider = new ModelListProvider(plugin);
+		provider.initialize();
+		const result = await provider.refresh();
+
+		expect(mockedRequestUrl).toHaveBeenCalledTimes(1);
+		expect(result.fetched).toBe(true);
+		expect(result.modelCount).toBe(2);
+		expect(provider.getModels().map((m) => m.value)).toEqual(['fresh-1', 'fresh-2']);
+	});
+
+	it('rejects when the network fetch fails so the caller can surface the error', async () => {
+		const plugin = buildPlugin();
+		setOnline(true);
+		mockedRequestUrl.mockResolvedValue({ status: 500, json: {} });
+
+		const provider = new ModelListProvider(plugin);
+		await expect(provider.refresh()).rejects.toThrow(/HTTP 500/);
+	});
+});
+
 describe('ModelListProvider.fetchRemoteModels error handling', () => {
 	let originalDescriptor: PropertyDescriptor | undefined;
 

--- a/test/services/model-manager.test.ts
+++ b/test/services/model-manager.test.ts
@@ -190,6 +190,43 @@ describe('ModelManager', () => {
 		});
 	});
 
+	describe('refreshRemoteModels', () => {
+		it('delegates to ModelListProvider.refresh and syncs global models on success', async () => {
+			const fetched = [
+				{ value: 'refreshed-1', label: 'Refreshed 1' },
+				{ value: 'refreshed-2', label: 'Refreshed 2' },
+			];
+			const listProvider = modelManager.getListProvider();
+			const refreshSpy = vi
+				.spyOn(listProvider, 'refresh')
+				.mockResolvedValue({ fetched: true, modelCount: fetched.length });
+			vi.spyOn(listProvider, 'getModels').mockReturnValue(fetched);
+			setGeminiModels([]);
+
+			const result = await modelManager.refreshRemoteModels();
+
+			expect(refreshSpy).toHaveBeenCalledTimes(1);
+			expect(result).toEqual({ fetched: true, modelCount: 2 });
+			expect(GEMINI_MODELS.map((m) => m.value)).toEqual(['refreshed-1', 'refreshed-2']);
+		});
+
+		it('does not update the global list when refresh is skipped', async () => {
+			const before = [{ value: 'before', label: 'Before' }];
+			setGeminiModels(before);
+			vi.spyOn(modelManager.getListProvider(), 'refresh').mockResolvedValue({
+				fetched: false,
+				modelCount: 0,
+				skippedReason: 'offline',
+			});
+
+			const result = await modelManager.refreshRemoteModels();
+
+			expect(result.fetched).toBe(false);
+			expect(result.skippedReason).toBe('offline');
+			expect(GEMINI_MODELS).toEqual(before);
+		});
+	});
+
 	describe('getParameterDisplayInfo', () => {
 		it('should return display strings and hasModelData flag', async () => {
 			const info = await modelManager.getParameterDisplayInfo();


### PR DESCRIPTION
## Summary

Adds an in-app refresh path for the Gemini remote model list so users no longer have to wait up to 24h (or use the dev console) to pick up a newly-published model.

Fixes #852

## Changes

- **`ModelListProvider.refresh()`** — Public, awaitable refresh that resets `cacheTimestamp = 0` and re-fetches `src/data/models.json`. Honors the existing provider and offline gates and returns `{ fetched, modelCount, skippedReason? }` so callers can report the outcome. Rejects on network/schema errors.
- **`ModelManager.refreshRemoteModels()`** — Thin wrapper that delegates to the list provider and, on success, syncs the global `GEMINI_MODELS` array so any open dropdowns reflect the new entries.
- **Settings button** — "Refresh model list" row in Settings → General (Gemini branch), mirroring the existing Ollama refresh.
- **Command palette** — New `gemini-scribe-refresh-model-list` command ("Gemini Scribe: Refresh model list").
- **Shared `refreshGeminiModelList()` helper** — Surfaces the outcome via `Notice` for success (`Model list updated: N models`), skip (`Skipped: offline` / `Skipped: provider is not Gemini`), or error (`Failed to refresh model list: <message>`). Used by both the settings button and the command.
- **Tests** — 4 new cases for `ModelListProvider.refresh()` (provider skip, offline skip, cache-bypass success, error propagation) and 2 for `ModelManager.refreshRemoteModels()` (delegation + global-list sync on success, no sync on skip).
- **Docs** — Updated `docs/reference/settings.md` (Model Configuration intro, Model Discovery section, Troubleshooting) and `README.md` to mention the new button and command.

The existing `startRemoteFetch()` auto-fetch path on plugin load is unchanged.

## Screenshots / Screencast

Backend + settings-row change; the new row uses the same `Setting().addButton()` pattern as the existing Ollama "Refresh model list" entry directly above it.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards)
- [x] Documentation has been updated (if applicable)
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude (Claude Code)
- [x] I have reviewed and understand all AI-generated code in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Refresh model list" button in General settings and a "Gemini Scribe: Refresh model list" command to manually refresh Gemini models.

* **Documentation**
  * Clarified that Gemini models are auto-fetched on startup, cached for 24 hours, and can be refreshed immediately via the settings button or command. Troubleshooting guidance updated to use the refresh action instead of restarting.

* **Tests**
  * Added tests covering the manual refresh flow, cache bypass, offline/provider skip behavior, and error handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/allenhutchison/obsidian-gemini/pull/908?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->