### PR TITLE
feat(tools): add google_maps grounding tool

### DIFF
--- a/docs/guide/agent-mode.md
+++ b/docs/guide/agent-mode.md
@@ -336,7 +336,7 @@ Find recent research on productivity methods
 
 Look up real-world places and location information grounded in Google Maps — businesses, points of interest, addresses, opening hours, ratings/reviews, and "near me" style questions. Returns an answer with inline citations and links to the places referenced. Include the location in your request for the best results. Available on the Gemini provider only.
 
-```
+```text
 Find highly-rated ramen near Union Square, San Francisco
 What are the opening hours for the British Museum?
 Coffee shops within walking distance of the Ferry Building

--- a/docs/guide/agent-mode.md
+++ b/docs/guide/agent-mode.md
@@ -332,6 +332,16 @@ Search for the latest Obsidian plugin development docs
 Find recent research on productivity methods
 ```
 
+#### google_maps
+
+Look up real-world places and location information grounded in Google Maps — businesses, points of interest, addresses, opening hours, ratings/reviews, and "near me" style questions. Returns an answer with inline citations and links to the places referenced. Include the location in your request for the best results. Available on the Gemini provider only.
+
+```
+Find highly-rated ramen near Union Square, San Francisco
+What are the opening hours for the British Museum?
+Coffee shops within walking distance of the Ferry Building
+```
+
 #### fetch_url
 
 Retrieve and analyze web page content:

--- a/src/agent/agent-loop-helpers.ts
+++ b/src/agent/agent-loop-helpers.ts
@@ -50,6 +50,7 @@ const TOOL_PRIORITY: Record<string, number> = {
 	google_search: 20,
 	fetch_url: 21,
 	deep_research: 22,
+	google_maps: 23,
 	// ── WRITES (30–39) ──────────────────────────────────────────────────────
 	write_file: 30,
 	create_folder: 31,

--- a/src/subscribers/tool-execution-logger.ts
+++ b/src/subscribers/tool-execution-logger.ts
@@ -18,6 +18,7 @@ const KEY_PARAM_MAP: Record<string, string | undefined> = {
 	find_files_by_content: 'query',
 	get_workspace_state: undefined,
 	google_search: 'query',
+	google_maps: 'query',
 	fetch_url: 'url',
 	vault_semantic_search: 'query',
 	deep_research: 'topic',

--- a/src/tools/google-maps-tool.ts
+++ b/src/tools/google-maps-tool.ts
@@ -1,0 +1,164 @@
+import { Tool, ToolResult, ToolExecutionContext } from './types';
+import { ToolCategory } from '../types/agent';
+import { ToolClassification } from '../types/tool-policy';
+import { getDefaultModelForRole } from '../models';
+import { createGoogleGenAI } from '../api/providers/gemini/google-genai-factory';
+import { executeWithRetry } from '../utils/retry';
+
+/**
+ * Google Maps grounding tool that uses a separate model instance with the
+ * `googleMaps` grounding tool enabled. Mirrors {@link GoogleSearchTool} but
+ * grounds answers in Google Maps place data (locations, hours, reviews,
+ * directions) instead of web search results.
+ */
+export class GoogleMapsTool implements Tool {
+	name = 'google_maps';
+	displayName = 'Google Maps';
+	category = ToolCategory.READ_ONLY;
+	classification = ToolClassification.EXTERNAL;
+	description =
+		'Look up real-world places and location information using Google Maps. Returns an answer with inline citations and links to the places referenced. Use this for finding businesses, points of interest, addresses, opening hours, ratings/reviews, or "near me" style queries. Include the location in the query (e.g. "coffee shops near Ferry Building, San Francisco") for best results.';
+
+	parameters = {
+		type: 'object' as const,
+		properties: {
+			query: {
+				type: 'string' as const,
+				description: 'The place or location question to answer with Google Maps. Include a location for best results.',
+			},
+		},
+		required: ['query'],
+	};
+
+	getProgressDescription(params: { query: string }): string {
+		if (params.query) {
+			const query = params.query.length > 30 ? params.query.substring(0, 27) + '...' : params.query;
+			return `Searching Maps for "${query}"`;
+		}
+		return 'Searching Google Maps';
+	}
+
+	async execute(params: { query: string }, context: ToolExecutionContext): Promise<ToolResult> {
+		const plugin = context.plugin;
+
+		try {
+			// Check if API key is available
+			if (!plugin.apiKey) {
+				return {
+					success: false,
+					error: 'Google API key not configured',
+				};
+			}
+
+			// Create a separate model instance with Google Maps grounding enabled
+			const genAI = createGoogleGenAI(plugin);
+			const modelToUse = plugin.settings.chatModelName || getDefaultModelForRole('chat');
+			const config = {
+				temperature: plugin.settings.temperature,
+				maxOutputTokens: 8192,
+				tools: [{ googleMaps: {} }],
+			};
+
+			const prompt = `Please answer the following using current Google Maps information about real-world places: ${params.query}`;
+
+			const result = await executeWithRetry(
+				() =>
+					genAI.models.generateContent({
+						model: modelToUse,
+						config: config,
+						contents: prompt,
+					}),
+				undefined,
+				{ operationName: 'GoogleMapsTool.generateContent', logger: plugin.logger }
+			);
+
+			// Extract text from response
+			let text = '';
+			if (result.candidates?.[0]?.content?.parts) {
+				for (const part of result.candidates[0].content.parts) {
+					if (part.text) {
+						text += part.text;
+					}
+				}
+			} else if (result.text) {
+				try {
+					text = result.text;
+				} catch (e) {
+					plugin.logger.warn('Failed to get text from result:', e);
+				}
+			}
+
+			// Extract grounding metadata and place citations if available
+			const groundingMetadata = result.candidates?.[0]?.groundingMetadata;
+			let citations: Array<{ title?: string; url: string; snippet?: string }> = [];
+			let textWithCitations = text;
+
+			// Maps grounding returns place evidence on `chunk.maps` rather than `chunk.web`.
+			if (groundingMetadata?.groundingChunks) {
+				const chunks = groundingMetadata.groundingChunks;
+				citations = chunks
+					.filter((chunk: any) => chunk.maps?.uri)
+					.map((chunk: any) => ({
+						url: chunk.maps.uri,
+						title: chunk.maps.title || chunk.maps.uri,
+						snippet: chunk.maps.text || '',
+					}));
+
+				// Add inline citations to text if supports are available
+				if (groundingMetadata.groundingSupports) {
+					const supports = groundingMetadata.groundingSupports;
+					// Sort supports by end_index in descending order so insertions don't shift later offsets
+					const sortedSupports = [...supports].sort(
+						(a: any, b: any) => (b.segment?.endIndex ?? 0) - (a.segment?.endIndex ?? 0)
+					);
+
+					for (const support of sortedSupports) {
+						const endIndex = support.segment?.endIndex;
+						if (endIndex === undefined || !support.groundingChunkIndices?.length) {
+							continue;
+						}
+
+						const citationLinks = support.groundingChunkIndices
+							.map((i: number) => {
+								const uri = chunks[i]?.maps?.uri;
+								if (uri) {
+									return `[${i + 1}](${uri})`;
+								}
+								return null;
+							})
+							.filter(Boolean);
+
+						if (citationLinks.length > 0) {
+							const citationString = ` ${citationLinks.join(', ')}`;
+							textWithCitations =
+								textWithCitations.slice(0, endIndex) + citationString + textWithCitations.slice(endIndex);
+						}
+					}
+				}
+			}
+
+			return {
+				success: true,
+				data: {
+					query: params.query,
+					answer: textWithCitations, // Text with inline citations
+					originalAnswer: text, // Original text without citations
+					citations: citations,
+					searchGrounding: groundingMetadata || undefined,
+				},
+			};
+		} catch (error) {
+			return {
+				success: false,
+				error: `Google Maps lookup failed: ${error instanceof Error ? error.message : 'Unknown error'}`,
+			};
+		}
+	}
+}
+
+/**
+ * Get Google Maps tool
+ */
+export function getGoogleMapsTool(): Tool {
+	return new GoogleMapsTool();
+}

--- a/src/tools/web-tools.ts
+++ b/src/tools/web-tools.ts
@@ -1,5 +1,6 @@
 import { Tool } from './types';
 import { GoogleSearchTool } from './google-search-tool';
+import { GoogleMapsTool } from './google-maps-tool';
 import { WebFetchTool } from './web-fetch-tool';
 import { DeepResearchTool } from './deep-research-tool';
 
@@ -7,5 +8,5 @@ import { DeepResearchTool } from './deep-research-tool';
  * Get web-related tools
  */
 export function getWebTools(): Tool[] {
-	return [new GoogleSearchTool(), new WebFetchTool(), new DeepResearchTool()];
+	return [new GoogleSearchTool(), new GoogleMapsTool(), new WebFetchTool(), new DeepResearchTool()];
 }

--- a/src/ui/agent-view/agent-view-tool-display.ts
+++ b/src/ui/agent-view/agent-view-tool-display.ts
@@ -17,6 +17,7 @@ const TOOL_ICONS: Record<string, string> = {
 	move_file: 'file-symlink',
 	find_files_by_name: 'search',
 	google_search: 'globe',
+	google_maps: 'map-pin',
 	fetch_url: 'link',
 	generate_image: 'image',
 };
@@ -438,8 +439,12 @@ export class AgentViewToolDisplay {
 					this.plugin.logger.log('Tool result is object for:', toolName);
 					this.plugin.logger.log('Result data keys:', Object.keys(result.data));
 
-					if (result.data.answer && result.data.citations && toolName === 'google_search') {
-						this.plugin.logger.log('Handling google_search result with citations');
+					if (
+						result.data.answer &&
+						result.data.citations &&
+						(toolName === 'google_search' || toolName === 'google_maps')
+					) {
+						this.plugin.logger.log(`Handling ${toolName} result with citations`);
 						const answerDiv = resultContent.createDiv({ cls: 'gemini-agent-tool-search-answer' });
 						answerDiv.createEl('h5', { text: 'Answer:' });
 

--- a/test/tools/google-maps-tool.test.ts
+++ b/test/tools/google-maps-tool.test.ts
@@ -1,0 +1,509 @@
+import type { Mock } from 'vitest';
+import { GoogleMapsTool, getGoogleMapsTool } from '../../src/tools/google-maps-tool';
+import { ToolExecutionContext } from '../../src/tools/types';
+import { GoogleGenAI } from '@google/genai';
+import { getDefaultModelForRole } from '../../src/models';
+
+// Mock Google Gen AI
+vi.mock('@google/genai', () => ({
+	GoogleGenAI: vi.fn(),
+}));
+
+vi.mock('../../src/utils/retry', async () => {
+	const actual = await vi.importActual<any>('../../src/utils/retry');
+	return {
+		...actual,
+		executeWithRetry: vi.fn().mockImplementation((operation, _config, options) => {
+			const zeroConfig = {
+				maxRetries: 0,
+				initialDelayMs: 1,
+				maxDelayMs: 1,
+				jitter: false,
+			};
+			return actual.executeWithRetry(operation, zeroConfig, options);
+		}),
+	};
+});
+
+describe('GoogleMapsTool', () => {
+	let tool: GoogleMapsTool;
+	let mockContext: ToolExecutionContext;
+	let mockGenAI: any;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+
+		tool = new GoogleMapsTool();
+
+		// Mock genAI methods
+		mockGenAI = {
+			models: {
+				generateContent: vi.fn(),
+			},
+		};
+
+		// Mock GoogleGenAI constructor
+		(GoogleGenAI as Mock).mockImplementation(function () {
+			return mockGenAI;
+		});
+
+		// Mock context
+		mockContext = {
+			plugin: {
+				apiKey: 'test-api-key',
+				settings: {
+					chatModelName: 'gemini-1.5-flash-002',
+					temperature: 0.7,
+				},
+			},
+			session: {
+				id: 'test-session',
+				type: 'agent-session',
+				context: {
+					contextFiles: [],
+					contextDepth: 2,
+					enabledTools: [],
+					requireConfirmation: [],
+				},
+			},
+		} as any;
+	});
+
+	describe('basic properties', () => {
+		it('should have correct name and category', () => {
+			expect(tool.name).toBe('google_maps');
+			expect(tool.category).toBe('read_only');
+			expect(tool.description).toContain('Google Maps');
+		});
+
+		it('should have correct parameters schema', () => {
+			expect(tool.parameters).toEqual({
+				type: 'object',
+				properties: {
+					query: {
+						type: 'string',
+						description:
+							'The place or location question to answer with Google Maps. Include a location for best results.',
+					},
+				},
+				required: ['query'],
+			});
+		});
+	});
+
+	describe('execute', () => {
+		it('should perform a maps lookup successfully', async () => {
+			const mockResponse = {
+				candidates: [
+					{
+						content: {
+							parts: [
+								{
+									text: 'Here are some coffee shops near you...',
+								},
+							],
+						},
+						groundingMetadata: {
+							googleMapsWidgetContextToken: 'token-123',
+						},
+					},
+				],
+			};
+
+			mockGenAI.models.generateContent.mockResolvedValue(mockResponse);
+
+			const result = await tool.execute({ query: 'coffee near me' }, mockContext);
+
+			expect(result.success).toBe(true);
+			expect(result.data).toEqual({
+				query: 'coffee near me',
+				answer: 'Here are some coffee shops near you...',
+				originalAnswer: 'Here are some coffee shops near you...',
+				citations: [],
+				searchGrounding: {
+					googleMapsWidgetContextToken: 'token-123',
+				},
+			});
+
+			// Verify API call was made with maps grounding
+			expect(mockGenAI.models.generateContent).toHaveBeenCalledWith({
+				model: 'gemini-1.5-flash-002',
+				config: {
+					temperature: 0.7,
+					maxOutputTokens: 8192,
+					tools: [{ googleMaps: {} }],
+				},
+				contents: expect.stringContaining('coffee near me'),
+			});
+		});
+
+		it('should handle a lookup without grounding metadata', async () => {
+			const mockResponse = {
+				candidates: [
+					{
+						content: {
+							parts: [
+								{
+									text: 'Basic response without metadata',
+								},
+							],
+						},
+					},
+				],
+			};
+
+			mockGenAI.models.generateContent.mockResolvedValue(mockResponse);
+
+			const result = await tool.execute({ query: 'where is the Eiffel Tower' }, mockContext);
+
+			expect(result.success).toBe(true);
+			expect(result.data).toEqual({
+				query: 'where is the Eiffel Tower',
+				answer: 'Basic response without metadata',
+				originalAnswer: 'Basic response without metadata',
+				citations: [],
+				searchGrounding: undefined,
+			});
+		});
+
+		it('should return error when API key is missing', async () => {
+			(mockContext.plugin as any).apiKey = '';
+
+			const result = await tool.execute({ query: 'test' }, mockContext);
+
+			expect(result.success).toBe(false);
+			expect(result.error).toBe('Google API key not configured');
+			expect(mockGenAI.models.generateContent).not.toHaveBeenCalled();
+		});
+
+		it('should handle API errors gracefully', async () => {
+			mockGenAI.models.generateContent.mockRejectedValue(new Error('API rate limit exceeded'));
+
+			const result = await tool.execute({ query: 'test' }, mockContext);
+
+			expect(result.success).toBe(false);
+			expect(result.error).toBe('Google Maps lookup failed: API rate limit exceeded');
+		});
+
+		it('should use default model when not specified', async () => {
+			(mockContext.plugin as any).settings.chatModelName = undefined;
+
+			const mockResponse = {
+				candidates: [
+					{
+						content: {
+							parts: [
+								{
+									text: 'Response with default model',
+								},
+							],
+						},
+					},
+				],
+			};
+
+			mockGenAI.models.generateContent.mockResolvedValue(mockResponse);
+
+			await tool.execute({ query: 'test' }, mockContext);
+
+			expect(mockGenAI.models.generateContent).toHaveBeenCalledWith(
+				expect.objectContaining({
+					model: getDefaultModelForRole('chat'),
+				})
+			);
+		});
+	});
+
+	describe('getGoogleMapsTool', () => {
+		it('should return a GoogleMapsTool instance', () => {
+			const tool = getGoogleMapsTool();
+			expect(tool).toBeInstanceOf(GoogleMapsTool);
+			expect(tool.name).toBe('google_maps');
+		});
+	});
+
+	describe('citation extraction from maps groundingChunks', () => {
+		it('should populate citations array with url, title, and snippet from maps chunks', async () => {
+			const mockResponse = {
+				candidates: [
+					{
+						content: {
+							parts: [{ text: 'Maps answer text' }],
+						},
+						groundingMetadata: {
+							groundingChunks: [
+								{
+									maps: {
+										uri: 'https://maps.google.com/?cid=1',
+										title: 'Blue Bottle Coffee',
+										text: 'Great espresso and pastries',
+									},
+								},
+								{
+									maps: {
+										uri: 'https://maps.google.com/?cid=2',
+										title: 'Sightglass Coffee',
+										text: 'Spacious roastery cafe',
+									},
+								},
+							],
+						},
+					},
+				],
+			};
+
+			mockGenAI.models.generateContent.mockResolvedValue(mockResponse);
+
+			const result = await tool.execute({ query: 'coffee in SF' }, mockContext);
+
+			expect(result.success).toBe(true);
+			expect(result.data.citations).toEqual([
+				{
+					url: 'https://maps.google.com/?cid=1',
+					title: 'Blue Bottle Coffee',
+					snippet: 'Great espresso and pastries',
+				},
+				{
+					url: 'https://maps.google.com/?cid=2',
+					title: 'Sightglass Coffee',
+					snippet: 'Spacious roastery cafe',
+				},
+			]);
+		});
+
+		it('should fallback title to uri when chunk.maps.title is undefined', async () => {
+			const mockResponse = {
+				candidates: [
+					{
+						content: {
+							parts: [{ text: 'Answer text' }],
+						},
+						groundingMetadata: {
+							groundingChunks: [
+								{
+									maps: {
+										uri: 'https://maps.google.com/?cid=no-title',
+										// title is undefined
+										text: 'Some place answer',
+									},
+								},
+							],
+						},
+					},
+				],
+			};
+
+			mockGenAI.models.generateContent.mockResolvedValue(mockResponse);
+
+			const result = await tool.execute({ query: 'test' }, mockContext);
+
+			expect(result.success).toBe(true);
+			expect(result.data.citations[0].title).toBe('https://maps.google.com/?cid=no-title');
+		});
+
+		it('should use empty string for snippet when chunk.maps.text is undefined', async () => {
+			const mockResponse = {
+				candidates: [
+					{
+						content: {
+							parts: [{ text: 'Answer text' }],
+						},
+						groundingMetadata: {
+							groundingChunks: [
+								{
+									maps: {
+										uri: 'https://maps.google.com/?cid=3',
+										title: 'Place Title',
+										// text is undefined
+									},
+								},
+							],
+						},
+					},
+				],
+			};
+
+			mockGenAI.models.generateContent.mockResolvedValue(mockResponse);
+
+			const result = await tool.execute({ query: 'test' }, mockContext);
+
+			expect(result.success).toBe(true);
+			expect(result.data.citations[0].snippet).toBe('');
+		});
+
+		it('should filter out chunks without a maps URI', async () => {
+			const mockResponse = {
+				candidates: [
+					{
+						content: {
+							parts: [{ text: 'Answer' }],
+						},
+						groundingMetadata: {
+							groundingChunks: [
+								{ maps: { uri: 'https://maps.google.com/?cid=valid' } },
+								{ maps: {} }, // no URI
+								{ web: { uri: 'https://example.com' } }, // web chunk, not maps
+							],
+						},
+					},
+				],
+			};
+
+			mockGenAI.models.generateContent.mockResolvedValue(mockResponse);
+
+			const result = await tool.execute({ query: 'test' }, mockContext);
+
+			expect(result.success).toBe(true);
+			expect(result.data.citations).toHaveLength(1);
+			expect(result.data.citations[0].url).toBe('https://maps.google.com/?cid=valid');
+		});
+	});
+
+	describe('inline citation insertion from groundingSupports', () => {
+		it('should insert citations at correct endIndex positions', async () => {
+			const mockResponse = {
+				candidates: [
+					{
+						content: {
+							parts: [{ text: 'Hello world' }],
+						},
+						groundingMetadata: {
+							groundingChunks: [
+								{ maps: { uri: 'https://maps.google.com/a', title: 'Place A' } },
+								{ maps: { uri: 'https://maps.google.com/b', title: 'Place B' } },
+							],
+							groundingSupports: [
+								{
+									segment: { endIndex: 5 },
+									groundingChunkIndices: [0],
+								},
+								{
+									segment: { endIndex: 11 },
+									groundingChunkIndices: [1],
+								},
+							],
+						},
+					},
+				],
+			};
+
+			mockGenAI.models.generateContent.mockResolvedValue(mockResponse);
+
+			const result = await tool.execute({ query: 'test' }, mockContext);
+
+			expect(result.success).toBe(true);
+			expect(result.data.answer).toBe('Hello [1](https://maps.google.com/a) world [2](https://maps.google.com/b)');
+			expect(result.data.originalAnswer).toBe('Hello world');
+		});
+
+		it('should skip supports with missing endIndex', async () => {
+			const mockResponse = {
+				candidates: [
+					{
+						content: {
+							parts: [{ text: 'Some text here' }],
+						},
+						groundingMetadata: {
+							groundingChunks: [{ maps: { uri: 'https://maps.google.com/a', title: 'Place A' } }],
+							groundingSupports: [
+								{
+									segment: {}, // no endIndex
+									groundingChunkIndices: [0],
+								},
+								{
+									// no segment at all
+									groundingChunkIndices: [0],
+								},
+							],
+						},
+					},
+				],
+			};
+
+			mockGenAI.models.generateContent.mockResolvedValue(mockResponse);
+
+			const result = await tool.execute({ query: 'test' }, mockContext);
+
+			expect(result.success).toBe(true);
+			expect(result.data.answer).toBe('Some text here');
+		});
+
+		it('should filter out citation links when a chunk has no URI', async () => {
+			const mockResponse = {
+				candidates: [
+					{
+						content: {
+							parts: [{ text: 'Hello world' }],
+						},
+						groundingMetadata: {
+							groundingChunks: [
+								{ maps: { uri: 'https://maps.google.com/a' } },
+								{ maps: {} }, // chunk without URI
+							],
+							groundingSupports: [
+								{
+									segment: { endIndex: 11 },
+									groundingChunkIndices: [0, 1], // index 1 has no URI
+								},
+							],
+						},
+					},
+				],
+			};
+
+			mockGenAI.models.generateContent.mockResolvedValue(mockResponse);
+
+			const result = await tool.execute({ query: 'test' }, mockContext);
+
+			expect(result.success).toBe(true);
+			expect(result.data.answer).toBe('Hello world [1](https://maps.google.com/a)');
+		});
+	});
+
+	describe('result.text fallback path', () => {
+		it('should extract text from result.text when candidates is missing', async () => {
+			const mockResponse = {
+				// no candidates
+				text: 'Fallback text from result.text',
+			};
+
+			mockGenAI.models.generateContent.mockResolvedValue(mockResponse);
+
+			const result = await tool.execute({ query: 'test' }, mockContext);
+
+			expect(result.success).toBe(true);
+			expect(result.data.originalAnswer).toBe('Fallback text from result.text');
+			expect(result.data.answer).toBe('Fallback text from result.text');
+		});
+	});
+
+	describe('getProgressDescription', () => {
+		it('should return full query when shorter than 30 chars', () => {
+			const desc = tool.getProgressDescription({ query: 'pizza nearby' });
+			expect(desc).toBe('Searching Maps for "pizza nearby"');
+		});
+
+		it('should truncate query longer than 30 chars with ellipsis', () => {
+			const longQuery = 'best ramen restaurants in the entire bay area';
+			const desc = tool.getProgressDescription({ query: longQuery });
+			expect(desc).toBe(`Searching Maps for "${longQuery.substring(0, 27)}..."`);
+			expect(desc).toContain('...');
+		});
+
+		it('should return generic message for empty query', () => {
+			const desc = tool.getProgressDescription({ query: '' });
+			expect(desc).toBe('Searching Google Maps');
+		});
+	});
+
+	describe('non-Error thrown by API', () => {
+		it('should include Unknown error for non-Error thrown', async () => {
+			mockGenAI.models.generateContent.mockRejectedValue('string error');
+
+			const result = await tool.execute({ query: 'test' }, mockContext);
+
+			expect(result.success).toBe(false);
+			expect(result.error).toBe('Google Maps lookup failed: Unknown error');
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Fixes #585. Adds a **Google Maps grounding** agent tool, implemented the same way as `google_search`: a separate Gemini model instance with the `googleMaps` grounding tool enabled. The agent can now answer real-world place/location questions — businesses, points of interest, addresses, opening hours, ratings/reviews, and "near me" style queries — with inline citations and links to the referenced places.

## Changes

- **New `GoogleMapsTool`** (`src/tools/google-maps-tool.ts`) — `read_only` / `EXTERNAL`, config `tools: [{ googleMaps: {} }]`. Extracts place citations from `groundingMetadata.groundingChunks[].maps` (`uri`/`title`/`text`) and inserts inline citation links from `groundingSupports`, mirroring the search tool's citation logic.
- **Registration** — added to `getWebTools()`, so it auto-registers for the Gemini provider (skipped on Ollama like the other web tools).
- **Wiring** — `TOOL_PRIORITY` (EXTERNAL band, `google_maps: 23`), `tool-execution-logger` key param (`query`), and the agent view (`map-pin` icon + the existing citation renderer extended to cover `google_maps`).
- **Tests** — `test/tools/google-maps-tool.test.ts` (20 cases) mirroring `google-search-tool.test.ts`: success path, maps-chunk citation extraction, inline citation insertion, error/fallback paths, progress descriptions.
- **Docs** — documented under Web & Research Operations in `docs/guide/agent-mode.md`.

No new settings — the tool follows the same always-available pattern as `google_search` and is gated only by the Gemini provider. SDK support confirmed in `@google/genai` 2.7.0 (`Tool.googleMaps`, `GroundingChunk.maps`).

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A: provider-gated tool reusing the existing web-tool registration path; no platform-specific code
- [x] Documentation has been updated (if applicable)
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Google Maps tool for real-world place/location lookups with inline citations (Gemini provider only).

* **UI**
  * Tool now appears with a map-pin icon and displays answers with inline place citations like other search tools.

* **Documentation**
  * Added guide entry and usage examples for the Google Maps tool.

* **Tests**
  * Added comprehensive tests covering Google Maps tool behavior and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->