### PR TITLE
refactor: collapse 24 inline error-extraction ternaries to getRawErrorMessage helper

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -42,7 +42,7 @@ import { BackgroundTaskManager } from './services/background-task-manager';
 import { BackgroundStatusBar } from './services/background-status-bar';
 import { ScheduledTaskManager } from './services/scheduled-task-manager';
 import { HookManager } from './services/hook-manager';
-import { getErrorMessage } from './utils/error-utils';
+import { getErrorMessage, getRawErrorMessage } from './utils/error-utils';
 
 export interface RagIndexingSettings {
 	enabled: boolean;
@@ -266,7 +266,7 @@ export default class ObsidianGemini extends Plugin {
 			this.previousHooksEnabled = this.settings.hooksEnabled;
 		} catch (error) {
 			this.logger.error('Failed to initialize Gemini Scribe:', error);
-			this.lastInitError = error instanceof Error ? error.message : String(error);
+			this.lastInitError = getRawErrorMessage(error);
 			new Notice(this.getInitErrorMessage(error));
 			this.isGeminiInitialized = false;
 		}
@@ -329,7 +329,7 @@ export default class ObsidianGemini extends Plugin {
 		if (error instanceof Error && error.message.includes('API key')) {
 			return this.getApiKeyErrorMessage();
 		}
-		const detail = error instanceof Error ? error.message : String(error);
+		const detail = getRawErrorMessage(error);
 		return `Gemini Scribe failed to initialize: ${detail}. Check the console for details.`;
 	}
 
@@ -993,7 +993,7 @@ export default class ObsidianGemini extends Plugin {
 				}
 			} catch (error) {
 				this.logger.error('Failed to re-initialize after settings change:', error);
-				this.lastInitError = error instanceof Error ? error.message : String(error);
+				this.lastInitError = getRawErrorMessage(error);
 				this.isGeminiInitialized = false;
 			}
 		}

--- a/src/mcp/mcp-fetch.ts
+++ b/src/mcp/mcp-fetch.ts
@@ -1,5 +1,6 @@
 import { requestUrl } from 'obsidian';
 import { MCP_FETCH_TIMEOUT_MS } from './mcp-constants';
+import { getRawErrorMessage } from '../utils/error-utils';
 
 /**
  * A fetch-compatible wrapper around Obsidian's `requestUrl`.
@@ -106,7 +107,7 @@ export async function obsidianFetch(url: string | URL, init?: RequestInit): Prom
 		if (error instanceof TypeError) {
 			throw error;
 		}
-		throw new TypeError(`Network request failed: ${error instanceof Error ? error.message : String(error)}`);
+		throw new TypeError(`Network request failed: ${getRawErrorMessage(error)}`);
 	} finally {
 		if (timer !== undefined) {
 			window.clearTimeout(timer);

--- a/src/mcp/mcp-manager.ts
+++ b/src/mcp/mcp-manager.ts
@@ -13,6 +13,7 @@ import {
 	MCP_OAUTH_WAIT_TIMEOUT_MS,
 } from './mcp-constants';
 import { withTimeout } from '../utils/timeout';
+import { getRawErrorMessage } from '../utils/error-utils';
 import type ObsidianGemini from '../main';
 import { Logger } from '../utils/logger';
 import { Notice, Platform } from 'obsidian';
@@ -308,7 +309,7 @@ export class MCPManager {
 				}
 			}
 
-			const errorMsg = error instanceof Error ? error.message : String(error);
+			const errorMsg = getRawErrorMessage(error);
 			const errorStack = error instanceof Error ? error.stack : undefined;
 			this.logger.error(`MCP: Connection failed for "${config.name}": ${errorMsg}`);
 			if (errorStack) {
@@ -471,7 +472,7 @@ export class MCPManager {
 			await withTimeout(transport.close(), MCP_CLOSE_TIMEOUT_MS, 'MCP transport close (test)');
 			return toolNames;
 		} catch (error) {
-			const errorMsg = error instanceof Error ? error.message : String(error);
+			const errorMsg = getRawErrorMessage(error);
 			const errorStack = error instanceof Error ? error.stack : undefined;
 			this.logger.error(`MCP: Test connection failed: ${errorMsg}`);
 			if (errorStack) {

--- a/src/mcp/mcp-tool-wrapper.ts
+++ b/src/mcp/mcp-tool-wrapper.ts
@@ -4,6 +4,7 @@ import { ToolCategory } from '../types/agent';
 import { ToolClassification } from '../types/tool-policy';
 import { MCP_CALL_TOOL_TIMEOUT_MS } from './mcp-constants';
 import { withTimeout } from '../utils/timeout';
+import { getRawErrorMessage } from '../utils/error-utils';
 
 /**
  * MCP tool definition as returned by client.listTools()
@@ -79,7 +80,7 @@ export class MCPToolWrapper implements Tool {
 		} catch (error) {
 			return {
 				success: false,
-				error: `MCP tool execution failed: ${error instanceof Error ? error.message : String(error)}`,
+				error: `MCP tool execution failed: ${getRawErrorMessage(error)}`,
 			};
 		}
 	}

--- a/src/services/hook-manager.ts
+++ b/src/services/hook-manager.ts
@@ -1,6 +1,7 @@
 import { Platform, TAbstractFile, TFile, normalizePath } from 'obsidian';
 import type ObsidianGemini from '../main';
 import { ensureFolderExists } from '../utils/file-utils';
+import { getRawErrorMessage } from '../utils/error-utils';
 import { FeatureToolPolicy } from '../types/tool-policy';
 import { formatToolPolicyYaml } from './feature-policy-yaml';
 import {
@@ -784,7 +785,7 @@ export class HookManager {
 		const pausedDueToErrors = consecutiveFailures >= MAX_CONSECUTIVE_FAILURES;
 		this.state[slug] = {
 			...prev,
-			lastError: error instanceof Error ? error.message : String(error),
+			lastError: getRawErrorMessage(error),
 			consecutiveFailures,
 			pausedDueToErrors,
 		};

--- a/src/services/rag-vault-scanner.ts
+++ b/src/services/rag-vault-scanner.ts
@@ -7,7 +7,7 @@ import type { RagCache } from './rag-cache';
 import type { RagRateLimiter } from './rag-rate-limiter';
 import { CACHE_VERSION } from './rag-types';
 import type { IndexProgress, IndexResult, FailedFileEntry, RagIndexStatus, RagProgressProvider } from './rag-types';
-import { getErrorMessage, isNotFoundError, isQuotaExhausted } from '../utils/error-utils';
+import { getErrorMessage, getRawErrorMessage, isNotFoundError, isQuotaExhausted } from '../utils/error-utils';
 import { executeWithRetry } from '../utils/retry';
 
 /**
@@ -133,7 +133,7 @@ export class RagVaultScanner {
 				return;
 			} catch (error) {
 				// Check if it's a 404/not found error vs other errors
-				const errorMessage = error instanceof Error ? error.message : String(error);
+				const errorMessage = getRawErrorMessage(error);
 				const isNotFound = isNotFoundError(error);
 				// A saved store name can be structurally invalid — e.g. a custom name
 				// entered via an older plugin version that the File Search API rejects

--- a/src/services/scheduled-task-manager.ts
+++ b/src/services/scheduled-task-manager.ts
@@ -1,6 +1,7 @@
 import { TFile, normalizePath } from 'obsidian';
 import type ObsidianGemini from '../main';
 import { ensureFolderExists } from '../utils/file-utils';
+import { getRawErrorMessage } from '../utils/error-utils';
 import { FeatureToolPolicy } from '../types/tool-policy';
 import { formatToolPolicyYaml } from './feature-policy-yaml';
 import {
@@ -786,7 +787,7 @@ export class ScheduledTaskManager {
 			}
 			return outputPath;
 		} catch (error) {
-			const msg = error instanceof Error ? error.message : String(error);
+			const msg = getRawErrorMessage(error);
 			const prev = this.state[task.slug];
 			const consecutiveFailures = (prev?.consecutiveFailures ?? 0) + 1;
 			const pausedDueToErrors = consecutiveFailures >= MAX_CONSECUTIVE_FAILURES;

--- a/src/tools/image-tools.ts
+++ b/src/tools/image-tools.ts
@@ -1,6 +1,7 @@
 import { Tool, ToolResult, ToolExecutionContext } from './types';
 import { ToolCategory } from '../types/agent';
 import { ToolClassification } from '../types/tool-policy';
+import { getRawErrorMessage } from '../utils/error-utils';
 
 /**
  * Tool to generate images from text prompts using Gemini's image generation API
@@ -91,7 +92,7 @@ export class GenerateImageTool implements Tool {
 				} catch (error) {
 					return {
 						success: false,
-						error: `Failed to resolve image output path: ${error instanceof Error ? error.message : String(error)}`,
+						error: `Failed to resolve image output path: ${getRawErrorMessage(error)}`,
 					};
 				}
 
@@ -124,7 +125,7 @@ export class GenerateImageTool implements Tool {
 		} catch (error) {
 			return {
 				success: false,
-				error: `Failed to generate image: ${error instanceof Error ? error.message : String(error)}`,
+				error: `Failed to generate image: ${getRawErrorMessage(error)}`,
 			};
 		}
 	}

--- a/src/tools/memory-tool.ts
+++ b/src/tools/memory-tool.ts
@@ -1,6 +1,7 @@
 import { Tool, ToolResult, ToolExecutionContext } from './types';
 import { ToolCategory } from '../types/agent';
 import { ToolClassification } from '../types/tool-policy';
+import { getRawErrorMessage } from '../utils/error-utils';
 
 /**
  * Tool for updating the AGENTS.md memory file
@@ -71,7 +72,7 @@ export class UpdateMemoryTool implements Tool {
 		} catch (error) {
 			return {
 				success: false,
-				error: `Failed to update memory: ${error instanceof Error ? error.message : String(error)}`,
+				error: `Failed to update memory: ${getRawErrorMessage(error)}`,
 			};
 		}
 	}
@@ -137,7 +138,7 @@ export class ReadMemoryTool implements Tool {
 		} catch (error) {
 			return {
 				success: false,
-				error: `Failed to read memory: ${error instanceof Error ? error.message : String(error)}`,
+				error: `Failed to read memory: ${getRawErrorMessage(error)}`,
 			};
 		}
 	}

--- a/src/tools/rag-search-tool.ts
+++ b/src/tools/rag-search-tool.ts
@@ -1,6 +1,7 @@
 import { Tool, ToolResult, ToolExecutionContext } from './types';
 import { ToolCategory } from '../types/agent';
 import { ToolClassification } from '../types/tool-policy';
+import { getRawErrorMessage } from '../utils/error-utils';
 
 /**
  * Search result from RAG semantic search
@@ -254,7 +255,7 @@ export class RagSearchTool implements Tool {
 			plugin.logger.error('RAG Search failed:', error);
 			return {
 				success: false,
-				error: `Search failed: ${error instanceof Error ? error.message : String(error)}`,
+				error: `Search failed: ${getRawErrorMessage(error)}`,
 			};
 		}
 	}

--- a/src/tools/skill-tools.ts
+++ b/src/tools/skill-tools.ts
@@ -1,6 +1,7 @@
 import { Tool, ToolResult, ToolExecutionContext } from './types';
 import { ToolCategory } from '../types/agent';
 import { ToolClassification } from '../types/tool-policy';
+import { getRawErrorMessage } from '../utils/error-utils';
 
 /**
  * Tool for activating (loading) a skill's full instructions or resources
@@ -110,7 +111,7 @@ export class ActivateSkillTool implements Tool {
 		} catch (error) {
 			return {
 				success: false,
-				error: `Failed to activate skill: ${error instanceof Error ? error.message : String(error)}`,
+				error: `Failed to activate skill: ${getRawErrorMessage(error)}`,
 			};
 		}
 	}
@@ -218,7 +219,7 @@ export class CreateSkillTool implements Tool {
 		} catch (error) {
 			return {
 				success: false,
-				error: `Failed to create skill: ${error instanceof Error ? error.message : String(error)}`,
+				error: `Failed to create skill: ${getRawErrorMessage(error)}`,
 			};
 		}
 	}
@@ -324,7 +325,7 @@ export class EditSkillTool implements Tool {
 		} catch (error) {
 			return {
 				success: false,
-				error: `Failed to edit skill: ${error instanceof Error ? error.message : String(error)}`,
+				error: `Failed to edit skill: ${getRawErrorMessage(error)}`,
 			};
 		}
 	}

--- a/src/ui/mcp-server-modal.ts
+++ b/src/ui/mcp-server-modal.ts
@@ -3,6 +3,7 @@ import { MCPServerConfig, MCP_TRANSPORT_STDIO, MCP_TRANSPORT_HTTP, MCPTransportT
 import { MCPManager } from '../mcp/mcp-manager';
 import { ObsidianOAuthClientProvider } from '../mcp/mcp-oauth-provider';
 import { resolveServerEnv, writeServerEnv } from '../mcp/mcp-secrets';
+import { getRawErrorMessage } from '../utils/error-utils';
 
 /**
  * Modal for adding or editing an MCP server configuration.
@@ -236,7 +237,7 @@ export class MCPServerModal extends Modal {
 					testSetting.setDesc(`Connected successfully! Found ${tools.length} tool(s).`);
 					this.renderDiscoveredTools();
 				} catch (error) {
-					const msg = error instanceof Error ? error.message : String(error);
+					const msg = getRawErrorMessage(error);
 					testSetting.setDesc(`Connection failed: ${msg}`);
 				} finally {
 					button.setButtonText('Test Connection');

--- a/src/ui/rag-status-modal.ts
+++ b/src/ui/rag-status-modal.ts
@@ -1,5 +1,6 @@
 import { App, Modal, Notice, Setting, setIcon } from 'obsidian';
 import type { RagIndexStatus, FailedFileEntry } from '../services/rag-types';
+import { getRawErrorMessage } from '../utils/error-utils';
 
 /**
  * Detailed status information for the modal
@@ -184,7 +185,7 @@ export class RagStatusModal extends Modal {
 							await this.onSyncNow();
 							this.close();
 						} catch (error) {
-							const message = error instanceof Error ? error.message : String(error);
+							const message = getRawErrorMessage(error);
 							new Notice(`Sync failed: ${message}`);
 							btn.setButtonText('Sync Now');
 							btn.setDisabled(false);

--- a/src/ui/settings-mcp.ts
+++ b/src/ui/settings-mcp.ts
@@ -2,7 +2,7 @@ import type ObsidianGemini from '../main';
 import { App, Setting, Notice, setIcon } from 'obsidian';
 import { sanitizeKeySegment } from '../mcp/mcp-oauth-provider';
 import { clearServerEnv } from '../mcp/mcp-secrets';
-import { getErrorMessage } from '../utils/error-utils';
+import { getErrorMessage, getRawErrorMessage } from '../utils/error-utils';
 import { createCollapsibleSection } from './settings-helpers';
 import type { SettingsSectionContext } from './settings';
 
@@ -15,10 +15,8 @@ export async function renderMCPSettings(
 	try {
 		await createMCPSettings(containerEl, plugin, app, context);
 	} catch (error) {
-		plugin.logger.error('MCP settings rendering error:', error instanceof Error ? error.message : String(error));
-		new Setting(containerEl)
-			.setName('MCP Servers')
-			.setDesc(`Error loading MCP settings: ${error instanceof Error ? error.message : String(error)}`);
+		plugin.logger.error('MCP settings rendering error:', getRawErrorMessage(error));
+		new Setting(containerEl).setName('MCP Servers').setDesc(`Error loading MCP settings: ${getRawErrorMessage(error)}`);
 	}
 }
 

--- a/src/utils/error-utils.ts
+++ b/src/utils/error-utils.ts
@@ -1,5 +1,8 @@
 /**
- * Utility functions for extracting user-friendly error messages from API errors
+ * Utility functions for extracting error messages from API errors.
+ *
+ * Raw extraction (no translation): `getRawErrorMessage`.
+ * User-facing translation (maps provider quirks to friendly guidance): `getErrorMessage`.
  */
 
 /**
@@ -104,8 +107,22 @@ export function isRateLimitError(error: unknown): boolean {
  * error shapes the Google File Search API and SDK return.
  */
 export function isNotFoundError(error: unknown): boolean {
-	const message = error instanceof Error ? error.message : String(error);
+	const message = getRawErrorMessage(error);
 	return message.includes('404') || message.includes('not found') || message.includes('NOT_FOUND');
+}
+
+/**
+ * Extract the raw string from an `unknown` error value without any translation.
+ *
+ * Returns `error.message` for `Error` instances and `String(error)` for everything
+ * else. Use this for logging, sidecar `lastError` fields, and tool error returns
+ * where the underlying message should pass through untouched. For user-facing
+ * surfaces that benefit from provider-specific guidance (Ollama 404 → "ollama pull X",
+ * quota → Studio billing, etc.), use `getErrorMessage` instead.
+ */
+export function getRawErrorMessage(error: unknown): string {
+	if (error instanceof Error) return error.message;
+	return String(error);
 }
 
 /**

--- a/src/utils/file-utils.ts
+++ b/src/utils/file-utils.ts
@@ -9,6 +9,7 @@
 import { TAbstractFile, TFolder, Vault, normalizePath, Notice } from 'obsidian';
 import type ObsidianGemini from '../main';
 import type { Logger } from './logger';
+import { getRawErrorMessage } from './error-utils';
 
 /**
  * Check if a file or folder path should be excluded from selection or operations.
@@ -100,7 +101,7 @@ export async function ensureFolderExists(
 	try {
 		await vault.createFolder(normalized);
 	} catch (error) {
-		const message = error instanceof Error ? error.message : String(error);
+		const message = getRawErrorMessage(error);
 
 		// Race condition: another process created it between our check and createFolder
 		if (await vault.adapter.exists(normalized)) {

--- a/test/services/rag-vault-scanner.test.ts
+++ b/test/services/rag-vault-scanner.test.ts
@@ -53,6 +53,7 @@ vi.mock('@allenhutchison/gemini-utils', () => ({
 
 vi.mock('../../src/utils/error-utils', () => ({
 	getErrorMessage: vi.fn((err: any) => (err instanceof Error ? err.message : String(err))),
+	getRawErrorMessage: vi.fn((err: any) => (err instanceof Error ? err.message : String(err))),
 	isQuotaExhausted: vi.fn().mockReturnValue(false),
 	isNotFoundError: vi.fn((err: any) => {
 		const msg = err instanceof Error ? err.message : String(err);

--- a/test/utils/error-utils.test.ts
+++ b/test/utils/error-utils.test.ts
@@ -1,5 +1,6 @@
 import {
 	getErrorMessage,
+	getRawErrorMessage,
 	getShortErrorMessage,
 	isNotFoundError,
 	isQuotaExhausted,
@@ -7,6 +8,46 @@ import {
 } from '../../src/utils/error-utils';
 
 describe('error-utils', () => {
+	describe('getRawErrorMessage', () => {
+		test('returns Error.message for Error instances', () => {
+			expect(getRawErrorMessage(new Error('boom'))).toBe('boom');
+		});
+
+		test('preserves message on Error subclasses', () => {
+			expect(getRawErrorMessage(new TypeError('bad type'))).toBe('bad type');
+		});
+
+		test('returns the string unchanged for string inputs', () => {
+			expect(getRawErrorMessage('plain string')).toBe('plain string');
+		});
+
+		test('coerces null to "null"', () => {
+			expect(getRawErrorMessage(null)).toBe('null');
+		});
+
+		test('coerces undefined to "undefined"', () => {
+			expect(getRawErrorMessage(undefined)).toBe('undefined');
+		});
+
+		test('uses toString() on objects that define it', () => {
+			const obj = {
+				toString() {
+					return 'custom-stringified';
+				},
+			};
+			expect(getRawErrorMessage(obj)).toBe('custom-stringified');
+		});
+
+		test('coerces numbers via String()', () => {
+			expect(getRawErrorMessage(42)).toBe('42');
+		});
+
+		test('does not translate raw messages (unlike getErrorMessage)', () => {
+			// getErrorMessage maps "api key" to friendly guidance; getRawErrorMessage must not.
+			expect(getRawErrorMessage(new Error('Invalid api key supplied'))).toBe('Invalid api key supplied');
+		});
+	});
+
 	describe('getErrorMessage', () => {
 		describe('HTTP status code errors', () => {
 			test('400 Bad Request', () => {


### PR DESCRIPTION
## Summary

Adds `getRawErrorMessage(error: unknown): string` to `src/utils/error-utils.ts` and replaces every site (24 across 14 files) that previously inlined `error instanceof Error ? error.message : String(error)`.

The existing `getErrorMessage` is a user-facing translator (maps Ollama 404 → "ollama pull X", quota → Studio guidance, etc.), so callers that wanted the raw underlying string couldn't reuse it and each re-rolled the ternary. Naming both helpers (`getRawErrorMessage` vs. `getErrorMessage`) makes the "translate vs. pass through" choice self-documenting at the call site.

Fixes #912

## Changes

- Add `getRawErrorMessage` to `src/utils/error-utils.ts`, positioned immediately above `getErrorMessage` with a doc comment cross-linking the two. File header updated to note the split.
- Refactor `isNotFoundError` to call the new helper internally.
- Replace 23 inline ternaries across 14 files (mechanical substitution, no behavior change):
  - `src/main.ts` (3), `src/ui/settings-mcp.ts` (2), `src/ui/mcp-server-modal.ts` (1), `src/ui/rag-status-modal.ts` (1)
  - `src/services/scheduled-task-manager.ts` (1), `src/services/rag-vault-scanner.ts` (1), `src/services/hook-manager.ts` (1)
  - `src/tools/image-tools.ts` (2), `src/tools/rag-search-tool.ts` (1), `src/tools/memory-tool.ts` (2), `src/tools/skill-tools.ts` (3)
  - `src/mcp/mcp-fetch.ts` (1), `src/mcp/mcp-manager.ts` (2), `src/mcp/mcp-tool-wrapper.ts` (1)
  - `src/utils/file-utils.ts` (1)
- Add 8 unit tests covering `Error`, `Error` subclass, string, `null`, `undefined`, number, object-with-`toString()`, and the no-translation contract.
- Extend the partial `error-utils` mock in `test/services/rag-vault-scanner.test.ts` to expose the new export.

## Screenshots / Screencast

N/A — backend-only refactor, no UI surface affected. User-facing error strings are identical (`getErrorMessage` translation behavior is unchanged; only the raw-extraction layer was de-duplicated).

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer (#912, filed by the architecture-audit skill with the proposed unit of work specified)
- [x] All CI checks pass (`npm test` 2999/2999, `npm run build` clean, `npm run format-check` clean, `npm run lint` 0 errors)
- [x] I have tested this change on Desktop
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — pure utility refactor with no platform-specific code
- [x] Documentation has been updated (if applicable) — no user-facing surface changed; the new helper's doc comment documents the raw-vs-translated split
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude (Claude Code)
- [x] I have reviewed and understand all AI-generated code in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized error message handling across the application with a centralized utility function applied to server operations, tool execution, image processing, task scheduling, and settings management.

* **Tests**
  * Added comprehensive unit tests for error message extraction covering Error instances, non-error inputs, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->