### PR TITLE
chore(daily): 2026-06-09 daily update

### DIFF
--- a/docs/reference/evals.md
+++ b/docs/reference/evals.md
@@ -225,7 +225,7 @@ function tierRate(row, tier) {
 A few patterns worth calling out from the current rows:
 
 - **The "lite" label is misleading.** `gemini-3.1-flash-lite` (74.1% solve^5)
-  materially beats `gemini-2.5-flash` (57.4%) on the same 54-task suite and
+  materially beats `gemini-2.5-flash` (57.4%) on the same 54-task suite (these baselines predate the June-7 expansion to 59 tasks) and
   the same judge — a ~17pp gap. The newer flash-lite is the more capable
   agentic model despite the name.
 - **The T1 → T4 gradient is doing real work.** Compare `gemma4:e4b`

--- a/docs/reference/evals.md
+++ b/docs/reference/evals.md
@@ -30,7 +30,7 @@ defaults) rather than maxing out at 100% on every model.
 
 ## Task catalog and difficulty tiers
 
-The suite currently has **54 tasks** across four tiers:
+The suite currently has **59 tasks** across four tiers:
 
 | Tier   | Intent                                                                            |
 | ------ | --------------------------------------------------------------------------------- |
@@ -146,7 +146,7 @@ signal.
 
 ## Published results
 
-Every model that's been blessed against the current 54-task suite. Rows are
+Every model that's been blessed against the current 59-task suite. Rows are
 sorted by `solve^k` (the headline reliability number) descending. The
 **Commit** column links to the SHA the harness was built from when the sweep
 ran; the **Date** column is the sweep's ISO timestamp (UTC).

--- a/planning/changelog/2026-06-08.md
+++ b/planning/changelog/2026-06-08.md
@@ -1,0 +1,48 @@
+# Daily changelog — June 08, 2026
+
+**Date:** 2026-06-08
+**PRs merged:** 9
+
+---
+
+## Summary
+
+Heavy architecture cleanup and type-safety day, with a user-facing feature landing at the end. The architecture-audit nightly sweep contributed five of the nine PRs: collapsing 24 error-extraction ternaries into a shared helper, replacing `any` casts with `unknown` in the loop-detector and example-prompts validators, introducing a typed `RetryableHttpError` class, and hardening the `ModelApi` discriminated union with an explicit `kind` field. The day also picked up a model-updater tooling fix and a DI refactor that eliminated the last `as any` workspace-leaf lookup in the tools layer. The final PR gives users copy buttons in the tool-call Parameters and Result sections — the first user-visible feature in a run otherwise dominated by internal hygiene.
+
+## What shipped
+
+### [#956 chore(daily): 2026-06-08 daily update](https://github.com/allenhutchison/obsidian-gemini/pull/956)
+
+Automated daily housekeeping documenting June 7 — 10 PRs covering the daily run, eval task mining (#929), dependency bumps, debug-util type guards, knip CI wiring, dead model-config deletion, tool-execution-logger tests, frontmatter parser typing, centralized folder-walk utility, and a security fix for wikilink-bypass in vault write tools.
+
+### [#953 refactor: type ExamplePromptsService validators with `unknown` instead of `any`](https://github.com/allenhutchison/obsidian-gemini/pull/953)
+
+Architecture-audit sweep fix. `isValidPrompt` and `isValidPromptsArray` in `src/services/example-prompts.ts` accepted `any` inputs, silently allowing unsafe property access on parsed vault JSON. Both signatures are now `unknown` with a `Partial<ExamplePrompt>` narrowing cast — same runtime behavior, stricter compile-time guarantees.
+
+### [#952 refactor: type ToolLoopDetector.sortObject with `unknown` instead of `any`](https://github.com/allenhutchison/obsidian-gemini/pull/952)
+
+Architecture-audit sweep fix. `ToolLoopDetector.sortObject` in `src/tools/loop-detector.ts` used `any` for its input, return type, and reduce accumulator. All three are now `unknown` / `Record<string, unknown>` with a single narrowing cast at the object branch — no behavior change, loop-detection keys are identical.
+
+### [#950 refactor: collapse 24 inline error-extraction ternaries to getRawErrorMessage helper](https://github.com/allenhutchison/obsidian-gemini/pull/950)
+
+Adds `getRawErrorMessage(error: unknown): string` to `src/utils/error-utils.ts` and mechanically replaces 23 sites across 14 files that inlined `error instanceof Error ? error.message : String(error)`. The existing `getErrorMessage` translates errors for users (Ollama 404 → "ollama pull X", quota → Studio guidance); the new helper is the raw-string extraction layer callers actually needed. Fixes #912. Eight new unit tests cover the full input-type matrix.
+
+### [#957 chore: retire preview models superseded by GA in model updater](https://github.com/allenhutchison/obsidian-gemini/pull/957)
+
+`scripts/update-models.mjs` previously only ever appended new models, which meant manually-pruned preview aliases kept re-appearing after each update run (#955 re-introduced the duplicates cleaned up in #922). The script now skips preview candidates when the GA model is already in `models.json`, retires existing preview entries when the GA version first lands (carrying over any `defaultForRoles`), and deduplicates within a single run.
+
+### [#951 refactor: typed RetryableHttpError replaces `as any` casts in proxy-fetch](https://github.com/allenhutchison/obsidian-gemini/pull/951)
+
+Architecture-audit sweep fix. `requestUrlWithRetry` in `src/utils/proxy-fetch.ts` attached `status` and `response` to thrown errors via two `(error as any).field = ...` casts. Introduces a `RetryableHttpError` class with typed `status: number` and `response: RequestUrlResponse` fields, removing both casts. No retry behavior change.
+
+### [#958 refactor(tools): inject view side effects into WriteFileTool via context](https://github.com/allenhutchison/obsidian-gemini/pull/958)
+
+Fixes #954. `WriteFileTool` was the last place in the tools layer that crossed the tool→view boundary via four `(agentView as any)` casts and a `getLeavesOfType` workspace lookup. Replaces that with dependency injection through a new `IToolHostView` interface on `ToolExecutionContext.viewActions`. The owning agent view passes its own side effects in; headless callers (scheduled tasks, hooks) leave `viewActions` unset so the shelf-update is a clean no-op — eliminating a latent bug where headless file writes could contaminate whatever agent view happened to be open.
+
+### [#959 refactor(api): harden ModelApi request-type discriminator with a required kind](https://github.com/allenhutchison/obsidian-gemini/pull/959)
+
+Closes #859. `ModelApi` previously distinguished `BaseModelRequest` from `ExtendedModelRequest` by key presence (`'userMessage' in request`), which silently reclassified any base request carrying a `userMessage` key — the root cause of the "Initialize Vault Context" JSON-parse bug. Adds a required literal `kind: 'base' | 'extended'` discriminant to both types, a canonical `isExtendedRequest()` type guard, and stamps `kind` on every construction site. TypeScript now catches the malformed-request class at compile time. Thirteen files updated; 13-plus new tests including a regression for the #859 scenario.
+
+### [#960 feat(agent-view): copy buttons for tool-call parameters and results](https://github.com/allenhutchison/obsidian-gemini/pull/960)
+
+Closes #731. Expanded tool-call rows in agent chat truncate long parameter values and result fields to 100 chars in the inline display. This adds a **copy button** to the Parameters and Result section headers that copies the full, untruncated value to the clipboard — useful for debugging tool calls without digging into session history files. Styling matches the existing message copy buttons; a brief check-icon confirmation acknowledges the copy. Documented in `docs/guide/agent-mode.md`.


### PR DESCRIPTION
## Summary

Automated daily housekeeping for 2026-06-09. Covers the June 8 changelog (9 PRs — a heavy architecture cleanup and type-safety day capped by the copy-buttons feature). Docs audit found one drift item in `docs/reference/evals.md`. No unlabeled open issues.

## Changes

- **Add `planning/changelog/2026-06-08.md`**: Documents June 8 — 9 PRs: daily housekeeping (#956), 3 architecture-audit type-safety sweeps (#953, #952, #951), error-extraction helper refactor (#950), model-updater preview-retirement fix (#957), WriteFileTool DI refactor (#958), ModelApi discriminated-union hardening (#959), and copy buttons for tool call Parameters/Result (#960).
- **Fix `docs/reference/evals.md`**: Update task count 54→59 to reflect the 5 eval tasks added in PR #929 (reading-list-curate, recency-sync-vs-age, tag-search-no-refusal, vary-repeated-word, word-count-exclude-outline) that weren't reflected in the docs text.

## Sub-skill outcomes

- **daily-changelog**: wrote `planning/changelog/2026-06-08.md`, 9 PRs (architecture cleanup + type-safety sweep + copy-buttons feature)
- **audit-docs**: 1 drift fix — `docs/reference/evals.md` task count updated 54→59; settings names/defaults, command IDs, schedule formats, tool names, folder paths, loop detection thresholds, and permission tier names all accurate
- **triage-issues**: no unlabeled open issues — 0 issues processed

## Screenshots / Screencast

N/A — changelog and docs fix only.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: daily housekeeping
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A: changelog and docs only
- [x] Documentation has been updated (if applicable) — this PR IS the documentation update
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01PnWKYqYXQcMUmRRP4mBYRf)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added copy buttons to tool-call Parameters and Result fields for easier copying of inputs and outputs.

* **Documentation**
  * Updated eval suite documentation to reflect expansion to 59 tasks, clarified published-results wording, and noted that the specific model comparison referenced remains on the original 54-task suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->