### PR TITLE
refactor: extract RagProgressProvider interface to replace 3 `progressProvider: any` sites

### DIFF
--- a/src/services/rag-types.ts
+++ b/src/services/rag-types.ts
@@ -87,6 +87,17 @@ export interface RagProgressInfo {
  */
 export type ProgressListener = (progress: RagProgressInfo) => void;
 
+/**
+ * Shape required by RagProgressModal to observe and control an ongoing indexing run.
+ * Implemented by RagIndexingService (and used by RagVaultScanner when invoking the modal).
+ */
+export interface RagProgressProvider {
+	addProgressListener: (listener: ProgressListener) => void;
+	removeProgressListener: (listener: ProgressListener) => void;
+	getProgressInfo: () => RagProgressInfo;
+	cancelIndexing: () => void;
+}
+
 export const CACHE_VERSION = '1.0';
 export const DEBOUNCE_MS = 2000;
 

--- a/src/services/rag-vault-scanner.ts
+++ b/src/services/rag-vault-scanner.ts
@@ -6,7 +6,7 @@ import type { ObsidianVaultAdapter } from './obsidian-file-adapter';
 import type { RagCache } from './rag-cache';
 import type { RagRateLimiter } from './rag-rate-limiter';
 import { CACHE_VERSION } from './rag-types';
-import type { IndexProgress, IndexResult, FailedFileEntry, RagIndexStatus } from './rag-types';
+import type { IndexProgress, IndexResult, FailedFileEntry, RagIndexStatus, RagProgressProvider } from './rag-types';
 import { getErrorMessage, isNotFoundError, isQuotaExhausted } from '../utils/error-utils';
 import { executeWithRetry } from '../utils/retry';
 
@@ -235,7 +235,7 @@ export class RagVaultScanner {
 	 * Handle interrupted indexing by prompting user to resume or start fresh.
 	 * @param progressProvider - The object to pass to the progress modal (typically the orchestrator)
 	 */
-	async handleInterruptedIndexing(progressProvider: any): Promise<void> {
+	async handleInterruptedIndexing(progressProvider: RagProgressProvider): Promise<void> {
 		if (!this.ragCache.cache) return;
 
 		const resumeInfo = {
@@ -268,7 +268,7 @@ export class RagVaultScanner {
 	 * Start resume indexing with progress modal.
 	 * @param progressProvider - The object to pass to the progress modal (typically the orchestrator)
 	 */
-	startResumeIndexing(progressProvider: any): void {
+	startResumeIndexing(progressProvider: RagProgressProvider): void {
 		import('../ui/rag-progress-modal').then(({ RagProgressModal }) => {
 			const progressModal = new RagProgressModal(this.plugin.app, progressProvider, (result) => {
 				new Notice(`RAG Indexing complete: ${result.indexed} indexed, ${result.skipped} unchanged`);
@@ -286,7 +286,7 @@ export class RagVaultScanner {
 	/**
 	 * Clear cache and store, then start fresh indexing
 	 */
-	private async startFresh(progressProvider: any): Promise<void> {
+	private async startFresh(progressProvider: RagProgressProvider): Promise<void> {
 		try {
 			// Clear local cache
 			this.ragCache.cache = {

--- a/src/ui/rag-progress-modal.ts
+++ b/src/ui/rag-progress-modal.ts
@@ -1,16 +1,11 @@
 import { App, Modal, Setting, setIcon } from 'obsidian';
-import type { RagProgressInfo, ProgressListener } from '../services/rag-types';
+import type { RagProgressInfo, ProgressListener, RagProgressProvider } from '../services/rag-types';
 
 /**
  * Modal showing live progress during RAG indexing operations
  */
 export class RagProgressModal extends Modal {
-	private ragService: {
-		addProgressListener: (listener: ProgressListener) => void;
-		removeProgressListener: (listener: ProgressListener) => void;
-		getProgressInfo: () => RagProgressInfo;
-		cancelIndexing: () => void;
-	};
+	private ragService: RagProgressProvider;
 	private onComplete?: (result: { indexed: number; skipped: number; failed: number }) => void;
 	private progressListener: ProgressListener;
 	private progressInfo: RagProgressInfo;
@@ -30,12 +25,7 @@ export class RagProgressModal extends Modal {
 
 	constructor(
 		app: App,
-		ragService: {
-			addProgressListener: (listener: ProgressListener) => void;
-			removeProgressListener: (listener: ProgressListener) => void;
-			getProgressInfo: () => RagProgressInfo;
-			cancelIndexing: () => void;
-		},
+		ragService: RagProgressProvider,
 		onComplete?: (result: { indexed: number; skipped: number; failed: number }) => void
 	) {
 		super(app);

--- a/test/services/rag-vault-scanner.test.ts
+++ b/test/services/rag-vault-scanner.test.ts
@@ -1033,7 +1033,7 @@ describe('RagVaultScanner', () => {
 			ragCache.cache = null;
 			const { scanner } = createScanner({ ragCache });
 
-			await scanner.handleInterruptedIndexing({});
+			await scanner.handleInterruptedIndexing({} as any);
 
 			// Should not throw or do anything
 		});
@@ -1064,7 +1064,7 @@ describe('RagVaultScanner', () => {
 			// Mock startResumeIndexing to avoid side effects
 			const spy = vi.spyOn(scanner, 'startResumeIndexing').mockImplementation(() => {});
 
-			const progressProvider = { foo: 'bar' };
+			const progressProvider = { foo: 'bar' } as any;
 			await scanner.handleInterruptedIndexing(progressProvider);
 
 			expect(spy).toHaveBeenCalledWith(progressProvider);
@@ -1102,7 +1102,7 @@ describe('RagVaultScanner', () => {
 			// Mock startResumeIndexing to prevent actual indexing
 			vi.spyOn(scanner, 'startResumeIndexing').mockImplementation(() => {});
 
-			await scanner.handleInterruptedIndexing({});
+			await scanner.handleInterruptedIndexing({} as any);
 
 			// startFresh should have cleared cache and deleted store
 			expect(ragCache.saveCache).toHaveBeenCalled();
@@ -1128,7 +1128,7 @@ describe('RagVaultScanner', () => {
 				this.open = vi.fn();
 			});
 
-			scanner.startResumeIndexing({});
+			scanner.startResumeIndexing({} as any);
 
 			// Use deterministic polling instead of a fixed setTimeout delay
 			await vi.waitFor(() => {


### PR DESCRIPTION
## Summary

Architecture-audit nightly sweep flagged: **`any` overuse** in `src/services/rag-vault-scanner.ts` (6th-highest density at 6 sites).

Three methods on `RagVaultScanner` (`handleInterruptedIndexing`, `startResumeIndexing`, `startFresh`) accepted `progressProvider: any` and passed it straight through to `RagProgressModal`'s constructor — whose constructor signature inlined the real four-method shape (`addProgressListener`, `removeProgressListener`, `getProgressInfo`, `cancelIndexing`). The shape is implemented by `RagIndexingService` and consumed by the modal; hoisting it into a named `RagProgressProvider` type in `rag-types.ts` lets all three scanner sites be typed and dedupes the inline literal in the modal.

No behavior change — pure type tightening.

## Changes

- `src/services/rag-types.ts`: add `RagProgressProvider` interface.
- `src/services/rag-vault-scanner.ts`: import the type and replace `progressProvider: any` on `handleInterruptedIndexing`, `startResumeIndexing`, `startFresh`.
- `src/ui/rag-progress-modal.ts`: replace the inline ragService shape with `RagProgressProvider`.
- `test/services/rag-vault-scanner.test.ts`: existing tests pass `{}` or `{ foo: 'bar' }` for the parameter because the modal is mocked; cast those to `as any` so they keep compiling without changing test intent.

## Screenshots / Screencast

Backend/internal — no UI surface changed.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — opened by the `architecture-audit` skill; no preceding issue
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop — `npm test` (2958 pass), `npm run build`, `npm run format-check` all green
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — pure type-only change, no runtime/platform code touched
- [x] Documentation has been updated (if applicable) — no user-facing surface change
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (architecture-audit skill)
- [x] I have reviewed and understand all AI-generated code in this PR


---
_Generated by [Claude Code](https://claude.ai/code/session_01NaGmeL9czvTabYjh3RLbnD)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved type safety across RAG indexing and progress tracking by introducing stricter type definitions for progress provider interface and related method signatures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->