### PR TITLE
chore(daily): 2026-06-02 daily update

### DIFF
--- a/docs/guide/semantic-search.md
+++ b/docs/guide/semantic-search.md
@@ -18,7 +18,7 @@ The agent has access to this as the `vault_semantic_search` tool. You don't need
 ### Enable Vault Indexing
 
 1. Open Settings → Gemini Scribe
-2. Scroll to **Vault Indexing (Experimental)**
+2. Scroll to **Vault Search Index**
 3. Toggle **Enable vault indexing** to ON
 4. The initial indexing starts automatically with a progress modal
 

--- a/planning/changelog/2026-06-01.md
+++ b/planning/changelog/2026-06-01.md
@@ -1,0 +1,16 @@
+# Daily changelog — June 01, 2026
+
+**Date:** 2026-06-01
+**PRs merged:** 1
+
+---
+
+## Summary
+
+Quiet housekeeping day — the only merge was the automated daily-update PR covering May 31. It added the May 31 changelog entry (5 PRs: dep bumps, a `@ts-ignore` cleanup, and two deferred housekeeping PRs), patched one README drift item (stale "What's New" version heading), and labeled one newly-filed bug.
+
+## What shipped
+
+### [#921 chore(daily): 2026-06-01 daily update](https://github.com/allenhutchison/obsidian-gemini/pull/921)
+
+Automated daily housekeeping. Added `planning/changelog/2026-05-31.md` documenting the five PRs that shipped May 31 (two deferred daily-update PRs, an `@ts-ignore` → `@ts-expect-error` architecture cleanup, and Dependabot bumps for `obsidian` 1.12.3→1.13.0 and `@google/genai` 2.6.0→2.7.0). Also fixed one drift item in `README.md` where the "What's New" section still showed v4.9.0 despite the current version being 4.9.1, and labeled issue #920 (`bug`+`architecture`) covering a RAG indexing 500 error in the v1beta API.


### PR DESCRIPTION
## Summary

Automated daily housekeeping for 2026-06-02. Covers the June 1 changelog (1 PR — housekeeping-only day) and one docs drift fix in `semantic-search.md`. No unlabeled issues to triage.

## Changes

- **Add `planning/changelog/2026-06-01.md`**: Documents the single PR merged on June 1 — the automated daily-update PR (#921) that added the May 31 changelog, patched the README v4.9.0→v4.9.1 drift, and labeled issue #920.
- **Fix `docs/guide/semantic-search.md`** (1 drift item): The "Enable Vault Indexing" step referred to the settings section as "**Vault Indexing (Experimental)**" but the actual UI renders it as "**Vault Search Index**" (`src/ui/settings-rag.ts:13`).

## Sub-skill outcomes

- **daily-changelog**: wrote `planning/changelog/2026-06-01.md`, 1 PR (housekeeping-only day — automated daily-update)
- **audit-docs**: fixed 1 drift item — `docs/guide/semantic-search.md` stale section name "Vault Indexing (Experimental)" → "Vault Search Index"; no other drift found across `docs/guide/`, `docs/reference/`, `README.md`, or `AGENTS.md`; no new docs warranted
- **triage-issues**: no unlabeled open issues — 0 issues processed

## Screenshots / Screencast

N/A — changelog and doc fix only.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: daily housekeeping
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A: changelog and doc fix only
- [x] Documentation has been updated (if applicable) — this PR IS the documentation update
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01MkPZXnaZhaGu1SrDh7dyf6)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated semantic search setup guide to reflect current interface labels.
  * Fixed version information in README to match current release.

* **Chores**
  * Added changelog entry documenting recent automated updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->