### PR TITLE
refactor: break circular import between bundled-skills and skill-manager

### DIFF
--- a/src/services/bundled-skills.ts
+++ b/src/services/bundled-skills.ts
@@ -1,4 +1,4 @@
-import { SkillSummary } from './skill-manager';
+import type { SkillSummary } from './skill-manager';
 
 // Import bundled skill SKILL.md files
 import helpSkillMd from '../../prompts/bundled-skills/gemini-scribe-help/SKILL.md';


### PR DESCRIPTION
## Summary

Architecture-audit nightly sweep flagged: **circular imports** in `src/services/bundled-skills.ts` ↔ `src/services/skill-manager.ts`.

`bundled-skills.ts` imported `SkillSummary` as a value from `skill-manager.ts`, while `skill-manager.ts` imports `BundledSkillRegistry` as a runtime value from `bundled-skills.ts`. Since `SkillSummary` is an interface (type-only), switching to `import type` removes the cycle in the bundled module graph without changing behavior.

A value-import cycle scan over `src/**/*.ts` (skipping `import type`) reports zero remaining 2-cycles after this change.

## Changes

- `src/services/bundled-skills.ts` — change `import { SkillSummary }` to `import type { SkillSummary }` (1 line).

## Test plan

- [x] `npm run format-check` — passes
- [x] `npm run build` — passes (typecheck + esbuild)
- [x] `npm test` — 127 files / 2958 tests pass

---

_Filed by the `architecture-audit` skill._


---
_Generated by [Claude Code](https://claude.ai/code/session_012r88UPGsHTBLoeUoFMAufp)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal module imports to reduce runtime dependencies and improve code efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->