### PR TITLE
chore: retire preview models superseded by GA in model updater

### DIFF
--- a/scripts/update-models.mjs
+++ b/scripts/update-models.mjs
@@ -94,6 +94,19 @@ function inferImageSupport(modelId) {
 	return modelId.includes('image');
 }
 
+function isPreviewModel(modelId) {
+	return modelId.includes('-preview');
+}
+
+// The GA (stable) equivalent of a preview model id. Per Google's naming
+// convention, preview models are `<base>-preview` optionally followed by a
+// date suffix (e.g. `gemini-2.5-flash-preview-09-2025` -> `gemini-2.5-flash`,
+// `gemini-3-pro-image-preview` -> `gemini-3-pro-image`). Strip `-preview` and
+// everything after it to recover the base id.
+function gaModelId(modelId) {
+	return modelId.replace(/-preview.*$/, '');
+}
+
 function main() {
 	const apiKey = process.env.GOOGLE_API_KEY;
 	if (!apiKey) {
@@ -109,10 +122,22 @@ function main() {
 		// Filter and map API models
 		const candidateModels = apiModels.filter(shouldIncludeModel);
 
-		const newModels = [];
+		let newModels = [];
+		// Existing preview entries that a newly-arrived GA model supersedes;
+		// keyed by preview value -> the new GA entry that replaces it.
+		const retiredPreviews = new Map();
 		for (const model of candidateModels) {
 			const modelId = extractModelId(model.name);
 			if (existingIds.has(modelId)) continue;
+
+			// Skip preview models once we've adopted the GA (stable) version
+			// of the same model. Google keeps listing the preview aliases
+			// indefinitely, but offering both shows duplicate options (often
+			// with identical labels) in the model dropdowns.
+			if (isPreviewModel(modelId) && existingIds.has(gaModelId(modelId))) {
+				console.log(`Skipping ${modelId}: superseded by adopted GA model ${gaModelId(modelId)}`);
+				continue;
+			}
 
 			const entry = {
 				value: modelId,
@@ -130,8 +155,34 @@ function main() {
 				entry.maxTemperature = 2;
 			}
 
+			// When a new GA (stable) model arrives, retire any existing preview
+			// entries it supersedes so the GA "replaces" rather than duplicates
+			// them. Carry over curated default-role assignments to the GA entry
+			// so we don't silently drop a configured default.
+			if (!isPreviewModel(modelId)) {
+				for (const existing of modelsFile.models) {
+					if (isPreviewModel(existing.value) && gaModelId(existing.value) === modelId) {
+						retiredPreviews.set(existing.value, entry);
+						if (existing.defaultForRoles && !entry.defaultForRoles) {
+							entry.defaultForRoles = existing.defaultForRoles;
+						}
+					}
+				}
+			}
+
 			newModels.push(entry);
 		}
+
+		// Same-run guard: if both a preview and its GA arrived in this batch,
+		// keep only the GA — mirroring the already-adopted-GA skip above.
+		const newGaIds = new Set(newModels.filter((m) => !isPreviewModel(m.value)).map((m) => m.value));
+		newModels = newModels.filter((m) => {
+			if (isPreviewModel(m.value) && newGaIds.has(gaModelId(m.value))) {
+				console.log(`Skipping ${m.value}: superseded by new GA model ${gaModelId(m.value)}`);
+				return false;
+			}
+			return true;
+		});
 
 		if (newModels.length === 0) {
 			console.log('No new models found.');
@@ -143,7 +194,13 @@ function main() {
 			console.log(`  - ${model.value} (${model.label})${model.supportsImageGeneration ? ' [image]' : ''}`);
 		}
 
-		// Append new models and update metadata
+		// Retire superseded preview entries, then append the new models.
+		if (retiredPreviews.size > 0) {
+			for (const [previewId, gaEntry] of retiredPreviews) {
+				console.log(`Retiring ${previewId}: superseded by new GA model ${gaEntry.value}`);
+			}
+			modelsFile.models = modelsFile.models.filter((m) => !retiredPreviews.has(m.value));
+		}
 		modelsFile.models.push(...newModels);
 		modelsFile.lastUpdated = new Date().toISOString();
 


### PR DESCRIPTION
## Summary

The automated model-update script (`scripts/update-models.mjs`) only ever *appended* new models from Google's API and never retired anything. Because Google keeps listing preview aliases indefinitely, the script kept re-adding superseded `-preview` entries — the exact duplicates that were removed by hand in #922 and then re-introduced by #955.

This teaches the script the preview→GA lifecycle so it curates these automatically.

## Changes

- **Skip** preview candidates once their GA (stable) version is already adopted in `models.json` (fixes the #955 re-add of `gemini-3-pro-image-preview` / `gemini-3.1-flash-image-preview`).
- **Retire** existing preview entries when their GA model first arrives, so the GA *replaces* rather than duplicates them. Any curated `defaultForRoles` on the preview is carried over to the GA entry so a configured default isn't silently dropped.
- **Dedupe within a single run** when both a preview and its GA surface together (order-independent).
- `gaModelId()` now strips `-preview` and any trailing date suffix, matching Google's documented `<base>-preview[-MM-YYYY]` naming convention (e.g. `gemini-2.5-flash-preview-09-2025` → `gemini-2.5-flash`). `latest` aliases are untouched.

Verified by simulating all scenarios against the decision logic (both orderings), plus `npm run build`, `npm test` (2994 passing), and `npm run format-check`.

Follow-up: #955 should be **closed** rather than merged — with this change the next run skips those preview aliases and produces no diff.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: small internal tooling fix for a regression observed in #955
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop — N/A: build-time script only, validated via simulation + existing test suite
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A: build-time script, not shipped in the plugin
- [x] Documentation has been updated (if applicable) — N/A: purely internal CI/tooling change, no user-facing behavior change
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR