### PR TITLE
refactor(api): harden ModelApi request-type discriminator with a required kind

### DIFF
--- a/src/api/interfaces/model-api.ts
+++ b/src/api/interfaces/model-api.ts
@@ -44,10 +44,16 @@ export interface ToolCall {
 /**
  * Represents a basic request to a model.
  *
+ * @property kind - Discriminant for the request union. `'base'` marks a one-shot
+ *   prompt request whose full input lives in `prompt`. Required so TypeScript
+ *   flags a base request that accidentally carries extended-only fields (e.g. a
+ *   stray `userMessage`) instead of the union silently misrouting it at runtime
+ *   (see #859).
  * @property model - Optional model identifier. If not provided, the default model will be used.
  * @property prompt - The prompt or input text for the model. Should be fully processed.
  */
 export interface BaseModelRequest {
+	kind: 'base';
 	model?: string;
 	prompt: string;
 	temperature?: number;
@@ -76,7 +82,9 @@ export interface InlineDataPart {
  * @property inlineAttachments - Optional array of inline data attachments for multimodal input
  * @property imageAttachments - Deprecated alias for inlineAttachments
  */
-export interface ExtendedModelRequest extends BaseModelRequest {
+export interface ExtendedModelRequest extends Omit<BaseModelRequest, 'kind'> {
+	/** Discriminant for the request union. `'extended'` marks a chat-style request. */
+	kind: 'extended';
 	conversationHistory: Content[];
 	userMessage: string;
 	renderContent?: boolean;
@@ -140,6 +148,16 @@ export type StreamCallback = (chunk: StreamChunk) => void;
 export interface StreamingModelResponse {
 	complete: Promise<ModelResponse>;
 	cancel: () => void;
+}
+
+/**
+ * Canonical discriminator for the `BaseModelRequest | ExtendedModelRequest`
+ * union. Narrows on the required `kind` field. Prefer this over ad-hoc
+ * `'userMessage' in request` checks, which silently misclassify a base request
+ * that happens to carry a stray `userMessage` (see #859).
+ */
+export function isExtendedRequest(request: BaseModelRequest | ExtendedModelRequest): request is ExtendedModelRequest {
+	return request.kind === 'extended';
 }
 
 /**

--- a/src/api/providers/gemini/client.ts
+++ b/src/api/providers/gemini/client.ts
@@ -21,6 +21,7 @@ import {
 	ToolCall,
 	StreamCallback,
 	StreamingModelResponse,
+	isExtendedRequest,
 } from '../../interfaces/model-api';
 import { GeminiPrompts } from '../../../prompts';
 import type ObsidianGemini from '../../../main';
@@ -201,7 +202,7 @@ export class GeminiClient implements ModelApi {
 	private async buildGenerateContentParams(
 		request: BaseModelRequest | ExtendedModelRequest
 	): Promise<GenerateContentParameters> {
-		const isExtended = 'userMessage' in request;
+		const isExtended = isExtendedRequest(request);
 		const model = request.model || this.config.model || getDefaultModelForRole('chat');
 
 		// Build system instruction
@@ -209,7 +210,7 @@ export class GeminiClient implements ModelApi {
 		if (isExtended) {
 			// Build layered system prompt: identity → vault context → project →
 			// agent rules → tool catalog → custom instructions → per-turn context
-			systemInstruction = await this.prompts.buildExtendedSystemInstruction(request as ExtendedModelRequest);
+			systemInstruction = await this.prompts.buildExtendedSystemInstruction(request);
 		} else {
 			// For BaseModelRequest, prompt is the full input
 			systemInstruction = request.prompt || '';
@@ -235,9 +236,9 @@ export class GeminiClient implements ModelApi {
 		}
 
 		// Add function calling tools
-		const hasTools = isExtended && (request as ExtendedModelRequest).availableTools?.length;
+		const hasTools = isExtended && request.availableTools?.length;
 		if (hasTools) {
-			const tools = (request as ExtendedModelRequest).availableTools!;
+			const tools = request.availableTools!;
 			const functionDeclarations = tools.map((tool) => ({
 				name: tool.name,
 				description: tool.description,
@@ -258,10 +259,9 @@ export class GeminiClient implements ModelApi {
 		if (contents.length === 0 && !isExtended) {
 			// For BaseModelRequest with no conversation, just pass the prompt as string
 			finalContents = request.prompt || '';
-		} else if (contents.length === 0) {
+		} else if (contents.length === 0 && isExtendedRequest(request)) {
 			// For ExtendedModelRequest with no history, create a simple user message
-			const extReq = request as ExtendedModelRequest;
-			finalContents = extReq.userMessage || '';
+			finalContents = request.userMessage || '';
 		}
 
 		const params: GenerateContentParameters = {
@@ -277,7 +277,7 @@ export class GeminiClient implements ModelApi {
 	 * Build Content[] array from request
 	 */
 	private buildContents(request: BaseModelRequest | ExtendedModelRequest): Content[] {
-		if (!('userMessage' in request)) {
+		if (!isExtendedRequest(request)) {
 			// BaseModelRequest - just send the prompt as user message
 			if (!request.prompt) return [];
 			return [
@@ -288,7 +288,7 @@ export class GeminiClient implements ModelApi {
 			];
 		}
 
-		const extReq = request as ExtendedModelRequest;
+		const extReq = request;
 		const contents: Content[] = [];
 
 		// Add conversation history

--- a/src/api/providers/ollama/client.ts
+++ b/src/api/providers/ollama/client.ts
@@ -29,6 +29,7 @@ import {
 	StreamCallback,
 	StreamingModelResponse,
 	InlineDataPart,
+	isExtendedRequest,
 } from '../../interfaces/model-api';
 import { GeminiPrompts } from '../../../prompts';
 import type ObsidianGemini from '../../../main';
@@ -53,7 +54,7 @@ export class OllamaClient implements ModelApi {
 	}
 
 	async generateModelResponse(request: BaseModelRequest | ExtendedModelRequest): Promise<ModelResponse> {
-		const isExtended = 'userMessage' in request;
+		const isExtended = isExtendedRequest(request);
 		// The factory (`ModelClientFactory.resolveModelName`) is the single
 		// source of role-aware model resolution and always populates
 		// `config.model` per use case (chat / summary / completions / rewrite).
@@ -80,7 +81,7 @@ export class OllamaClient implements ModelApi {
 				};
 			}
 
-			const chatRequest = await this.buildChatRequest(request as ExtendedModelRequest, model, false);
+			const chatRequest = await this.buildChatRequest(request, model, false);
 			const response = await this.client.chat(chatRequest as ChatRequest & { stream: false });
 			return this.toModelResponse(response);
 		} catch (error) {
@@ -93,7 +94,7 @@ export class OllamaClient implements ModelApi {
 		request: BaseModelRequest | ExtendedModelRequest,
 		onChunk: StreamCallback
 	): StreamingModelResponse {
-		const isExtended = 'userMessage' in request;
+		const isExtended = isExtendedRequest(request);
 		// See note in generateModelResponse — the factory provides the
 		// role-correct model; no chat-default fallback here.
 		const model = request.model || this.config.model;
@@ -139,7 +140,7 @@ export class OllamaClient implements ModelApi {
 						}
 					}
 				} else {
-					const chatRequest = await this.buildChatRequest(request as ExtendedModelRequest, model, true);
+					const chatRequest = await this.buildChatRequest(request, model, true);
 					const stream = await this.client.chat(chatRequest as ChatRequest & { stream: true });
 					activeStream = stream;
 					if (cancelled) {
@@ -210,7 +211,7 @@ export class OllamaClient implements ModelApi {
 		};
 	}
 
-	private buildOptions(request: BaseModelRequest): Record<string, unknown> {
+	private buildOptions(request: BaseModelRequest | ExtendedModelRequest): Record<string, unknown> {
 		const options: Record<string, unknown> = {};
 		const temperature = request.temperature ?? this.config.temperature;
 		const topP = request.topP ?? this.config.topP;

--- a/src/api/utils/debug.ts
+++ b/src/api/utils/debug.ts
@@ -95,7 +95,8 @@ export function redactLinkedFileSections(prompt: string): string {
 	return result;
 }
 
-// Helper to detect BaseModelRequest
+// Helper to detect BaseModelRequest. Structural (not `kind`-based) on purpose:
+// this logs arbitrary debug payloads that may predate or omit the discriminant.
 export function isBaseModelRequest(obj: unknown): obj is BaseModelRequest {
 	return !!(obj && typeof obj === 'object' && typeof (obj as { prompt?: unknown }).prompt === 'string');
 }
@@ -103,7 +104,7 @@ export function isBaseModelRequest(obj: unknown): obj is BaseModelRequest {
 // Helper to detect ExtendedModelRequest
 export function isExtendedModelRequest(obj: unknown): obj is ExtendedModelRequest {
 	if (!isBaseModelRequest(obj)) return false;
-	const extended = obj as ExtendedModelRequest;
+	const extended = obj as { conversationHistory?: unknown; userMessage?: unknown };
 	return Array.isArray(extended.conversationHistory) && typeof extended.userMessage === 'string';
 }
 

--- a/src/completions.ts
+++ b/src/completions.ts
@@ -50,6 +50,7 @@ export class GeminiCompletions {
 		const modelApi = ModelClientFactory.createCompletionsModel(this.plugin);
 
 		let request: BaseModelRequest = {
+			kind: 'base',
 			prompt: this.prompts.completionsPrompt({
 				contentBeforeCursor: contentBeforeCursor,
 				contentAfterCursor: contentAfterCursor,

--- a/src/rewrite-selection.ts
+++ b/src/rewrite-selection.ts
@@ -55,6 +55,7 @@ export class SelectionRewriter {
 		// Send request without conversation history
 		// The file context will be added automatically by the API layer
 		const request: ExtendedModelRequest = {
+			kind: 'extended',
 			prompt: '', // Unused in ExtendedModelRequest path
 			perTurnContext: prompt, // The rewrite template is per-turn context
 			conversationHistory: [], // Empty history for rewrite operations
@@ -106,6 +107,7 @@ Rewrite the entire document according to the user's instructions. Maintain the m
 		});
 
 		const request: ExtendedModelRequest = {
+			kind: 'extended',
 			prompt: '', // Unused in ExtendedModelRequest path
 			perTurnContext: prompt, // Full-file rewrite template as per-turn context
 			conversationHistory: [],
@@ -158,6 +160,7 @@ Rewrite the entire document according to the user's instructions. Maintain the m
 		});
 
 		const request: ExtendedModelRequest = {
+			kind: 'extended',
 			prompt: '',
 			perTurnContext: prompt,
 			conversationHistory: [],

--- a/src/services/context-manager.ts
+++ b/src/services/context-manager.ts
@@ -521,6 +521,7 @@ export class ContextManager {
 				// instead of the user's configured `summaryModelName`.
 				const summaryClient = ModelClientFactory.createFromPlugin(this.plugin, ModelUseCase.SUMMARY);
 				const response = await summaryClient.generateModelResponse({
+					kind: 'base',
 					prompt: fullPrompt,
 					temperature: 0.3,
 				});

--- a/src/services/hook-runner.ts
+++ b/src/services/hook-runner.ts
@@ -107,6 +107,7 @@ export class HookRunner {
 		const model = hook.model ?? this.plugin.settings.chatModelName;
 
 		const initialRequest: ExtendedModelRequest = {
+			kind: 'extended',
 			userMessage,
 			conversationHistory: [],
 			model,

--- a/src/services/image-generation.ts
+++ b/src/services/image-generation.ts
@@ -180,6 +180,7 @@ export class ImageGeneration {
 		const modelApi = ModelClientFactory.createSummaryModel(this.plugin);
 
 		const request: BaseModelRequest = {
+			kind: 'base',
 			prompt: this.prompts.imagePromptGenerator({ content: fileContent }),
 		};
 

--- a/src/services/scheduled-task-runner.ts
+++ b/src/services/scheduled-task-runner.ts
@@ -94,6 +94,7 @@ export class ScheduledTaskRunner {
 		const model = this.task.model ?? this.plugin.settings.chatModelName;
 
 		const initialRequest: ExtendedModelRequest = {
+			kind: 'extended',
 			userMessage,
 			conversationHistory: [],
 			model,

--- a/src/services/selection-action-service.ts
+++ b/src/services/selection-action-service.ts
@@ -136,6 +136,7 @@ export class SelectionActionService {
 			// Add timeout protection (60 seconds) to prevent indefinite hanging
 			const timeoutMs = 60000;
 			const responsePromise = modelApi.generateModelResponse({
+				kind: 'extended',
 				userMessage: userMessage,
 				conversationHistory: [],
 				model: this.plugin.settings.chatModelName,

--- a/src/services/vault-analyzer.ts
+++ b/src/services/vault-analyzer.ts
@@ -76,6 +76,7 @@ export class VaultAnalyzer {
 			modal.updateStatus(`Generating vault context with ${modelName}...`);
 			const modelApi = ModelClientFactory.createChatModel(this.plugin);
 			const response = await modelApi.generateModelResponse({
+				kind: 'base',
 				prompt: analysisPrompt,
 				model: this.plugin.settings.chatModelName,
 			});
@@ -129,6 +130,7 @@ export class VaultAnalyzer {
 
 			const examplePromptsPrompt = this.plugin.prompts.examplePromptsPrompt(vaultInfo, existingPromptsString);
 			const examplePromptsResponse = await modelApi.generateModelResponse({
+				kind: 'base',
 				prompt: examplePromptsPrompt,
 				model: this.plugin.settings.chatModelName,
 			});

--- a/src/summary.ts
+++ b/src/summary.ts
@@ -55,6 +55,7 @@ export class GeminiSummary {
 
 		const modelApi = ModelClientFactory.createSummaryModel(this.plugin);
 		const request: BaseModelRequest = {
+			kind: 'base',
 			prompt: this.prompts.summaryPrompt({ content: fileContent }),
 		};
 		const summary = await modelApi.generateModelResponse(request);

--- a/src/ui/agent-view/agent-view-send.ts
+++ b/src/ui/agent-view/agent-view-send.ts
@@ -341,6 +341,7 @@ To reference an attachment in your response, use the path shown above.`;
 				};
 
 				const request: ExtendedModelRequest = {
+					kind: 'extended',
 					userMessage: message,
 					conversationHistory: compactionResult.compactedHistory,
 					model: modelName,

--- a/src/ui/agent-view/agent-view-session.ts
+++ b/src/ui/agent-view/agent-view-session.ts
@@ -233,6 +233,7 @@ Assistant: ${modelSummary}`;
 			// Generate title using the model
 			const modelApi = ModelClientFactory.createChatModel(this.plugin);
 			const response = await modelApi.generateModelResponse({
+				kind: 'extended',
 				userMessage: titlePrompt,
 				conversationHistory: [],
 				model: this.plugin.settings.chatModelName,

--- a/src/ui/agent-view/agent-view-tool-followup.ts
+++ b/src/ui/agent-view/agent-view-tool-followup.ts
@@ -72,6 +72,7 @@ export function buildFollowUpRequest(params: FollowUpRequestParams): ExtendedMod
 	// would make `buildContents` append it a second time, duplicating the
 	// (potentially large) context payload on every tool iteration.
 	return {
+		kind: 'extended',
 		userMessage: '', // Empty since tool results are already in conversation history
 		conversationHistory: updatedHistory,
 		model: modelConfig.model || plugin.settings.chatModelName,
@@ -99,6 +100,7 @@ export function buildRetryRequest(params: RetryRequestParams): ExtendedModelRequ
 	// `perTurnContext` is deliberately omitted — see `buildFollowUpRequest`:
 	// it is already embedded in `updatedHistory` via `buildToolHistoryTurns`.
 	return {
+		kind: 'extended',
 		userMessage: 'Please summarize what you just did with the tools.',
 		conversationHistory: updatedHistory,
 		model: modelConfig.model || plugin.settings.chatModelName,

--- a/test/api/interfaces/model-api.test.ts
+++ b/test/api/interfaces/model-api.test.ts
@@ -1,0 +1,33 @@
+import { isExtendedRequest, BaseModelRequest, ExtendedModelRequest } from '../../../src/api/interfaces/model-api';
+
+describe('isExtendedRequest', () => {
+	it('classifies a base request by its kind discriminant', () => {
+		const request: BaseModelRequest = { kind: 'base', prompt: 'one-shot prompt' };
+		expect(isExtendedRequest(request)).toBe(false);
+	});
+
+	it('classifies an extended request by its kind discriminant', () => {
+		const request: ExtendedModelRequest = {
+			kind: 'extended',
+			prompt: '',
+			userMessage: 'hello',
+			conversationHistory: [],
+		};
+		expect(isExtendedRequest(request)).toBe(true);
+	});
+
+	it('treats an extended request with an empty userMessage as extended (#859 regression)', () => {
+		// The previous `'userMessage' in request` heuristic misclassified any
+		// request carrying a userMessage key — even an empty string — and, on the
+		// flip side, a base request with a stray empty userMessage was wrongly
+		// routed through the extended path. The kind discriminant is authoritative,
+		// so an empty userMessage no longer flips the branch either way.
+		const followUp: ExtendedModelRequest = {
+			kind: 'extended',
+			prompt: '',
+			userMessage: '',
+			conversationHistory: [{ role: 'user', parts: [{ text: 'earlier turn' }] }],
+		};
+		expect(isExtendedRequest(followUp)).toBe(true);
+	});
+});

--- a/test/api/providers/gemini/client.test.ts
+++ b/test/api/providers/gemini/client.test.ts
@@ -253,6 +253,7 @@ describe('GeminiClient', () => {
 			const request: ExtendedModelRequest = {
 				prompt: '',
 				userMessage: 'list the places',
+				kind: 'extended',
 				conversationHistory: [],
 				perTurnContext: renderedContext,
 				projectInstructions: 'always cite paths',
@@ -284,6 +285,7 @@ describe('GeminiClient', () => {
 			await client.generateModelResponse({
 				prompt: '',
 				userMessage: 'just chat',
+				kind: 'extended',
 				conversationHistory: [],
 			});
 
@@ -680,6 +682,7 @@ describe('GeminiClient', () => {
 			await client.generateModelResponse({
 				prompt: '',
 				userMessage: 'follow up',
+				kind: 'extended',
 				conversationHistory: [historyEntry],
 			} as ExtendedModelRequest);
 
@@ -694,6 +697,7 @@ describe('GeminiClient', () => {
 			await client.generateModelResponse({
 				prompt: '',
 				userMessage: 'new msg',
+				kind: 'extended',
 				conversationHistory: [{ role: 'user', text: 'old msg' }],
 			} as unknown as ExtendedModelRequest);
 
@@ -707,6 +711,7 @@ describe('GeminiClient', () => {
 			await client.generateModelResponse({
 				prompt: '',
 				userMessage: 'new msg',
+				kind: 'extended',
 				conversationHistory: [{ role: 'assistant', message: 'I helped' }],
 			} as unknown as ExtendedModelRequest);
 
@@ -720,6 +725,7 @@ describe('GeminiClient', () => {
 			await client.generateModelResponse({
 				prompt: '',
 				userMessage: 'q',
+				kind: 'extended',
 				conversationHistory: [{ role: 'model', text: 'answer' }],
 			} as unknown as ExtendedModelRequest);
 
@@ -733,6 +739,7 @@ describe('GeminiClient', () => {
 			await client.generateModelResponse({
 				prompt: '',
 				userMessage: 'look at this',
+				kind: 'extended',
 				conversationHistory: [],
 				inlineAttachments: [{ base64: 'abc123', mimeType: 'image/png' }],
 			} as ExtendedModelRequest);
@@ -749,6 +756,7 @@ describe('GeminiClient', () => {
 			await client.generateModelResponse({
 				prompt: '',
 				userMessage: 'see these',
+				kind: 'extended',
 				conversationHistory: [],
 				inlineAttachments: [{ base64: 'inline1', mimeType: 'image/jpeg' }],
 				imageAttachments: [{ base64: 'img1', mimeType: 'image/gif' }],
@@ -765,6 +773,7 @@ describe('GeminiClient', () => {
 			await client.generateModelResponse({
 				prompt: '',
 				userMessage: '',
+				kind: 'extended',
 				conversationHistory: [],
 			} as ExtendedModelRequest);
 
@@ -855,6 +864,7 @@ describe('GeminiClient', () => {
 			await client.generateModelResponse({
 				prompt: '',
 				userMessage: 'read that file',
+				kind: 'extended',
 				conversationHistory: [],
 				availableTools: tools,
 			} as ExtendedModelRequest);
@@ -889,6 +899,7 @@ describe('GeminiClient', () => {
 			await clientWithTokens.generateModelResponse({
 				prompt: '',
 				userMessage: 'hello',
+				kind: 'extended',
 				conversationHistory: [],
 			} as ExtendedModelRequest);
 

--- a/test/api/providers/ollama/client.test.ts
+++ b/test/api/providers/ollama/client.test.ts
@@ -108,6 +108,7 @@ describe('OllamaClient', () => {
 			const request: ExtendedModelRequest = {
 				prompt: '',
 				userMessage: 'what is up',
+				kind: 'extended',
 				conversationHistory: [
 					{ role: 'user', parts: [{ text: 'previous user turn' }] },
 					{ role: 'model', parts: [{ text: 'previous assistant turn' }] },
@@ -144,6 +145,7 @@ describe('OllamaClient', () => {
 			const response = await client.generateModelResponse({
 				prompt: '',
 				userMessage: 'read foo',
+				kind: 'extended',
 				conversationHistory: [],
 				availableTools: [
 					{
@@ -178,6 +180,7 @@ describe('OllamaClient', () => {
 			await client.generateModelResponse({
 				prompt: '',
 				userMessage: 'what is in this picture',
+				kind: 'extended',
 				conversationHistory: [],
 				inlineAttachments: [{ mimeType: 'image/png', base64: 'b64data' }],
 			});
@@ -208,6 +211,7 @@ describe('OllamaClient', () => {
 			await client.generateModelResponse({
 				prompt: '',
 				userMessage: 'what does the file say',
+				kind: 'extended',
 				conversationHistory: [],
 				perTurnContext: renderedContext,
 				projectInstructions: 'always cite file paths',
@@ -236,6 +240,7 @@ describe('OllamaClient', () => {
 				client.generateModelResponse({
 					prompt: '',
 					userMessage: 'read this',
+					kind: 'extended',
 					conversationHistory: [],
 					inlineAttachments: [{ mimeType: 'application/pdf', base64: 'b64data' }],
 				})
@@ -261,7 +266,7 @@ describe('OllamaClient', () => {
 
 			const chunks: string[] = [];
 			const streaming = client.generateStreamingResponse(
-				{ prompt: '', userMessage: 'hi', conversationHistory: [] },
+				{ prompt: '', userMessage: 'hi', kind: 'extended', conversationHistory: [] },
 				(chunk) => chunks.push(chunk.text)
 			);
 			const result = await streaming.complete;
@@ -286,7 +291,7 @@ describe('OllamaClient', () => {
 			ollamaCalls.chat.mockResolvedValue(stream);
 
 			const streaming = client.generateStreamingResponse(
-				{ prompt: '', userMessage: 'hi', conversationHistory: [] },
+				{ prompt: '', userMessage: 'hi', kind: 'extended', conversationHistory: [] },
 				() => {}
 			);
 			// Allow the first chunk to be consumed
@@ -310,7 +315,7 @@ describe('OllamaClient', () => {
 			ollamaCalls.chat.mockResolvedValue(stream);
 
 			const streaming = client.generateStreamingResponse(
-				{ prompt: '', userMessage: 'hi', conversationHistory: [] },
+				{ prompt: '', userMessage: 'hi', kind: 'extended', conversationHistory: [] },
 				() => {}
 			);
 			await new Promise((r) => window.setTimeout(r, 0));
@@ -336,6 +341,7 @@ describe('OllamaClient', () => {
 			await client.generateModelResponse({
 				prompt: '',
 				userMessage: 'do it',
+				kind: 'extended',
 				conversationHistory: [
 					{ role: 'model', parts: [{ functionCall: { name: 'read_file', args: { path: 'test.md' } } }] },
 				],
@@ -352,6 +358,7 @@ describe('OllamaClient', () => {
 			await client.generateModelResponse({
 				prompt: '',
 				userMessage: 'ok',
+				kind: 'extended',
 				conversationHistory: [
 					{
 						role: 'user',
@@ -371,6 +378,7 @@ describe('OllamaClient', () => {
 			await client.generateModelResponse({
 				prompt: '',
 				userMessage: 'ok',
+				kind: 'extended',
 				conversationHistory: [
 					{ role: 'user', parts: [{ functionResponse: { name: 'tool1', response: null as any } }] },
 				],
@@ -385,6 +393,7 @@ describe('OllamaClient', () => {
 			await client.generateModelResponse({
 				prompt: '',
 				userMessage: 'ok',
+				kind: 'extended',
 				conversationHistory: [
 					{ role: 'user', parts: [{ functionResponse: { name: 'tool1', response: 'raw result' as any } }] },
 				],
@@ -399,6 +408,7 @@ describe('OllamaClient', () => {
 			await client.generateModelResponse({
 				prompt: '',
 				userMessage: 'go',
+				kind: 'extended',
 				conversationHistory: [
 					{
 						role: 'model',
@@ -418,6 +428,7 @@ describe('OllamaClient', () => {
 			await client.generateModelResponse({
 				prompt: '',
 				userMessage: 'describe it',
+				kind: 'extended',
 				conversationHistory: [
 					{
 						role: 'user',
@@ -438,6 +449,7 @@ describe('OllamaClient', () => {
 				client.generateModelResponse({
 					prompt: '',
 					userMessage: 'read it',
+					kind: 'extended',
 					conversationHistory: [
 						{ role: 'user', parts: [{ inlineData: { mimeType: 'application/pdf', data: 'abc' } }] },
 					],
@@ -449,6 +461,7 @@ describe('OllamaClient', () => {
 			await client.generateModelResponse({
 				prompt: '',
 				userMessage: 'hi',
+				kind: 'extended',
 				conversationHistory: [{ role: 'system', parts: [{ text: 'system instruction' }] }],
 			});
 
@@ -463,6 +476,7 @@ describe('OllamaClient', () => {
 			await client.generateModelResponse({
 				prompt: '',
 				userMessage: 'hi',
+				kind: 'extended',
 				conversationHistory: [null as any, { role: 'user', parts: [{ text: 'hello' }] }],
 			});
 
@@ -475,6 +489,7 @@ describe('OllamaClient', () => {
 			await client.generateModelResponse({
 				prompt: '',
 				userMessage: 'go',
+				kind: 'extended',
 				conversationHistory: [{ role: 'model', text: 'hello' } as any],
 			});
 
@@ -487,6 +502,7 @@ describe('OllamaClient', () => {
 			await client.generateModelResponse({
 				prompt: '',
 				userMessage: 'go',
+				kind: 'extended',
 				conversationHistory: [{ role: 'user', message: 'hey' } as any],
 			});
 
@@ -499,6 +515,7 @@ describe('OllamaClient', () => {
 			await client.generateModelResponse({
 				prompt: '',
 				userMessage: 'go',
+				kind: 'extended',
 				conversationHistory: [{ role: 'user', text: '  ' } as any],
 			});
 
@@ -513,6 +530,7 @@ describe('OllamaClient', () => {
 			await client.generateModelResponse({
 				prompt: '',
 				userMessage: 'go',
+				kind: 'extended',
 				conversationHistory: [{ role: 'assistant', text: 'response' } as any],
 			});
 
@@ -637,7 +655,7 @@ describe('OllamaClient', () => {
 			ollamaCalls.chat.mockResolvedValue(stream);
 
 			const streaming = client.generateStreamingResponse(
-				{ prompt: '', userMessage: 'hi', conversationHistory: [] },
+				{ prompt: '', userMessage: 'hi', kind: 'extended', conversationHistory: [] },
 				() => {}
 			);
 			const result = await streaming.complete;
@@ -656,7 +674,7 @@ describe('OllamaClient', () => {
 
 			const thoughts: string[] = [];
 			const streaming = client.generateStreamingResponse(
-				{ prompt: '', userMessage: 'think', conversationHistory: [] },
+				{ prompt: '', userMessage: 'think', kind: 'extended', conversationHistory: [] },
 				(chunk) => {
 					if (chunk.thought) thoughts.push(chunk.thought);
 				}
@@ -678,7 +696,7 @@ describe('OllamaClient', () => {
 		it('streaming throws when no model configured', async () => {
 			const c = new OllamaClient({ baseUrl: 'http://localhost:11434' }, undefined, buildPlugin());
 			const streaming = c.generateStreamingResponse(
-				{ prompt: '', userMessage: 'hi', conversationHistory: [] },
+				{ prompt: '', userMessage: 'hi', kind: 'extended', conversationHistory: [] },
 				() => {}
 			);
 			await expect(streaming.complete).rejects.toThrow('No Ollama model selected');
@@ -690,7 +708,7 @@ describe('OllamaClient', () => {
 			ollamaCalls.chat.mockRejectedValue(new Error('connection refused'));
 
 			const streaming = client.generateStreamingResponse(
-				{ prompt: '', userMessage: 'hi', conversationHistory: [] },
+				{ prompt: '', userMessage: 'hi', kind: 'extended', conversationHistory: [] },
 				() => {}
 			);
 

--- a/test/api/providers/ollama/client.test.ts
+++ b/test/api/providers/ollama/client.test.ts
@@ -75,6 +75,7 @@ describe('OllamaClient', () => {
 			});
 
 			const response = await client.generateModelResponse({
+				kind: 'base',
 				prompt: 'say hi',
 				temperature: 0.2,
 			});
@@ -554,7 +555,7 @@ describe('OllamaClient', () => {
 				done: true,
 			});
 
-			await c.generateModelResponse({ prompt: 'test' });
+			await c.generateModelResponse({ kind: 'base', prompt: 'test' });
 
 			expect(ollamaCalls.generate.mock.calls[0][0].options.num_predict).toBe(1024);
 		});
@@ -625,7 +626,9 @@ describe('OllamaClient', () => {
 			ollamaCalls.generate.mockResolvedValue(stream);
 
 			const chunks: string[] = [];
-			const streaming = client.generateStreamingResponse({ prompt: 'hello' }, (chunk) => chunks.push(chunk.text));
+			const streaming = client.generateStreamingResponse({ kind: 'base', prompt: 'hello' }, (chunk) =>
+				chunks.push(chunk.text)
+			);
 			const result = await streaming.complete;
 
 			expect(chunks.join('')).toBe('hello!');
@@ -690,7 +693,9 @@ describe('OllamaClient', () => {
 	describe('no model error', () => {
 		it('generateModelResponse throws when no model configured', async () => {
 			const c = new OllamaClient({ baseUrl: 'http://localhost:11434' }, undefined, buildPlugin());
-			await expect(c.generateModelResponse({ prompt: 'test' })).rejects.toThrow('No Ollama model selected');
+			await expect(c.generateModelResponse({ kind: 'base', prompt: 'test' })).rejects.toThrow(
+				'No Ollama model selected'
+			);
 		});
 
 		it('streaming throws when no model configured', async () => {

--- a/test/api/retry-decorator.test.ts
+++ b/test/api/retry-decorator.test.ts
@@ -34,7 +34,7 @@ function createRetryConfig(overrides?: Partial<RetryConfig>): RetryConfig {
 }
 
 const successResponse: ModelResponse = { markdown: 'Hello', rendered: '' };
-const dummyRequest: BaseModelRequest = { prompt: 'test' };
+const dummyRequest: BaseModelRequest = { kind: 'base', prompt: 'test' };
 
 describe('RetryDecorator', () => {
 	beforeEach(() => {

--- a/test/api/utils/debug.test.ts
+++ b/test/api/utils/debug.test.ts
@@ -55,6 +55,7 @@ describe('logDebugInfo', () => {
 
 	it('should log formatted ExtendedModelRequest if data is an ExtendedModelRequest', () => {
 		const extendedReq = {
+			kind: 'extended' as const,
 			prompt: 'system prompt',
 			conversationHistory: [],
 			userMessage: 'hello',
@@ -70,6 +71,7 @@ describe('logDebugInfo', () => {
 
 	it('should log formatted BaseModelRequest if data is a BaseModelRequest (and not Extended)', () => {
 		const baseReq = {
+			kind: 'base' as const,
 			prompt: 'simple prompt',
 			model: 'gemini-pro-base',
 		};
@@ -167,7 +169,7 @@ describe('isExtendedModelRequest', () => {
 
 describe('formatBaseModelRequest', () => {
 	it('should format a basic request correctly', () => {
-		const req = { prompt: 'Hello\nWorld' };
+		const req = { kind: 'base' as const, prompt: 'Hello\nWorld' };
 		// Using stringContaining because JSON.stringify might have OS-dependent newline for prompt
 		// and the order of properties in the stringified prompt object isn't guaranteed.
 		expect(formatBaseModelRequest(req)).toContain('Model: [default]');
@@ -175,7 +177,7 @@ describe('formatBaseModelRequest', () => {
 	});
 
 	it('should include model name if provided', () => {
-		const req = { model: 'gemini-pro', prompt: 'test' };
+		const req = { kind: 'base' as const, model: 'gemini-pro', prompt: 'test' };
 		expect(formatBaseModelRequest(req)).toContain('Model: gemini-pro');
 		expect(formatBaseModelRequest(req)).toContain('Prompt: "test"');
 	});
@@ -183,6 +185,7 @@ describe('formatBaseModelRequest', () => {
 
 describe('formatExtendedModelRequest', () => {
 	const req = {
+		kind: 'extended' as const,
 		model: 'gemini-1.5-pro',
 		prompt: 'System prompt here',
 		userMessage: 'User says hi',

--- a/test/completions.test.ts
+++ b/test/completions.test.ts
@@ -139,6 +139,7 @@ describe('GeminiCompletions', () => {
 
 			expect(result).toBe('next line');
 			expect(mockCompletionsModel.generateModelResponse).toHaveBeenCalledWith({
+				kind: 'base',
 				prompt: 'rendered prompt text',
 			});
 		});

--- a/test/prompts/gemini-prompts.test.ts
+++ b/test/prompts/gemini-prompts.test.ts
@@ -117,6 +117,7 @@ describe('GeminiPrompts', () => {
 
 	describe('buildExtendedSystemInstruction', () => {
 		const baseRequest: ExtendedModelRequest = {
+			kind: 'extended',
 			model: 'gemini-test',
 			prompt: '',
 			conversationHistory: [],

--- a/test/rewrite-selection.test.ts
+++ b/test/rewrite-selection.test.ts
@@ -107,6 +107,7 @@ describe('SelectionRewriter', () => {
 			expect(mockRewriteModel.generateModelResponse).toHaveBeenCalledWith({
 				prompt: '',
 				perTurnContext: 'rendered selection prompt',
+				kind: 'extended',
 				conversationHistory: [],
 				userMessage: 'instructions',
 			});

--- a/test/services/image-generation.test.ts
+++ b/test/services/image-generation.test.ts
@@ -495,6 +495,7 @@ describe('ImageGeneration.suggestPromptFromPage', () => {
 
 		expect(ModelClientFactory.createSummaryModel).toHaveBeenCalledWith(mockPlugin);
 		expect(mockModelApi.generateModelResponse).toHaveBeenCalledWith({
+			kind: 'base',
 			prompt: 'generated prompt text',
 		});
 		expect(result).toBe('A beautiful cat sitting on a table');

--- a/test/summary.test.ts
+++ b/test/summary.test.ts
@@ -131,6 +131,7 @@ describe('GeminiSummary', () => {
 			expect(result).toBe('model generated summary');
 			expect(mockPlugin.app.vault.read).toHaveBeenCalledWith(mockFile);
 			expect(mockSummaryModel.generateModelResponse).toHaveBeenCalledWith({
+				kind: 'base',
 				prompt: 'rendered summary prompt text',
 			});
 


### PR DESCRIPTION
## Summary

Closes #859. `ModelApi` distinguished `BaseModelRequest` from `ExtendedModelRequest` purely by key presence (`'userMessage' in request`). Any base request that carried a `userMessage` key — even an empty string — was silently reclassified as extended, which **discarded the `prompt`** and built the system prompt from the chat identity layers instead. No type error, no runtime warning, and the failure surfaced far from the call site (the "Initialize Vault Context" JSON-parse bug).

This makes the union a **properly discriminated union** so the malformed-request class is caught at compile time, and centralizes the runtime check.

Per the issue's options, this is **Option 1 (explicit discriminant)** — the cleanest long-term fix.

## Changes

- **`src/api/interfaces/model-api.ts`**
  - Add a required literal `kind: 'base'` / `kind: 'extended'` to `BaseModelRequest` / `ExtendedModelRequest` (the latter now `extends Omit<BaseModelRequest, 'kind'>`). TypeScript now flags a base request that accidentally carries extended-only fields (e.g. a stray `userMessage`) via discriminated-union excess-property checking.
  - Add a canonical `isExtendedRequest()` type guard.
- **`src/api/providers/gemini/client.ts`, `src/api/providers/ollama/client.ts`** — route every classification through `isExtendedRequest()`, replacing all `'userMessage' in request` checks and removing the now-unnecessary `as ExtendedModelRequest` casts (narrowing handles them). `OllamaClient.buildOptions` widened to the union (it only reads the shared `temperature`/`topP`).
- **Request construction sites** — stamp `kind` on every `BaseModelRequest` / `ExtendedModelRequest` literal (completions, summary, rewrite, image-gen, vault-analyzer, context-manager, hook-runner, scheduled-task-runner, selection-action-service, agent-view send/session/tool-followup).
- **`src/api/utils/debug.ts`** — left **structural** on purpose (documented). These guards pretty-print arbitrary debug payloads that may predate or omit the discriminant; they're cosmetic and separate from the authoritative `isExtendedRequest`.
- **Tests** — stamped `kind` on request literals/assertions in the affected client and feature tests; added `test/api/interfaces/model-api.test.ts` covering the guard, including the #859 regression (an extended follow-up with an empty `userMessage` stays extended, and `kind` is authoritative either way).

## Behavior

No runtime behavior change for any current caller — `kind` matches how each request was already being classified. The win is compile-time: a base request can no longer silently carry extended-only fields, and the scattered string-key heuristic is replaced by one tested guard.

`OllamaClient` audited as the issue requested — it had the same `'userMessage' in request` pattern in two spots, both now using `isExtendedRequest`.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer — Closes #859 (issue enumerates the approach options; this is option 1)
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop — N/A: type-level + classification refactor with no runtime behavior change, covered by the suite (3007 passing)
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A: no platform-specific code
- [x] Documentation has been updated (if applicable) — N/A: internal API typing, no user-facing surface
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized how model requests are classified, improving consistency and reliability of model interactions across the app.

* **Tests**
  * Added and updated tests to verify request classification and guard against regressions, ensuring continued correct behavior of model-driven features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->