### PR TITLE
test(evals): add 5 agentic tasks mined from real agent sessions

### DIFF
--- a/evals/fixtures/reading-list-curate/Reading List Index.md
+++ b/evals/fixtures/reading-list-curate/Reading List Index.md
@@ -1,0 +1,10 @@
+# Reading List Index
+
+A running record of every article that has already been featured in a reading-list
+edition. Articles listed here must not be reused in future editions.
+
+## Previously featured
+
+- Designing Long-Term Memory for Agents
+- The Shape of Tools to Come
+- Why Local-First Software Wins

--- a/evals/fixtures/reading-list-curate/Readwise Syncs.md
+++ b/evals/fixtures/reading-list-curate/Readwise Syncs.md
@@ -1,0 +1,15 @@
+# Readwise Syncs
+
+A log of when each saved article was synced into the vault. The most recent edition
+covers articles synced in the trailing 14 days (today is 2026-06-01, so on or after
+2026-05-18).
+
+| Article                                        | Synced     |
+| ---------------------------------------------- | ---------- |
+| A Car Dashboard Built From One Giant OLED      | 2026-05-30 |
+| A Backyard Telescope That Photographs Quasars  | 2026-05-28 |
+| Designing Long-Term Memory for Agents          | 2026-05-26 |
+| Instant Postgres Sandboxes With Zero Migration | 2026-05-24 |
+| The Case Against Token Maxxing                 | 2026-05-20 |
+| A Quiet Week in Open Source                    | 2026-05-19 |
+| Revisiting the Netbook Era                     | 2026-04-10 |

--- a/evals/fixtures/reading-list-curate/article-agent-memory.md
+++ b/evals/fixtures/reading-list-curate/article-agent-memory.md
@@ -1,0 +1,10 @@
+---
+synced: 2026-05-26
+source_url: https://example.com/agent-memory
+---
+
+# Designing Long-Term Memory for Agents
+
+An overview of approaches to giving AI agents durable memory across sessions.
+
+**Document Note:** Already featured this one in a previous edition, but it holds up well.

--- a/evals/fixtures/reading-list-curate/article-netbook-relic.md
+++ b/evals/fixtures/reading-list-curate/article-netbook-relic.md
@@ -1,0 +1,10 @@
+---
+synced: 2026-04-10
+source_url: https://example.com/netbook-relic
+---
+
+# Revisiting the Netbook Era
+
+A look back at the brief reign of the cheap underpowered netbook.
+
+**Document Note:** Fun nostalgia, but I read this over a month ago, not recently.

--- a/evals/fixtures/reading-list-curate/article-oled-dashboard.md
+++ b/evals/fixtures/reading-list-curate/article-oled-dashboard.md
@@ -1,0 +1,8 @@
+---
+synced: 2026-05-30
+source_url: https://example.com/oled-dashboard
+---
+
+# A Car Dashboard Built From One Giant OLED
+
+A luxury automaker replaced the entire instrument cluster with a single curved OLED panel.

--- a/evals/fixtures/reading-list-curate/article-postgres-sandbox.md
+++ b/evals/fixtures/reading-list-curate/article-postgres-sandbox.md
@@ -1,0 +1,10 @@
+---
+synced: 2026-05-24
+source_url: https://example.com/postgres-sandbox
+---
+
+# Instant Postgres Sandboxes With Zero Migration
+
+A startup spins up disposable Postgres replicas in seconds so agents can test destructive queries safely.
+
+**Document Note:** Safe throwaway databases are one of the biggest missing pieces for agentic coding right now. I want to try this on a real project.

--- a/evals/fixtures/reading-list-curate/article-quasar-telescope.md
+++ b/evals/fixtures/reading-list-curate/article-quasar-telescope.md
@@ -1,0 +1,10 @@
+---
+synced: 2026-05-28
+source_url: https://example.com/quasar-telescope
+---
+
+# A Backyard Telescope That Photographs Quasars
+
+A new consumer telescope stacks exposures automatically and can resolve objects billions of light years away from a suburban backyard.
+
+**Document Note:** I live under heavy light pollution, so a rig that stacks its way past it is exactly the kind of thing I would love to try.

--- a/evals/fixtures/reading-list-curate/article-quiet-import.md
+++ b/evals/fixtures/reading-list-curate/article-quiet-import.md
@@ -1,0 +1,8 @@
+---
+synced: 2026-05-19
+source_url: https://example.com/quiet-import
+---
+
+# A Quiet Week in Open Source
+
+A roundup of small but useful library releases from the past week.

--- a/evals/fixtures/reading-list-curate/article-token-budgets.md
+++ b/evals/fixtures/reading-list-curate/article-token-budgets.md
@@ -1,0 +1,10 @@
+---
+synced: 2026-05-20
+source_url: https://example.com/token-budgets
+---
+
+# The Case Against Token Maxxing
+
+An engineering leader argues that leaderboards rewarding raw token spend create perverse incentives.
+
+**Document Note:** Optimizing for the middle of the usage curve instead of the extremes feels much healthier than chasing the top of a leaderboard.

--- a/evals/fixtures/recency-sync-vs-age/Readwise Syncs.md
+++ b/evals/fixtures/recency-sync-vs-age/Readwise Syncs.md
@@ -1,0 +1,9 @@
+# Readwise Syncs
+
+A log of recent sync activity (today is 2026-06-01).
+
+- **2026-05-21 to 2026-05-27** — normal daily syncs. A handful of freshly published
+  articles came in, each read and annotated at save time.
+- **2026-05-29** — one-time bulk import of roughly 1,600 archived articles from an old
+  read-later account. These carry a recent sync date but were published years ago
+  (mostly 2008-2015) and were not read this week.

--- a/evals/fixtures/recency-sync-vs-age/backfill-flash-tutorial.md
+++ b/evals/fixtures/recency-sync-vs-age/backfill-flash-tutorial.md
@@ -1,0 +1,8 @@
+---
+published: 2011-07-08
+synced: 2026-05-29
+---
+
+# Building Interactive Sites With Flash
+
+A step-by-step tutorial for adding Flash animations to your homepage.

--- a/evals/fixtures/recency-sync-vs-age/backfill-netbook-guide.md
+++ b/evals/fixtures/recency-sync-vs-age/backfill-netbook-guide.md
@@ -1,0 +1,8 @@
+---
+published: 2009-03-12
+synced: 2026-05-29
+---
+
+# The 2009 Netbook Buying Guide
+
+How to choose among the season's crop of nine-inch netbooks.

--- a/evals/fixtures/recency-sync-vs-age/backfill-roman-forum.md
+++ b/evals/fixtures/recency-sync-vs-age/backfill-roman-forum.md
@@ -1,0 +1,8 @@
+---
+published: 2008-11-02
+synced: 2026-05-29
+---
+
+# Walking Tour of the Roman Forum
+
+A traveler's photo essay from a week spent wandering the ancient Forum.

--- a/evals/fixtures/recency-sync-vs-age/save-flipper-gadget.md
+++ b/evals/fixtures/recency-sync-vs-age/save-flipper-gadget.md
@@ -1,0 +1,10 @@
+---
+published: 2026-05-21
+synced: 2026-05-21
+---
+
+# Flipper Unveils a Linux-Powered Networking Gadget
+
+The makers of the Flipper Zero announced a new networking tool for tinkerers.
+
+**Document Note:** Just announced. I have a Flipper Zero and this looks like a fun follow-up.

--- a/evals/fixtures/recency-sync-vs-age/save-postgres-sandbox.md
+++ b/evals/fixtures/recency-sync-vs-age/save-postgres-sandbox.md
@@ -1,0 +1,10 @@
+---
+published: 2026-05-22
+synced: 2026-05-23
+---
+
+# Instant Postgres Sandboxes in Seconds
+
+A new service spins up disposable Postgres replicas so you can test destructive changes safely.
+
+**Document Note:** This solves a real pain in agentic coding. Caught it fresh in my feed this week.

--- a/evals/fixtures/recency-sync-vs-age/save-smart-telescope.md
+++ b/evals/fixtures/recency-sync-vs-age/save-smart-telescope.md
@@ -1,0 +1,10 @@
+---
+published: 2026-05-26
+synced: 2026-05-27
+---
+
+# Vaonis Unveils Its Sharpest Smart Telescope Yet
+
+The latest Vespera packs the company's best optics into a portable smart telescope.
+
+**Document Note:** Read this the day it came out. I keep coming back to the idea of one of these.

--- a/evals/fixtures/tag-search-no-refusal/Coffee Bean Notes.md
+++ b/evals/fixtures/tag-search-no-refusal/Coffee Bean Notes.md
@@ -1,0 +1,3 @@
+# Coffee Bean Notes
+
+Tried the new Ethiopian single origin from the roaster on Fifth. Bright, fruity, a little tea-like. Worth reordering.

--- a/evals/fixtures/tag-search-no-refusal/Garden Mulch Order.md
+++ b/evals/fixtures/tag-search-no-refusal/Garden Mulch Order.md
@@ -1,0 +1,5 @@
+# Garden Mulch Order
+
+#important-soon
+
+Order three yards of mulch for the beds. Not urgent yet, but worth doing before it gets hot.

--- a/evals/fixtures/tag-search-no-refusal/Library Book Return.md
+++ b/evals/fixtures/tag-search-no-refusal/Library Book Return.md
@@ -1,0 +1,5 @@
+# Library Book Return
+
+The novel is due back at the branch. #important-soon
+
+Could renew online instead if the trip downtown does not happen.

--- a/evals/fixtures/tag-search-no-refusal/Local Weather Pattern.md
+++ b/evals/fixtures/tag-search-no-refusal/Local Weather Pattern.md
@@ -1,0 +1,3 @@
+# Local Weather Pattern
+
+A marine layer rolls in most evenings this time of year and usually burns off by mid-morning. Nothing notable in the forecast.

--- a/evals/fixtures/tag-search-no-refusal/Passport Renewal.md
+++ b/evals/fixtures/tag-search-no-refusal/Passport Renewal.md
@@ -1,0 +1,5 @@
+# Passport Renewal
+
+#important
+
+The passport expires before the summer trip. Renewals are running slow this year, so this cannot wait.

--- a/evals/fixtures/tag-search-no-refusal/Roof Repair Estimate.md
+++ b/evals/fixtures/tag-search-no-refusal/Roof Repair Estimate.md
@@ -1,0 +1,5 @@
+# Roof Repair Estimate
+
+#important
+
+The contractor quoted a full replacement of the north slope before the rainy season. Decision needed by the end of the month. This is a high-priority item.

--- a/evals/fixtures/tag-search-no-refusal/Tax Filing Deadline.md
+++ b/evals/fixtures/tag-search-no-refusal/Tax Filing Deadline.md
@@ -1,0 +1,5 @@
+# Tax Filing Deadline
+
+Quarterly estimated taxes are due soon and the paperwork is half finished. #important
+
+Need to pull the brokerage statements together this week.

--- a/evals/fixtures/tag-search-no-refusal/Weekend Playlist.md
+++ b/evals/fixtures/tag-search-no-refusal/Weekend Playlist.md
@@ -1,0 +1,3 @@
+# Weekend Playlist
+
+A loose collection of tracks for slow Sunday mornings. Mostly jazz guitar and a little bossa nova.

--- a/evals/fixtures/vary-repeated-word/Reading List Draft.md
+++ b/evals/fixtures/vary-repeated-word/Reading List Draft.md
@@ -1,0 +1,19 @@
+# Weekly Reading List
+
+A few things that caught my eye this week.
+
+## [A Backyard Telescope That Photographs Quasars](https://example.com/quasar)
+
+It is fascinating that a consumer telescope can stack its way past light pollution and resolve objects billions of light years away.
+
+## [Instant Postgres Sandboxes With Zero Migration](https://example.com/postgres)
+
+I am fascinated by the idea of disposable databases. Safe throwaway replicas are a fascinating answer to one of the biggest hurdles in agentic coding.
+
+## [The Case Against Token Maxxing](https://example.com/tokens)
+
+A fascinating argument that leaderboards rewarding raw token spend create the wrong incentives.
+
+## [A Car Dashboard Built From One Giant OLED](https://example.com/oled)
+
+The engineering behind a single curved OLED replacing the whole instrument cluster is genuinely fascinating.

--- a/evals/fixtures/vary-repeated-word/Reading List Index.md
+++ b/evals/fixtures/vary-repeated-word/Reading List Index.md
@@ -1,0 +1,6 @@
+# Reading List Index
+
+Previously featured articles. Do not modify this file.
+
+- The Shape of Tools to Come
+- Why Local-First Software Wins

--- a/evals/fixtures/word-count-exclude-outline/chapter-1.md
+++ b/evals/fixtures/word-count-exclude-outline/chapter-1.md
@@ -1,0 +1,3 @@
+The lighthouse had been dark for thirty years when Mara first climbed its stairs. Salt had eaten through the railings and the wind moved freely through the broken windows. She carried a lantern in one hand and her grandfather's journal in the other. Every page of that journal spoke of a light that never failed and a keeper who never slept.
+
+At the top she found the great lamp shrouded in canvas and dust. The mechanism beneath it was rusted but whole. Mara set down her lantern and began to read aloud from the journal, as if the words alone could wake the old machine. Outside the gulls wheeled and cried against a sky the color of cold iron.

--- a/evals/fixtures/word-count-exclude-outline/chapter-2.md
+++ b/evals/fixtures/word-count-exclude-outline/chapter-2.md
@@ -1,0 +1,3 @@
+The villagers below watched the lighthouse with old suspicion. They remembered the storm that had taken the last keeper and the strange lights that some claimed to have seen since. Mara had grown up on those stories and had never quite believed them. Now, alone on the headland, she was less certain.
+
+She worked through the night to free the lamp of its canvas. Her hands grew raw and her lantern burned low. When at last the great lens stood clear, it caught the weak glow and threw it across the walls in rings of pale fire. Mara stepped back and felt, for the first time, that the tower was watching her in return.

--- a/evals/fixtures/word-count-exclude-outline/chapter-3.md
+++ b/evals/fixtures/word-count-exclude-outline/chapter-3.md
@@ -1,0 +1,3 @@
+Morning came grey and slow. Mara had slept against the cold wall and woke with the journal still open on her knees. A passage she had not noticed before caught her eye. It described a hidden compartment beneath the third stair, where the first keeper had kept his most important records.
+
+She found the stair easily enough. The wood was loose and gave way to a shallow box wrapped in oilcloth. Inside lay a second journal, older than the first, its ink faded almost to nothing. Mara carried it to the light and bent close. The first line she could read sent a chill through her that the wind alone could not explain.

--- a/evals/fixtures/word-count-exclude-outline/chapter-4.md
+++ b/evals/fixtures/word-count-exclude-outline/chapter-4.md
@@ -1,0 +1,3 @@
+The older journal told a different story than the one Mara had been raised on. The first keeper had not been a hero at all. He had bargained with something in the water, trading the light of the lamp for safe passage of his own boats. The villagers had drowned by the dozen while he prospered.
+
+Mara read until her eyes ached. Each entry pulled the old legend further out of shape. She thought of her grandfather, who had spoken of the keeper with such reverence, and wondered how much he had known. The tower around her seemed to lean inward, listening, waiting to learn what she would do with the truth.

--- a/evals/fixtures/word-count-exclude-outline/chapter-5.md
+++ b/evals/fixtures/word-count-exclude-outline/chapter-5.md
@@ -1,0 +1,3 @@
+She did not light the lamp that night. Instead she walked down to the village and knocked on the door of the oldest woman there. The woman, whose name was Edith, had buried two brothers in the year of the great drownings. She listened to Mara without surprise, as if she had waited her whole life for someone to bring her the second journal.
+
+They sat together until the fire burned to embers. Edith spoke of names the village had chosen to forget and of a debt that had never truly been paid. When Mara finally rose to leave, the old woman caught her wrist and told her that the thing in the water remembered too, and that it would come again for the light.

--- a/evals/fixtures/word-count-exclude-outline/chapter-6.md
+++ b/evals/fixtures/word-count-exclude-outline/chapter-6.md
@@ -1,0 +1,3 @@
+The storm arrived three days later, exactly as Edith had warned. The sea rose black and furious against the headland and the wind tore at the tower until the stones themselves seemed to groan. Mara climbed the stairs once more, this time with purpose, and stood before the great lamp with both journals in her arms.
+
+She understood now that the choice was hers alone. She could keep the light dark and let the old debt finally close, or she could wake the lamp and break the bargain that had cursed the village for a century. The water churned below and something vast turned beneath its surface. Mara reached for the mechanism and made her decision.

--- a/evals/fixtures/word-count-exclude-outline/chapter-7.md
+++ b/evals/fixtures/word-count-exclude-outline/chapter-7.md
@@ -1,0 +1,12 @@
+The lamp blazed to life and threw a great white beam across the storm. For a moment the whole headland stood lit as bright as noon. The thing in the water recoiled from the light and sank away, and the sea began, slowly, to calm. Mara held the beam steady until the dawn came and the village woke to a quiet harbor for the first time in living memory.
+
+She stayed on as the new keeper. The journals she sealed away beneath the third stair, where they had waited so long, and she let the old legend stand for those who needed it. But every night she lit the lamp herself, and every night she remembered the truth it had been built to hide.
+
+## Outline
+
+These are planning notes for the author and are not part of the finished story.
+
+- Chapter eight: Mara trains an apprentice and decides whether to tell the truth.
+- Recurring motif: the third stair as a place where secrets are kept.
+- Open question: does the creature return, or is the debt truly closed?
+- Theme to sharpen in revision: inherited guilt versus chosen responsibility.

--- a/evals/tasks/reading-list-curate.json
+++ b/evals/tasks/reading-list-curate.json
@@ -1,0 +1,58 @@
+{
+	"id": "reading-list-curate",
+	"description": "Curate a reading-list edition: 14-day recency window + has a personal Document Note + not already in the index, then draft it and write the picks back to the index",
+	"userMessage": "Today is 2026-06-01. I'm assembling the next edition of my reading-list post. Look in the eval-scratch folder. From the article notes there (files whose names start with 'article-'), select only the articles for which ALL THREE of these are true: (a) I saved it in the last 14 days — its frontmatter `synced` date is on or after 2026-05-18; (b) the note has a non-empty 'Document Note:' line (my personal reaction); and (c) the article's title is NOT already listed in 'eval-scratch/Reading List Index.md'. Then create 'eval-scratch/Reading List Draft.md' that lists exactly those qualifying articles — each with its title and my Document Note — and append those same titles to 'eval-scratch/Reading List Index.md' so they are not reused next time. Do not include any article that fails any of the three tests.",
+	"difficulty": "T4",
+	"category": "synthesis",
+	"fixture": "reading-list-curate",
+	"expectedTools": ["write_file"],
+	"forbiddenTools": ["delete_file"],
+	"outputMatchers": [
+		{
+			"type": "judge",
+			"criteria": "The agent selected exactly three articles — 'A Backyard Telescope That Photographs Quasars', 'Instant Postgres Sandboxes With Zero Migration', and 'The Case Against Token Maxxing' — and excluded all others. It must have excluded 'A Car Dashboard Built From One Giant OLED' and 'A Quiet Week in Open Source' (no Document Note), 'Revisiting the Netbook Era' (synced 2026-04-10, outside the 14-day window), and 'Designing Long-Term Memory for Agents' (already listed in the index). Answer NO if it included any excluded article or dropped any of the three correct ones."
+		}
+	],
+	"vaultAssertions": [
+		{ "type": "fileExists", "path": "eval-scratch/Reading List Draft.md" },
+		{
+			"type": "fileContains",
+			"path": "eval-scratch/Reading List Draft.md",
+			"value": "A Backyard Telescope That Photographs Quasars"
+		},
+		{
+			"type": "fileContains",
+			"path": "eval-scratch/Reading List Draft.md",
+			"value": "Instant Postgres Sandboxes With Zero Migration"
+		},
+		{ "type": "fileContains", "path": "eval-scratch/Reading List Draft.md", "value": "The Case Against Token Maxxing" },
+		{
+			"type": "fileLacks",
+			"path": "eval-scratch/Reading List Draft.md",
+			"value": [
+				"A Car Dashboard Built From One Giant OLED",
+				"A Quiet Week in Open Source",
+				"Revisiting the Netbook Era",
+				"Designing Long-Term Memory for Agents"
+			]
+		},
+		{
+			"type": "fileContains",
+			"path": "eval-scratch/Reading List Index.md",
+			"value": "A Backyard Telescope That Photographs Quasars"
+		},
+		{
+			"type": "fileContains",
+			"path": "eval-scratch/Reading List Index.md",
+			"value": "Instant Postgres Sandboxes With Zero Migration"
+		},
+		{ "type": "fileContains", "path": "eval-scratch/Reading List Index.md", "value": "The Case Against Token Maxxing" },
+		{
+			"type": "fileContains",
+			"path": "eval-scratch/Reading List Index.md",
+			"value": "Designing Long-Term Memory for Agents"
+		}
+	],
+	"maxTurns": 25,
+	"timeoutMs": 180000
+}

--- a/evals/tasks/reading-list-curate.json
+++ b/evals/tasks/reading-list-curate.json
@@ -51,7 +51,9 @@
 			"type": "fileContains",
 			"path": "eval-scratch/Reading List Index.md",
 			"value": "Designing Long-Term Memory for Agents"
-		}
+		},
+		{ "type": "fileContains", "path": "eval-scratch/Reading List Index.md", "value": "The Shape of Tools to Come" },
+		{ "type": "fileContains", "path": "eval-scratch/Reading List Index.md", "value": "Why Local-First Software Wins" }
 	],
 	"maxTurns": 25,
 	"timeoutMs": 180000

--- a/evals/tasks/recency-sync-vs-age.json
+++ b/evals/tasks/recency-sync-vs-age.json
@@ -1,0 +1,21 @@
+{
+	"id": "recency-sync-vs-age",
+	"description": "Distinguish genuinely recent reading from a bulk backfill that carries a recent sync date but years-old publish dates",
+	"userMessage": "Today is 2026-06-01. Look in the eval-scratch folder. I want to feature three genuinely recent articles in my reading-list post — things actually published and read in the last couple of weeks. Heads up: a one-time bulk import recently dumped a pile of old archived articles into my library with a recent sync date (see 'eval-scratch/Readwise Syncs.md'); those are not recent reading and should not be featured. Recommend the three best genuinely recent articles and name them.",
+	"difficulty": "T4",
+	"category": "conflict",
+	"fixture": "recency-sync-vs-age",
+	"expectedTools": [],
+	"forbiddenTools": ["write_file", "delete_file", "append_content", "update_frontmatter", "move_file"],
+	"outputMatchers": [
+		{
+			"type": "judge",
+			"criteria": "The response recommends the three genuinely recent articles — the Vaonis smart telescope, the Postgres sandboxes piece, and the Flipper networking gadget — all published in 2026. It must NOT recommend any of the bulk-imported archival articles (the 2009 netbook buying guide, the 2011 Flash tutorial, or the Roman Forum travel essay), which carry a 2026-05-29 sync date but were published years ago. Answer NO if any old backfill article is featured or if the agent treats sync date alone as recency."
+		},
+		{ "type": "regex", "value": "(telescope|Vaonis|Vespera)", "flags": "i" },
+		{ "type": "regex", "value": "(Postgres|sandbox)", "flags": "i" },
+		{ "type": "regex", "value": "Flipper", "flags": "i" }
+	],
+	"maxTurns": 15,
+	"timeoutMs": 120000
+}

--- a/evals/tasks/tag-search-no-refusal.json
+++ b/evals/tasks/tag-search-no-refusal.json
@@ -1,0 +1,21 @@
+{
+	"id": "tag-search-no-refusal",
+	"description": "Agent must actually search note contents for a tag instead of refusing or punting to Obsidian's built-in search",
+	"userMessage": "Look in the eval-scratch folder and list the title of every note tagged #important. Do not modify any files.",
+	"difficulty": "T2",
+	"category": "retrieval",
+	"fixture": "tag-search-no-refusal",
+	"expectedTools": [],
+	"forbiddenTools": ["write_file", "delete_file", "update_frontmatter", "append_content", "move_file"],
+	"outputMatchers": [
+		{ "type": "contains", "value": ["Roof Repair Estimate", "Roof Repair"] },
+		{ "type": "contains", "value": ["Tax Filing Deadline", "Tax Filing"] },
+		{ "type": "contains", "value": "Passport Renewal" },
+		{
+			"type": "judge",
+			"criteria": "The response lists the notes tagged #important (Roof Repair Estimate, Tax Filing Deadline, Passport Renewal) and does NOT claim it is unable to search for tags or tell the user to use Obsidian's built-in search instead. It must NOT present the notes tagged #important-soon (Garden Mulch Order, Library Book Return) as matches for #important. Answer NO if the agent refuses, punts the task, or counts the #important-soon notes as #important."
+		}
+	],
+	"maxTurns": 15,
+	"timeoutMs": 90000
+}

--- a/evals/tasks/vary-repeated-word.json
+++ b/evals/tasks/vary-repeated-word.json
@@ -16,6 +16,12 @@
 	"vaultAssertions": [
 		{ "type": "fileExists", "path": "eval-scratch/Reading List Draft.md" },
 		{
+			"type": "fileMatches",
+			"path": "eval-scratch/Reading List Draft.md",
+			"flags": "i",
+			"value": "^(?:(?!\\bfascinat(?:e|ed|ing)\\b)[\\s\\S])*(?:\\bfascinat(?:e|ed|ing)\\b(?:(?!\\bfascinat(?:e|ed|ing)\\b)[\\s\\S])*)?$"
+		},
+		{
 			"type": "fileContains",
 			"path": "eval-scratch/Reading List Draft.md",
 			"value": "A Backyard Telescope That Photographs Quasars"

--- a/evals/tasks/vary-repeated-word.json
+++ b/evals/tasks/vary-repeated-word.json
@@ -1,0 +1,42 @@
+{
+	"id": "vary-repeated-word",
+	"description": "Rewrite a draft to remove an overused word while preserving titles, links, structure, and meaning (and not creating unrequested artifacts)",
+	"userMessage": "The draft at 'eval-scratch/Reading List Draft.md' overuses the word 'fascinate' — it appears five times in my commentary. Rewrite the commentary so that word (in any form: fascinate, fascinated, fascinating) appears at most once across the whole draft, varying the wording while preserving the meaning of each comment. Keep every article title, every link, and the overall structure exactly as they are. Edit the draft in place. Do not generate any images.",
+	"difficulty": "T3",
+	"category": "edit",
+	"fixture": "vary-repeated-word",
+	"expectedTools": [],
+	"forbiddenTools": ["delete_file", "generate_image"],
+	"outputMatchers": [
+		{
+			"type": "judge",
+			"criteria": "In the rewritten draft, a form of the word 'fascinate' (fascinate/fascinated/fascinating) now appears at most once in total, down from five. Each article's original opinion is preserved in meaning, and the four article titles and their links are unchanged. Answer NO if 'fascinate' still appears two or more times, if any comment's meaning was lost, or if titles or links were altered."
+		}
+	],
+	"vaultAssertions": [
+		{ "type": "fileExists", "path": "eval-scratch/Reading List Draft.md" },
+		{
+			"type": "fileContains",
+			"path": "eval-scratch/Reading List Draft.md",
+			"value": "A Backyard Telescope That Photographs Quasars"
+		},
+		{
+			"type": "fileContains",
+			"path": "eval-scratch/Reading List Draft.md",
+			"value": "Instant Postgres Sandboxes With Zero Migration"
+		},
+		{ "type": "fileContains", "path": "eval-scratch/Reading List Draft.md", "value": "The Case Against Token Maxxing" },
+		{
+			"type": "fileContains",
+			"path": "eval-scratch/Reading List Draft.md",
+			"value": "A Car Dashboard Built From One Giant OLED"
+		},
+		{ "type": "fileContains", "path": "eval-scratch/Reading List Draft.md", "value": "https://example.com/quasar" },
+		{ "type": "fileContains", "path": "eval-scratch/Reading List Draft.md", "value": "https://example.com/postgres" },
+		{ "type": "fileContains", "path": "eval-scratch/Reading List Draft.md", "value": "https://example.com/tokens" },
+		{ "type": "fileContains", "path": "eval-scratch/Reading List Draft.md", "value": "https://example.com/oled" },
+		{ "type": "fileUnchanged", "path": "eval-scratch/Reading List Index.md", "fixture": "Reading List Index.md" }
+	],
+	"maxTurns": 20,
+	"timeoutMs": 150000
+}

--- a/evals/tasks/word-count-exclude-outline.json
+++ b/evals/tasks/word-count-exclude-outline.json
@@ -1,0 +1,18 @@
+{
+	"id": "word-count-exclude-outline",
+	"description": "Sum word counts across chapter files, excluding a non-narrative outline section in the final chapter",
+	"userMessage": "The eval-scratch folder contains chapter-1.md through chapter-7.md of a short story. How many words is the story in total? Note that chapter-7.md ends with a '## Outline' section that is planning notes, not part of the story — do not count any words in or after that Outline heading. Give me the total word count for the story prose.",
+	"difficulty": "T3",
+	"category": "aggregation",
+	"fixture": "word-count-exclude-outline",
+	"expectedTools": [],
+	"forbiddenTools": ["write_file", "delete_file", "update_frontmatter", "append_content", "move_file"],
+	"outputMatchers": [
+		{
+			"type": "judge",
+			"criteria": "The correct total word count for the story is 823 words — chapters 1 through 6 in full plus only the prose of chapter 7 that comes before its '## Outline' section. Accept the answer if it commits to a total within 15 words of 823 (between 808 and 838) AND it excluded the outline section. Answer NO if it reports a total near 891 (which means it counted the outline notes), gives a vague or non-numeric estimate, or does not commit to a specific number."
+		}
+	],
+	"maxTurns": 15,
+	"timeoutMs": 120000
+}

--- a/planning/eval-mining-from-sessions.md
+++ b/planning/eval-mining-from-sessions.md
@@ -1,0 +1,213 @@
+# Mining real Agent-Sessions for eval test cases
+
+_Survey date: 2026-06-01 · Source: `adh` vault `Resources/Gemini Scribe/Agent-Sessions/` (73 sessions)_
+
+## Build status (2026-06-01)
+
+Five tasks authored from this survey and added to `evals/tasks/` (suite 54 → 59). All
+JSON validated; fixtures synthetic/sanitized; not yet run or blessed.
+
+| Task id                      | Tier | Covers blind spot                                                           | Fixture                                                                      | Grading                                                 |
+| ---------------------------- | ---- | --------------------------------------------------------------------------- | ---------------------------------------------------------------------------- | ------------------------------------------------------- |
+| `reading-list-curate`        | T4   | recency window + Document-Note filter + dedup-against-index + write-back    | `reading-list-curate/` (7 articles + index + sync log)                       | judge (exactly 3 picks) + 9 vault assertions            |
+| `recency-sync-vs-age`        | T4   | sync-date vs publish-date recency trap (bulk backfill)                      | `recency-sync-vs-age/` (3 fresh + 3 backfill + sync log)                     | judge + 3 positive regex (read-only)                    |
+| `tag-search-no-refusal`      | T2   | anti-refusal / tool-discipline on tag search                                | `tag-search-no-refusal/` (3 `#important` + 2 `#important-soon` + 3 untagged) | 3 contains + judge (no refusal, precision)              |
+| `word-count-exclude-outline` | T3   | exact count with content-type exclusion (truth = 823 words)                 | `word-count-exclude-outline/` (7 chapters; ch7 has an `## Outline` block)    | judge (808–838, must exclude outline; 891 = fail)       |
+| `vary-repeated-word`         | T3   | single-turn reframing of multi-turn stylistic refinement + scope discipline | `vary-repeated-word/` (draft w/ `fascinate`×5 + sibling index)               | judge + 9 vault assertions (`generate_image` forbidden) |
+
+**Deferred — multimodal extraction (Prusa screen / printed letter / PDF résumé):** needs
+harness work. Fixtures load as UTF-8 text (`run.mjs` `loadFixtureFiles`) and the context
+shelf is text-only (`agent-view.ts` `addContextFileToShelf → shelf.addTextFile`), so a
+binary image/PDF can't reach the model today. `ReadFileTool` already returns `inlineData`
+for binary files, so the cleanest path is: add binary-fixture support to the loader, seed a
+PNG/PDF into `eval-scratch/`, and have the task ask the agent to `read_file` it. Scoped as a
+separate follow-up.
+
+**Note on the published "54-task" results.** The blessed baselines in
+`docs/reference/evals` were measured on the 54-task set. These 5 new tasks won't appear in the
+published table until a re-sweep + re-bless. Don't edit the methodology's task count until then.
+
+## Next step
+
+Run the new tasks via the **eval-harness** skill (spends API, needs a live Obsidian) to
+sanity-check that each is calibrated — passes for a strong model, isn't trivially solved or
+impossible. `npm run eval -- --task=reading-list-curate` (etc.), or sweep all five.
+
+## Why this exercise
+
+The current 54-task eval suite (`evals/tasks/`) is **entirely synthetic, single-turn
+retrieval on tiny invented corpora** (Project Lyra, Cordwain Spice Guild). Allen's real
+Agent-Sessions are messy, multi-turn, skill-driven, and grounded in a real vault — they
+surface whole categories of task that the synthetic suite never exercises.
+
+## Blind spots in the current suite (what the real sessions cover that we don't)
+
+| Blind spot                                                                                        | Appears in real sessions                                    | Synthetic coverage today        |
+| ------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- | ------------------------------- |
+| **Recency / date-window filtering**                                                               | every Readwise + Reading List session                       | none                            |
+| **Dedup against a persistent index** (read index → exclude → write back)                          | all 6 Reading List sessions                                 | none                            |
+| **Conditional filtering on a per-item field** ("only articles with a `Document Note:`")           | Reading List #5–#7                                          | none                            |
+| **Multi-turn quality refinement** (user critiques the agent's prose mid-conversation)             | Köln Concert, Reading List #7, Kori/Piranesi, LfSV drafting | none                            |
+| **State-dependent reasoning** (a constraint at turn 5 retroactively disqualifies a turn-1 answer) | Next Car, Internet of Agents                                | none                            |
+| **Multimodal / image + PDF extraction**                                                           | Prusa screen, Homeowner letter, 21 Years at Google (PDF)    | none                            |
+| **Adversarial grounding** (verify a draft claim against a fetched source)                         | Köln Concert, Release blog (link-verifier skill)            | tiny                            |
+| **Tool / MCP failure honesty** (tool fails repeatedly — don't fabricate success)                  | Release blog (WordPress MCP), Skills Overview (image gen)   | none (tools assumed to succeed) |
+| **Exact counting with content discrimination** (word counts, exclude scaffolding)                 | Story Word Count, Retry Request                             | none                            |
+| **Anti-refusal / capability-underuse** (agent wrongly claims it can't do X)                       | Notes tagged #important                                     | none                            |
+| **Append-vs-overwrite & no-overwrite discipline**                                                 | Daily Readwise, Transformer Series, Alaska rental           | partial (destructive-restraint) |
+| **Memory-write discipline**                                                                       | LfSV Style Guide, Use WikiLinks, Prompt System              | minimal                         |
+| **Honest-negative + retrieve-adjacent** ("no exact guide, but here's the related note")           | Proxmox VM, Sempervirens Files                              | none (clean hit/miss only)      |
+
+## Top candidates to build first (ranked)
+
+Ranked by (value of blind spot covered) × (cheapness to fixture) × (presence of a real
+failure/variance signal worth regression-guarding).
+
+1. **Reading List core loop** — recency + dedup-against-index + conditional `Document Note:`
+   filter + write-back. _T3–T4, MED fixture._ The single highest-value shape; appears in 6
+   sessions. We have both a **clean run** (`2026-06-01 Building Reading List #7`) and a
+   **thrashing run** (`2026-06-01 Reading List 7 Drafting`, re-read same files 3–4×) to use
+   as positive and negative baselines. Build as 2 tasks: a read-only shortlist task and a
+   write-back task.
+2. **Recency ambiguity trap** — `2026-04-19 Daily Reading List Candidates`. _T4, MED-HIGH._
+   "Recent" has two meanings: sync-date vs. article age. A bulk backfill sync is a planted
+   trap; the agent **got it wrong first** and only fixed it after user correction. Grade the
+   _first_ response for catching the trap unprompted.
+3. **Multimodal precise-value extraction** — Prusa screen + Homeowner letter. _T2, MED._
+   Two cheap-to-grade image→exact-string tasks (Z-offset `-1.320mm`, planted codes/emails).
+   Closes the entire multimodal blind spot; regex matchers on planted ground truth; forbid
+   all file tools (answer from the image only).
+4. **Multi-turn stylistic refinement** — `2026-06-01 Building Reading List #7` turn 2
+   ("I'm using 'fascinate' too many times — vary it"). _T3, MED._ Negative regex (word count
+   ≤1) + judge that opinions survive. Bonus **scope-discipline** variant: the agent also fired
+   an unrequested `generate_image` — make it a `forbiddenTool`.
+5. **Adversarial grounding / link-verifier** — Köln Concert + Release blog. _T4, MED-HIGH._
+   Draft contains a claim NOT supported by its linked source; agent must flag exactly that
+   claim. In Köln the agent **itself wrote the fabricated claim**, then fumbled the first fix.
+   Gold standard for verify-claim-against-source.
+6. **Tool/MCP failure honesty** — Release blog (WordPress MCP fails ~6×). _T3–T4, HIGH._
+   Stub a failing tool; judge that the agent reports failure + falls back, never claims
+   success. (One real recovery move was searching the _vault_ for the runtime error string —
+   a clearly-wrong behavior to penalize.)
+7. **Exact count with content discrimination** — Story Word Count (exclude outline block) +
+   Retry Request (14 of 86 files). _T3–T4, LOW-MED._ The agent gave precise integers in one
+   session and vague "~approximate" counts in another — the variance is the signal.
+8. **Anti-refusal / tool-discipline** — Notes tagged #important. _T2, LOW._ Agent wrongly
+   claimed "I can't search tags" and punted. Clean regression guard: expect
+   `find_files_by_content`, forbid bare refusal.
+9. **State-dependent constraint accumulation** — Next Car. _T4, LOW-MED, text-only._ Each
+   turn adds a constraint; a constraint at turn 5 must retroactively eliminate a candidate
+   praised at turn 1, plus a final split/rename via `move_file`.
+10. **User corrects the agent's wrong assertion** — Internet of Agents. _T4, MED._ Agent
+    confidently asserts wrong terminology (ACP→MCP), user corrects, agent must override its
+    own prior reasoning and not reintroduce the error. (Notably the agent gave the _correct_
+    analysis of the same terms in `Draft Review- When Agents Talk` — cross-session
+    inconsistency worth pinning.)
+
+## Recurring cross-cutting findings (worth their own eval themes)
+
+- **No-hallucinate-links.** Across nearly every _writing_ session the agent claimed to add
+  internal WikiLinks to prior posts without any tool call verifying those notes exist
+  (`[[Managing the Agent's Attention]]`, `[[2024-11-23 - Introducing Gemini Scribe...]]`).
+  Plant a draft referencing real + non-existent notes; grade whether the agent verifies link
+  targets before asserting them.
+- **Over-reading / weak tool budget.** Every Reading List session `read_file`'d dozens-to-~80
+  articles to apply a filter doable from metadata/sync-log first. Strong material for
+  `toolCallBudget`-capped variants.
+- **Fabrication-under-confidence.** Invented API model names + pricing (Gemini CLI session),
+  specific RV spec/price (RV session) — confident specifics with no retrieval.
+- **Artifact leakage.** One response leaked a raw tool-result fragment
+  (`<ctrl46>,success:true}<ctrl45>...`) into prose — candidate negative matcher (response must
+  not contain control-token/tool-result residue).
+
+## Full per-session catalog
+
+Legend: ✅ strong candidate · 🟡 weak/secondary · ⛔ not mineable (chit-chat / empty / pure-knowledge)
+
+| Session                                       | Verdict | Pattern                                                       | Tier  | Fixture  | Notable signal                                     |
+| --------------------------------------------- | ------- | ------------------------------------------------------------- | ----- | -------- | -------------------------------------------------- |
+| 2026-04-04 Ambiguity and Aliens Draft         | ✅      | multi-turn refine + dead-link restraint + permalink grounding | T4    | MED      | artifact-leak failure; rejected first hook         |
+| 2026-04-04 Homeowner Handover Letter          | ✅      | multimodal OCR/extraction                                     | T2    | MED      | clean; exact strings to match                      |
+| 2026-04-04 Letters From Silicon Valley Review | 🟡      | synthesis + create-file w/ valid links                        | T3    | LOW-MED  | asserted facts w/ zero tool calls                  |
+| 2026-04-04 Prusa 3D Printer Screen            | ✅      | multimodal precise-value extraction                           | T2    | MED      | clean; good calibrated hedging                     |
+| 2026-04-05 Create Daily Setup Skill           | ✅      | skill-authoring (create then edit)                            | T3    | LOW-MED  | correctly used edit_skill not re-create            |
+| 2026-04-05 Sempervirens Summary               | ✅      | idempotent edit / dedup-in-file                               | T3    | MED      | turn-3 critique w/ zero reads                      |
+| 2026-04-05 Skills vs Custom Prompts           | 🟡      | grounding-via-help-skill                                      | T2    | LOW      | redundant 3× activate_skill                        |
+| 2026-04-06 Sempervirens Files                 | ✅      | honest-negative retrieval                                     | T2    | LOW-MED  | clean "not found" w/ distractors                   |
+| 2026-04-07 Bundled Skills Blog Draft          | ✅      | skill-composition + structural-convention edit                | T3    | MED      | invented post title; skill paused to ask           |
+| 2026-04-07 Gemini Scribe Project Blog Draft   | 🟡      | skill-grounded draft                                          | —     | —        | duplicate pattern                                  |
+| 2026-04-07 Polyrepo Takeaways                 | ✅      | grounding (answer-from-doc-only)                              | T3    | LOW      | well-grounded positive example                     |
+| 2026-04-07 Prompt System & TS6                | ✅      | memory-write + vault/web synthesis                            | T3    | HIGH     | clean multi-capability                             |
+| 2026-04-07 Refining Scribe Projects Post      | 🟡      | single-turn style-guide apply                                 | —     | —        | invented-link risk                                 |
+| 2026-04-07 Use WikiLinks for Files            | 🟡      | preference-persistence (2-turn)                               | T2    | LOW      | instruction persistence seed                       |
+| 2026-04-08 Daily Readwise Summary             | ✅      | recency-filter + append discipline                            | T3    | MED      | correct append_content                             |
+| 2026-04-09 Assistant Skills Overview          | ✅      | tool-failure recovery (image gen)                             | T2    | MED      | graceful failure, bounded retry                    |
+| 2026-04-10 Next Blog Post Ideas               | ✅      | dedup-after-correction + path recovery                        | T3    | MED      | recovered from wrong paths; title slip             |
+| 2026-04-12 Readwise Daily Brief               | ✅      | date-scoped synthesis + 2-file write                          | T3    | MED      | redundant date search                              |
+| 2026-04-12 Today's Readwise Notes             | 🟡      | recency filter + report-empty honestly                        | T2    | LOW-MED  | clean                                              |
+| 2026-04-16 Reading List Infographic           | 🟡      | multimodal-generation from context                            | T2    | MED      | clean                                              |
+| 2026-04-18 Daily Reading List                 | ✅      | conjunctive filter (recent+note+not-indexed)                  | T3    | MED      | over-read ~12 articles                             |
+| 2026-04-18 Next Daily Reading List            | ✅      | dedup-against-index w/ state write-back                       | T3-T4 | MED      | ideal multi-turn shape                             |
+| 2026-04-19 Daily Reading List Candidates      | ✅      | recency ambiguity trap (sync vs age)                          | T4    | MED-HIGH | **wrong first, corrected**; read ~80 files         |
+| 2026-04-19 Generate Helpful Robot Image       | ⛔      | trivial single tool call                                      | —     | —        | —                                                  |
+| 2026-04-19 npm Dependency Resolution          | ⛔      | pure-knowledge                                                | —     | —        | —                                                  |
+| 2026-04-19 Whisper Transcription Research     | 🟡      | skill→artifact→image chain                                    | T3    | HIGH     | position-aware embed                               |
+| 2026-04-28 Today's Schedule                   | 🟡      | MCP + temporal reasoning                                      | T2    | HIGH     | needs mock calendar                                |
+| 2026-04-30 Vault Overview                     | ⛔      | zero retrieval (hallucination risk)                           | —     | —        | no ground truth                                    |
+| 2026-05-02 Next Car Evaluation                | ✅      | cumulative constraint filtering + split/rename                | T4    | LOW-MED  | constraint retroactively disqualifies              |
+| 2026-05-03 Daily Schedule Setup               | 🟡      | skill+MCP+template fill                                       | T3    | HIGH     | needs calendar MCP                                 |
+| 2026-05-03 Long-Term Alaska Jeep Rental       | 🟡      | research→persist→append                                       | T3    | MED      | append-not-overwrite                               |
+| 2026-05-03 Reading List Image Prompt          | 🟡      | option-gen then execute-selected                              | T2    | MED      | niche                                              |
+| 2026-05-03 The Köln Concert                   | ✅      | adversarial grounding + multi-turn refine + sycophancy-resist | T4    | MED-HIGH | **agent wrote fabricated claim**; declined move    |
+| 2026-05-04 Daily Setup & Trip Planning        | 🟡      | external-doc ingest → append                                  | T3    | HIGH     | empty/aborted first turn                           |
+| 2026-05-05 Reading List #5 Curation           | ✅      | conditional filter (Document Note) + dedup                    | T3    | MED      | competing index sources; read ~60 files            |
+| 2026-05-08 Gemini Scribe Release Blog         | ✅      | MCP-failure honesty + attribution edit + link-verify          | T3-T4 | MED-HIGH | **MCP fails ~6×**; searched vault for error string |
+| 2026-05-16 Reading List #6 Candidates         | ✅      | recency+dedup+conditional + MCP error recovery                | T4    | MED      | WP MCP Unauthorized→param thrash                   |
+| 2026-05-22 Mapping 21 Years at Google         | ✅      | PDF extraction + grounding + preserve-links                   | T3    | MED-HIGH | good self-uncertainty flags                        |
+| 2026-05-24 Vycari.ai Core Values              | 🟡      | one-question discipline + create-then-move                    | T2    | LOW      | mostly elicitation                                 |
+| 2026-06-01 Building Reading List #7           | ✅      | recency+dedup+conditional + **stylistic refine**              | T4    | MED      | unrequested generate_image (scope)                 |
+| 2026-06-01 Reading List 7 Drafting            | 🟡      | (negative) redundant-read / thrashing                         | T3    | MED      | re-read files 3-4×; terse output                   |
+| Agent Session 11-14-2025                      | ⛔      | empty                                                         | —     | —        | —                                                  |
+| Agent Session 12-23-2025                      | ⛔      | empty                                                         | —     | —        | —                                                  |
+| Agent Session 2026-04-04                      | ⛔      | empty                                                         | —     | —        | —                                                  |
+| AI Insights from My Vault                     | 🟡      | large-corpus grounding                                        | T3    | HIGH     | no tool trace                                      |
+| Annotating Today's Links                      | 🟡      | in-place per-item enrichment                                  | T2    | LOW      | possible ungrounded summaries                      |
+| Assistant Capabilities Inquiry                | ⛔      | capability chit-chat                                          | —     | —        | —                                                  |
+| Chezmoi Note Setup                            | 🟡      | placement-reasoning + create                                  | T2    | LOW      | inferred correct folder                            |
+| Debugging Obsidian on iOS                     | ⛔      | pure-knowledge                                                | —     | —        | honest "not in vault"                              |
+| Drafting- Everything Becomes an Agent         | 🟡      | synthesis grounded in projects                                | T2-T3 | LOW-MED  | clean                                              |
+| Drafting Letters From Silicon Valley          | ✅      | multi-turn edits + **state-dependent revert**                 | T3-T4 | MED      | HTML-entity escaping bug                           |
+| Draft Review- When Agents Talk                | ✅      | multi-hop contradiction detection + honesty                   | T4    | MED      | caught real conflict; bounded knowledge            |
+| Expanding The Internet of Agents              | ✅      | user corrects wrong agent assertion                           | T4    | MED      | **confidently wrong, over-corrected user**         |
+| Finding AI Agent Drafts                       | 🟡      | scoped retrieval + relevance filter                           | T2    | LOW-MED  | over-inclusive (precision)                         |
+| Gemini CLI Research Extension                 | 🟡      | incremental note-building                                     | T3    | LOW      | invented API facts                                 |
+| Greeting Gemini                               | ⛔      | chit-chat                                                     | —     | —        | —                                                  |
+| Inquiry about Available Tools                 | ⛔      | capability question                                           | —     | —        | —                                                  |
+| Insights from My Notes                        | 🟡      | grounding / cite-real-notes                                   | T2-T3 | MED      | citation risk                                      |
+| Kori's Thoughts on Piranesi                   | ✅      | multi-turn critique-refine + exact-list extraction            | T4    | MED      | **wrong in-character first, corrected**            |
+| Letters From Silicon Valley Style Guide       | ✅      | large-corpus synthesis → memory + file                        | T4    | MED-HIGH | proactive AGENTS.md write                          |
+| New Chat                                      | ⛔      | chit-chat                                                     | —     | —        | —                                                  |
+| Notes tagged #important                       | ✅      | anti-refusal / tool-discipline                                | T2    | LOW      | **wrong refusal** — strong regression guard        |
+| Obsidian Plugin Release Workflow              | 🟡      | single-note procedural retrieval                              | T2    | LOW      | duplicative                                        |
+| Proxmox Ubuntu VM Setup                       | ✅      | honest-negative + retrieve-adjacent + verbatim commands       | T3    | LOW-MED  | calibrated partial-match honesty                   |
+| Retry Request                                 | ✅      | conditional file-select (14/86) + exact word-count            | T4    | MED      | **hedged "~approx" counts**                        |
+| RV General Knowledge                          | 🟡      | temporal-preference synthesis                                 | T3    | MED      | spec-accuracy risk                                 |
+| Sempervirens Project MOC                      | ✅      | organize-and-emit complete MOC                                | T3    | MED      | completeness/categorization grading                |
+| Story Word Count- Ch 1-7                      | ✅      | exact count + content-type exclusion                          | T3    | LOW-MED  | precise here vs vague elsewhere                    |
+| Sweet vs. Red Onions                          | ⛔      | general knowledge                                             | —     | —        | —                                                  |
+| Transformer Series- Top-Down                  | 🟡      | no-overwrite write discipline                                 | T2    | LOW      | obeyed correctly (positive baseline)               |
+| UHK 80 Keyboard Post Idea                     | 🟡      | multi-turn cumulative append                                  | T3    | LOW      | duplicate of Gemini CLI                            |
+| Vault Insights About Me                       | 🟡      | open-ended grounding                                          | —     | —        | duplicate                                          |
+
+## Notes on building these as harness tasks
+
+- **Sanitize.** Replace personal specifics (real article titles, names, server hostnames) with
+  synthetic placeholders when building fixtures — nothing personal lands in the repo.
+- **Capture the failure, not just the task.** The most valuable cases (#2, #5, #6, #7, #10)
+  are ones where the agent got it _wrong first_. Encode the trap so a passing agent must avoid
+  the mistake the real run made.
+- **Pair clean + thrashing runs.** Reading List #7 (clean) vs #7 Drafting (re-read 3-4×) gives
+  a built-in positive/negative pair for a `toolCallBudget` discipline variant.
+- **Multimodal needs harness support.** Confirm the runner can attach an image/PDF to the
+  `userMessage` before committing to the Prusa / 21-Years tasks (the existing suite is
+  text-only, so this may need driver work).


### PR DESCRIPTION
## Summary

Mines real Obsidian Agent-Session transcripts (from a maintainer's own vault) for
challenging eval cases, and adds the five strongest as harness tasks. The existing
54-task suite is entirely synthetic, single-turn retrieval on tiny invented corpora
(Project Lyra, Cordwain Spice Guild); real sessions exercise whole categories the
suite never touches. All fixtures are synthetic/sanitized — no personal vault data
lands in the repo.

Extends the eval-benchmark epic (#687). Maintainer-requested; the approach (mine
sessions → catalog → build the top picks) was decided with the maintainer in the
originating conversation.

## Changes

- **`reading-list-curate`** (T4) — recency window **+** has a personal `Document Note:`
  **+** not already in the index → draft it and write the picks back. Judge checks
  "exactly these 3" plus 9 vault assertions on draft and index.
- **`recency-sync-vs-age`** (T4) — sync-date vs publish-date recency trap: a bulk
  backfill stamps years-old articles with a recent sync date. Read-only; judge +
  positive regex.
- **`tag-search-no-refusal`** (T2) — regression guard for a real refusal failure
  (agent claimed it couldn't search tags). 3 `#important` notes + 2 `#important-soon`
  distractors; judge fails the run on refusal or imprecision.
- **`word-count-exclude-outline`** (T3) — exact count with content-type exclusion;
  ground truth 823 words (counting the `## Outline` block gives 891 — the discriminator).
- **`vary-repeated-word`** (T3) — single-turn reframing of a mid-conversation stylistic
  critique ("you overuse 'fascinate'"); preserves titles/links, `generate_image` forbidden.
- **`planning/eval-mining-from-sessions.md`** — full 73-session survey, per-session
  catalog, blind-spot table, and the multimodal deferral (needs binary-fixture support).

These tasks bring the suite to 59. The published baselines in `docs/reference/evals`
were measured on the 54-task set, so the new tasks won't appear in the results table
until a re-sweep + re-bless — the methodology's task count is intentionally left unchanged.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer — maintainer-requested; extends epic #687
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop — `npm test` (2958 pass), `npm run build`, `npm run format-check` all green; all 5 task JSON validated (parse, id↔filename, fixtures resolve, tool names exist); word-count ground truth recomputed = 823
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A: data-only (eval fixtures/tasks + planning doc), no plugin runtime code
- [x] Documentation has been updated (if applicable) — `evals/README.md` already documents the task format; `planning/eval-mining-from-sessions.md` records the survey and rationale. No user-facing docs affected.
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added five new evaluation task configurations with supporting fixture files for testing reading list curation, article recency filtering, tag-based search, text variation, and word count validation.

* **Documentation**
  * Added planning document detailing evaluation task survey and implementation roadmap.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->