### PR TITLE
refactor: type AgentView confirmation/result params with Tool and ToolResult

### DIFF
--- a/src/ui/agent-view/agent-view-send.ts
+++ b/src/ui/agent-view/agent-view-send.ts
@@ -15,7 +15,7 @@ import { AgentViewTools } from './agent-view-tools';
 import { AgentViewSession } from './agent-view-session';
 import { AgentViewShelf } from './agent-view-shelf';
 import type ObsidianGemini from '../../main';
-import type { ConfirmationResult, DiffContext } from '../../tools/types';
+import type { ConfirmationResult, DiffContext, Tool } from '../../tools/types';
 
 /**
  * Context interface for the send module.
@@ -38,7 +38,7 @@ export interface SendContext {
 	isToolAllowedWithoutConfirmation: (toolName: string) => boolean;
 	allowToolWithoutConfirmation: (toolName: string) => void;
 	showConfirmationInChat: (
-		tool: any,
+		tool: Tool,
 		parameters: any,
 		executionId: string,
 		diffContext?: DiffContext

--- a/src/ui/agent-view/agent-view.ts
+++ b/src/ui/agent-view/agent-view.ts
@@ -2,6 +2,7 @@ import { ItemView, MarkdownView, Platform, WorkspaceLeaf, TFile, Notice } from '
 import { ChatSession, SessionModelConfig } from '../../types/agent';
 import { GeminiConversationEntry } from '../../types/conversation';
 import type ObsidianGemini from '../../main';
+import type { Tool, ToolResult } from '../../tools/types';
 import { HandlerPriority } from '../../types/agent-events';
 
 // Import all component modules
@@ -663,7 +664,7 @@ export class AgentView extends ItemView {
 	 * Returns Promise that resolves when user clicks a button
 	 */
 	public async showConfirmationInChat(
-		tool: any,
+		tool: Tool,
 		parameters: any,
 		executionId: string,
 		diffContext?: import('../../tools/types').DiffContext
@@ -750,7 +751,7 @@ export class AgentView extends ItemView {
 	 * Public method to show tool result (delegates to tools component)
 	 * Used by tests and external components
 	 */
-	async showToolResult(toolName: string, result: any, executionId?: string): Promise<void> {
+	async showToolResult(toolName: string, result: ToolResult, executionId?: string): Promise<void> {
 		// Lazy initialization for tests that don't call onOpen()
 		if (!this.tools) {
 			this.ensureToolsInitialized();


### PR DESCRIPTION
## Summary

Architecture-audit nightly sweep flagged: **`any` overuse** in `src/ui/agent-view/agent-view.ts` and `src/ui/agent-view/agent-view-send.ts`.

`AgentView.showConfirmationInChat` declared `tool: any` and the matching `SendContext.showConfirmationInChat` callback declared the same — even though the canonical `IConfirmationProvider` interface in `src/tools/types.ts` already uses `tool: Tool`. The unused freedom was unprincipled; tighten both sites to `Tool`.

While here, `AgentView.showToolResult` accepted `result: any` but already delegates to `AgentViewTools.showToolResult`, which is typed `result: ToolResult` — make the public method match.

`parameters: any` on the same signatures stays as-is: that one's a deliberate per-tool generic, matching the underlying `Tool.execute(params: any, ...)` contract.

## Changes

- `src/ui/agent-view/agent-view.ts`: import `Tool`, `ToolResult` from `../../tools/types`; replace `tool: any` with `tool: Tool` in `showConfirmationInChat`; replace `result: any` with `result: ToolResult` in `showToolResult`.
- `src/ui/agent-view/agent-view-send.ts`: import `Tool`; replace `tool: any` with `tool: Tool` in `SendContext.showConfirmationInChat`.

## Screenshots / Screencast

Backend/internal — no UI surface changed.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — opened by the `architecture-audit` skill; no preceding issue
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop — `npm test` (2958 pass), `npm run build`, `npm run format-check` all green
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — pure type-only change, no runtime/platform code touched
- [x] Documentation has been updated (if applicable) — no user-facing surface change
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (architecture-audit skill)
- [x] I have reviewed and understand all AI-generated code in this PR


---
_Generated by [Claude Code](https://claude.ai/code/session_01NaGmeL9czvTabYjh3RLbnD)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced type safety in agent view confirmation and result handling operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->