### PR TITLE
feat(agent-view): copy buttons for tool-call parameters and results

### DIFF
--- a/docs/guide/agent-mode.md
+++ b/docs/guide/agent-mode.md
@@ -68,7 +68,7 @@ Agent: I'll help you find and summarize your meeting notes. Let me:
 [Executes write_file tool to create summary]
 ```
 
-Each tool call in the chat is collapsible — click a tool row to expand its **Parameters** and **Result** sections. Both sections have a copy button in their header that copies the full, untruncated value to the clipboard (handy for debugging, since long values are abbreviated in the inline display).
+Each tool call in the chat is collapsible — click a tool row to expand its details. When present, the **Parameters** and **Result** sections each include a copy button in the header that copies the full, untruncated value to the clipboard (handy for debugging, since long values are abbreviated in the inline display).
 
 ### File Attachments & Drag-and-Drop
 

--- a/docs/guide/agent-mode.md
+++ b/docs/guide/agent-mode.md
@@ -68,6 +68,8 @@ Agent: I'll help you find and summarize your meeting notes. Let me:
 [Executes write_file tool to create summary]
 ```
 
+Each tool call in the chat is collapsible — click a tool row to expand its **Parameters** and **Result** sections. Both sections have a copy button in their header that copies the full, untruncated value to the clipboard (handy for debugging, since long values are abbreviated in the inline display).
+
 ### File Attachments & Drag-and-Drop
 
 You can include images, audio, video, PDFs, and text files in your chat. Files are automatically classified and routed:

--- a/src/ui/agent-view/agent-view-tool-display.ts
+++ b/src/ui/agent-view/agent-view-tool-display.ts
@@ -44,17 +44,20 @@ export class AgentViewToolDisplay {
 			attr: { 'aria-label': `Copy ${title.toLowerCase()}`, type: 'button' },
 		});
 		setIcon(copyBtn, 'copy');
-		copyBtn.addEventListener('click', (e) => {
+		copyBtn.addEventListener('click', async (e) => {
 			// Sections live inside the expandable details; don't let the click
 			// bubble up and collapse the row.
 			e.stopPropagation();
-			navigator.clipboard.writeText(getCopyText()).then(
-				() => {
-					setIcon(copyBtn, 'check');
-					window.setTimeout(() => setIcon(copyBtn, 'copy'), 1500);
-				},
-				(err) => this.plugin.logger.error('Failed to copy tool detail to clipboard:', err)
-			);
+			// getCopyText() can throw synchronously (e.g. JSON.stringify on
+			// circular data), so keep it inside the try with the clipboard write.
+			try {
+				const text = getCopyText();
+				await navigator.clipboard.writeText(text);
+				setIcon(copyBtn, 'check');
+				window.setTimeout(() => setIcon(copyBtn, 'copy'), 1500);
+			} catch (err) {
+				this.plugin.logger.error('Failed to copy tool detail to clipboard:', err);
+			}
 		});
 	}
 

--- a/src/ui/agent-view/agent-view-tool-display.ts
+++ b/src/ui/agent-view/agent-view-tool-display.ts
@@ -31,6 +31,48 @@ export class AgentViewToolDisplay {
 	) {}
 
 	/**
+	 * Render a tool-detail section header (title + a copy-to-clipboard button).
+	 * The button copies the full, untruncated value so users can grab parameters
+	 * or results for debugging even when the inline display is truncated (#731).
+	 */
+	private createSectionHeader(section: HTMLElement, title: string, getCopyText: () => string): void {
+		const header = section.createDiv({ cls: 'gemini-agent-tool-section-header' });
+		header.createEl('h4', { text: title });
+
+		const copyBtn = header.createEl('button', {
+			cls: 'gemini-agent-tool-copy-section',
+			attr: { 'aria-label': `Copy ${title.toLowerCase()}`, type: 'button' },
+		});
+		setIcon(copyBtn, 'copy');
+		copyBtn.addEventListener('click', (e) => {
+			// Sections live inside the expandable details; don't let the click
+			// bubble up and collapse the row.
+			e.stopPropagation();
+			navigator.clipboard.writeText(getCopyText()).then(
+				() => {
+					setIcon(copyBtn, 'check');
+					window.setTimeout(() => setIcon(copyBtn, 'copy'), 1500);
+				},
+				(err) => this.plugin.logger.error('Failed to copy tool detail to clipboard:', err)
+			);
+		});
+	}
+
+	/**
+	 * The full, untruncated text to copy for a tool result: the error message on
+	 * failure, the raw string for string data, otherwise pretty-printed JSON.
+	 */
+	private getResultCopyText(result: ToolResult): string {
+		if (result.success === false || result.success === undefined) {
+			return result.error || TOOL_EXECUTION_FAILED_DEFAULT_MSG;
+		}
+		if (result.data === undefined || result.data === null) {
+			return OPERATION_COMPLETED_SUCCESSFULLY_MSG;
+		}
+		return typeof result.data === 'string' ? result.data : JSON.stringify(result.data, null, 2);
+	}
+
+	/**
 	 * Get a brief parameter summary for a tool row (e.g. file path or query)
 	 */
 	public getToolParamSummary(_toolName: string, parameters: any): string {
@@ -243,7 +285,7 @@ export class AgentViewToolDisplay {
 		// Parameters section inside details
 		if (parameters && Object.keys(parameters).length > 0) {
 			const paramsSection = rowDetails.createDiv({ cls: 'gemini-agent-tool-section' });
-			paramsSection.createEl('h4', { text: 'Parameters' });
+			this.createSectionHeader(paramsSection, 'Parameters', () => JSON.stringify(parameters, null, 2));
 
 			const paramsList = paramsSection.createDiv({ cls: 'gemini-agent-tool-params-list' });
 			for (const [key, value] of Object.entries(parameters)) {
@@ -340,7 +382,7 @@ export class AgentViewToolDisplay {
 		const details = toolRow.querySelector('.gemini-tool-row-details');
 		if (details) {
 			const resultSection = details.createDiv({ cls: 'gemini-agent-tool-section' });
-			resultSection.createEl('h4', { text: 'Result' });
+			this.createSectionHeader(resultSection, 'Result', () => this.getResultCopyText(result));
 
 			if (result.success === false || result.success === undefined) {
 				const errorContent = resultSection.createDiv({ cls: 'gemini-agent-tool-error-content' });

--- a/styles.css
+++ b/styles.css
@@ -2152,6 +2152,38 @@ If your plugin does not need CSS, delete this file.
 	letter-spacing: 0.05em;
 }
 
+/* Section header: title + copy-to-clipboard button (#731) */
+.gemini-agent-tool-section-header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: var(--size-2-2);
+}
+
+.gemini-agent-tool-copy-section {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	padding: var(--size-2-1);
+	margin-bottom: var(--size-2-2);
+	background-color: var(--interactive-normal);
+	border: 1px solid var(--background-modifier-border);
+	border-radius: var(--radius-s);
+	cursor: pointer;
+	color: var(--text-muted);
+	transition: all 0.15s ease;
+}
+
+.gemini-agent-tool-copy-section:hover {
+	background-color: var(--interactive-hover);
+	color: var(--text-normal);
+}
+
+.gemini-agent-tool-copy-section svg {
+	width: 14px;
+	height: 14px;
+}
+
 /* Parameters list */
 .gemini-agent-tool-params-list {
 	display: flex;

--- a/test/ui/agent-view.test.ts
+++ b/test/ui/agent-view.test.ts
@@ -698,6 +698,43 @@ describe('AgentView UI Tests', () => {
 			const errorMessage = errorContent?.querySelector('.gemini-agent-tool-error-message');
 			expect(errorMessage?.textContent).toBe('Something went wrong');
 		});
+
+		it('copies the full, untruncated parameters via the Parameters copy button (#731)', async () => {
+			const writeText = vi.fn().mockResolvedValue(undefined);
+			Object.defineProperty(navigator, 'clipboard', { value: { writeText }, configurable: true });
+
+			// Value longer than the 100-char inline truncation limit.
+			const longContent = 'x'.repeat(250);
+			await agentView.showToolExecution('write_file', { path: 'a.md', content: longContent }, 'exec-copy-1');
+
+			const chatContainer = (agentView as any).chatContainer as HTMLElement;
+			const copyBtn = chatContainer.querySelector('.gemini-agent-tool-copy-section') as HTMLButtonElement | null;
+			expect(copyBtn).toBeTruthy();
+
+			copyBtn!.click();
+
+			expect(writeText).toHaveBeenCalledWith(JSON.stringify({ path: 'a.md', content: longContent }, null, 2));
+		});
+
+		it('copies the full result data via the Result copy button (#731)', async () => {
+			const writeText = vi.fn().mockResolvedValue(undefined);
+			Object.defineProperty(navigator, 'clipboard', { value: { writeText }, configurable: true });
+
+			await agentView.showToolExecution('read_file', { path: 'a.md' }, 'exec-copy-2');
+			const data = { path: 'a.md', size: 1, extra: 'y'.repeat(250) };
+			await agentView.showToolResult('read_file', { success: true, data }, 'exec-copy-2');
+
+			const chatContainer = (agentView as any).chatContainer as HTMLElement;
+			const resultSection = Array.from(chatContainer.querySelectorAll('.gemini-agent-tool-section')).find(
+				(s) => s.querySelector('h4')?.textContent === 'Result'
+			);
+			const copyBtn = resultSection?.querySelector('.gemini-agent-tool-copy-section') as HTMLButtonElement | null;
+			expect(copyBtn).toBeTruthy();
+
+			copyBtn!.click();
+
+			expect(writeText).toHaveBeenCalledWith(JSON.stringify(data, null, 2));
+		});
 	});
 
 	describe('Grouped Tool Activity Bar', () => {


### PR DESCRIPTION
## Summary

Closes #731. The tool-call UI in agent chat truncates long parameter values (100 chars) and result-object fields, with the full value only in a `title` tooltip — which isn't copyable. So you couldn't grab the raw parameters/results for debugging, which is exactly what the issue asked for.

Adds a **copy-to-clipboard button** to the **Parameters** and **Result** section headers (shown when a tool row is expanded). It copies the full, untruncated value regardless of how the inline display abbreviates it.

## Changes

- **`src/ui/agent-view/agent-view-tool-display.ts`**
  - New `createSectionHeader(section, title, getCopyText)` helper — renders the section title plus a copy button that writes the full value to the clipboard, with a brief check-icon confirmation and `stopPropagation` so it doesn't collapse the expandable row.
  - New `getResultCopyText(result)` — error message on failure, raw string for string data, otherwise pretty-printed JSON.
  - Parameters copy full `JSON.stringify(parameters, null, 2)`; Result copies the full result.
- **`styles.css`** — styling for `.gemini-agent-tool-section-header` (title/button flex row) and `.gemini-agent-tool-copy-section` (icon button), consistent with the existing agent copy button.
- **`test/ui/agent-view.test.ts`** — two tests asserting the buttons copy the **full untruncated** value (250-char param value and a result object).
- **`docs/guide/agent-mode.md`** — documents the expandable tool rows and the copy buttons under Tool Calling.

## Screenshots / Screencast

UI is a small icon button in the Parameters/Result section headers (matches the existing wikilink/message copy buttons). No layout change beyond the header becoming a title+button row.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer — Closes #731 (labeled enhancement / chat-ux / quick-win)
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop — covered by unit tests; copy path mocks `navigator.clipboard`
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A: `navigator.clipboard.writeText` is standard on mobile WebView; failures are caught and logged
- [x] Documentation has been updated (if applicable) — `docs/guide/agent-mode.md`
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added copy-to-clipboard buttons to tool Parameters and Result sections so users can copy full, untruncated values for debugging.

* **Documentation**
  * Updated guide to document collapsible tool calls and expandable Parameters and Result sections with copy controls.

* **Style**
  * Added styling for tool section headers and copy buttons with hover effects.

* **Tests**
  * Added regression tests verifying the copy behavior for Parameters and Result sections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->