### PR TITLE
chore(daily): 2026-06-07 daily update

### DIFF
--- a/docs/guide/agent-mode.md
+++ b/docs/guide/agent-mode.md
@@ -37,12 +37,15 @@ In v4.0+, the agent is always available and can:
 
 ### 3. Configure Permissions
 
-Choose which operations require confirmation in Settings → Gemini Scribe:
+Choose which operations require confirmation in **Settings → Gemini Scribe → Tool Permissions**:
 
-- Create files
-- Modify files
-- Delete files
-- Move/rename files
+- **write_file**: Creating or modifying files
+- **delete_file**: Removing files
+- **move_file**: Moving or renaming files
+- **append_content**: Adding text to the end of files
+- **update_frontmatter**: Modifying note properties (frontmatter)
+- **create_skill**: Creating new skill packages
+- **edit_skill**: Updating existing skill instructions
 
 When the agent needs to perform these operations, an **in-chat confirmation request** appears with interactive buttons. You can also use "Don't ask again this session" for trusted workflows. See [Tool Confirmations](#tool-confirmations) for details.
 

--- a/docs/guide/agent-mode.md
+++ b/docs/guide/agent-mode.md
@@ -550,6 +550,7 @@ By default, these operations require confirmation:
 - **delete_file**: Removing files
 - **move_file**: Moving or renaming files
 - **append_content**: Adding text to the end of files
+- **update_frontmatter**: Modifying note properties (frontmatter)
 - **create_skill**: Creating new skill packages
 - **edit_skill**: Updating existing skill instructions
 

--- a/docs/guide/lifecycle-hooks.md
+++ b/docs/guide/lifecycle-hooks.md
@@ -102,7 +102,7 @@ The `toolPolicy` block uses the same shape every other policy-bearing feature us
 toolPolicy:
   preset: read_only # one of: read_only, cautious, edit_mode, yolo
   overrides:
-    web_fetch: deny
+    fetch_url: deny
 ```
 
 - `preset` chooses the baseline permission for every tool by classification. Omit to inherit the global plugin preset.

--- a/docs/guide/scheduled-tasks.md
+++ b/docs/guide/scheduled-tasks.md
@@ -86,7 +86,7 @@ The `toolPolicy` block controls what the agent can do during a run. It uses the 
 toolPolicy:
   preset: read_only # one of: read_only, cautious, edit_mode, yolo
   overrides: # optional per-tool overrides
-    web_fetch: deny
+    fetch_url: deny
     write_file: allow
 ```
 

--- a/planning/changelog/2026-06-06.md
+++ b/planning/changelog/2026-06-06.md
@@ -1,0 +1,16 @@
+# Daily changelog — June 06, 2026
+
+**Date:** 2026-06-06
+**PRs merged:** 1
+
+---
+
+## Summary
+
+Quiet day — a single daily housekeeping PR landed, carrying the June 5 changelog and two doc drift fixes: a stale command-palette label for "Rewrite text with AI" and a removed `modelDiscovery` toggle reference in the FAQ.
+
+## What shipped
+
+### [#939 chore(daily): 2026-06-06 daily update](https://github.com/allenhutchison/obsidian-gemini/pull/939)
+
+The automated daily-update run for June 6. It delivered the June 5 changelog (one PR — the prior day's housekeeping run, #938), patched `docs/guide/ai-writing.md` to correct the rewrite command's palette label (`"Rewrite text with AI"` vs. the context-menu label `"Rewrite Text..."`), and removed a stale mention of the `modelDiscovery` setting from `docs/guide/faq.md`, replacing it with the current behavior: models are fetched automatically on startup with a 24-hour cache, and a manual **Refresh model list** button is available in Settings → General.


### PR DESCRIPTION
## Summary

Automated daily housekeeping for 2026-06-07. Covers the June 6 changelog (1 PR — daily housekeeping only). Docs audit found 3 drift items and fixed them in-place. No unlabeled open issues.

## Changes

- **Add `planning/changelog/2026-06-06.md`**: Documents June 6 — a single daily housekeeping PR (#939) that landed the June 5 changelog and two doc drift fixes.
- **Fix `docs/guide/scheduled-tasks.md`**: Corrected YAML example in the Tool Access section — `web_fetch: deny` changed to `fetch_url: deny` to match the actual registered tool name.
- **Fix `docs/guide/lifecycle-hooks.md`**: Same stale tool name: `web_fetch: deny` → `fetch_url: deny`.
- **Fix `docs/guide/agent-mode.md`**: Added `update_frontmatter` to the "What Operations Require Confirmation" list. `UpdateFrontmatterTool` has `requiresConfirmation = true` and was missing from the doc.

## Sub-skill outcomes

- **daily-changelog**: wrote `planning/changelog/2026-06-06.md`, 1 PR (daily housekeeping #939 — quiet day)
- **audit-docs**: fixed 3 drift items — `docs/guide/scheduled-tasks.md` and `docs/guide/lifecycle-hooks.md` (stale `web_fetch` tool name → `fetch_url`), `docs/guide/agent-mode.md` (added `update_frontmatter` to confirmation-required operations list)
- **triage-issues**: no unlabeled open issues — 0 issues processed

## Screenshots / Screencast

N/A — changelog and doc fixes only.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: daily housekeeping
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A: changelog and doc fixes only
- [x] Documentation has been updated (if applicable) — this PR IS the documentation update
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_014Z4exZZbS2ty4ui2A3y4Nx)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified which vault operations require user confirmation, explicitly listing append_content and update_frontmatter.
  * Updated tool-override examples to use the fetch_url key instead of the previous example.
  * Documented automatic model discovery with 24-hour caching and a Refresh model list button.

* **Chores**
  * Added a daily changelog entry summarizing recent housekeeping updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->