### PR TITLE
refactor: break circular import between settings-helpers and main

### DIFF
--- a/src/ui/settings-helpers.ts
+++ b/src/ui/settings-helpers.ts
@@ -1,6 +1,6 @@
 import { Setting } from 'obsidian';
 import type ObsidianGemini from '../main';
-import { ObsidianGeminiSettings } from '../main';
+import type { ObsidianGeminiSettings } from '../main';
 import { GEMINI_MODELS } from '../models';
 
 export interface CollapsibleSectionOptions {


### PR DESCRIPTION
## Summary

Architecture-audit nightly sweep flagged: **circular imports** between `src/ui/settings-helpers.ts` and `src/main.ts`.

`settings-helpers.ts` value-imported `ObsidianGeminiSettings` from `../main` even though every use in the file is in a type position (`keyof`, conditional type, `as` cast). Since `ObsidianGeminiSettings` is an interface (type-only), switching to `import type` removes the cycle in the bundled module graph without changing behavior.

A value-import cycle scan over `src/**/*.ts` (skipping `import type`) reports **9 cycles before, 1 after**. The remaining one (`bundled-skills.ts` ↔ `skill-manager.ts`) is already addressed by open PR #923. The 8 settings-* multi-hop cycles (`main → settings → settings-{ui,general,debug,mcp,rag,tools,automation,agent-config} → settings-helpers → main`) collapse along with the direct 2-cycle.

Same pattern as PR #923.

## Changes

- `src/ui/settings-helpers.ts` — change `import { ObsidianGeminiSettings }` to `import type { ObsidianGeminiSettings }` (1 line).

## Test plan

- [x] `npm run format-check` — passes
- [x] `npm run build` — passes (typecheck + esbuild)
- [x] `npm test` — 127 files / 2958 tests pass

---

_Filed by the `architecture-audit` skill._

---
_Generated by [Claude Code](https://claude.ai/code/session_016NX15UTLVwNh94kcCxbf7g)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

No user-facing changes in this release. This update includes internal code optimizations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->