### PR TITLE
refactor: use @ts-expect-error for inline-attachment internal-API access

### DIFF
--- a/src/ui/agent-view/inline-attachment.ts
+++ b/src/ui/agent-view/inline-attachment.ts
@@ -93,7 +93,7 @@ function getExtensionFromMimeType(mimeType: string): string {
  */
 function getAttachmentFolder(app: App): string {
 	// Access Obsidian's internal config for attachment location
-	// @ts-ignore - accessing internal Obsidian config
+	// @ts-expect-error - accessing internal Obsidian config
 	const attachmentFolderPath = app.vault.getConfig('attachmentFolderPath') as string;
 
 	// If not set or empty, default to vault root


### PR DESCRIPTION
## Summary

Architecture-audit nightly sweep flagged: **`@ts-ignore` overuse** in `src/ui/agent-view/inline-attachment.ts:96`.

Every other Obsidian-internal-API access in the codebase uses `@ts-expect-error` (`src/main.ts:776,778`, `src/ui/background-tasks-modal.ts:478,480`, `src/services/rag-status-bar.ts:69,71`). Only this one site uses `@ts-ignore`, which silently swallows compilation feedback if the suppression ever becomes unnecessary (e.g. the Obsidian typings adopt the internal `getConfig` signature). Swap to `@ts-expect-error` so future improvements in Obsidian's public types surface as a compiler error here instead of leaving a dead `@ts-ignore` behind.

## Changes

- `src/ui/agent-view/inline-attachment.ts` — replace `// @ts-ignore` with `// @ts-expect-error` on the `app.vault.getConfig('attachmentFolderPath')` call (the comment body is unchanged).

## Checklist

- [x] `npm run format-check` passes
- [x] `npm run build` passes (tsc + esbuild)
- [x] `npm test` passes (127 files / 2958 tests)
- [x] No behavior change — pure compiler-directive swap.

---

*Filed by the `architecture-audit` skill.*

---
_Generated by [Claude Code](https://claude.ai/code/session_01FHjzaoMEx7VgEZA3c3LnRq)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved code quality by updating TypeScript error handling directives for better compatibility with modern TypeScript tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->