### PR TITLE
refactor(tools): inject view side effects into WriteFileTool via context

### DIFF
--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -4,7 +4,7 @@ import type { ChatSession, PerTurnContext } from '../types/agent';
 import type { FeatureToolPolicy } from '../types/tool-policy';
 import type { ToolCall, ModelResponse, ModelApi } from '../api/interfaces/model-api';
 import type { CustomPrompt } from '../prompts/types';
-import type { IConfirmationProvider, ToolExecutionContext, ToolResult } from '../tools/types';
+import type { IConfirmationProvider, IToolHostView, ToolExecutionContext, ToolResult } from '../tools/types';
 import { generateToolDescription } from '../utils/text-generation';
 import { sortToolCallsByPriority, buildToolHistoryTurns, type ToolCallResultPair } from './agent-loop-helpers';
 import {
@@ -90,6 +90,12 @@ export interface AgentLoopOptions {
 	 * sets these once when the user submits the turn.
 	 */
 	perTurn?: PerTurnContext;
+	/**
+	 * View-owned side effects (shelf updates, header refresh) for tools that need
+	 * them. UI callers (AgentViewTools) pass the owning agent view; headless
+	 * callers leave it unset, so those tool calls become no-ops.
+	 */
+	viewActions?: IToolHostView;
 	hooks?: AgentLoopHooks;
 	/**
 	 * Factory for the model API used for follow-up and retry requests.
@@ -172,8 +178,18 @@ export class AgentLoop {
 		options: AgentLoopOptions;
 	}): Promise<AgentLoopResult> {
 		const { initialResponse, initialUserMessage, initialHistory, options } = args;
-		const { plugin, session, isCancelled, hooks, customPrompt, projectRootPath, featureToolPolicy, perTurn, headless } =
-			options;
+		const {
+			plugin,
+			session,
+			isCancelled,
+			hooks,
+			customPrompt,
+			projectRootPath,
+			featureToolPolicy,
+			perTurn,
+			headless,
+			viewActions,
+		} = options;
 		const maxIterations = options.maxIterations;
 
 		const toolContext: ToolExecutionContext = {
@@ -181,6 +197,7 @@ export class AgentLoop {
 			session,
 			projectRootPath,
 			featureToolPolicy,
+			viewActions,
 		};
 
 		// `currentToolCalls` is what we execute on the next iteration. Seed it

--- a/src/tools/types.ts
+++ b/src/tools/types.ts
@@ -1,6 +1,7 @@
 import { ChatSession } from '../types/agent';
 import { ToolClassification } from '../types/tool-policy';
 import type ObsidianGemini from '../main';
+import type { TFile } from 'obsidian';
 
 // Re-export ToolCall from its canonical definition in model-api
 export type { ToolCall } from '../api/interfaces/model-api';
@@ -24,6 +25,23 @@ export interface ToolResult {
 }
 
 /**
+ * Side effects a tool may trigger on the agent view that owns its session.
+ *
+ * Implemented by `AgentView` and injected into {@link ToolExecutionContext} by
+ * the UI layer, so a tool in `src/tools/` can request view updates without
+ * importing `AgentView` (which would create a tools→ui layering edge) or
+ * reaching for the active workspace leaf. Currently used by `write_file` to add
+ * a newly-created file to the session shelf and refresh the header. Headless
+ * callers leave it unset, so these calls become no-ops.
+ */
+export interface IToolHostView {
+	getCurrentSessionForToolExecution(): ChatSession | null;
+	addContextFileToShelf(file: TFile): void;
+	updateSessionHeader(): void;
+	updateSessionMetadata(): Promise<void>;
+}
+
+/**
  * Context provided to tools during execution
  */
 export interface ToolExecutionContext {
@@ -31,6 +49,12 @@ export interface ToolExecutionContext {
 	plugin: ObsidianGemini;
 	/** When set, discovery tools default their search scope to this directory */
 	projectRootPath?: string;
+	/**
+	 * Side effects on the agent view that owns this session (shelf updates, header
+	 * refresh). Set by the UI when an agent view drives the turn; unset for headless
+	 * callers, where the tool simply skips the view updates.
+	 */
+	viewActions?: IToolHostView;
 	/**
 	 * Feature-level tool policy applied on top of the global plugin policy.
 	 * Used by Projects, Scheduled Tasks, Hooks, and Sessions to narrow or open

--- a/src/tools/vault/write-file-tool.ts
+++ b/src/tools/vault/write-file-tool.ts
@@ -91,23 +91,18 @@ export class WriteFileTool implements Tool {
 				file = plugin.app.vault.getAbstractFileByPath(normalizedPath);
 			}
 
-			// Add the file to session context if it's a new file and we have a session
+			// Add the file to session context if it's a new file and we have a session.
+			// The owning agent view (when one drives this turn) is injected as
+			// context.viewActions; headless callers leave it unset, making this a no-op.
 			if (file instanceof TFile && context.session && isNewFile) {
-				const agentView = plugin.app.workspace.getLeavesOfType('gemini-agent-view')[0]?.view;
-				if (agentView && 'getCurrentSessionForToolExecution' in agentView) {
-					const session = (agentView as any).getCurrentSessionForToolExecution();
-					if (session && !session.context.contextFiles.includes(file)) {
-						session.context.contextFiles.push(file);
-						// Sync the shelf (which is the source of truth for context files)
-						if ('addContextFileToShelf' in agentView) {
-							(agentView as any).addContextFileToShelf(file);
-						}
-						// Update UI if agent view is active
-						if ('updateSessionHeader' in agentView) {
-							(agentView as any).updateSessionHeader();
-							(agentView as any).updateSessionMetadata();
-						}
-					}
+				const viewActions = context.viewActions;
+				const session = viewActions?.getCurrentSessionForToolExecution();
+				if (viewActions && session && !session.context.contextFiles.includes(file)) {
+					session.context.contextFiles.push(file);
+					// Sync the shelf (the source of truth for context files), then refresh the UI.
+					viewActions.addContextFileToShelf(file);
+					viewActions.updateSessionHeader();
+					void viewActions.updateSessionMetadata();
 				}
 			}
 

--- a/src/ui/agent-view/agent-view-tools.ts
+++ b/src/ui/agent-view/agent-view-tools.ts
@@ -2,7 +2,7 @@ import type { Content } from '@google/genai';
 import type ObsidianGemini from '../../main';
 import { ChatSession } from '../../types/agent';
 import { GeminiConversationEntry } from '../../types/conversation';
-import { IConfirmationProvider, ToolResult } from '../../tools/types';
+import { IConfirmationProvider, IToolHostView, ToolResult } from '../../tools/types';
 import { CustomPrompt } from '../../prompts/types';
 import { AgentLoop } from '../../agent/agent-loop';
 import type { ToolCall } from '../../api/interfaces/model-api';
@@ -21,6 +21,8 @@ export interface AgentViewContext {
 	incrementToolCallCount?(count: number): void;
 	/** Who approves tool calls that require confirmation — AgentView implements this. */
 	confirmationProvider: IConfirmationProvider;
+	/** View side effects tools can trigger (shelf updates, header refresh). */
+	viewActions: IToolHostView;
 }
 
 /**
@@ -81,6 +83,7 @@ export class AgentViewTools {
 					customPrompt,
 					projectRootPath: activeProject?.rootPath,
 					featureToolPolicy: activeProject?.config.toolPolicy,
+					viewActions: this.context.viewActions,
 					perTurn,
 					hooks: {
 						onToolBatchStart: (batch) => {

--- a/src/ui/agent-view/agent-view.ts
+++ b/src/ui/agent-view/agent-view.ts
@@ -732,6 +732,14 @@ export class AgentView extends ItemView {
 			},
 			// AgentView implements IConfirmationProvider directly (see methods below).
 			confirmationProvider: this,
+			// View side effects tools can trigger. Wrapped in closures so the
+			// private header/metadata methods stay private to AgentView.
+			viewActions: {
+				getCurrentSessionForToolExecution: () => this.getCurrentSessionForToolExecution(),
+				addContextFileToShelf: (file: TFile) => this.addContextFileToShelf(file),
+				updateSessionHeader: () => this.updateSessionHeader(),
+				updateSessionMetadata: () => this.updateSessionMetadata(),
+			},
 		};
 	}
 

--- a/test/tools/vault/write-file-tool.test.ts
+++ b/test/tools/vault/write-file-tool.test.ts
@@ -158,6 +158,47 @@ describe('WriteFileTool', () => {
 		expect(mockVault.create).toHaveBeenCalledWith('new.md', 'new content');
 	});
 
+	it('should add a newly-created file to the session shelf via context.viewActions', async () => {
+		mockVault.getAbstractFileByPath.mockReturnValueOnce(null).mockReturnValueOnce(mockFile);
+		mockVault.create.mockResolvedValue(mockFile);
+
+		const hostSession = { context: { contextFiles: [] as any[] } };
+		const viewActions = {
+			getCurrentSessionForToolExecution: vi.fn().mockReturnValue(hostSession),
+			addContextFileToShelf: vi.fn(),
+			updateSessionHeader: vi.fn(),
+			updateSessionMetadata: vi.fn().mockResolvedValue(undefined),
+		};
+
+		const result = await tool.execute({ path: 'shelf-me.md', content: 'content' }, {
+			...mockContext,
+			viewActions,
+		} as any);
+
+		expect(result.success).toBe(true);
+		expect(hostSession.context.contextFiles).toContain(mockFile);
+		expect(viewActions.addContextFileToShelf).toHaveBeenCalledWith(mockFile);
+		expect(viewActions.updateSessionHeader).toHaveBeenCalled();
+		expect(viewActions.updateSessionMetadata).toHaveBeenCalled();
+	});
+
+	it('should not touch the shelf for a modified (non-new) file', async () => {
+		mockVault.getAbstractFileByPath.mockReturnValue(mockFile);
+		mockVault.modify.mockResolvedValue(undefined);
+
+		const viewActions = {
+			getCurrentSessionForToolExecution: vi.fn().mockReturnValue({ context: { contextFiles: [] } }),
+			addContextFileToShelf: vi.fn(),
+			updateSessionHeader: vi.fn(),
+			updateSessionMetadata: vi.fn().mockResolvedValue(undefined),
+		};
+
+		const result = await tool.execute({ path: 'test.md', content: 'updated' }, { ...mockContext, viewActions } as any);
+
+		expect(result.success).toBe(true);
+		expect(viewActions.addContextFileToShelf).not.toHaveBeenCalled();
+	});
+
 	it('should create parent directories when creating file in non-existent folder', async () => {
 		// ensureFolderExists calls getAbstractFileByPath twice per folder:
 		// once to check existence (null), once to verify after creation (TFolder)


### PR DESCRIPTION
## Summary

Fixes #954. `WriteFileTool` was the last place in the tools layer that reached across the tool→view boundary with `(agentView as any)` casts — four of them, behind `'method' in agentView` runtime guards, plus a `getLeavesOfType('gemini-agent-view')` lookup inside a vault tool.

This replaces that with dependency injection: the owning agent view passes its side effects into the tool through `ToolExecutionContext`, so the tool never imports `AgentView`, never looks up a workspace leaf, and never casts.

Took **option 2** from the issue (inject through the context) over option 1 (narrow the leaf lookup), because it removes the workspace-leaf lookup — the bigger smell — and it fits the existing `AgentViewContext` / `AgentLoopHooks` injection pattern already used for other view side effects.

## Changes

- **`src/tools/types.ts`** — new `IToolHostView` interface (the four view side effects: `getCurrentSessionForToolExecution`, `addContextFileToShelf`, `updateSessionHeader`, `updateSessionMetadata`) and an optional `viewActions?: IToolHostView` on `ToolExecutionContext`.
- **`src/agent/agent-loop.ts`** — `AgentLoopOptions.viewActions` threaded into the `toolContext` it builds.
- **`src/ui/agent-view/agent-view-tools.ts`** — `AgentViewContext.viewActions` added and passed into the loop options.
- **`src/ui/agent-view/agent-view.ts`** — `createToolsContext()` supplies `viewActions` via closures, keeping the private `updateSessionHeader` / `updateSessionMetadata` methods private to `AgentView`.
- **`src/tools/vault/write-file-tool.ts`** — calls `context.viewActions?.*` directly; the leaf lookup, the `'method' in` guards, and all four `as any` casts are gone.
- **`test/tools/vault/write-file-tool.test.ts`** — added coverage for the positive shelf-add path (previously untested) and a non-new-file no-op case.

## Behavior

- **Interactive path:** unchanged — the owning view's session shelf and header update exactly as before.
- **Headless callers** (scheduled tasks, hooks) leave `viewActions` unset, so the shelf update is a clean no-op. Previously the tool's live leaf lookup could push a headless-written file into whatever agent view happened to be open — that latent cross-contamination is now gone.

No user-facing behavior change, so no docs update required.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer — Fixes #954 (filed by the architecture-audit skill, approach options enumerated there)
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop — N/A: covered by unit tests (3004 passing); no runtime behavior change on the interactive path
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A: no platform-specific code; pure typing/wiring refactor
- [x] Documentation has been updated (if applicable) — N/A: internal architecture change, no user-facing behavior
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Files created by tools are now automatically added to your current session shelf
  * Session headers and metadata refresh instantly when tools perform file operations
  * Workspace stays synchronized in real-time with tool execution, eliminating manual file management after tool operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->