### PR TITLE
refactor: centralize recursive TFolder.children walks (#913)

### DIFF
--- a/src/services/vault-analyzer.ts
+++ b/src/services/vault-analyzer.ts
@@ -3,6 +3,7 @@ import type ObsidianGemini from '../main';
 import { ModelClientFactory } from '../api';
 import { AgentsMemoryData } from './agents-memory';
 import { VaultAnalysisModal } from '../ui/vault-analysis-modal';
+import { collectFilesFromFolder } from '../utils/folder-walk';
 
 /**
  * Simple cache entry for vault information
@@ -274,20 +275,7 @@ export class VaultAnalyzer {
 	 * Count markdown files in a folder (including subfolders)
 	 */
 	private countMarkdownFilesInFolder(folder: TFolder): number {
-		let count = 0;
-
-		const countRecursive = (f: TFolder) => {
-			f.children.forEach((child) => {
-				if (child instanceof TFile && child.extension === 'md') {
-					count++;
-				} else if (child instanceof TFolder) {
-					countRecursive(child);
-				}
-			});
-		};
-
-		countRecursive(folder);
-		return count;
+		return collectFilesFromFolder(folder, { filter: (f) => f.extension === 'md' }).length;
 	}
 
 	/**

--- a/src/ui/agent-view/agent-view-shelf.ts
+++ b/src/ui/agent-view/agent-view-shelf.ts
@@ -1,6 +1,7 @@
 import { App, TFile, TFolder, setIcon, setTooltip } from 'obsidian';
 import { InlineAttachment } from './inline-attachment';
 import { classifyFile, FileCategory } from '../../utils/file-classification';
+import { collectFilesFromFolder } from '../../utils/folder-walk';
 
 /**
  * Recursively collects all supported text files from a folder,
@@ -9,23 +10,10 @@ import { classifyFile, FileCategory } from '../../utils/file-classification';
  * @param isExcluded Predicate that returns true for paths to skip
  */
 export function getTextFilesFromFolder(folder: TFolder, isExcluded?: (path: string) => boolean): TFile[] {
-	const files: TFile[] = [];
-	const collect = (f: TFolder) => {
-		for (const child of f.children) {
-			if (child instanceof TFile) {
-				if (isExcluded?.(child.path)) continue;
-				const result = classifyFile(child.extension);
-				if (result.category === FileCategory.TEXT) {
-					files.push(child);
-				}
-			} else if (child instanceof TFolder) {
-				if (isExcluded?.(child.path)) continue;
-				collect(child);
-			}
-		}
-	};
-	collect(folder);
-	return files;
+	return collectFilesFromFolder(folder, {
+		prune: isExcluded ? (item) => isExcluded(item.path) : undefined,
+		filter: (file) => classifyFile(file.extension).category === FileCategory.TEXT,
+	});
 }
 
 /**

--- a/src/ui/agent-view/agent-view-ui.ts
+++ b/src/ui/agent-view/agent-view-ui.ts
@@ -3,6 +3,7 @@ import type ObsidianGemini from '../../main';
 import { ChatSession } from '../../types/agent';
 import { insertTextAtCursor, moveCursorToEnd, execContextCommand } from '../../utils/dom-context';
 import { sanitizeFileName, shouldExcludePathForPlugin } from '../../utils/file-utils';
+import { collectFilesFromFolder } from '../../utils/folder-walk';
 import {
 	InlineAttachment,
 	generateAttachmentId,
@@ -562,12 +563,16 @@ export class AgentViewUI {
 					return;
 				}
 
-				// Expand folders → collect all child TFiles recursively
+				// Expand folders → collect all child TFiles recursively, pruning
+				// any subtree that lives inside the plugin state folder or `.obsidian`.
 				const allTFiles: TFile[] = [];
 				for (const file of filteredFiles) {
 					if (file instanceof TFolder) {
-						const children = this.collectFilesFromFolder(file);
-						allTFiles.push(...children.filter((f) => !shouldExcludePathForPlugin(f.path, this.plugin)));
+						allTFiles.push(
+							...collectFilesFromFolder(file, {
+								prune: (item) => shouldExcludePathForPlugin(item.path, this.plugin),
+							})
+						);
 					} else if (file instanceof TFile) {
 						allTFiles.push(file);
 					}
@@ -875,20 +880,5 @@ export class AgentViewUI {
 			nameSpan.textContent = ' No Project';
 			setTooltip(badge, 'Click to link a project');
 		}
-	}
-
-	/**
-	 * Recursively collect all TFile children from a folder
-	 */
-	private collectFilesFromFolder(folder: TFolder): TFile[] {
-		const files: TFile[] = [];
-		for (const child of folder.children) {
-			if (child instanceof TFile) {
-				files.push(child);
-			} else if (child instanceof TFolder) {
-				files.push(...this.collectFilesFromFolder(child));
-			}
-		}
-		return files;
 	}
 }

--- a/src/ui/agent-view/file-mention-modal.ts
+++ b/src/ui/agent-view/file-mention-modal.ts
@@ -1,6 +1,7 @@
 import { FuzzySuggestModal, TFile, TFolder, TAbstractFile } from 'obsidian';
 import { shouldExcludePathForPlugin } from '../../utils/file-utils';
 import { classifyFile, FileCategory } from '../../utils/file-classification';
+import { collectFoldersFromFolder } from '../../utils/folder-walk';
 import type ObsidianGemini from '../../main';
 
 export class FileMentionModal extends FuzzySuggestModal<TAbstractFile> {
@@ -27,21 +28,11 @@ export class FileMentionModal extends FuzzySuggestModal<TAbstractFile> {
 		items.push(...filteredFiles);
 
 		// Add all folders except system and plugin folders
-		const addFolders = (folder: TFolder) => {
-			if (shouldExcludePathForPlugin(folder.path, this.plugin)) return;
-
-			if (folder.path) {
-				items.push(folder);
-			}
-
-			for (const child of folder.children) {
-				if (child instanceof TFolder) {
-					addFolders(child);
-				}
-			}
-		};
-
-		addFolders(this.app.vault.getRoot());
+		items.push(
+			...collectFoldersFromFolder(this.app.vault.getRoot(), {
+				prune: (folder) => shouldExcludePathForPlugin(folder.path, this.plugin),
+			})
+		);
 
 		return items;
 	}

--- a/src/ui/agent-view/file-picker-modal.ts
+++ b/src/ui/agent-view/file-picker-modal.ts
@@ -1,5 +1,6 @@
 import { App, prepareFuzzySearch, setIcon, SuggestModal, TAbstractFile, TFile, TFolder } from 'obsidian';
 import { shouldExcludePathForPlugin } from '../../utils/file-utils';
+import { collectFoldersFromFolder } from '../../utils/folder-walk';
 import type ObsidianGemini from '../../main';
 
 /** Undocumented internal SuggestModal API for programmatic highlight control. */
@@ -31,15 +32,9 @@ export class FilePickerModal extends SuggestModal<TAbstractFile> {
 
 		const files = this.app.vault.getMarkdownFiles().filter((f) => !shouldExcludePathForPlugin(f.path, this.plugin));
 
-		const folders: TFolder[] = [];
-		const collectFolders = (folder: TFolder) => {
-			if (shouldExcludePathForPlugin(folder.path, this.plugin)) return;
-			if (folder.path) folders.push(folder); // skip root
-			for (const child of folder.children) {
-				if (child instanceof TFolder) collectFolders(child);
-			}
-		};
-		collectFolders(this.app.vault.getRoot());
+		const folders = collectFoldersFromFolder(this.app.vault.getRoot(), {
+			prune: (folder) => shouldExcludePathForPlugin(folder.path, this.plugin),
+		});
 
 		// Only include folders that contain at least one markdown file
 		const nonEmptyFolders = folders.filter((folder) => files.some((file) => file.path.startsWith(folder.path + '/')));

--- a/src/utils/folder-walk.ts
+++ b/src/utils/folder-walk.ts
@@ -1,0 +1,70 @@
+/**
+ * Recursive folder-traversal helpers over Obsidian's `TFolder.children` tree.
+ *
+ * These centralize the "iterate children; recurse into folders; collect what
+ * matches" skeleton so callers don't reimplement it (and so the prune-vs-post-
+ * filter behavior has a single home — see issue #913).
+ *
+ * `prune` is checked first on every child and skips the item entirely (a file
+ * is not collected; a folder is not collected *and* not recursed into).
+ * `filter` runs only on files that survived `prune` and decides inclusion in
+ * the result.
+ */
+
+import { TAbstractFile, TFile, TFolder } from 'obsidian';
+
+export interface CollectFilesOptions {
+	/** Return true to include a file in the output. Defaults to including all files. */
+	filter?: (file: TFile) => boolean;
+	/** Return true to skip this file or subtree entirely. */
+	prune?: (item: TAbstractFile) => boolean;
+}
+
+export interface CollectFoldersOptions {
+	/** Return true to skip this folder (and its subtree). */
+	prune?: (folder: TFolder) => boolean;
+}
+
+/**
+ * Recursively collect all files beneath `root`.
+ * The `root` folder itself is never tested against `prune` — only its descendants.
+ */
+export function collectFilesFromFolder(root: TFolder, opts: CollectFilesOptions = {}): TFile[] {
+	const { filter, prune } = opts;
+	const files: TFile[] = [];
+
+	const walk = (folder: TFolder): void => {
+		for (const child of folder.children) {
+			if (prune?.(child)) continue;
+			if (child instanceof TFile) {
+				if (!filter || filter(child)) files.push(child);
+			} else if (child instanceof TFolder) {
+				walk(child);
+			}
+		}
+	};
+
+	walk(root);
+	return files;
+}
+
+/**
+ * Recursively collect all descendant folders beneath `root`.
+ * The `root` folder itself is not included in the output.
+ */
+export function collectFoldersFromFolder(root: TFolder, opts: CollectFoldersOptions = {}): TFolder[] {
+	const { prune } = opts;
+	const folders: TFolder[] = [];
+
+	const walk = (folder: TFolder): void => {
+		for (const child of folder.children) {
+			if (!(child instanceof TFolder)) continue;
+			if (prune?.(child)) continue;
+			folders.push(child);
+			walk(child);
+		}
+	};
+
+	walk(root);
+	return folders;
+}

--- a/test/utils/folder-walk.test.ts
+++ b/test/utils/folder-walk.test.ts
@@ -2,17 +2,13 @@ import { TAbstractFile, TFile, TFolder } from 'obsidian';
 import { collectFilesFromFolder, collectFoldersFromFolder } from '../../src/utils/folder-walk';
 
 function makeFile(path: string): TFile {
-	const file = new TFile(path);
-	// __mocks__/obsidian's TFile only sets `path`; add the extension the way Obsidian does.
 	const dot = path.lastIndexOf('.');
-	(file as any).extension = dot >= 0 ? path.slice(dot + 1) : '';
-	return file;
+	const extension = dot >= 0 ? path.slice(dot + 1) : '';
+	return Object.assign(new TFile(), { path, extension });
 }
 
 function makeFolder(path: string, children: TAbstractFile[] = []): TFolder {
-	const folder = new TFolder(path);
-	folder.children = children;
-	return folder;
+	return Object.assign(new TFolder(), { path, children });
 }
 
 describe('folder-walk', () => {

--- a/test/utils/folder-walk.test.ts
+++ b/test/utils/folder-walk.test.ts
@@ -1,0 +1,149 @@
+import { TAbstractFile, TFile, TFolder } from 'obsidian';
+import { collectFilesFromFolder, collectFoldersFromFolder } from '../../src/utils/folder-walk';
+
+function makeFile(path: string): TFile {
+	const file = new TFile(path);
+	// __mocks__/obsidian's TFile only sets `path`; add the extension the way Obsidian does.
+	const dot = path.lastIndexOf('.');
+	(file as any).extension = dot >= 0 ? path.slice(dot + 1) : '';
+	return file;
+}
+
+function makeFolder(path: string, children: TAbstractFile[] = []): TFolder {
+	const folder = new TFolder(path);
+	folder.children = children;
+	return folder;
+}
+
+describe('folder-walk', () => {
+	describe('collectFilesFromFolder', () => {
+		it('returns an empty array for an empty folder', () => {
+			expect(collectFilesFromFolder(makeFolder('root'))).toEqual([]);
+		});
+
+		it('collects a single file at the root', () => {
+			const file = makeFile('root/note.md');
+			const root = makeFolder('root', [file]);
+
+			expect(collectFilesFromFolder(root)).toEqual([file]);
+		});
+
+		it('collects files across three levels of nesting', () => {
+			const deepFile = makeFile('root/a/b/c/deep.md');
+			const midFile = makeFile('root/a/mid.md');
+			const topFile = makeFile('root/top.md');
+
+			const c = makeFolder('root/a/b/c', [deepFile]);
+			const b = makeFolder('root/a/b', [c]);
+			const a = makeFolder('root/a', [b, midFile]);
+			const root = makeFolder('root', [a, topFile]);
+
+			expect(collectFilesFromFolder(root)).toEqual([deepFile, midFile, topFile]);
+		});
+
+		it('prune skips a whole subtree', () => {
+			const insideExcluded = makeFile('root/excluded/secret.md');
+			const excluded = makeFolder('root/excluded', [insideExcluded]);
+			const keptFile = makeFile('root/kept.md');
+			const root = makeFolder('root', [excluded, keptFile]);
+
+			const result = collectFilesFromFolder(root, {
+				prune: (item) => item.path === 'root/excluded',
+			});
+
+			expect(result).toEqual([keptFile]);
+		});
+
+		it('prune skips an individual file without affecting siblings', () => {
+			const skip = makeFile('root/skip.md');
+			const keep = makeFile('root/keep.md');
+			const root = makeFolder('root', [skip, keep]);
+
+			const result = collectFilesFromFolder(root, {
+				prune: (item) => item.path === 'root/skip.md',
+			});
+
+			expect(result).toEqual([keep]);
+		});
+
+		it('filter only includes matching files', () => {
+			const md = makeFile('root/note.md');
+			const txt = makeFile('root/notes.txt');
+			const root = makeFolder('root', [md, txt]);
+
+			const result = collectFilesFromFolder(root, {
+				filter: (f) => f.extension === 'md',
+			});
+
+			expect(result).toEqual([md]);
+		});
+
+		it('filter and prune compose: prune wins on folders, filter narrows surviving files', () => {
+			const excludedMd = makeFile('root/excluded/note.md');
+			const keptMd = makeFile('root/kept/note.md');
+			const keptTxt = makeFile('root/kept/notes.txt');
+			const excluded = makeFolder('root/excluded', [excludedMd]);
+			const kept = makeFolder('root/kept', [keptMd, keptTxt]);
+			const root = makeFolder('root', [excluded, kept]);
+
+			const result = collectFilesFromFolder(root, {
+				prune: (item) => item.path.startsWith('root/excluded'),
+				filter: (f) => f.extension === 'md',
+			});
+
+			expect(result).toEqual([keptMd]);
+		});
+
+		it('does not test the root folder against prune', () => {
+			const file = makeFile('root/note.md');
+			const root = makeFolder('root', [file]);
+			const prune = vi.fn().mockReturnValue(true);
+
+			collectFilesFromFolder(root, { prune });
+
+			// prune is called once (for the child file), never for the root itself.
+			expect(prune).toHaveBeenCalledTimes(1);
+			expect(prune).toHaveBeenCalledWith(file);
+		});
+	});
+
+	describe('collectFoldersFromFolder', () => {
+		it('returns an empty array when there are no subfolders', () => {
+			const file = makeFile('root/note.md');
+			const root = makeFolder('root', [file]);
+
+			expect(collectFoldersFromFolder(root)).toEqual([]);
+		});
+
+		it('collects nested folders in depth-first order, excluding the root', () => {
+			const c = makeFolder('root/a/b/c');
+			const b = makeFolder('root/a/b', [c]);
+			const a = makeFolder('root/a', [b]);
+			const sibling = makeFolder('root/sibling');
+			const root = makeFolder('root', [a, sibling]);
+
+			expect(collectFoldersFromFolder(root)).toEqual([a, b, c, sibling]);
+		});
+
+		it('prune skips a folder and its subtree', () => {
+			const inside = makeFolder('root/excluded/inner');
+			const excluded = makeFolder('root/excluded', [inside]);
+			const kept = makeFolder('root/kept');
+			const root = makeFolder('root', [excluded, kept]);
+
+			const result = collectFoldersFromFolder(root, {
+				prune: (folder) => folder.path === 'root/excluded',
+			});
+
+			expect(result).toEqual([kept]);
+		});
+
+		it('ignores non-folder children', () => {
+			const file = makeFile('root/note.md');
+			const folder = makeFolder('root/sub');
+			const root = makeFolder('root', [file, folder]);
+
+			expect(collectFoldersFromFolder(root)).toEqual([folder]);
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Fixes #913. Five sites in the codebase hand-rolled near-identical recursive walks over `TFolder.children`, each with a slightly different per-node filter and exclusion behavior. One of them (the drag-and-drop folder expansion in `agent-view-ui`) didn't apply the plugin-state-folder / `.obsidian` exclusion check at all and relied on a post-hoc filter at the call site — a latent gap waiting for a future caller to forget the filter and leak system files.

This PR introduces a shared `src/utils/folder-walk.ts` and rewrites all five sites against it, fixing the missing-exclusion gap in the process.

## Changes

- **New `src/utils/folder-walk.ts`** with two focused helpers:
  - `collectFilesFromFolder(root, { filter?, prune? })` — `prune` is called on every child (skipping a file or pruning a whole subtree); `filter` runs only on files that survive `prune`.
  - `collectFoldersFromFolder(root, { prune? })` — collects all descendant folders, skipping any subtree where `prune` returns true. The root is never returned.
- **New `test/utils/folder-walk.test.ts`** — 12 focused tests: empty folder, single file, three-level nesting, prune-skips-subtree, prune-skips-individual-file, filter narrowing, prune+filter composition, root-is-never-pruned, and the folder collector's depth-first order / non-folder skipping / prune behavior.
- **Replaced five sites:**
  - `src/ui/agent-view/agent-view-shelf.ts:getTextFilesFromFolder` — keeps its public signature, body is now a thin call into the helper.
  - `src/ui/agent-view/file-picker-modal.ts` — `collectFolders` closure deleted.
  - `src/ui/agent-view/file-mention-modal.ts` — `addFolders` closure deleted.
  - `src/services/vault-analyzer.ts:countMarkdownFilesInFolder` — collapses to a one-liner.
  - `src/ui/agent-view/agent-view-ui.ts` — the private `collectFilesFromFolder` and the post-hoc `shouldExcludePathForPlugin` filter at the call site are both removed; the helper's `prune` predicate now closes the gap.

Net: -73 / +244 lines (the +244 is mostly tests; production-code surface shrinks).

## Test plan

- `npm test` — 2991 tests pass (12 new).
- `npm run build` — clean.
- `npm run format-check` / `npm run lint` — clean (no new warnings).
- `npm run knip` — no new findings.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop — covered by the new unit tests and the existing 2991-test suite; no UI behavior change at the four non-bug sites, and the agent-view drag-and-drop site now prunes excluded subtrees instead of post-filtering (same observable result, no leak)
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — pure TypeScript refactor with no platform-specific code paths
- [x] Documentation has been updated (if applicable) — N/A, internal refactor with no user-visible behavior change
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated folder traversal logic across components into shared utilities, improving code maintainability and consistency across the vault navigation experience.

* **Tests**
  * Added comprehensive test coverage for folder traversal utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->