### PR TITLE
fix(tools): use canonical resolver in extended vault tools

### DIFF
--- a/src/tools/execution-engine.ts
+++ b/src/tools/execution-engine.ts
@@ -13,6 +13,7 @@ import { ToolLoopDetector } from './loop-detector';
 import { TFile, normalizePath } from 'obsidian';
 import type ObsidianGemini from '../main';
 import { shouldExcludePath } from '../utils/file-utils';
+import { resolvePathToFile } from './vault/utils';
 
 /**
  * Handles execution of tools with permission checks and UI feedback
@@ -271,22 +272,11 @@ export class ToolExecutionEngine {
 		}
 
 		if (tool.name === 'append_content' && parameters.path && parameters.content !== undefined) {
-			const normalizedPath = normalizePath(parameters.path);
-			if (shouldExcludePath(normalizedPath, plugin.settings.historyFolder)) return undefined;
-
-			// Resolve the file the same way AppendContentTool does so the diff
-			// matches what will actually be written: direct path, then .md suffix,
-			// then wikilink resolution via the metadata cache.
-			let file = plugin.app.vault.getAbstractFileByPath(normalizedPath);
-			if (!file && !normalizedPath.endsWith('.md')) {
-				file = plugin.app.vault.getAbstractFileByPath(normalizedPath + '.md');
-			}
-			if (!file) {
-				const linkPath = parameters.path.replace(/^\[\[/, '').replace(/\]\]$/, '').replace(/\.md$/, '');
-				const resolved = plugin.app.metadataCache.getFirstLinkpathDest(linkPath, '');
-				if (resolved) file = resolved;
-			}
-			if (!(file instanceof TFile)) return undefined; // Tool will return its own error
+			// Use the canonical resolver, same as AppendContentTool — applies
+			// system-folder exclusion at every resolution strategy (including
+			// the wikilink path), so the diff matches what will actually be written.
+			const { file } = resolvePathToFile(parameters.path, plugin);
+			if (!file) return undefined; // Tool will return its own error
 
 			const originalContent = await this.safeReadFile(file);
 			// Mirror the newline-insertion logic from AppendContentTool.execute()

--- a/src/tools/vault-tools-extended.ts
+++ b/src/tools/vault-tools-extended.ts
@@ -1,8 +1,7 @@
 import { Tool, ToolResult, ToolExecutionContext } from './types';
 import { ToolCategory } from '../types/agent';
 import { ToolClassification } from '../types/tool-policy';
-import { TFile, normalizePath } from 'obsidian';
-import { shouldExcludePathForPlugin as shouldExcludePath } from '../utils/file-utils';
+import { resolvePathToFile } from './vault/utils';
 
 /**
  * Tool to safely update YAML frontmatter without touching content
@@ -66,32 +65,8 @@ class UpdateFrontmatterTool implements Tool {
 		const { path, key, value } = params;
 
 		try {
-			const normalizedPath = normalizePath(path);
-
-			// Check if path is excluded
-			if (shouldExcludePath(normalizedPath, plugin)) {
-				return {
-					success: false,
-					error: `Cannot modify files in system folder: ${path}`,
-				};
-			}
-
-			// Try direct path lookup, then with .md extension
-			let file = plugin.app.vault.getAbstractFileByPath(normalizedPath);
-			if (!file && !normalizedPath.endsWith('.md')) {
-				file = plugin.app.vault.getAbstractFileByPath(normalizedPath + '.md');
-			}
-
-			// Try wikilink resolution
-			if (!file) {
-				const linkPath = path.replace(/^\[\[/, '').replace(/\]\]$/, '').replace(/\.md$/, '');
-				const resolved = plugin.app.metadataCache.getFirstLinkpathDest(linkPath, '');
-				if (resolved) {
-					file = resolved;
-				}
-			}
-
-			if (!file || !(file instanceof TFile) || file.extension !== 'md') {
+			const { file } = resolvePathToFile(path, plugin);
+			if (!file || file.extension !== 'md') {
 				return {
 					success: false,
 					error: `File not found or is not a markdown file: ${path}`,
@@ -187,32 +162,8 @@ class AppendContentTool implements Tool {
 		const { path, content } = params;
 
 		try {
-			const normalizedPath = normalizePath(path);
-
-			// Check if path is excluded
-			if (shouldExcludePath(normalizedPath, plugin)) {
-				return {
-					success: false,
-					error: `Cannot modify files in system folder: ${path}`,
-				};
-			}
-
-			// Try direct path lookup, then with .md extension
-			let file = plugin.app.vault.getAbstractFileByPath(normalizedPath);
-			if (!file && !normalizedPath.endsWith('.md')) {
-				file = plugin.app.vault.getAbstractFileByPath(normalizedPath + '.md');
-			}
-
-			// Try wikilink resolution
+			const { file } = resolvePathToFile(path, plugin);
 			if (!file) {
-				const linkPath = path.replace(/^\[\[/, '').replace(/\]\]$/, '').replace(/\.md$/, '');
-				const resolved = plugin.app.metadataCache.getFirstLinkpathDest(linkPath, '');
-				if (resolved) {
-					file = resolved;
-				}
-			}
-
-			if (!file || !(file instanceof TFile)) {
 				return {
 					success: false,
 					error: `File not found: ${path}`,

--- a/test/tools/execution-engine.test.ts
+++ b/test/tools/execution-engine.test.ts
@@ -810,6 +810,24 @@ describe('ToolExecutionEngine - buildDiffContext for append_content', () => {
 
 		expect(diff).toBeUndefined();
 	});
+
+	it('returns undefined when wikilink resolves to a file inside the history folder', async () => {
+		// Regression for issue #910: the prior inline resolver only checked
+		// shouldExcludePath on the user-supplied input string, so a bare wikilink
+		// like "Foo" could resolve via metadataCache to gemini-scribe/Skills/Foo/SKILL.md
+		// and produce a diff preview for a file the tool would actually be blocked from writing.
+		const skillFile = new TFile();
+		(skillFile as any).path = 'gemini-scribe/Skills/Foo/SKILL.md';
+		plugin.app.vault.getAbstractFileByPath.mockReturnValue(null);
+		plugin.app.metadataCache.getFirstLinkpathDest.mockReturnValue(skillFile);
+
+		const tool = { name: 'append_content' } as any;
+		const params = { path: 'Foo', content: 'text' };
+
+		const diff = await (engine as any).buildDiffContext(tool, params);
+
+		expect(diff).toBeUndefined();
+	});
 });
 
 describe('ToolExecutionEngine - buildDiffContext for create_skill', () => {

--- a/test/tools/vault/vault-tools-extended.test.ts
+++ b/test/tools/vault/vault-tools-extended.test.ts
@@ -31,6 +31,7 @@ function createMockPlugin(overrides: Record<string, any> = {}): any {
 		app: {
 			vault: {
 				getAbstractFileByPath: vi.fn().mockReturnValue(null),
+				getFiles: vi.fn().mockReturnValue([]),
 				modify: vi.fn().mockResolvedValue(undefined),
 				read: vi.fn().mockResolvedValue(''),
 				append: vi.fn().mockResolvedValue(undefined),
@@ -155,16 +156,36 @@ describe('UpdateFrontmatterTool', () => {
 
 	it('rejects paths inside the history folder', async () => {
 		const plugin = createMockPlugin();
+		// Even if the file exists at that path, the resolver returns null for excluded paths
+		const file = makeTFile('gemini-scribe/some.md');
+		plugin.app.vault.getAbstractFileByPath.mockReturnValue(file);
 		const result = await tool.execute({ path: 'gemini-scribe/some.md', key: 'k', value: 'v' }, makeContext(plugin));
 		expect(result.success).toBe(false);
-		expect(result.error).toContain('system folder');
+		expect(result.error).toContain('not found');
+		expect(plugin.app.fileManager.processFrontMatter).not.toHaveBeenCalled();
 	});
 
 	it('rejects .obsidian paths', async () => {
 		const plugin = createMockPlugin();
-		const result = await tool.execute({ path: '.obsidian/config.json', key: 'k', value: 'v' }, makeContext(plugin));
+		const file = makeTFile('.obsidian/config.md');
+		plugin.app.vault.getAbstractFileByPath.mockReturnValue(file);
+		const result = await tool.execute({ path: '.obsidian/config.md', key: 'k', value: 'v' }, makeContext(plugin));
 		expect(result.success).toBe(false);
-		expect(result.error).toContain('system folder');
+		expect(result.error).toContain('not found');
+		expect(plugin.app.fileManager.processFrontMatter).not.toHaveBeenCalled();
+	});
+
+	it('rejects wikilink that resolves to a file inside the history folder', async () => {
+		// Regression for issue #910: a bare wikilink like "Foo" could resolve via
+		// metadataCache.getFirstLinkpathDest() to a file inside gemini-scribe/Skills/,
+		// and the prior inline resolver skipped the exclusion check on the resolved path.
+		const plugin = createMockPlugin();
+		const skillFile = makeTFile('gemini-scribe/Skills/Foo/SKILL.md');
+		plugin.app.metadataCache.getFirstLinkpathDest.mockReturnValue(skillFile);
+		const result = await tool.execute({ path: 'Foo', key: 'k', value: 'v' }, makeContext(plugin));
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('not found');
+		expect(plugin.app.fileManager.processFrontMatter).not.toHaveBeenCalled();
 	});
 
 	// ── File not found ───────────────────────────────────────────────────
@@ -439,9 +460,28 @@ describe('AppendContentTool', () => {
 
 	it('rejects paths inside the history folder', async () => {
 		const plugin = createMockPlugin();
+		const file = makeTFile('gemini-scribe/some.md');
+		plugin.app.vault.getAbstractFileByPath.mockReturnValue(file);
 		const result = await tool.execute({ path: 'gemini-scribe/some.md', content: 'x' }, makeContext(plugin));
 		expect(result.success).toBe(false);
-		expect(result.error).toContain('system folder');
+		expect(result.error).toContain('File not found');
+		expect(plugin.app.vault.append).not.toHaveBeenCalled();
+		expect(plugin.app.vault.modify).not.toHaveBeenCalled();
+	});
+
+	it('rejects wikilink that resolves to a file inside the history folder', async () => {
+		// Regression for issue #910: a bare wikilink like "Foo" could resolve via
+		// metadataCache.getFirstLinkpathDest() to a file inside gemini-scribe/Skills/,
+		// and the prior inline resolver skipped the exclusion check on the resolved path,
+		// letting vault.append() write into the plugin's state folder.
+		const plugin = createMockPlugin();
+		const skillFile = makeTFile('gemini-scribe/Skills/Foo/SKILL.md');
+		plugin.app.metadataCache.getFirstLinkpathDest.mockReturnValue(skillFile);
+		const result = await tool.execute({ path: 'Foo', content: 'appended' }, makeContext(plugin));
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('File not found');
+		expect(plugin.app.vault.append).not.toHaveBeenCalled();
+		expect(plugin.app.vault.modify).not.toHaveBeenCalled();
 	});
 
 	// ── File not found ───────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

`UpdateFrontmatterTool`, `AppendContentTool`, and the `append_content` diff-preview branch in `ToolExecutionEngine` each carried an inline 3-step path resolver (direct → `.md` suffix → wikilink) and ran `shouldExcludePath()` only on the input string. Because the wikilink fallback uses `metadataCache.getFirstLinkpathDest()`, a bare name like `"Foo"` could resolve to `gemini-scribe/Skills/Foo/SKILL.md` inside the plugin's state folder — bypassing system-folder protection on the two write tools.

Replace each inline copy with `resolvePathToFile()` from `src/tools/vault/utils.ts`, which applies `shouldExcludePath()` against the resolved path at every resolution strategy.

Fixes #910

## Changes

- `src/tools/vault-tools-extended.ts`: `UpdateFrontmatterTool.execute()` and `AppendContentTool.execute()` now call `resolvePathToFile()`; the redundant upfront `shouldExcludePath` checks and inline 3-step resolvers are deleted along with the now-unused `normalizePath` / `TFile` imports.
- `src/tools/execution-engine.ts`: `append_content` branch in `buildDiffContext` uses `resolvePathToFile()` instead of duplicating the resolver. The comment is updated to point at the canonical helper.
- `test/tools/vault/vault-tools-extended.test.ts`: existing system-folder tests now mock a resolved file so they exercise the resolver's exclusion (rather than the deleted upfront input check). Added regression tests for each write tool asserting that a wikilink-style input resolving into the plugin state folder is rejected and no write occurs.
- `test/tools/execution-engine.test.ts`: added a regression test for the diff-preview branch covering the same wikilink-bypass shape.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards)
- [x] Documentation has been updated (if applicable)
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Improved path resolution consistency across append content and update frontmatter tools
- Fixed handling of wikilinks and file paths within system folders and restricted directories
- Enhanced error handling for invalid or unresolved file paths across both tools
- Strengthened exclusion logic to prevent operations on system-protected and history folders

<!-- end of auto-generated comment: release notes by coderabbit.ai -->