### PR TITLE
test(subscribers): cover tool-execution-logger pure helpers

### DIFF
--- a/test/subscribers/tool-execution-logger.test.ts
+++ b/test/subscribers/tool-execution-logger.test.ts
@@ -1,0 +1,235 @@
+import { formatToolBlock, formatToolLine, mergeToolBlock } from '../../src/subscribers/tool-execution-logger';
+import { ToolResult } from '../../src/tools/types';
+
+function success(data: unknown = {}): ToolResult {
+	return { success: true, data };
+}
+
+function failure(error: string): ToolResult {
+	return { success: false, error };
+}
+
+describe('formatToolLine', () => {
+	it('renders the configured key param for a mapped tool when the arg is a string', () => {
+		const line = formatToolLine({
+			toolName: 'read_file',
+			args: { path: 'notes/foo.md' },
+			result: success(),
+			durationMs: 50,
+		});
+		expect(line).toBe('🔧 `read_file` path="notes/foo.md" → success (50ms)');
+	});
+
+	it('uses the configured key (sourcePath) for move_file rather than the generic "path"', () => {
+		const line = formatToolLine({
+			toolName: 'move_file',
+			args: { sourcePath: 'a.md', destinationPath: 'b.md' },
+			result: success(),
+			durationMs: 12,
+		});
+		expect(line).toBe('🔧 `move_file` sourcePath="a.md" → success (12ms)');
+	});
+
+	it('omits the param prefix for mapped tools whose KEY_PARAM_MAP entry is undefined', () => {
+		const line = formatToolLine({
+			toolName: 'get_workspace_state',
+			args: { ignored: 'value' },
+			result: success(),
+			durationMs: 4,
+		});
+		expect(line).toBe('🔧 `get_workspace_state` → success (4ms)');
+	});
+
+	it('omits the param prefix when the mapped key is missing from args', () => {
+		const line = formatToolLine({
+			toolName: 'read_file',
+			args: {},
+			result: success(),
+			durationMs: 3,
+		});
+		expect(line).toBe('🔧 `read_file` → success (3ms)');
+	});
+
+	it('omits the param prefix when the mapped key is present but not a string', () => {
+		const line = formatToolLine({
+			toolName: 'read_file',
+			args: { path: 42 },
+			result: success(),
+			durationMs: 3,
+		});
+		expect(line).toBe('🔧 `read_file` → success (3ms)');
+	});
+
+	it('falls back to the first string arg for unmapped tools', () => {
+		const line = formatToolLine({
+			toolName: 'totally_new_tool',
+			args: { count: 7, label: 'hello', other: 'world' },
+			result: success(),
+			durationMs: 8,
+		});
+		expect(line).toBe('🔧 `totally_new_tool` label="hello" → success (8ms)');
+	});
+
+	it('omits the param prefix for unmapped tools when no string arg is present', () => {
+		const line = formatToolLine({
+			toolName: 'numeric_only_tool',
+			args: { count: 7, ratio: 0.5 },
+			result: success(),
+			durationMs: 1,
+		});
+		expect(line).toBe('🔧 `numeric_only_tool` → success (1ms)');
+	});
+
+	it('renders success status for successful results', () => {
+		const line = formatToolLine({
+			toolName: 'read_file',
+			args: { path: 'a.md' },
+			result: success(),
+			durationMs: 10,
+		});
+		expect(line).toContain(' → success ');
+	});
+
+	it('renders error status with the message for failed results', () => {
+		const line = formatToolLine({
+			toolName: 'read_file',
+			args: { path: 'a.md' },
+			result: failure('file not found'),
+			durationMs: 10,
+		});
+		expect(line).toBe('🔧 `read_file` path="a.md" → error: file not found (10ms)');
+	});
+
+	it('falls back to "unknown" when a failed result carries no error string', () => {
+		const line = formatToolLine({
+			toolName: 'read_file',
+			args: { path: 'a.md' },
+			result: { success: false },
+			durationMs: 10,
+		});
+		expect(line).toBe('🔧 `read_file` path="a.md" → error: unknown (10ms)');
+	});
+
+	it('truncates error messages longer than 60 chars and appends an ellipsis', () => {
+		const longError = 'a'.repeat(70);
+		const line = formatToolLine({
+			toolName: 'read_file',
+			args: { path: 'a.md' },
+			result: failure(longError),
+			durationMs: 10,
+		});
+		expect(line).toBe(`🔧 \`read_file\` path="a.md" → error: ${'a'.repeat(60)}... (10ms)`);
+	});
+
+	it('does not truncate error messages of exactly 60 chars', () => {
+		const exactError = 'b'.repeat(60);
+		const line = formatToolLine({
+			toolName: 'read_file',
+			args: { path: 'a.md' },
+			result: failure(exactError),
+			durationMs: 10,
+		});
+		expect(line).toBe(`🔧 \`read_file\` path="a.md" → error: ${exactError} (10ms)`);
+	});
+});
+
+describe('formatToolBlock', () => {
+	it('returns just the callout header when given an empty lines array', () => {
+		expect(formatToolBlock([])).toBe('> [!tools]- Tool Execution\n');
+	});
+
+	it('prefixes each input line with "> " under the callout header', () => {
+		const block = formatToolBlock(['line one', 'line two', 'line three']);
+		expect(block).toBe('> [!tools]- Tool Execution\n> line one\n> line two\n> line three');
+	});
+
+	it('produces a block that can be round-tripped through mergeToolBlock', () => {
+		const block = formatToolBlock(['🔧 `read_file` path="a.md" → success (5ms)']);
+		expect(block.startsWith('> [!tools]- Tool Execution\n')).toBe(true);
+		expect(block).toContain('> 🔧 `read_file`');
+	});
+});
+
+describe('mergeToolBlock', () => {
+	const block = formatToolBlock(['🔧 `read_file` path="a.md" → success (5ms)']);
+
+	it('returns a leading newline plus the block when content is empty', () => {
+		// Pin current behavior — the leading newline is intentional and any change
+		// should be a deliberate decision, not a silent regression.
+		expect(mergeToolBlock('', block)).toBe('\n' + block + '\n');
+	});
+
+	it('appends as a new block when content has no existing callout', () => {
+		const content = '# Session\n\nSome prose here.\n';
+		const merged = mergeToolBlock(content, block);
+		expect(merged).toBe(content + '\n' + block + '\n');
+	});
+
+	it('merges new lines into an existing trailing callout without duplicating the header', () => {
+		const existing = '# Session\n\n> [!tools]- Tool Execution\n> 🔧 `read_file` path="a.md" → success (5ms)';
+		const newBlock = formatToolBlock(['🔧 `write_file` path="b.md" → success (8ms)']);
+		const merged = mergeToolBlock(existing, newBlock);
+
+		// Header should appear only once.
+		expect(merged.match(/> \[!tools\]- Tool Execution/g)).toHaveLength(1);
+		// Both tool lines should be present.
+		expect(merged).toContain('> 🔧 `read_file` path="a.md"');
+		expect(merged).toContain('> 🔧 `write_file` path="b.md"');
+		// Order preserved — old line precedes new line.
+		expect(merged.indexOf('read_file')).toBeLessThan(merged.indexOf('write_file'));
+	});
+
+	it('appends as a new block when a non-blockquote line sits between EOF and the last callout', () => {
+		// The backward scan must bail when it hits a non-blockquote, non-empty line,
+		// so the earlier callout is invisible to the merge logic.
+		const existing = [
+			'> [!tools]- Tool Execution',
+			'> 🔧 `read_file` path="a.md" → success (5ms)',
+			'',
+			'Some explanatory prose after the callout.',
+		].join('\n');
+
+		const merged = mergeToolBlock(existing, block);
+
+		// Two distinct callouts should now exist — the original and the appended one.
+		expect(merged.match(/> \[!tools\]- Tool Execution/g)).toHaveLength(2);
+		expect(merged.endsWith(block + '\n')).toBe(true);
+	});
+
+	it('merges only into the trailing callout when content has multiple callouts', () => {
+		const existing = [
+			'# Session',
+			'',
+			'> [!tools]- Tool Execution',
+			'> 🔧 `read_file` path="old.md" → success (1ms)',
+			'',
+			'> [!tools]- Tool Execution',
+			'> 🔧 `read_file` path="recent.md" → success (2ms)',
+		].join('\n');
+
+		const newBlock = formatToolBlock(['🔧 `write_file` path="new.md" → success (3ms)']);
+		const merged = mergeToolBlock(existing, newBlock);
+
+		// Still exactly two headers — the trailing callout absorbed the new lines,
+		// no third callout was appended.
+		expect(merged.match(/> \[!tools\]- Tool Execution/g)).toHaveLength(2);
+		// The new line should land after the "recent.md" line, in the trailing block.
+		expect(merged.indexOf('write_file')).toBeGreaterThan(merged.indexOf('recent.md'));
+		// And after the trailing block's header, not after the first.
+		const firstHeader = merged.indexOf('> [!tools]- Tool Execution');
+		const lastHeader = merged.lastIndexOf('> [!tools]- Tool Execution');
+		expect(firstHeader).not.toBe(lastHeader);
+		expect(merged.indexOf('write_file')).toBeGreaterThan(lastHeader);
+	});
+
+	it('treats content not ending in a newline the same as content that does', () => {
+		const withNewline = '# Session\n\n> [!tools]- Tool Execution\n> 🔧 `read_file` path="a.md" → success (5ms)\n';
+		const withoutNewline = withNewline.trimEnd();
+
+		const newBlock = formatToolBlock(['🔧 `write_file` path="b.md" → success (8ms)']);
+		const mergedWith = mergeToolBlock(withNewline, newBlock);
+		const mergedWithout = mergeToolBlock(withoutNewline, newBlock);
+
+		expect(mergedWith).toBe(mergedWithout);
+	});
+});


### PR DESCRIPTION
## Summary

Add a Vitest test mirror for the pure helpers in `src/subscribers/tool-execution-logger.ts` — `formatToolLine`, `formatToolBlock`, and `mergeToolBlock` — which were added after the umbrella missing-tests sweep in #829 closed and had no coverage. `extractKeyParam` is internal but exercised transitively via `formatToolLine`.

Fixes #927

## Changes

- Add `test/subscribers/tool-execution-logger.test.ts` with 21 cases covering:
  - **`formatToolLine`**: mapped tools with key param present, mapped tools whose `KEY_PARAM_MAP` entry is `undefined`, missing-key fallback, non-string-key fallback, unmapped-tool fallback to first string arg, no-string-arg case, success/error status segments, 60-char error truncation, and the "unknown" fallback when a failed result has no error string.
  - **`formatToolBlock`**: empty input returns just the header, multi-line input prefixes each line with `> `, and a round-trip sanity check.
  - **`mergeToolBlock`**: empty content (pins the leading newline as deliberate behavior), no-callout append, trailing-callout merge with no header duplication, non-blockquote-line-between-EOF-and-callout case (must append as new block, not merge), multiple-callouts case (only trailing one merged), and trailing-newline-insensitivity.
- No source changes — the helpers are pure functions over strings/POJOs, so no mocking was required.

The class-level event-wiring tests in `tool-execution-logger-subscriber.test.ts` already cover `ToolExecutionLogger`'s subscription/snapshot/drain behavior; this new file complements that by pinning the rendering primitives.

## Screenshots / Screencast

N/A — test-only change.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — test-only, no runtime impact
- [x] Documentation has been updated (if applicable) — N/A, internal helpers
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude (Claude Code)
- [x] I have reviewed and understand all AI-generated code in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for tool execution logging functionality, including validation of formatting behaviors, error handling, and content merging scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->