### PR TITLE
feat(skills): bundle obsidian-markdown and json-canvas, enrich obsidian-bases

### DIFF
--- a/docs/guide/agent-skills.md
+++ b/docs/guide/agent-skills.md
@@ -32,7 +32,9 @@ For the design rationale behind bundled skills — why they exist, how progressi
 Gemini Scribe ships with built-in skills that are always available:
 
 - **gemini-scribe-help** — The agent can answer questions about the plugin itself by loading the relevant documentation on demand. Ask things like "How do I set up completions?" or "What settings are available?"
+- **obsidian-markdown** — Guides the agent through Obsidian Flavored Markdown: wikilinks, embeds, callouts, block references, tags, comments, highlights, and math.
 - **obsidian-bases** — Guides the agent through creating and configuring Obsidian Bases, including filters, formulas, views, and common patterns like task trackers and project dashboards.
+- **json-canvas** — Guides the agent through creating and editing Obsidian Canvas (`.canvas`) files — text, file, link, and group nodes plus the edges between them.
 - **obsidian-properties** — Helps the agent work with Obsidian note properties (frontmatter), including creating, editing, and querying properties.
 - **audio-transcription** — Guides the agent through transcribing audio and video files into structured notes with timestamps, speaker labels, and summaries.
 - **deep-research** — Guides the agent to use deep research for comprehensive, multi-source investigation and report generation, with clear guidance on when to use it vs a quick Google search.

--- a/prompts/bundled-skills/json-canvas/SKILL.md
+++ b/prompts/bundled-skills/json-canvas/SKILL.md
@@ -1,0 +1,183 @@
+---
+name: json-canvas
+description: Create and edit Obsidian Canvas (.canvas) files — text/file/link/group nodes and the edges between them, using the JSON Canvas spec. Activate this skill when users want to build a canvas, mind map, flowchart, or visual board of notes.
+---
+
+# JSON Canvas
+
+Obsidian Canvas files use the open [JSON Canvas](https://jsoncanvas.org) format: a `.canvas` file is plain JSON describing nodes (cards) laid out on an infinite spatial board and edges (connections) between them.
+
+Write canvas files with the `write_file` tool — pass the full JSON as the file content with a `.canvas` extension. The plugin classifies `.canvas` as a text file, so `read_file` returns its JSON for editing. After writing, the user opens the file in Obsidian to see it rendered; remind them a `.canvas` file shows as raw JSON in a text editor but renders as a board in Canvas view.
+
+## Top-Level Structure
+
+```json
+{
+	"nodes": [],
+	"edges": []
+}
+```
+
+Both arrays are optional. `nodes` holds the cards; `edges` holds the connections.
+
+## Coordinates
+
+The canvas is an infinite 2D plane. Each node has a top-left origin (`x`, `y`) and a `width`/`height` in pixels. `x` increases rightward, `y` increases **downward**. Lay nodes out with enough spacing that they don't overlap (e.g. step `x` by `width + 100`).
+
+## Nodes
+
+Every node requires: `id`, `type`, `x`, `y`, `width`, `height`.
+
+- **`id`** — a unique string. Use a 16-character lowercase hex string (e.g. `"a1b2c3d4e5f60718"`); each id must be unique within the file.
+- **`color`** (optional, any node) — a preset `"1"`–`"6"` or a hex string like `"#FF0000"`.
+
+Preset colors: `"1"` red, `"2"` orange, `"3"` yellow, `"4"` green, `"5"` cyan, `"6"` purple.
+
+### Text node
+
+Holds Markdown content (Obsidian Flavored Markdown is supported, including wikilinks):
+
+```json
+{
+	"id": "6f0ad84f44ce9c17",
+	"type": "text",
+	"x": 0,
+	"y": 0,
+	"width": 400,
+	"height": 200,
+	"text": "# Hello\n\n**Bold** text and a [[Linked Note]]."
+}
+```
+
+### File node
+
+References a vault file (note, image, PDF, etc.) by path. Optional `subpath` targets a heading (`#Heading`) or block (`#^block-id`):
+
+```json
+{
+	"id": "a1b2c3d4e5f67890",
+	"type": "file",
+	"x": 500,
+	"y": 0,
+	"width": 400,
+	"height": 300,
+	"file": "Folder/My Note.md",
+	"subpath": "#Overview"
+}
+```
+
+### Link node
+
+Embeds an external URL:
+
+```json
+{
+	"id": "c3d4e5f678901234",
+	"type": "link",
+	"x": 1000,
+	"y": 0,
+	"width": 400,
+	"height": 200,
+	"url": "https://obsidian.md"
+}
+```
+
+### Group node
+
+A labeled container drawn behind other nodes (position child nodes within its bounds). Optional `label`, `background` (image path), and `backgroundStyle` (`cover`, `ratio`, or `repeat`):
+
+```json
+{
+	"id": "d4e5f6789012345a",
+	"type": "group",
+	"x": -50,
+	"y": -50,
+	"width": 1000,
+	"height": 600,
+	"label": "Overview"
+}
+```
+
+## Edges
+
+Edges connect two nodes. Required: `id`, `fromNode`, `toNode` (node ids). Optional:
+
+- **`fromSide` / `toSide`** — anchor point on each node: `top`, `right`, `bottom`, `left`.
+- **`fromEnd` / `toEnd`** — endpoint shape: `none` (default) or `arrow`.
+- **`color`** — preset `"1"`–`"6"` or hex.
+- **`label`** — text drawn on the connection.
+
+```json
+{
+	"id": "0123456789abcdef",
+	"fromNode": "6f0ad84f44ce9c17",
+	"fromSide": "right",
+	"toNode": "a1b2c3d4e5f67890",
+	"toSide": "left",
+	"toEnd": "arrow",
+	"label": "leads to"
+}
+```
+
+## Complete Example
+
+A small flow: a text node pointing to a file node, both inside a group.
+
+```json
+{
+	"nodes": [
+		{
+			"id": "1111111111111111",
+			"type": "group",
+			"x": -40,
+			"y": -40,
+			"width": 1040,
+			"height": 320,
+			"label": "Research"
+		},
+		{
+			"id": "2222222222222222",
+			"type": "text",
+			"x": 0,
+			"y": 0,
+			"width": 400,
+			"height": 240,
+			"text": "## Question\n\nWhat should we build next?",
+			"color": "5"
+		},
+		{
+			"id": "3333333333333333",
+			"type": "file",
+			"x": 560,
+			"y": 0,
+			"width": 400,
+			"height": 240,
+			"file": "Notes/Findings.md"
+		}
+	],
+	"edges": [
+		{
+			"id": "4444444444444444",
+			"fromNode": "2222222222222222",
+			"fromSide": "right",
+			"toNode": "3333333333333333",
+			"toSide": "left",
+			"toEnd": "arrow",
+			"label": "explores"
+		}
+	]
+}
+```
+
+## Editing an Existing Canvas
+
+1. `read_file` the `.canvas` file to get the current JSON.
+2. Parse it, add or modify nodes/edges (keep every `id` unique), and recompute positions if you insert nodes.
+3. `write_file` the full updated JSON back.
+
+## Tips
+
+- Always emit valid JSON — a malformed `.canvas` file fails to open in Canvas view.
+- Reference vault files in file nodes by their full vault-relative path; verify the path exists (`list_files`) before pointing at it.
+- Give related nodes the same `color` and wrap them in a group to convey structure.
+- Space nodes generously so edges are readable; Obsidian does not auto-layout.

--- a/prompts/bundled-skills/obsidian-bases/SKILL.md
+++ b/prompts/bundled-skills/obsidian-bases/SKILL.md
@@ -282,3 +282,54 @@ views:
 - Embed bases in daily notes using `this` to create context-aware views
 - Export views as CSV for spreadsheet use
 - Properties edited in table view update the note's frontmatter directly
+
+## Troubleshooting
+
+### YAML syntax errors
+
+**Unquoted special characters.** Strings containing any of `: { } [ ] , & * # ? | - < > = ! % @ `` ` `` ` must be quoted.
+
+```yaml
+# WRONG
+displayName: Status: Active
+# CORRECT
+displayName: 'Status: Active'
+```
+
+**Mismatched quotes in formulas.** When a formula contains double quotes, wrap the whole value in single quotes.
+
+```yaml
+# WRONG
+formulas:
+  label: "if(done, "Yes", "No")"
+# CORRECT
+formulas:
+  label: 'if(done, "Yes", "No")'
+```
+
+### Common formula errors
+
+**Duration math without a field accessor.** Subtracting two dates returns a duration, not a number — access `.days`, `.hours`, etc. (Subtracting raw datetimes yields milliseconds, so divide if you skip the accessor.)
+
+```yaml
+# WRONG
+'(now() - file.ctime).round(0)'
+# CORRECT
+'(now() - file.ctime).days.round(0)'
+```
+
+**Missing null checks.** Guard properties that may be absent with `if()`, or the formula errors on notes that lack them.
+
+```yaml
+# WRONG
+'(date(due_date) - today()).days'
+# CORRECT
+'if(due_date, (date(due_date) - today()).days, "")'
+```
+
+**Referencing an undefined formula.** Every `formula.X` used in `order` or `properties` must have a matching entry under `formulas`.
+
+### Rendering
+
+- Embedded `base` code blocks only render in Reading view or Live Preview — they show as raw YAML in Source mode.
+- Map view requires the Maps plugin (Obsidian 1.10+); without it, a `map` view won't render.

--- a/prompts/bundled-skills/obsidian-markdown/SKILL.md
+++ b/prompts/bundled-skills/obsidian-markdown/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: obsidian-markdown
+description: Write and edit Obsidian Flavored Markdown — wikilinks, embeds, callouts, block references, tags, comments, highlights, and math. Activate this skill when users want to link notes, embed content, add callouts, or use Obsidian-specific Markdown syntax.
+---
+
+# Obsidian Flavored Markdown
+
+Obsidian extends standard Markdown (CommonMark + GitHub Flavored Markdown) with syntax for connecting and enriching notes: wikilinks, embeds, callouts, block references, tags, comments, highlights, and math.
+
+When creating or editing notes, use the `write_file` tool for note bodies and the `update_frontmatter` tool for properties. Place all body content **after** the YAML frontmatter block (if present) — frontmatter must start with `---` on line 1 and end with a closing `---`.
+
+## Internal Links (Wikilinks)
+
+Link to other notes by title — no path or extension needed unless disambiguating:
+
+| Syntax                        | Meaning                               |
+| ----------------------------- | ------------------------------------- |
+| `[[Note Name]]`               | Link by note title                    |
+| `[[Note Name\|Display Text]]` | Custom display text                   |
+| `[[Note Name#Heading]]`       | Link to a heading within a note       |
+| `[[Note Name#^block-id]]`     | Link to a specific block              |
+| `[[#Heading]]`                | Link to a heading in the current note |
+| `[[folder/Note Name]]`        | Disambiguate when titles collide      |
+
+Wikilinks are the preferred linking style in Obsidian. Standard Markdown links (`[text](path)`) also work, but wikilinks integrate with the graph view, backlinks, and autocomplete.
+
+### Block References
+
+Append a caret + identifier to the end of any block (paragraph, list item, etc.) to give it a stable anchor, then link to it:
+
+```markdown
+This is an important paragraph. ^key-point
+
+See [[Other Note#^key-point]] for context.
+```
+
+Block IDs may contain letters, numbers, and hyphens. Obsidian auto-generates one (e.g. `^a1b2c3`) if you link to a block before naming it.
+
+## Embeds
+
+Prefix any wikilink with `!` to embed the target's content inline instead of linking to it:
+
+| Syntax                     | Meaning                       |
+| -------------------------- | ----------------------------- |
+| `![[Note Name]]`           | Embed an entire note          |
+| `![[Note Name#Heading]]`   | Embed one section             |
+| `![[Note Name#^block-id]]` | Embed a single block          |
+| `![[image.png]]`           | Embed an image                |
+| `![[image.png\|300]]`      | Embed an image at 300px width |
+| `![[image.png\|300x200]]`  | Width x height                |
+| `![[document.pdf]]`        | Embed a PDF                   |
+| `![[document.pdf#page=3]]` | Embed a specific PDF page     |
+| `![[recording.mp3]]`       | Embed audio                   |
+| `![[clip.mp4]]`            | Embed video                   |
+
+Embeds only render in Reading view and Live Preview — they appear as raw `![[...]]` text in Source mode. After adding embeds, let the user know they may need Reading view to see them rendered.
+
+## Callouts
+
+Callouts are styled blockquotes for admonitions. Structure: a blockquote whose first line is `> [!type]`, optionally followed by a custom title:
+
+```markdown
+> [!note]
+> This is a note callout with default title.
+
+> [!warning] Custom Title
+> This callout has a custom title.
+
+> [!tip]+ Expanded by default
+> The `+` makes a foldable callout that starts open.
+
+> [!info]- Collapsed by default
+> The `-` makes a foldable callout that starts closed.
+```
+
+Built-in types (each has its own icon/color): `note`, `abstract`/`summary`/`tldr`, `info`, `todo`, `tip`/`hint`/`important`, `success`/`check`/`done`, `question`/`help`/`faq`, `warning`/`caution`/`attention`, `failure`/`fail`/`missing`, `danger`/`error`, `bug`, `example`, `quote`/`cite`. Unknown types fall back to the `note` style. Callouts can be nested by adding more `>` levels, and may contain any Markdown, including wikilinks and embeds.
+
+## Properties (Frontmatter)
+
+YAML metadata at the very top of a note. **Always use the `update_frontmatter` tool** to add or change properties — it formats YAML safely via Obsidian's API rather than hand-editing the block.
+
+```yaml
+---
+title: My Note
+tags:
+  - project
+  - active
+aliases:
+  - Alt Name
+date: 2026-06-09
+cssclasses:
+  - wide-page
+---
+```
+
+For full guidance on property types (text, list, number, checkbox, date, datetime) and their interaction with Bases, Templates, and Search, activate the `obsidian-properties` skill.
+
+## Tags
+
+Inline `#tags` categorize notes and can be nested with `/`:
+
+```markdown
+#project #status/active #area/work
+```
+
+Tags can also live in frontmatter under the `tags` property (without the `#`). Tags may contain letters, numbers, `-`, `_`, and `/`, but not spaces, and cannot be purely numeric.
+
+## Comments
+
+Text wrapped in `%%` is hidden from Reading view but stays in the file:
+
+```markdown
+%%This is a private note that won't render.%%
+
+Visible text %%inline hidden%% more visible text.
+```
+
+## Other Syntax
+
+| Feature     | Syntax                                                        |
+| ----------- | ------------------------------------------------------------- |
+| Highlight   | `==highlighted text==`                                        |
+| Inline math | `$e = mc^2$`                                                  |
+| Block math  | `$$\int_a^b f(x)\,dx$$` on its own line                       |
+| Footnote    | `Some text.[^1]` then `[^1]: The definition.` on its own line |
+
+Mermaid diagrams render from a fenced `mermaid` code block and support wikilinks between nodes:
+
+```mermaid
+graph TD
+  A[[Note A]] --> B[[Note B]]
+```
+
+Standard GitHub Flavored Markdown — tables, task lists (`- [ ]` / `- [x]`), fenced code blocks, strikethrough (`~~text~~`) — all work as expected.
+
+## Workflow
+
+1. If the note needs metadata, add frontmatter first via `update_frontmatter`.
+2. Write the body with `write_file`, placing content after any frontmatter.
+3. Use wikilinks to connect related notes and embeds to pull in supporting content.
+4. Remind the user that embeds and callouts render in Reading view / Live Preview, not Source mode.
+
+## Tips
+
+- Prefer `[[wikilinks]]` over Markdown links so the note participates in the graph and backlinks.
+- When linking to a heading or block that doesn't exist yet, create the anchor in the target note so the link resolves.
+- Keep callout types lowercase; the title after `[!type]` is free-form text.
+- Don't place body content before frontmatter unless explicitly editing the frontmatter block.

--- a/src/services/bundled-skills.ts
+++ b/src/services/bundled-skills.ts
@@ -2,7 +2,9 @@ import type { SkillSummary } from './skill-manager';
 
 // Import bundled skill SKILL.md files
 import helpSkillMd from '../../prompts/bundled-skills/gemini-scribe-help/SKILL.md';
+import markdownSkillMd from '../../prompts/bundled-skills/obsidian-markdown/SKILL.md';
 import basesSkillMd from '../../prompts/bundled-skills/obsidian-bases/SKILL.md';
+import canvasSkillMd from '../../prompts/bundled-skills/json-canvas/SKILL.md';
 import propertiesSkillMd from '../../prompts/bundled-skills/obsidian-properties/SKILL.md';
 import audioTranscriptionSkillMd from '../../prompts/bundled-skills/audio-transcription/SKILL.md';
 import deepResearchSkillMd from '../../prompts/bundled-skills/deep-research/SKILL.md';
@@ -57,11 +59,27 @@ skills.set('gemini-scribe-help', {
 	resources: helpResources,
 });
 
+// Register obsidian-markdown
+skills.set('obsidian-markdown', {
+	name: 'obsidian-markdown',
+	description: parseDescription(markdownSkillMd),
+	content: stripFrontmatter(markdownSkillMd),
+	resources: new Map(),
+});
+
 // Register obsidian-bases
 skills.set('obsidian-bases', {
 	name: 'obsidian-bases',
 	description: parseDescription(basesSkillMd),
 	content: stripFrontmatter(basesSkillMd),
+	resources: new Map(),
+});
+
+// Register json-canvas
+skills.set('json-canvas', {
+	name: 'json-canvas',
+	description: parseDescription(canvasSkillMd),
+	content: stripFrontmatter(canvasSkillMd),
 	resources: new Map(),
 });
 

--- a/test/services/bundled-skills.test.ts
+++ b/test/services/bundled-skills.test.ts
@@ -18,11 +18,25 @@ describe('BundledSkillRegistry', () => {
 			expect(help!.description).toBeTruthy();
 		});
 
+		it('should include obsidian-markdown skill', () => {
+			const summaries = BundledSkillRegistry.getSummaries();
+			const md = summaries.find((s) => s.name === 'obsidian-markdown');
+			expect(md).toBeDefined();
+			expect(md!.description).toBeTruthy();
+		});
+
 		it('should include obsidian-bases skill', () => {
 			const summaries = BundledSkillRegistry.getSummaries();
 			const bases = summaries.find((s) => s.name === 'obsidian-bases');
 			expect(bases).toBeDefined();
 			expect(bases!.description).toBeTruthy();
+		});
+
+		it('should include json-canvas skill', () => {
+			const summaries = BundledSkillRegistry.getSummaries();
+			const canvas = summaries.find((s) => s.name === 'json-canvas');
+			expect(canvas).toBeDefined();
+			expect(canvas!.description).toBeTruthy();
 		});
 
 		it('should include obsidian-properties skill', () => {

--- a/test/services/bundled-skills.test.ts
+++ b/test/services/bundled-skills.test.ts
@@ -107,10 +107,22 @@ describe('BundledSkillRegistry', () => {
 			expect(content).toContain('<!-- STATE_FOLDER -->');
 		});
 
+		it('should return body content for obsidian-markdown', () => {
+			const content = BundledSkillRegistry.loadSkill('obsidian-markdown');
+			expect(content).not.toBeNull();
+			expect(content).toContain('wikilink');
+		});
+
 		it('should return body content for obsidian-bases', () => {
 			const content = BundledSkillRegistry.loadSkill('obsidian-bases');
 			expect(content).not.toBeNull();
 			expect(content).toContain('Bases');
+		});
+
+		it('should return body content for json-canvas', () => {
+			const content = BundledSkillRegistry.loadSkill('json-canvas');
+			expect(content).not.toBeNull();
+			expect(content).toContain('JSON Canvas');
 		});
 
 		it('should return body content for obsidian-properties', () => {


### PR DESCRIPTION
## Summary

Addresses #564 — evaluated [kepano/obsidian-skills](https://github.com/kepano/obsidian-skills) as a replacement for our bundled skills. Rather than a wholesale swap (those skills assume an external agent with shell + `obsidian-cli`, whereas ours run **inside Obsidian** with function-calling tools and no shell), this adapts the genuinely-missing format/spec knowledge to our tooling and enriches our existing Bases skill. Full rationale is recorded in the [issue comment](https://github.com/allenhutchison/obsidian-gemini/issues/564#issuecomment-4663373431).

## Changes

- **Add `obsidian-markdown` bundled skill** — Obsidian Flavored Markdown: wikilinks, embeds, callouts, block references, tags, comments, highlights, math. Routed through `write_file` / `update_frontmatter`.
- **Add `json-canvas` bundled skill** — JSON Canvas spec (text/file/link/group nodes, edges, colors) with a worked example; read/edit via `read_file` + `write_file`.
- **Enrich `obsidian-bases`** — new Troubleshooting section (YAML quoting, duration/null formula errors, undefined-formula refs, render gotchas).
- **Register** both new skills in `src/services/bundled-skills.ts` and add registry test coverage.
- **Document** both in `docs/guide/agent-skills.md`.

Skipped upstream `obsidian-cli` (we keep our plugin-specific dev skill in `.agents/skills/`) and `defuddle` (shell-only; we already have `web_fetch` via Google URL Context).

### Follow-up (not in this PR)

The three forked content skills (`obsidian-markdown`, `json-canvas`, `obsidian-bases`) are adaptations, so they can drift from upstream. A separate issue will propose pinning the reconciled upstream SHA + a low-frequency scheduled diff check. `obsidian-cli` is excluded — it tracks the Obsidian CLI directly, not kepano.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A: content-only bundled skill markdown + registration, no platform-specific code
- [x] Documentation has been updated (if applicable)
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Added Obsidian Markdown bundled skill with comprehensive Markdown guidance
  - Added JSON Canvas bundled skill for creating and editing Canvas files

* **Documentation**
  - Updated Agent Skills list to include the new bundled skills
  - Added Troubleshooting to Obsidian Bases covering YAML, formulas, and rendering

* **Tests**
  - Updated tests to verify the new bundled skills are listed and load expected content
<!-- end of auto-generated comment: release notes by coderabbit.ai -->