### PR TITLE
feat: configurable headless tool-iteration cap for tasks and hooks

### DIFF
--- a/docs/guide/lifecycle-hooks.md
+++ b/docs/guide/lifecycle-hooks.md
@@ -117,7 +117,7 @@ An `agent-task` fire drives an agent loop that calls tools, reads the results, a
 
 When a fire exhausts the cap without producing a response, it fails with an error like:
 
-```
+```text
 Hook "<slug>" exhausted 20 tool iterations without producing a response
 ```
 

--- a/docs/guide/lifecycle-hooks.md
+++ b/docs/guide/lifecycle-hooks.md
@@ -70,6 +70,7 @@ The user just saved {{filePath}}. Read it and write a one-paragraph summary high
 | `toolPolicy`        | No                     | _inherit global plugin policy_ | Per-fire tool policy (preset + per-tool overrides). Same shape used by projects and scheduled tasks — see [Tool Access](#tool-access) below.                                     |
 | `enabledSkills`     | No                     | `[]`                           | Skill slugs to pre-activate in the headless session.                                                                                                                             |
 | `model`             | No                     | Plugin chat model              | Override the model for this hook (e.g. `gemini-2.5-flash-lite`).                                                                                                                 |
+| `maxIterations`     | No                     | `20`                           | Cap on agent tool-call batches per fire (`agent-task` only). Raise it for long multi-step hooks that exhaust the default. See [Tool Iteration Limit](#tool-iteration-limit).     |
 | `outputPath`        | No                     | (no file written)              | Where to write the agent's final response. Supports `{slug}`, `{date}`, and `{fileName}` placeholders.                                                                           |
 | `enabled`           | No                     | `true`                         | Set to `false` to disable the hook without deleting it.                                                                                                                          |
 | `desktopOnly`       | No                     | `true`                         | When `true` the hook is skipped on mobile. Headless agent runs can be heavyweight on phones.                                                                                     |
@@ -109,6 +110,28 @@ toolPolicy:
 - An omitted `toolPolicy` block means "inherit the global plugin tool policy entirely."
 
 > **Legacy note** — older hook files used `enabledTools: ['read_only', …]` instead of `toolPolicy`. They still load: the plugin maps the old category list onto the closest preset and rewrites the file to the new shape the first time it is read.
+
+### Tool Iteration Limit
+
+An `agent-task` fire drives an agent loop that calls tools, reads the results, and calls more tools until it produces a final response. To guard against runaway loops in unattended fires, that loop is capped at **20 tool-call batches** by default. A batch is one round of tool calls (which may run several tools in parallel), not a single tool call.
+
+When a fire exhausts the cap without producing a response, it fails with an error like:
+
+```
+Hook "<slug>" exhausted 20 tool iterations without producing a response
+```
+
+If a legitimately long hook keeps hitting this, raise the cap with the `maxIterations` frontmatter key (or the **Max tool iterations** field under **Advanced options** in the hook editor):
+
+```yaml
+---
+trigger: file-modified
+action: agent-task
+maxIterations: 50
+---
+```
+
+`maxIterations` must be a positive whole number; blank or invalid values fall back to the default of 20. It only affects `agent-task` hooks — the other actions don't drive the agent loop. This is the same limit (and the same default) used by [scheduled tasks](./scheduled-tasks.md#tool-iteration-limit); the interactive agent chat has no such cap.
 
 ### `summarize`
 

--- a/docs/guide/scheduled-tasks.md
+++ b/docs/guide/scheduled-tasks.md
@@ -107,7 +107,7 @@ Each run drives an agent loop that calls tools, reads the results, and calls mor
 
 When a task exhausts the cap without producing a response, the run fails with an error like:
 
-```
+```text
 Task "<slug>" exhausted 20 tool iterations without producing a response
 ```
 

--- a/docs/guide/scheduled-tasks.md
+++ b/docs/guide/scheduled-tasks.md
@@ -42,14 +42,15 @@ Summarise the notes I created or modified today. List the key topics and any ope
 
 ### Frontmatter Fields
 
-| Field         | Required | Default                                                | Description                                                                                                                 |
-| ------------- | -------- | ------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------- |
-| `schedule`    | Yes      | —                                                      | When to run. See [Schedule Formats](#schedule-formats) below.                                                               |
-| `toolPolicy`  | No       | _inherit global plugin policy_                         | Per-run tool policy (preset + per-tool overrides). See [Tool Access](#tool-access).                                         |
-| `outputPath`  | No       | `[state-folder]/Scheduled-Tasks/Runs/<slug>/{date}.md` | Where to write results. Supports `{slug}` and `{date}` placeholders.                                                        |
-| `model`       | No       | Plugin chat model                                      | Override the model for this task (e.g. `gemini-flash-latest`).                                                              |
-| `enabled`     | No       | `true`                                                 | Set to `false` to disable the task without deleting it.                                                                     |
-| `runIfMissed` | No       | `false`                                                | When `true`, tasks missed while Obsidian was closed are caught up on the next startup. See [Catch-up Runs](#catch-up-runs). |
+| Field           | Required | Default                                                | Description                                                                                                                                             |
+| --------------- | -------- | ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `schedule`      | Yes      | —                                                      | When to run. See [Schedule Formats](#schedule-formats) below.                                                                                           |
+| `toolPolicy`    | No       | _inherit global plugin policy_                         | Per-run tool policy (preset + per-tool overrides). See [Tool Access](#tool-access).                                                                     |
+| `outputPath`    | No       | `[state-folder]/Scheduled-Tasks/Runs/<slug>/{date}.md` | Where to write results. Supports `{slug}` and `{date}` placeholders.                                                                                    |
+| `model`         | No       | Plugin chat model                                      | Override the model for this task (e.g. `gemini-flash-latest`).                                                                                          |
+| `maxIterations` | No       | `20`                                                   | Cap on agent tool-call batches per run. Raise it for long multi-step tasks that exhaust the default. See [Tool Iteration Limit](#tool-iteration-limit). |
+| `enabled`       | No       | `true`                                                 | Set to `false` to disable the task without deleting it.                                                                                                 |
+| `runIfMissed`   | No       | `false`                                                | When `true`, tasks missed while Obsidian was closed are caught up on the next startup. See [Catch-up Runs](#catch-up-runs).                             |
 
 ### Schedule Formats
 
@@ -99,6 +100,27 @@ toolPolicy:
 Omitting `toolPolicy` (or setting it to an empty object) means **inherit the global plugin tool policy**. The Scheduler UI exposes the same controls — picking a preset and adjusting per-tool overrides — so you usually don't need to author the YAML by hand.
 
 > **Legacy note** — older task files used `enabledTools: ['read_only', …]` instead of `toolPolicy`. They still load: the plugin maps the old category list onto the closest preset and rewrites the file to the new shape the first time it is read.
+
+## Tool Iteration Limit
+
+Each run drives an agent loop that calls tools, reads the results, and calls more tools until it produces a final response. To guard against runaway loops in unattended runs, that loop is capped at **20 tool-call batches** by default. A batch is one round of tool calls (which may run several tools in parallel), not a single tool call — so a task doing parallel work fits more real calls into 20 batches than a strictly sequential one.
+
+When a task exhausts the cap without producing a response, the run fails with an error like:
+
+```
+Task "<slug>" exhausted 20 tool iterations without producing a response
+```
+
+If a legitimately long task keeps hitting this, raise the cap with the `maxIterations` frontmatter key (or the **Max tool iterations** field under **Advanced options** in the Scheduler):
+
+```yaml
+---
+schedule: 'daily@06:00'
+maxIterations: 50
+---
+```
+
+`maxIterations` must be a positive whole number; blank or invalid values fall back to the default of 20. The interactive agent chat has no such cap — this limit applies only to unattended runs (scheduled tasks and lifecycle hooks).
 
 ## Managing Tasks
 

--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -140,6 +140,16 @@ export interface AgentLoopResult {
 const AGENT_LOOP_ABORT_THRESHOLD = 3;
 
 /**
+ * Default cap on tool-execution iterations for unattended (headless) runs —
+ * scheduled tasks and lifecycle hooks. Each iteration is one tool-call batch
+ * (which may contain several parallel calls), not a single tool call. Acts as a
+ * runaway-loop guard; callers can override it per run via
+ * `AgentLoopOptions.maxIterations` (exposed to users through the `maxIterations`
+ * frontmatter key on tasks and hooks). Interactive agent-view runs pass no cap.
+ */
+export const DEFAULT_HEADLESS_MAX_ITERATIONS = 20;
+
+/**
  * Drives the tool-execution loop after the initial model response. Iterates
  * until the model returns a text response (or cancellation / iteration cap /
  * empty-fallback fires). UI-agnostic — callers attach behavior via hooks.

--- a/src/services/feature-definition.ts
+++ b/src/services/feature-definition.ts
@@ -79,6 +79,21 @@ export function extractMarkdownBody(content: string): string {
 }
 
 /**
+ * Coerce a raw frontmatter `maxIterations` value into a positive integer, or
+ * undefined when absent/invalid. Invalid values (non-numbers, zero, negatives,
+ * non-integers) fall back to undefined so the runner applies its default cap
+ * (DEFAULT_HEADLESS_MAX_ITERATIONS) rather than a nonsensical limit. Shared by
+ * scheduled tasks and lifecycle hooks, which expose the same frontmatter key.
+ */
+export function parseMaxIterations(raw: unknown): number | undefined {
+	const value = typeof raw === 'string' ? Number(raw) : raw;
+	if (typeof value !== 'number' || !Number.isInteger(value) || value <= 0) {
+		return undefined;
+	}
+	return value;
+}
+
+/**
  * Resolve the tool policy for a feature definition from its frontmatter:
  * prefer the canonical `toolPolicy:` block, falling back to the legacy
  * `enabledTools:` category array. `undefined` means "inherit the global policy".

--- a/src/services/hook-manager.ts
+++ b/src/services/hook-manager.ts
@@ -397,10 +397,14 @@ export class HookManager {
 		if (this.hooks.has(slug)) throw new Error(`A hook named "${slug}" already exists`);
 
 		const filePath = normalizePath(`${this.hooksFolder}/${slug}.md`);
-		const content = this.serializeHook({ ...params, slug });
+		// Normalize at the write boundary so an invalid value from a programmatic
+		// caller can't be persisted or held in memory — matches the read-path
+		// contract (parseHookFile), where invalid values fall back to the default.
+		const normalizedParams = { ...params, maxIterations: parseMaxIterations(params.maxIterations) };
+		const content = this.serializeHook({ ...normalizedParams, slug });
 		await this.plugin.app.vault.create(filePath, content);
 
-		const hook: Hook = this.toHook(slug, filePath, params);
+		const hook: Hook = this.toHook(slug, filePath, normalizedParams);
 		this.hooks.set(slug, hook);
 		if (!this.state[slug]) {
 			this.state[slug] = {};
@@ -435,8 +439,9 @@ export class HookManager {
 			enabledSkills: params.enabledSkills ?? hook.enabledSkills,
 			model: params.model ?? hook.model ?? '',
 			// `in` check (not ??) so callers can clear back to the default by
-			// passing maxIterations: undefined explicitly.
-			maxIterations: 'maxIterations' in params ? params.maxIterations : hook.maxIterations,
+			// passing maxIterations: undefined explicitly. Normalize incoming
+			// values so an invalid number can't be persisted (matches parseHookFile).
+			maxIterations: 'maxIterations' in params ? parseMaxIterations(params.maxIterations) : hook.maxIterations,
 			outputPath: params.outputPath ?? hook.outputPath ?? '',
 			enabled: params.enabled ?? hook.enabled,
 			desktopOnly: params.desktopOnly ?? hook.desktopOnly,

--- a/src/services/hook-manager.ts
+++ b/src/services/hook-manager.ts
@@ -7,6 +7,7 @@ import {
 	JsonSidecarStateStore,
 	extractMarkdownBody,
 	migrateLegacyEnabledTools,
+	parseMaxIterations,
 	purgeOrphanState,
 	resolveFeatureToolPolicy,
 } from './feature-definition';
@@ -80,6 +81,13 @@ export interface Hook {
 	enabledSkills: string[];
 	/** Optional model override; defaults to plugin chat model. */
 	model?: string;
+	/**
+	 * Cap on agent tool-execution iterations for an `agent-task` fire. Each
+	 * iteration is one tool-call batch, not a single tool call. Omitted means
+	 * use DEFAULT_HEADLESS_MAX_ITERATIONS. Ignored for non-`agent-task` actions,
+	 * which don't drive the agent loop.
+	 */
+	maxIterations?: number;
 	/**
 	 * Optional output path template for the agent run's final response.
 	 * Supports {slug}, {date}, and {fileName} placeholders. When omitted no
@@ -168,6 +176,7 @@ export interface HookCreateParams {
 	toolPolicy?: FeatureToolPolicy;
 	enabledSkills?: string[];
 	model?: string;
+	maxIterations?: number;
 	outputPath?: string;
 	enabled?: boolean;
 	desktopOnly?: boolean;
@@ -425,6 +434,9 @@ export class HookManager {
 			toolPolicy: 'toolPolicy' in params ? params.toolPolicy : hook.toolPolicy,
 			enabledSkills: params.enabledSkills ?? hook.enabledSkills,
 			model: params.model ?? hook.model ?? '',
+			// `in` check (not ??) so callers can clear back to the default by
+			// passing maxIterations: undefined explicitly.
+			maxIterations: 'maxIterations' in params ? params.maxIterations : hook.maxIterations,
 			outputPath: params.outputPath ?? hook.outputPath ?? '',
 			enabled: params.enabled ?? hook.enabled,
 			desktopOnly: params.desktopOnly ?? hook.desktopOnly,
@@ -482,6 +494,7 @@ export class HookManager {
 			toolPolicy: params.toolPolicy,
 			enabledSkills: params.enabledSkills ?? [],
 			model: params.model || undefined,
+			maxIterations: params.maxIterations,
 			outputPath: params.outputPath || undefined,
 			enabled: params.enabled ?? true,
 			desktopOnly: params.desktopOnly ?? true,
@@ -532,6 +545,7 @@ export class HookManager {
 		}
 
 		if (params.model) lines.push(`model: ${JSON.stringify(params.model)}`);
+		if (params.maxIterations !== undefined) lines.push(`maxIterations: ${params.maxIterations}`);
 		if (params.outputPath) lines.push(`outputPath: ${JSON.stringify(params.outputPath)}`);
 		if (params.commandId) lines.push(`commandId: ${JSON.stringify(params.commandId)}`);
 
@@ -920,6 +934,7 @@ export class HookManager {
 			toolPolicy: resolveFeatureToolPolicy(frontmatter),
 			enabledSkills: Array.isArray(frontmatter.enabledSkills) ? (frontmatter.enabledSkills as string[]) : [],
 			model: typeof frontmatter.model === 'string' ? frontmatter.model : undefined,
+			maxIterations: parseMaxIterations(frontmatter.maxIterations),
 			outputPath: typeof frontmatter.outputPath === 'string' ? frontmatter.outputPath : undefined,
 			commandId,
 			focusFile: frontmatter.focusFile === true ? true : undefined,
@@ -962,6 +977,7 @@ export class HookManager {
 			toolPolicy: hook.toolPolicy,
 			enabledSkills: hook.enabledSkills,
 			model: hook.model,
+			maxIterations: hook.maxIterations,
 			outputPath: hook.outputPath,
 			enabled: hook.enabled,
 			desktopOnly: hook.desktopOnly,

--- a/src/services/hook-runner.ts
+++ b/src/services/hook-runner.ts
@@ -8,7 +8,7 @@ import { ExtendedModelRequest } from '../api/interfaces/model-api';
 import { ensureFolderExists } from '../utils/file-utils';
 import { formatLocalDate, formatLocalTimestamp } from '../utils/format-utils';
 import { buildTurnPreamble } from '../utils/turn-preamble';
-import { AgentLoop } from '../agent/agent-loop';
+import { AgentLoop, DEFAULT_HEADLESS_MAX_ITERATIONS } from '../agent/agent-loop';
 import { GeminiSummary } from '../summary';
 import { SelectionRewriter } from '../rewrite-selection';
 import { HookFireContext, renderPrompt } from './hook-manager';
@@ -129,6 +129,8 @@ export class HookRunner {
 
 		let finalText: string;
 		if (initialResponse.toolCalls?.length) {
+			// Per-hook override falls back to the shared headless default when unset.
+			const maxIterations = hook.maxIterations ?? DEFAULT_HEADLESS_MAX_ITERATIONS;
 			const loop = new AgentLoop();
 			const result = await loop.run({
 				initialResponse,
@@ -139,14 +141,16 @@ export class HookRunner {
 					session,
 					isCancelled,
 					confirmationProvider: new HeadlessConfirmationProvider(),
-					maxIterations: 20,
+					maxIterations,
 					featureToolPolicy: hook.toolPolicy,
 					headless: true,
 				},
 			});
 			if (result.cancelled) return undefined;
 			if (result.exhausted) {
-				throw new Error(`[HookRunner] Hook "${hook.slug}" exhausted 20 tool iterations without producing a response`);
+				throw new Error(
+					`[HookRunner] Hook "${hook.slug}" exhausted ${maxIterations} tool iterations without producing a response`
+				);
 			}
 			finalText = result.markdown;
 		} else {

--- a/src/services/scheduled-task-manager.ts
+++ b/src/services/scheduled-task-manager.ts
@@ -7,6 +7,7 @@ import {
 	JsonSidecarStateStore,
 	extractMarkdownBody,
 	migrateLegacyEnabledTools,
+	parseMaxIterations,
 	purgeOrphanState,
 	resolveFeatureToolPolicy,
 } from './feature-definition';
@@ -61,6 +62,13 @@ export interface ScheduledTask {
 	 * Defaults to the plugin's chat model when omitted.
 	 */
 	model?: string;
+	/**
+	 * Cap on agent tool-execution iterations for this run. Each iteration is one
+	 * tool-call batch, not a single tool call. Omitted means use
+	 * DEFAULT_HEADLESS_MAX_ITERATIONS. Raise this for long multi-step tasks that
+	 * legitimately need more than the default before producing a final response.
+	 */
+	maxIterations?: number;
 	/** When false the scheduler skips this task entirely. Default: true. */
 	enabled: boolean;
 	/**
@@ -501,6 +509,7 @@ export class ScheduledTaskManager {
 		toolPolicy?: FeatureToolPolicy;
 		outputPath?: string;
 		model?: string;
+		maxIterations?: number;
 		enabled?: boolean;
 		runIfMissed?: boolean;
 		prompt: string;
@@ -527,6 +536,7 @@ export class ScheduledTaskManager {
 			toolPolicy: params.toolPolicy,
 			outputPath: params.outputPath ?? defaultOutputPath,
 			model: params.model,
+			maxIterations: params.maxIterations,
 			enabled: params.enabled ?? true,
 			runIfMissed: params.runIfMissed ?? false,
 			prompt: params.prompt,
@@ -569,6 +579,7 @@ export class ScheduledTaskManager {
 			toolPolicy?: FeatureToolPolicy;
 			outputPath?: string;
 			model?: string;
+			maxIterations?: number;
 			enabled?: boolean;
 			runIfMissed?: boolean;
 			prompt?: string;
@@ -591,6 +602,9 @@ export class ScheduledTaskManager {
 			toolPolicy: 'toolPolicy' in params ? params.toolPolicy : task.toolPolicy,
 			outputPath: params.outputPath ?? task.outputPath,
 			model: params.model ?? task.model,
+			// Use the `in` check (not ??) so callers can clear back to the default
+			// by passing maxIterations: undefined explicitly.
+			maxIterations: 'maxIterations' in params ? params.maxIterations : task.maxIterations,
 			enabled: params.enabled ?? task.enabled,
 			runIfMissed: params.runIfMissed ?? task.runIfMissed,
 			prompt: params.prompt ?? task.prompt,
@@ -854,6 +868,7 @@ export class ScheduledTaskManager {
 			toolPolicy: resolveFeatureToolPolicy(frontmatter),
 			outputPath: typeof frontmatter.outputPath === 'string' ? frontmatter.outputPath : defaultOutputPath,
 			model: typeof frontmatter.model === 'string' ? frontmatter.model : undefined,
+			maxIterations: parseMaxIterations(frontmatter.maxIterations),
 			enabled: frontmatter.enabled !== false,
 			runIfMissed: frontmatter.runIfMissed === true,
 			prompt,
@@ -884,6 +899,7 @@ export class ScheduledTaskManager {
 		toolPolicy?: FeatureToolPolicy;
 		outputPath?: string;
 		model?: string;
+		maxIterations?: number;
 		enabled?: boolean;
 		runIfMissed?: boolean;
 		prompt: string;
@@ -904,6 +920,9 @@ export class ScheduledTaskManager {
 
 		if (params.model) {
 			lines.push(`model: '${params.model}'`);
+		}
+		if (params.maxIterations !== undefined) {
+			lines.push(`maxIterations: ${params.maxIterations}`);
 		}
 		if (params.enabled === false) {
 			lines.push('enabled: false');

--- a/src/services/scheduled-task-manager.ts
+++ b/src/services/scheduled-task-manager.ts
@@ -525,7 +525,11 @@ export class ScheduledTaskManager {
 
 		const filePath = normalizePath(`${this.scheduledTasksFolder}/${slug}.md`);
 		const defaultOutputPath = normalizePath(`${this.scheduledTasksFolder}/${RUNS_SUBFOLDER}/${slug}/{date}.md`);
-		const content = this.serializeTask({ ...params, slug });
+		// Normalize at the write boundary so an invalid value from a programmatic
+		// caller can't be persisted or held in memory — matches the read-path
+		// contract (parseTaskFile), where invalid values fall back to the default.
+		const maxIterations = parseMaxIterations(params.maxIterations);
+		const content = this.serializeTask({ ...params, slug, maxIterations });
 		await this.plugin.app.vault.create(filePath, content);
 
 		// Immediately reflect in the in-memory map — don't wait for the vault
@@ -536,7 +540,7 @@ export class ScheduledTaskManager {
 			toolPolicy: params.toolPolicy,
 			outputPath: params.outputPath ?? defaultOutputPath,
 			model: params.model,
-			maxIterations: params.maxIterations,
+			maxIterations,
 			enabled: params.enabled ?? true,
 			runIfMissed: params.runIfMissed ?? false,
 			prompt: params.prompt,
@@ -603,8 +607,9 @@ export class ScheduledTaskManager {
 			outputPath: params.outputPath ?? task.outputPath,
 			model: params.model ?? task.model,
 			// Use the `in` check (not ??) so callers can clear back to the default
-			// by passing maxIterations: undefined explicitly.
-			maxIterations: 'maxIterations' in params ? params.maxIterations : task.maxIterations,
+			// by passing maxIterations: undefined explicitly. Normalize incoming
+			// values so an invalid number can't be persisted (matches parseTaskFile).
+			maxIterations: 'maxIterations' in params ? parseMaxIterations(params.maxIterations) : task.maxIterations,
 			enabled: params.enabled ?? task.enabled,
 			runIfMissed: params.runIfMissed ?? task.runIfMissed,
 			prompt: params.prompt ?? task.prompt,

--- a/src/services/scheduled-task-runner.ts
+++ b/src/services/scheduled-task-runner.ts
@@ -9,7 +9,7 @@ import { ExtendedModelRequest } from '../api/interfaces/model-api';
 import { ensureFolderExists } from '../utils/file-utils';
 import { formatLocalDate, formatLocalTimestamp } from '../utils/format-utils';
 import { buildTurnPreamble } from '../utils/turn-preamble';
-import { AgentLoop } from '../agent/agent-loop';
+import { AgentLoop, DEFAULT_HEADLESS_MAX_ITERATIONS } from '../agent/agent-loop';
 
 /**
  * Auto-approve all tool confirmations for headless scheduled-task runs.
@@ -112,6 +112,8 @@ export class ScheduledTaskRunner {
 		let finalText: string;
 
 		if (initialResponse.toolCalls?.length) {
+			// Per-task override falls back to the shared default when unset.
+			const maxIterations = this.task.maxIterations ?? DEFAULT_HEADLESS_MAX_ITERATIONS;
 			// Hand off to AgentLoop — handles thoughtSignature propagation,
 			// history construction, follow-up requests, empty-response retry,
 			// and agentEventBus events without any UI coupling.
@@ -125,7 +127,7 @@ export class ScheduledTaskRunner {
 					session,
 					isCancelled,
 					confirmationProvider: new HeadlessConfirmationProvider(),
-					maxIterations: 20,
+					maxIterations,
 					featureToolPolicy: this.task.toolPolicy,
 					headless: true,
 				},
@@ -135,7 +137,7 @@ export class ScheduledTaskRunner {
 
 			if (result.exhausted) {
 				throw new Error(
-					`[ScheduledTaskRunner] Task "${this.task.slug}" exhausted 20 tool iterations without producing a response`
+					`[ScheduledTaskRunner] Task "${this.task.slug}" exhausted ${maxIterations} tool iterations without producing a response`
 				);
 			}
 

--- a/src/ui/hook-management-modal.ts
+++ b/src/ui/hook-management-modal.ts
@@ -1,6 +1,7 @@
 import { Notice, Setting, setIcon } from 'obsidian';
 import type { Hook, HookAction, HookState, HookTrigger, HooksState } from '../services/hook-manager';
 import type { FeatureToolPolicy } from '../types/tool-policy';
+import { DEFAULT_HEADLESS_MAX_ITERATIONS } from '../agent/agent-loop';
 import { ManagementModalBase } from './components/management-modal-base';
 import { ToolPolicyEditor } from './components/tool-policy-editor';
 
@@ -385,6 +386,20 @@ export class HookManagementModal extends ManagementModalBase<Hook, HookState> {
 			);
 
 		new Setting(advDetails)
+			.setName('Max tool iterations')
+			.setDesc(
+				`Cap on agent tool-call batches per fire (agent-task only). Raise it for long multi-step hooks that hit the limit. Leave blank for the default (${DEFAULT_HEADLESS_MAX_ITERATIONS}).`
+			)
+			.addText((text) =>
+				text
+					.setPlaceholder(String(DEFAULT_HEADLESS_MAX_ITERATIONS))
+					.setValue(this.form.maxIterations)
+					.onChange((v) => {
+						this.form.maxIterations = v.trim();
+					})
+			);
+
+		new Setting(advDetails)
 			.setName('Output path (optional)')
 			.setDesc(
 				'Where to write the agent response. Supports {slug}, {date}, {fileName}. Leave blank to skip writing a file.'
@@ -440,6 +455,19 @@ export class HookManagementModal extends ManagementModalBase<Hook, HookState> {
 			return;
 		}
 
+		// Blank means "use the default" (undefined). A non-blank value must be a
+		// positive integer — reject garbage rather than silently dropping it.
+		let maxIterations: number | undefined;
+		const rawMaxIterations = this.form.maxIterations.trim();
+		if (rawMaxIterations) {
+			const parsed = Number(rawMaxIterations);
+			if (!Number.isInteger(parsed) || parsed <= 0) {
+				new Notice('Max tool iterations must be a positive whole number, or blank for the default.');
+				return;
+			}
+			maxIterations = parsed;
+		}
+
 		const manager = this.plugin.hookManager;
 		if (!manager) {
 			new Notice('Hook manager not available.');
@@ -458,6 +486,7 @@ export class HookManagementModal extends ManagementModalBase<Hook, HookState> {
 					toolPolicy: this.form.toolPolicy,
 					enabledSkills: this.form.enabledSkills,
 					model: this.form.model || undefined,
+					maxIterations,
 					outputPath: this.form.outputPath || undefined,
 					enabled: this.form.enabled,
 					desktopOnly: this.form.desktopOnly,
@@ -479,6 +508,7 @@ export class HookManagementModal extends ManagementModalBase<Hook, HookState> {
 					toolPolicy: this.form.toolPolicy,
 					enabledSkills: this.form.enabledSkills,
 					model: this.form.model || undefined,
+					maxIterations,
 					outputPath: this.form.outputPath || undefined,
 					enabled: this.form.enabled,
 					desktopOnly: this.form.desktopOnly,
@@ -514,6 +544,7 @@ export class HookManagementModal extends ManagementModalBase<Hook, HookState> {
 			toolPolicy: hook.toolPolicy,
 			enabledSkills: [...hook.enabledSkills],
 			model: hook.model ?? '',
+			maxIterations: hook.maxIterations !== undefined ? String(hook.maxIterations) : '',
 			outputPath: hook.outputPath ?? '',
 			enabled: hook.enabled,
 			desktopOnly: hook.desktopOnly,
@@ -543,6 +574,7 @@ export class HookManagementModal extends ManagementModalBase<Hook, HookState> {
 			toolPolicy: undefined as FeatureToolPolicy | undefined,
 			enabledSkills: [] as string[],
 			model: '',
+			maxIterations: '',
 			outputPath: '',
 			enabled: true,
 			desktopOnly: true,

--- a/src/ui/scheduler-management-modal.ts
+++ b/src/ui/scheduler-management-modal.ts
@@ -1,5 +1,6 @@
 import { Notice, Setting, setIcon } from 'obsidian';
 import type { ScheduledTask, TaskState, ScheduledTasksState } from '../services/scheduled-task-manager';
+import { DEFAULT_HEADLESS_MAX_ITERATIONS } from '../agent/agent-loop';
 import type { FeatureToolPolicy } from '../types/tool-policy';
 import { ManagementModalBase } from './components/management-modal-base';
 import { ToolPolicyEditor } from './components/tool-policy-editor';
@@ -322,6 +323,20 @@ export class SchedulerManagementModal extends ManagementModalBase<ScheduledTask,
 			);
 
 		new Setting(advDetails)
+			.setName('Max tool iterations')
+			.setDesc(
+				`Cap on agent tool-call batches per run. Raise this for long multi-step tasks that hit the limit. Leave blank for the default (${DEFAULT_HEADLESS_MAX_ITERATIONS}).`
+			)
+			.addText((text) =>
+				text
+					.setPlaceholder(String(DEFAULT_HEADLESS_MAX_ITERATIONS))
+					.setValue(this.form.maxIterations)
+					.onChange((v) => {
+						this.form.maxIterations = v.trim();
+					})
+			);
+
+		new Setting(advDetails)
 			.setName('Run if missed')
 			.setDesc(
 				'When Obsidian was closed and this task was due, show it in the catch-up approval modal on next startup.'
@@ -365,6 +380,19 @@ export class SchedulerManagementModal extends ManagementModalBase<ScheduledTask,
 			return;
 		}
 
+		// Blank means "use the default" (undefined). A non-blank value must be a
+		// positive integer — reject garbage rather than silently dropping it.
+		let maxIterations: number | undefined;
+		const rawMaxIterations = this.form.maxIterations.trim();
+		if (rawMaxIterations) {
+			const parsed = Number(rawMaxIterations);
+			if (!Number.isInteger(parsed) || parsed <= 0) {
+				new Notice('Max tool iterations must be a positive whole number, or blank for the default.');
+				return;
+			}
+			maxIterations = parsed;
+		}
+
 		const manager = this.plugin.scheduledTaskManager;
 		if (!manager) {
 			new Notice('Scheduled task manager not available.');
@@ -378,6 +406,7 @@ export class SchedulerManagementModal extends ManagementModalBase<ScheduledTask,
 					toolPolicy: this.form.toolPolicy,
 					outputPath: this.form.outputPath || undefined,
 					model: this.form.model || undefined,
+					maxIterations,
 					enabled: this.form.enabled,
 					runIfMissed: this.form.runIfMissed,
 					prompt: this.form.prompt,
@@ -390,6 +419,7 @@ export class SchedulerManagementModal extends ManagementModalBase<ScheduledTask,
 					toolPolicy: this.form.toolPolicy,
 					outputPath: this.form.outputPath || undefined,
 					model: this.form.model || undefined,
+					maxIterations,
 					enabled: this.form.enabled,
 					runIfMissed: this.form.runIfMissed,
 					prompt: this.form.prompt,
@@ -424,6 +454,7 @@ export class SchedulerManagementModal extends ManagementModalBase<ScheduledTask,
 			toolPolicy: task.toolPolicy,
 			outputPath: task.outputPath,
 			model: task.model ?? '',
+			maxIterations: task.maxIterations !== undefined ? String(task.maxIterations) : '',
 			enabled: task.enabled,
 			runIfMissed: task.runIfMissed,
 			prompt: task.prompt,
@@ -465,6 +496,7 @@ export class SchedulerManagementModal extends ManagementModalBase<ScheduledTask,
 			toolPolicy: undefined as FeatureToolPolicy | undefined,
 			outputPath: '',
 			model: '',
+			maxIterations: '',
 			enabled: true,
 			runIfMissed: false,
 			prompt: '',

--- a/test/services/feature-definition.test.ts
+++ b/test/services/feature-definition.test.ts
@@ -3,6 +3,7 @@ import {
 	JsonSidecarStateStore,
 	extractMarkdownBody,
 	migrateLegacyEnabledTools,
+	parseMaxIterations,
 	purgeOrphanState,
 	resolveFeatureToolPolicy,
 } from '../../src/services/feature-definition';
@@ -233,5 +234,25 @@ describe('purgeOrphanState', () => {
 
 	it('returns an empty array for an empty state map', () => {
 		expect(purgeOrphanState({}, () => false)).toEqual([]);
+	});
+});
+
+// ─── parseMaxIterations ──────────────────────────────────────────────────────
+
+describe('parseMaxIterations', () => {
+	it('accepts positive integers (number or numeric string)', () => {
+		expect(parseMaxIterations(50)).toBe(50);
+		expect(parseMaxIterations('30')).toBe(30);
+		expect(parseMaxIterations(1)).toBe(1);
+	});
+
+	it('rejects non-positive, non-integer, and non-numeric values', () => {
+		expect(parseMaxIterations(0)).toBeUndefined();
+		expect(parseMaxIterations(-5)).toBeUndefined();
+		expect(parseMaxIterations(2.5)).toBeUndefined();
+		expect(parseMaxIterations('abc')).toBeUndefined();
+		expect(parseMaxIterations(undefined)).toBeUndefined();
+		expect(parseMaxIterations(null)).toBeUndefined();
+		expect(parseMaxIterations('')).toBeUndefined();
 	});
 });

--- a/test/services/hook-manager.test.ts
+++ b/test/services/hook-manager.test.ts
@@ -325,6 +325,18 @@ describe('HookManager CRUD', () => {
 		expect(content).toContain('desktopOnly: false');
 	});
 
+	it('coerces an invalid createHook maxIterations to undefined (not persisted)', async () => {
+		const plugin = createPluginWithVaultStore();
+		const manager = newManager(plugin);
+
+		// -5 is invalid — must not be serialized nor kept on the in-memory hook.
+		await manager.createHook({ ...baseCreateParams, slug: 'bad-iters', maxIterations: -5 });
+
+		const content = plugin.__files.get('gemini-scribe/Hooks/bad-iters.md');
+		expect(content).not.toContain('maxIterations');
+		expect(manager.getHooks().find((h) => h.slug === 'bad-iters')?.maxIterations).toBeUndefined();
+	});
+
 	it('serialises focusFile only when the user opts in (default false stays out of the file)', async () => {
 		const plugin = createPluginWithVaultStore();
 		const manager = newManager(plugin);

--- a/test/services/hook-manager.test.ts
+++ b/test/services/hook-manager.test.ts
@@ -281,6 +281,7 @@ describe('HookManager CRUD', () => {
 		// Defaults should NOT be serialised — keeps the file clean.
 		expect(content).not.toContain('debounceMs');
 		expect(content).not.toContain('cooldownMs');
+		expect(content).not.toContain('maxIterations');
 		expect(content).not.toContain('enabled:');
 		expect(content).not.toContain('desktopOnly:');
 	});
@@ -297,6 +298,7 @@ describe('HookManager CRUD', () => {
 			toolPolicy: { preset: PolicyPreset.READ_ONLY },
 			enabledSkills: ['index-files'],
 			model: 'gemini-2.5-flash-lite',
+			maxIterations: 50,
 			outputPath: 'Hooks/Runs/{slug}/{date}.md',
 			enabled: false,
 			desktopOnly: false,
@@ -307,6 +309,7 @@ describe('HookManager CRUD', () => {
 		expect(content).toContain('debounceMs: 7500');
 		expect(content).toContain('cooldownMs: 60000');
 		expect(content).toContain('maxRunsPerHour: 12');
+		expect(content).toContain('maxIterations: 50');
 		expect(content).toContain('toolPolicy:');
 		expect(content).toContain('preset: read_only');
 		// Regression guard: the serializer must not also emit the legacy
@@ -1166,6 +1169,7 @@ describe('HookManager discoverHooks via initialize()', () => {
 					maxRunsPerHour: 10,
 					cooldownMs: 60000,
 					model: 'gemini-2.5-flash',
+					maxIterations: 50,
 					outputPath: 'Runs/{slug}/{date}.md',
 					enabled: true,
 					desktopOnly: false,
@@ -1191,6 +1195,7 @@ describe('HookManager discoverHooks via initialize()', () => {
 		expect(hook.maxRunsPerHour).toBe(10);
 		expect(hook.cooldownMs).toBe(60000);
 		expect(hook.model).toBe('gemini-2.5-flash');
+		expect(hook.maxIterations).toBe(50);
 		expect(hook.enabledSkills).toEqual(['index-files']);
 		expect(hook.frontmatterFilter).toEqual({ type: 'journal' });
 		expect(hook.desktopOnly).toBe(false);

--- a/test/services/hook-runner.test.ts
+++ b/test/services/hook-runner.test.ts
@@ -63,6 +63,7 @@ vi.mock('../../src/agent/agent-loop', () => ({
 	AgentLoop: vi.fn().mockImplementation(function () {
 		return { run: mockAgentLoopRun };
 	}),
+	DEFAULT_HEADLESS_MAX_ITERATIONS: 20,
 }));
 
 import { ModelClientFactory } from '../../src/api';
@@ -668,6 +669,43 @@ describe('HookRunner agent-task: exhausted iterations', () => {
 		const runner = new HookRunner(plugin as any, makeContext(hook));
 
 		await expect(runner.run()).rejects.toThrow(/exhausted 20 tool iterations/);
+	});
+
+	it('forwards a per-hook maxIterations override to AgentLoop', async () => {
+		const generateModelResponse = vi.fn().mockResolvedValue({
+			markdown: '',
+			toolCalls: [{ name: 'some_tool', arguments: {} }],
+		});
+		(ModelClientFactory.createChatModel as any).mockReturnValue({ generateModelResponse });
+		mockAgentLoopRun.mockResolvedValue(successfulLoopResult('Done.'));
+
+		const plugin = createMockPlugin();
+		const runner = new HookRunner(plugin as any, makeContext(makeHook({ maxIterations: 50 })));
+		await runner.run();
+
+		expect(mockAgentLoopRun).toHaveBeenCalledWith(
+			expect.objectContaining({
+				options: expect.objectContaining({ maxIterations: 50 }),
+			})
+		);
+	});
+
+	it('exhausted error message reflects the per-hook maxIterations', async () => {
+		const generateModelResponse = vi.fn().mockResolvedValue({
+			markdown: '',
+			toolCalls: [{ name: 'some_tool', arguments: {} }],
+		});
+		(ModelClientFactory.createChatModel as any).mockReturnValue({ generateModelResponse });
+		mockAgentLoopRun.mockResolvedValue({
+			...successfulLoopResult(),
+			exhausted: true,
+			markdown: '',
+		});
+
+		const plugin = createMockPlugin();
+		const runner = new HookRunner(plugin as any, makeContext(makeHook({ maxIterations: 50 })));
+
+		await expect(runner.run()).rejects.toThrow(/exhausted 50 tool iterations/);
 	});
 });
 

--- a/test/services/scheduled-task-manager.test.ts
+++ b/test/services/scheduled-task-manager.test.ts
@@ -453,6 +453,36 @@ describe('ScheduledTaskManager', () => {
 			expect(manager.getTasks()[0].enabled).toBe(true);
 		});
 
+		it('parses maxIterations from frontmatter when set to a positive integer', async () => {
+			const plugin = createMockPlugin();
+			plugin.app.vault.getMarkdownFiles.mockReturnValue([
+				{ path: 'gemini-scribe/Scheduled-Tasks/long-task.md', basename: 'long-task' },
+			]);
+			plugin.app.metadataCache.getFileCache.mockReturnValue({
+				frontmatter: { schedule: 'daily', maxIterations: 50 },
+			});
+			plugin.app.vault.read = vi.fn().mockResolvedValue('A long multi-step task.');
+			const manager = new ScheduledTaskManager(plugin);
+			await manager.initialize();
+
+			expect(manager.getTasks()[0].maxIterations).toBe(50);
+		});
+
+		it('maxIterations is undefined when omitted or invalid', async () => {
+			const plugin = createMockPlugin();
+			plugin.app.vault.getMarkdownFiles.mockReturnValue([
+				{ path: 'gemini-scribe/Scheduled-Tasks/bad-iters.md', basename: 'bad-iters' },
+			]);
+			plugin.app.metadataCache.getFileCache.mockReturnValue({
+				frontmatter: { schedule: 'daily', maxIterations: 0 },
+			});
+			plugin.app.vault.read = vi.fn().mockResolvedValue('Invalid cap.');
+			const manager = new ScheduledTaskManager(plugin);
+			await manager.initialize();
+
+			expect(manager.getTasks()[0].maxIterations).toBeUndefined();
+		});
+
 		it('toolPolicy is undefined when no toolPolicy or enabledTools frontmatter is present', async () => {
 			const plugin = createMockPlugin();
 			plugin.app.vault.getMarkdownFiles.mockReturnValue([
@@ -1004,8 +1034,26 @@ describe('ScheduledTaskManager', () => {
 
 			const written = (plugin.app.vault.create as Mock).mock.calls[0][1] as string;
 			expect(written).not.toContain('model:');
+			expect(written).not.toContain('maxIterations:');
 			expect(written).not.toContain('enabled: false');
 			expect(written).not.toContain('runIfMissed:');
+		});
+
+		it('serialized content includes maxIterations when set', async () => {
+			const plugin = createMockPlugin();
+			plugin.app.vault.create = vi.fn().mockResolvedValue(undefined);
+			const manager = new ScheduledTaskManager(plugin);
+			await manager.initialize();
+
+			await manager.createTask({
+				slug: 'long-task',
+				schedule: 'daily',
+				maxIterations: 50,
+				prompt: 'A long task.',
+			});
+
+			const written = (plugin.app.vault.create as Mock).mock.calls[0][1] as string;
+			expect(written).toContain('maxIterations: 50');
 		});
 	});
 

--- a/test/services/scheduled-task-manager.test.ts
+++ b/test/services/scheduled-task-manager.test.ts
@@ -1055,6 +1055,25 @@ describe('ScheduledTaskManager', () => {
 			const written = (plugin.app.vault.create as Mock).mock.calls[0][1] as string;
 			expect(written).toContain('maxIterations: 50');
 		});
+
+		it('coerces an invalid createTask maxIterations to undefined (not persisted)', async () => {
+			const plugin = createMockPlugin();
+			plugin.app.vault.create = vi.fn().mockResolvedValue(undefined);
+			const manager = new ScheduledTaskManager(plugin);
+			await manager.initialize();
+
+			// 0 is invalid — must not be serialized nor kept on the in-memory task.
+			await manager.createTask({
+				slug: 'bad-iters',
+				schedule: 'daily',
+				maxIterations: 0,
+				prompt: 'Invalid cap.',
+			});
+
+			const written = (plugin.app.vault.create as Mock).mock.calls[0][1] as string;
+			expect(written).not.toContain('maxIterations:');
+			expect(manager.getTasks().find((t) => t.slug === 'bad-iters')?.maxIterations).toBeUndefined();
+		});
 	});
 
 	// ── deleteTask ───────────────────────────────────────────────────────────

--- a/test/services/scheduled-task-runner.test.ts
+++ b/test/services/scheduled-task-runner.test.ts
@@ -46,6 +46,7 @@ vi.mock('../../src/agent/agent-loop', () => ({
 	AgentLoop: vi.fn().mockImplementation(function () {
 		return { run: mockAgentLoopRun };
 	}),
+	DEFAULT_HEADLESS_MAX_ITERATIONS: 20,
 }));
 
 import { ModelClientFactory } from '../../src/api';
@@ -219,6 +220,38 @@ describe('ScheduledTaskRunner', () => {
 			expect.any(String),
 			expect.stringContaining('Tool result text.')
 		);
+	});
+
+	it('forwards a per-task maxIterations override to AgentLoop', async () => {
+		const toolCalls = [{ name: 'list_files', arguments: { path: '/' } }];
+		(ModelClientFactory.createChatModel as Mock).mockReturnValue(createMockModelApi('', toolCalls));
+		mockAgentLoopRun.mockResolvedValue(successfulLoopResult('Tool result text.'));
+
+		const plugin = createMockPlugin();
+		const runner = new ScheduledTaskRunner(plugin, makeTask({ maxIterations: 50 }));
+
+		await runner.run(() => false);
+
+		expect(mockAgentLoopRun).toHaveBeenCalledWith(
+			expect.objectContaining({
+				options: expect.objectContaining({ maxIterations: 50 }),
+			})
+		);
+	});
+
+	it('exhausted error message reflects the per-task maxIterations', async () => {
+		const toolCalls = [{ name: 'list_files', arguments: { path: '/' } }];
+		(ModelClientFactory.createChatModel as Mock).mockReturnValue(createMockModelApi('', toolCalls));
+		mockAgentLoopRun.mockResolvedValue({
+			...successfulLoopResult(),
+			exhausted: true,
+			markdown: '',
+		});
+
+		const plugin = createMockPlugin();
+		const runner = new ScheduledTaskRunner(plugin, makeTask({ maxIterations: 50 }));
+
+		await expect(runner.run(() => false)).rejects.toThrow('exhausted 50 tool iterations');
 	});
 
 	it('returns undefined when AgentLoop reports cancellation', async () => {


### PR DESCRIPTION
## Summary

Scheduled tasks and lifecycle hooks drive a headless agent loop that was capped at a hardcoded **20 tool-call iterations**, with no way to raise it. A legitimately long multi-step run would fail with `exhausted 20 tool iterations without producing a response` and there was no escape hatch.

This makes the cap configurable **per task and per hook** via a `maxIterations` frontmatter key (and a matching UI field), falling back to a shared default of 20 when unset. The interactive agent chat is unaffected — it has no cap; this only governs unattended runs.

While wiring hooks for parity, the two previously-duplicated hardcoded `20`s and the duplicated frontmatter parser were consolidated into single shared definitions.

## Changes

- **Shared definitions (de-duplication):**
  - Add `DEFAULT_HEADLESS_MAX_ITERATIONS` in `src/agent/agent-loop.ts` — the single source of truth for the headless cap, referenced by both runners and both UI modals.
  - Add `parseMaxIterations()` in `src/services/feature-definition.ts` (the existing shared-helper home for both managers) — coerces frontmatter to a positive integer or `undefined`, rejecting `0`/negatives/non-integers/garbage.
- **Scheduled tasks:** `maxIterations` on the `ScheduledTask` interface, wired through parse/serialize/`createTask`/`updateTask`; runner uses `task.maxIterations ?? DEFAULT_HEADLESS_MAX_ITERATIONS` and the exhausted-iterations error reports the actual cap.
- **Hooks:** same treatment for the `agent-task` action (ignored for `summarize`/`rewrite`/`command`, which don't drive the agent loop); wired through the `Hook` interface, parse/serialize/`createHook`/`updateHook`/`toHook`/`hookToParams`.
- **UI:** a **Max tool iterations** field under *Advanced options* in both the Scheduler modal and the Hook editor modal, with positive-integer validation and edit round-tripping.
- **Docs:** new **Tool Iteration Limit** sections in `docs/guide/scheduled-tasks.md` and `docs/guide/lifecycle-hooks.md`, plus the `maxIterations` row in both frontmatter tables.
- **Tests:** parse/serialize/validation coverage for both features, the shared `parseMaxIterations` helper, and per-run override forwarding + dynamic error-message assertions for both runners.

## Screenshots / Screencast

UI change is a single text field ("Max tool iterations") added to the *Advanced options* section of the existing Scheduler and Hook editor modals; placeholder shows the default (20). No layout changes.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: small follow-up to an existing limitation reported by a user hitting the cap; happy to file a tracking issue if preferred.
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — parsing/runner logic is platform-agnostic; the UI field uses the same `Setting` text input as adjacent fields.
- [x] Documentation has been updated (if applicable)
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Max tool iterations" advanced setting to hook and scheduler UIs to override the default cap for unattended runs (blank = use default).

* **Documentation**
  * Guides updated to document the new maxIterations frontmatter, validation rules, and iteration-limit behavior (applies to unattended/headless runs only).

* **Bug Fixes**
  * Exhausted-run error messages now report the actual iteration limit used.

* **Tests**
  * Added/updated tests covering parsing, validation, persistence, UI behavior, and exhausted-run reporting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/allenhutchison/obsidian-gemini/pull/909?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->