### PR TITLE
chore(daily): 2026-05-28 daily update

### DIFF
--- a/docs/reference/advanced-settings.md
+++ b/docs/reference/advanced-settings.md
@@ -94,9 +94,12 @@ Configure how the plugin handles API failures:
 
 ## Model Discovery
 
-Model discovery is fully automatic — there are no user-configurable settings for it. On startup, the plugin fetches the latest available Gemini models from Google's API and updates the model dropdowns. If the API fetch fails, the bundled static model list is used as a fallback.
+Model discovery is automatic — no configuration is required. On startup, the plugin fetches the latest available Gemini models from GitHub and caches the result for 24 hours. If the fetch fails, the bundled static model list is used as a fallback.
 
-When using the **Ollama** provider, a **Refresh model list** button appears in Settings → General. Click it after pulling new models with `ollama pull <name>` to force a re-query of the Ollama daemon without restarting Obsidian.
+Both providers expose a **Refresh model list** button in Settings → General:
+
+- **Gemini** — bypasses the 24-hour cache and re-fetches the remote model list immediately. You can also trigger this from the command palette with **Gemini Scribe: Refresh model list** (`gemini-scribe-refresh-model-list`). Useful when a newly-published model doesn't appear yet.
+- **Ollama** — re-queries the Ollama daemon for any models you've pulled since the plugin loaded (`ollama pull <name>`). Use this instead of restarting Obsidian.
 
 ## Performance Optimization
 
@@ -161,7 +164,7 @@ In v4.0+, context is manually managed through session-based file selection:
 
 ### Model List
 
-1. **Restart Obsidian** to pick up newly published Gemini models — discovery runs automatically on startup
+1. **Use Refresh model list** in Settings → General (or run **Gemini Scribe: Refresh model list** from the command palette) to pick up newly published Gemini models without waiting for the 24-hour cache to expire
 2. **Use Refresh model list** (Ollama provider) after pulling new models with `ollama pull`
 3. **Check your API key** if the model list looks empty or stale
 
@@ -201,9 +204,9 @@ In v4.0+, context is manually managed through session-based file selection:
 
 **Models not appearing or stale:**
 
-- For Gemini: check API key validity and network connectivity; restart Obsidian to trigger a fresh fetch
+- For Gemini: click **Refresh model list** in Settings → General (or run the **Gemini Scribe: Refresh model list** command) to bypass the 24-hour cache; check API key validity and network connectivity if it still fails
 - For Ollama: click **Refresh model list** in Settings → General after pulling new models
-- If the list still looks wrong, restart Obsidian to clear the cached model list
+- If the list still looks wrong after refreshing, restart Obsidian
 
 ## Security Considerations
 

--- a/planning/changelog/2026-05-28.md
+++ b/planning/changelog/2026-05-28.md
@@ -1,0 +1,32 @@
+# Daily changelog — May 28, 2026
+
+**Date:** 2026-05-28
+**PRs merged:** 5
+
+---
+
+## Summary
+
+Active day across the whole stack. The headline change is a new in-app Gemini model-list refresh button and command, so users no longer have to wait up to 24 hours to see a newly-published model. Alongside that, two long-standing technical-debt items landed: a DRY refactor of system-instruction assembly across providers, and removal of three dead `AgentFactory` methods (including a latent bug hiding behind an `as any` cast). A narrow error-message fix rounds out the day.
+
+## What shipped
+
+### [#905 chore(daily): 2026-05-28 daily update](https://github.com/allenhutchison/obsidian-gemini/pull/905)
+
+Daily housekeeping PR covering the May 27 changelog (2 PRs) and two doc-drift fixes: corrected a 2M-token context-window claim to 1M (matching `DEFAULT_INPUT_TOKEN_LIMIT` in `context-manager.ts`), and moved `autoRunCatchUp` / `hooksEnabled` into a proper `## Automation Settings` section in `docs/reference/settings.md`.
+
+### [#904 refactor(prompts): extract shared system-instruction assembly (#901)](https://github.com/allenhutchison/obsidian-gemini/pull/904)
+
+Both `GeminiClient` and `OllamaClient` were independently running the same six-step recipe to build the system instruction — load AGENTS.md, swallow errors, load skill summaries, filter by `projectSkills`, call `GeminiPrompts.getSystemPromptWithCustom`. This PR centralizes that work into `GeminiPrompts.buildExtendedSystemInstruction(request)` and collapses both call sites to a one-line call. Eight new unit tests cover the full error-swallow and filtering matrix. Pure code motion; no behavior change.
+
+### [#906 fix(error-utils): drop overly broad 'service' substring match](https://github.com/allenhutchison/obsidian-gemini/pull/906)
+
+Fixes #861. The `getErrorMessage()` unavailability branch was matching the bare substring `service`, which silently mapped `SERVICE_DISABLED` and service-account credential errors onto the "temporarily unavailable" outage copy — sending users to chase a Google outage that wasn't happening. Now matches `unavailable` only. Real 503s remain covered by the HTTP status-code path. Two regression tests added.
+
+### [#908 feat(models): add in-app refresh for the remote Gemini model list](https://github.com/allenhutchison/obsidian-gemini/pull/908)
+
+Fixes #852. Adds a "Refresh model list" button in Settings → General (mirroring the existing Ollama button) and a `gemini-scribe-refresh-model-list` command palette entry. Both surface the outcome via `Notice` (updated count, skip reason, or error). `ModelListProvider.refresh()` bypasses the 24-hour cache and re-fetches `src/data/models.json`; `ModelManager.refreshRemoteModels()` syncs the result into the global `GEMINI_MODELS` array so any open dropdowns reflect it immediately. Six new tests cover the cache-bypass, offline/provider-skip, and error paths. Docs updated in `docs/reference/settings.md` and `README.md`.
+
+### [#907 refactor(agent): drop unused AgentFactory methods (#855)](https://github.com/allenhutchison/obsidian-gemini/pull/907)
+
+Fixes #855. Deletes `AgentFactory.createAgent`, `createAgentTaskModel`, and `initializeAgent` — three methods with no production callers (the real wiring lives in `LifecycleService.initializeReinitializableServices`). Also removes the now-dead `AgentConfig` interface. Of note: `initializeAgent` contained a latent bug — it assigned `(plugin as any).executionEngine = executionEngine`, but the field on `main.ts` is `toolExecutionEngine`; the `as any` cast masked the typo. Deleting the method removes the trap. `AgentFactory.createAgentModel` (the only method with real callers) is kept. Net: 177 lines removed.


### PR DESCRIPTION
## Summary

Automated daily housekeeping for 2026-05-28. Covers the May 28 changelog (5 PRs) and fixes 3 doc-drift items in `docs/reference/advanced-settings.md` introduced by PR #908 (in-app Gemini model list refresh).

## Changes

- **Add `planning/changelog/2026-05-28.md`**: Documents the five PRs that merged on May 28 PDT — daily housekeeping #905, system-instruction assembly refactor #904, error-utils substring fix #906, in-app Gemini model refresh #908, and dead AgentFactory methods cleanup #907.
- **Fix `docs/reference/advanced-settings.md`** (3 drift items from PR #908):
  - **Model Discovery section**: Was Ollama-only ("a Refresh model list button appears when using Ollama"). Now covers both providers: Gemini has a Refresh button _and_ a `gemini-scribe-refresh-model-list` command; Ollama has its existing Refresh button.
  - **Best Practices > Model List item 1**: Was "Restart Obsidian to pick up newly published Gemini models". Now directs to the Refresh button / command.
  - **Troubleshooting > Models not appearing or stale**: Was "restart Obsidian to trigger a fresh fetch" for Gemini. Now says to use the Refresh button first, fall back to restart only if still wrong.

## Sub-skill outcomes

- **daily-changelog**: wrote `planning/changelog/2026-05-28.md`, 5 PRs (active day — daily housekeeping, two refactors, one bug fix, one new feature)
- **audit-docs**: fixed 3 drift items in `docs/reference/advanced-settings.md` — all three were stale after PR #908 added the Gemini model-list refresh button and command
- **triage-issues**: 0 unlabeled open issues — tracker is clean

## Screenshots / Screencast

N/A — changelog and doc fixes only.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: daily housekeeping
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A: changelog and docs only
- [x] Documentation has been updated (if applicable) — this PR IS the documentation update
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bm4E9XM9iNmjooRqgAXck8)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated advanced settings guide clarifying automatic model discovery behavior with 24-hour caching and GitHub fetching
  * Added clear refresh button location and command palette action for managing Gemini models
  * Enhanced troubleshooting section with improved cache bypass guidance and API validity checks for model list issues

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/allenhutchison/obsidian-gemini/pull/911?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->