### PR TITLE
refactor: replace `any` in agent-view modal constructors with proper types

### DIFF
--- a/src/ui/agent-view/file-mention-modal.ts
+++ b/src/ui/agent-view/file-mention-modal.ts
@@ -1,4 +1,4 @@
-import { FuzzySuggestModal, TFile, TFolder, TAbstractFile } from 'obsidian';
+import { App, FuzzySuggestModal, TFile, TFolder, TAbstractFile } from 'obsidian';
 import { shouldExcludePathForPlugin } from '../../utils/file-utils';
 import { classifyFile, FileCategory } from '../../utils/file-classification';
 import { collectFoldersFromFolder } from '../../utils/folder-walk';
@@ -8,7 +8,7 @@ export class FileMentionModal extends FuzzySuggestModal<TAbstractFile> {
 	private onSelect: (file: TAbstractFile) => void;
 	private plugin: ObsidianGemini;
 
-	constructor(app: any, onSelect: (file: TAbstractFile) => void, plugin: ObsidianGemini) {
+	constructor(app: App, onSelect: (file: TAbstractFile) => void, plugin: ObsidianGemini) {
 		super(app);
 		this.onSelect = onSelect;
 		this.plugin = plugin;

--- a/src/ui/agent-view/session-settings-modal.ts
+++ b/src/ui/agent-view/session-settings-modal.ts
@@ -1,5 +1,6 @@
-import { Modal, Setting, DropdownComponent, SliderComponent, TFile, TFolder } from 'obsidian';
+import { App, Modal, Setting, DropdownComponent, SliderComponent, TFile, TFolder } from 'obsidian';
 import { ChatSession, SessionModelConfig } from '../../types/agent';
+import { GeminiModel } from '../../models';
 import type ObsidianGemini from '../../main';
 
 export class SessionSettingsModal extends Modal {
@@ -10,7 +11,7 @@ export class SessionSettingsModal extends Modal {
 	private topPSlider: SliderComponent | null = null;
 
 	constructor(
-		app: any,
+		app: App,
 		plugin: ObsidianGemini,
 		session: ChatSession,
 		onSave: (config: SessionModelConfig) => Promise<void>
@@ -43,7 +44,7 @@ export class SessionSettingsModal extends Modal {
 				dropdown.addOption('__default__', 'Use default');
 
 				// Add available models
-				models.forEach((model: any) => {
+				models.forEach((model: GeminiModel) => {
 					dropdown.addOption(model.value, model.label);
 				});
 


### PR DESCRIPTION
## Summary

Architecture-audit nightly sweep flagged: **improper typing** in `src/ui/agent-view/file-mention-modal.ts` and `src/ui/agent-view/session-settings-modal.ts`.

Two modal classes declared their constructor's `app` parameter as `any`, even though the correct Obsidian `App` type was already in scope (both files import from `obsidian` and call `super(app)` against a base class that accepts `App`). One file also had a `models.forEach((model: any) => ...)` callback where the iteratee is already `GeminiModel[]` per `getAvailableModels()`'s return type.

Pure typing fix — no behavior change. `super(app)` continues to work because `App` is the type the `Modal` / `FuzzySuggestModal` base classes expect.

## Changes

- `src/ui/agent-view/file-mention-modal.ts` — `constructor(app: any, ...)` → `constructor(app: App, ...)`, import `App` from `obsidian`.
- `src/ui/agent-view/session-settings-modal.ts` — same constructor change, plus replace `(model: any) =>` with `(model: GeminiModel) =>` in the dropdown population loop; import `App` and `GeminiModel`.

## Checklist

- [x] `npm run format-check` clean
- [x] `npm run build` clean (TypeScript check + bundle)
- [x] `npm test` — 3009 tests passing
- [x] Labels: `architecture`, `automated` (applied post-merge by the audit)

---

*Filed by the `architecture-audit` skill.*

---
_Generated by [Claude Code](https://claude.ai/code/session_017FmZBX1SvUANg2gZeQjksy)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal type safety and consistency for modal components to enhance code reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->