### PR TITLE
feat(agent): persist and display model reasoning (thoughts)

### DIFF
--- a/docs/guide/agent-mode.md
+++ b/docs/guide/agent-mode.md
@@ -189,10 +189,11 @@ For detailed information about context files and advanced usage, see the [Contex
 
 When you use a thinking model (e.g. Gemini 2.5 Pro), the agent captures the model's reasoning ("thinking") for each turn and keeps it after the response completes:
 
-- A collapsed **Reasoning** section appears below each model message — expand it to see how the model worked through the request. It stays collapsed by default so it doesn't clutter the conversation.
-- Reasoning the model produces _before_ deciding to call tools is preserved too, as its own reasoning-only entry — so a session reads as the full arc: your request → the model's reasoning → the tools it ran → its answer (and the reasoning behind it).
-- Reasoning is persisted to the session history file as a collapsed `[!reasoning]` callout, so it round-trips when you reopen a past session. This makes session files a faithful, self-contained record of the whole interaction.
-- Sessions created before this feature simply have no reasoning sections — nothing changes for them.
+- Each reasoning step shows as a collapsed **🧠 Reasoning** line (collapsed by default) — click to expand and see how the model worked through that step.
+- During a tool-using turn, reasoning is **interleaved into the tool activity block** alongside the tool calls, in the order it happened (reason → call tools → reason → call more tools). Expand the activity block to see the full stream.
+- The final answer's reasoning appears as a 🧠 line directly beneath the answer.
+- Reasoning is persisted to the session history file as a collapsed `[!reasoning]` callout, so it round-trips when you reopen a past session — making session files a faithful, self-contained record of the whole interaction: your request → reasoning → tools → answer.
+- Sessions created before this feature simply have no reasoning lines — nothing changes for them.
 
 ## Available Tools
 

--- a/docs/guide/agent-mode.md
+++ b/docs/guide/agent-mode.md
@@ -185,6 +185,15 @@ For detailed information about context files and advanced usage, see the [Contex
 - All files the agent reads or writes during a session are tracked in `accessed_files` frontmatter for auditing and session recall
 - Tool execution summaries are logged to session history as collapsible callout blocks (controlled by the `logToolExecution` setting)
 
+### Model Reasoning
+
+When you use a thinking model (e.g. Gemini 2.5 Pro), the agent captures the model's reasoning ("thinking") for each turn and keeps it after the response completes:
+
+- A collapsed **Reasoning** section appears below each model message — expand it to see how the model worked through the request. It stays collapsed by default so it doesn't clutter the conversation.
+- Reasoning the model produces _before_ deciding to call tools is preserved too, as its own reasoning-only entry — so a session reads as the full arc: your request → the model's reasoning → the tools it ran → its answer (and the reasoning behind it).
+- Reasoning is persisted to the session history file as a collapsed `[!reasoning]` callout, so it round-trips when you reopen a past session. This makes session files a faithful, self-contained record of the whole interaction.
+- Sessions created before this feature simply have no reasoning sections — nothing changes for them.
+
 ## Available Tools
 
 ### Read-Only Tools

--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -47,6 +47,15 @@ export interface AgentLoopHooks {
 	onFollowUpRequestStart?(): void | Promise<void>;
 	/** Fired when the loop falls into the empty-response retry path. */
 	onEmptyResponseRetry?(): void | Promise<void>;
+	/**
+	 * Fired when an intermediate follow-up response carries model reasoning but
+	 * continues to another tool batch (i.e. the model "thought" before deciding
+	 * to call more tools). UI/headless callers use this to persist a
+	 * reasoning-only model turn so the full session — user → reasoning → tools →
+	 * reasoning → answer — is captured. The terminal response's reasoning is
+	 * returned on `AgentLoopResult.thoughts` instead, not via this hook.
+	 */
+	onModelReasoning?(thoughts: string): void | Promise<void>;
 }
 
 export interface AgentLoopOptions {
@@ -112,6 +121,14 @@ export interface AgentLoopResult {
 	 * (which the caller may display but should not save to session history).
 	 */
 	markdown: string;
+	/**
+	 * Model reasoning ("thinking") from the terminal follow-up response that
+	 * produced `markdown`. Undefined when the model emitted no thoughts or the
+	 * turn ended without a text response. The caller attaches this to the final
+	 * model history entry. Intermediate reasoning (before further tool batches)
+	 * is surfaced via the `onModelReasoning` hook instead, not here.
+	 */
+	thoughts?: string;
 	/** Final conversation history including all tool turns. */
 	history: Content[];
 	/** True if cancellation interrupted the loop. */
@@ -327,6 +344,13 @@ export class AgentLoop {
 			}
 
 			if (followUpResponse.toolCalls && followUpResponse.toolCalls.length > 0) {
+				// Surface intermediate reasoning (the "why I'm calling these tools"
+				// thinking) so the caller can persist a reasoning-only turn before
+				// the next tool batch runs.
+				if (followUpResponse.thoughts?.trim()) {
+					await this.safeHook('onModelReasoning', plugin, () => hooks?.onModelReasoning?.(followUpResponse.thoughts!));
+				}
+
 				// Continue iterating with the new tool calls.
 				if (isCancelled()) {
 					return this.cancelledResult(updatedHistory, iterations);
@@ -344,6 +368,7 @@ export class AgentLoop {
 			if (followUpResponse.markdown && followUpResponse.markdown.trim()) {
 				return {
 					markdown: followUpResponse.markdown,
+					thoughts: followUpResponse.thoughts?.trim() ? followUpResponse.thoughts : undefined,
 					history: updatedHistory,
 					cancelled: false,
 					retried: false,
@@ -383,6 +408,7 @@ export class AgentLoop {
 			if (retryResponse.markdown && retryResponse.markdown.trim()) {
 				return {
 					markdown: retryResponse.markdown,
+					thoughts: retryResponse.thoughts?.trim() ? retryResponse.thoughts : undefined,
 					history: updatedHistory,
 					cancelled: false,
 					retried: true,

--- a/src/agent/session-history.ts
+++ b/src/agent/session-history.ts
@@ -90,7 +90,12 @@ export class SessionHistory {
 
 		// Generate the new entry content
 		const role = entry.role.charAt(0).toUpperCase() + entry.role.slice(1);
-		const messageLines = entry.message.split('\n');
+		const hasMessage = entry.message.trim().length > 0;
+		const messageLines = hasMessage ? entry.message.split('\n') : [];
+		// Model reasoning, when present, is serialized as a collapsed
+		// `[!reasoning]` callout. A model entry may carry thoughts with no
+		// message (reasoning produced before the model decided to call tools).
+		const thoughtLines = entry.thoughts?.trim() ? entry.thoughts.split('\n') : null;
 
 		// Use configured user name for user entries, capitalized role for model
 		const userDisplayName = (this.plugin.settings.userName ?? '').trim();
@@ -102,7 +107,9 @@ export class SessionHistory {
 		const entryContent = this.entryTemplate({
 			role: role,
 			displayName: displayName,
+			hasMessage: hasMessage,
 			messageLines: messageLines,
+			thoughtLines: thoughtLines,
 			timestamp: formatLocalTimestamp(entryTimestamp),
 			pluginVersion: this.plugin.manifest.version,
 			model: entry.model,
@@ -208,79 +215,102 @@ export class SessionHistory {
 			const roleMatch = section.match(/^## (.+?)\s*$/m);
 			if (!roleMatch) continue;
 
-			// Extract message content from callout blocks
-			// Look for > [!user]+ or > [!assistant]+ blocks
+			const lines = section.split('\n');
+
+			// Extract the message from the `> [!user]+` / `> [!assistant]+` callout.
 			const calloutRegex = /^> \[!(user|assistant)\]\+\s*$/m;
 			const calloutMatch = section.match(calloutRegex);
-
+			let role: 'user' | 'model' | null = null;
+			let message = '';
 			if (calloutMatch) {
-				const role = calloutMatch[1] === 'user' ? 'user' : 'model';
-
-				// Extract lines after the callout marker
-				const lines = section.split('\n');
+				role = calloutMatch[1] === 'user' ? 'user' : 'model';
 				const calloutIndex = lines.findIndex((line) => calloutRegex.test(line));
-
 				if (calloutIndex !== -1) {
-					const messageLines: string[] = [];
-					let inMessage = false;
-
-					for (let i = calloutIndex + 1; i < lines.length; i++) {
-						const line = lines[i];
-
-						// Stop at metadata blocks or empty lines after content
-						if (line.startsWith('> [!metadata]') || (messageLines.length > 0 && !line.startsWith('>'))) {
-							break;
-						}
-
-						// Extract content from quoted lines
-						if (line.startsWith('> ')) {
-							messageLines.push(line.substring(2));
-							inMessage = true;
-						} else if (inMessage) {
-							// Stop if we hit a non-quoted line after starting
-							break;
-						}
-					}
-
-					const message = messageLines.join('\n').trim();
-
-					if (message) {
-						// Extract timestamp from metadata if available
-						const timeMatch = section.match(/\| Time \| ([^|]+) \|/);
-						const timestamp = timeMatch ? new Date(timeMatch[1].trim()) : new Date();
-
-						// Extract model info if available
-						const modelMatch = section.match(/\| Model \| ([^|]+) \|/);
-						const model = modelMatch ? modelMatch[1].trim() : undefined;
-
-						// Check for tool execution info
-						const toolNameMatch = section.match(/\*\*Tool:\*\* `([^`]+)`/);
-						const toolStatusMatch = section.match(/\*\*Status:\*\* (Success|Error)/);
-
-						const entry: GeminiConversationEntry = {
-							role,
-							message,
-							notePath: '',
-							created_at: timestamp,
-							model,
-						};
-
-						// Add tool execution info if found
-						if (toolNameMatch) {
-							entry.metadata = {
-								...entry.metadata,
-								toolName: toolNameMatch[1],
-								toolStatus: toolStatusMatch ? toolStatusMatch[1].toLowerCase() : undefined,
-							};
-						}
-
-						entries.push(entry);
-					}
+					message = this.extractCalloutBody(lines, calloutIndex).join('\n').trim();
 				}
+			}
+
+			// Extract model reasoning from the optional `> [!reasoning]-` callout.
+			// A section with reasoning but no message callout is a "reasoning-only"
+			// model turn (thoughts the model produced before calling tools).
+			const reasoningIndex = lines.findIndex((line) => /^> \[!reasoning\]-/.test(line));
+			let thoughts: string | undefined;
+			if (reasoningIndex !== -1) {
+				const body = this.extractCalloutBody(lines, reasoningIndex).join('\n').trim();
+				if (body) {
+					thoughts = body;
+					if (!role) role = 'model';
+				}
+			}
+
+			if (role && (message || thoughts)) {
+				// Extract timestamp from metadata if available
+				const timeMatch = section.match(/\| Time \| ([^|]+) \|/);
+				const timestamp = timeMatch ? new Date(timeMatch[1].trim()) : new Date();
+
+				// Extract model info if available
+				const modelMatch = section.match(/\| Model \| ([^|]+) \|/);
+				const model = modelMatch ? modelMatch[1].trim() : undefined;
+
+				// Check for tool execution info
+				const toolNameMatch = section.match(/\*\*Tool:\*\* `([^`]+)`/);
+				const toolStatusMatch = section.match(/\*\*Status:\*\* (Success|Error)/);
+
+				const entry: GeminiConversationEntry = {
+					role,
+					message,
+					notePath: '',
+					created_at: timestamp,
+					model,
+				};
+
+				if (thoughts) {
+					entry.thoughts = thoughts;
+				}
+
+				// Add tool execution info if found
+				if (toolNameMatch) {
+					entry.metadata = {
+						...entry.metadata,
+						toolName: toolNameMatch[1],
+						toolStatus: toolStatusMatch ? toolStatusMatch[1].toLowerCase() : undefined,
+					};
+				}
+
+				entries.push(entry);
 			}
 		}
 
 		return entries;
+	}
+
+	/**
+	 * Collect the de-quoted body lines of a callout. `startIndex` is the index
+	 * of the callout marker line (e.g. `> [!assistant]+`). Stops at the next
+	 * callout marker (`> [!...]`), or at the first non-quoted line once content
+	 * has started. Bare `>` lines are preserved as blank body lines so
+	 * multi-paragraph messages and reasoning round-trip intact.
+	 */
+	private extractCalloutBody(lines: string[], startIndex: number): string[] {
+		const body: string[] = [];
+		let started = false;
+		for (let i = startIndex + 1; i < lines.length; i++) {
+			const line = lines[i];
+			// Stop at the next callout (metadata, reasoning, user, assistant, …).
+			if (/^> \[!/.test(line)) break;
+			if (line.startsWith('> ')) {
+				body.push(line.substring(2));
+				started = true;
+			} else if (line === '>') {
+				body.push('');
+				started = true;
+			} else if (started) {
+				// A non-quoted line after content ends the callout.
+				break;
+			}
+			// Leading blank/non-quoted lines before content are skipped.
+		}
+		return body;
 	}
 
 	/**

--- a/src/agent/session-history.ts
+++ b/src/agent/session-history.ts
@@ -210,11 +210,10 @@ export class SessionHistory {
 		for (const section of contentSections) {
 			if (!section.trim()) continue;
 
-			// Look for role header — ## Assistant/Model for AI, or any other name for user
-			// The callout type (> [!user]+ or > [!assistant]+) determines the actual role
-			const roleMatch = section.match(/^## (.+?)\s*$/m);
-			if (!roleMatch) continue;
-
+			// An entry is identified by its callout, not a `## ` header: user and
+			// assistant turns carry a header + metadata, but streamlined
+			// reasoning-only turns are just a `> [!reasoning]-` callout. The role
+			// is derived from the callout type below.
 			const lines = section.split('\n');
 
 			// Extract the message from the `> [!user]+` / `> [!assistant]+` callout.

--- a/src/agent/session-history.ts
+++ b/src/agent/session-history.ts
@@ -210,73 +210,72 @@ export class SessionHistory {
 		for (const section of contentSections) {
 			if (!section.trim()) continue;
 
-			// An entry is identified by its callout, not a `## ` header: user and
-			// assistant turns carry a header + metadata, but streamlined
-			// reasoning-only turns are just a `> [!reasoning]-` callout. The role
-			// is derived from the callout type below.
+			// A section can hold more than one entry: a streamlined activity run
+			// is several `> [!reasoning]-` callouts (and `> [!tools]-` logs) with no
+			// `---` between them, and the final-answer section is an
+			// `> [!assistant]+` message followed by its reasoning. Walk every callout
+			// in order rather than assuming one entry per section.
 			const lines = section.split('\n');
 
-			// Extract the message from the `> [!user]+` / `> [!assistant]+` callout.
-			const calloutRegex = /^> \[!(user|assistant)\]\+\s*$/m;
-			const calloutMatch = section.match(calloutRegex);
-			let role: 'user' | 'model' | null = null;
-			let message = '';
-			if (calloutMatch) {
-				role = calloutMatch[1] === 'user' ? 'user' : 'model';
-				const calloutIndex = lines.findIndex((line) => calloutRegex.test(line));
-				if (calloutIndex !== -1) {
-					message = this.extractCalloutBody(lines, calloutIndex).join('\n').trim();
-				}
-			}
+			// Section-level metadata (timestamp / model) lives in the `## ` header's
+			// Message Info table and applies to the message entry in the section.
+			const timeMatch = section.match(/\| Time \| ([^|]+) \|/);
+			const sectionTimestamp = timeMatch ? new Date(timeMatch[1].trim()) : new Date();
+			const modelMatch = section.match(/\| Model \| ([^|]+) \|/);
+			const sectionModel = modelMatch ? modelMatch[1].trim() : undefined;
+			const toolNameMatch = section.match(/\*\*Tool:\*\* `([^`]+)`/);
+			const toolStatusMatch = section.match(/\*\*Status:\*\* (Success|Error)/);
 
-			// Extract model reasoning from the optional `> [!reasoning]-` callout.
-			// A section with reasoning but no message callout is a "reasoning-only"
-			// model turn (thoughts the model produced before calling tools).
-			const reasoningIndex = lines.findIndex((line) => /^> \[!reasoning\]-/.test(line));
-			let thoughts: string | undefined;
-			if (reasoningIndex !== -1) {
-				const body = this.extractCalloutBody(lines, reasoningIndex).join('\n').trim();
-				if (body) {
-					thoughts = body;
-					if (!role) role = 'model';
-				}
-			}
+			// The most recent entry created in this section — a reasoning callout that
+			// immediately follows an answer attaches to it as `thoughts`; otherwise
+			// it's a standalone reasoning-only turn.
+			let lastInSection: GeminiConversationEntry | null = null;
 
-			if (role && (message || thoughts)) {
-				// Extract timestamp from metadata if available
-				const timeMatch = section.match(/\| Time \| ([^|]+) \|/);
-				const timestamp = timeMatch ? new Date(timeMatch[1].trim()) : new Date();
+			for (let i = 0; i < lines.length; i++) {
+				const messageMatch = lines[i].match(/^> \[!(user|assistant)\]\+\s*$/);
+				if (messageMatch) {
+					const role = messageMatch[1] === 'user' ? 'user' : 'model';
+					const message = this.extractCalloutBody(lines, i).join('\n').trim();
+					if (!message) continue;
 
-				// Extract model info if available
-				const modelMatch = section.match(/\| Model \| ([^|]+) \|/);
-				const model = modelMatch ? modelMatch[1].trim() : undefined;
-
-				// Check for tool execution info
-				const toolNameMatch = section.match(/\*\*Tool:\*\* `([^`]+)`/);
-				const toolStatusMatch = section.match(/\*\*Status:\*\* (Success|Error)/);
-
-				const entry: GeminiConversationEntry = {
-					role,
-					message,
-					notePath: '',
-					created_at: timestamp,
-					model,
-				};
-
-				if (thoughts) {
-					entry.thoughts = thoughts;
-				}
-
-				// Add tool execution info if found
-				if (toolNameMatch) {
-					entry.metadata = {
-						...entry.metadata,
-						toolName: toolNameMatch[1],
-						toolStatus: toolStatusMatch ? toolStatusMatch[1].toLowerCase() : undefined,
+					const entry: GeminiConversationEntry = {
+						role,
+						message,
+						notePath: '',
+						created_at: sectionTimestamp,
+						model: sectionModel,
 					};
+					if (toolNameMatch) {
+						entry.metadata = {
+							toolName: toolNameMatch[1],
+							toolStatus: toolStatusMatch ? toolStatusMatch[1].toLowerCase() : undefined,
+						};
+					}
+					entries.push(entry);
+					lastInSection = entry;
+					continue;
 				}
 
-				entries.push(entry);
+				if (/^> \[!reasoning\]-/.test(lines[i])) {
+					const body = this.extractCalloutBody(lines, i).join('\n').trim();
+					if (!body) continue;
+
+					if (lastInSection && lastInSection.role === 'model' && lastInSection.message && !lastInSection.thoughts) {
+						// Reasoning that follows an answer is that answer's thinking.
+						lastInSection.thoughts = body;
+					} else {
+						const entry: GeminiConversationEntry = {
+							role: 'model',
+							message: '',
+							notePath: '',
+							created_at: sectionTimestamp,
+							model: sectionModel,
+							thoughts: body,
+						};
+						entries.push(entry);
+						lastInSection = entry;
+					}
+				}
 			}
 		}
 

--- a/src/history/templates/historyEntry.hbs
+++ b/src/history/templates/historyEntry.hbs
@@ -6,6 +6,7 @@
 ---
 
 {{/if}}
+{{#if hasMessage}}
 ## {{displayName}}
 
 > [!metadata]- Message Info
@@ -28,7 +29,6 @@
 > | Context | {{context}} |
 {{/if}}
 
-{{#if hasMessage}}
 {{#if (eq role "User")}}
 > [!user]+
 {{else}}
@@ -46,4 +46,4 @@
 {{/each}}
 
 {{/if}}
---- 
+---

--- a/src/history/templates/historyEntry.hbs
+++ b/src/history/templates/historyEntry.hbs
@@ -28,6 +28,7 @@
 > | Context | {{context}} |
 {{/if}}
 
+{{#if hasMessage}}
 {{#if (eq role "User")}}
 > [!user]+
 {{else}}
@@ -37,4 +38,12 @@
 > {{{this}}}
 {{/each}}
 
+{{/if}}
+{{#if thoughtLines}}
+> [!reasoning]- Reasoning
+{{#each thoughtLines}}
+> {{{this}}}
+{{/each}}
+
+{{/if}}
 --- 

--- a/src/history/templates/historyEntry.hbs
+++ b/src/history/templates/historyEntry.hbs
@@ -46,4 +46,6 @@
 {{/each}}
 
 {{/if}}
+{{#if hasMessage}}
 ---
+{{/if}}

--- a/src/types/conversation.ts
+++ b/src/types/conversation.ts
@@ -11,4 +11,13 @@ export interface GeminiConversationEntry extends BasicGeminiConversationEntry {
 	notePath: string;
 	created_at: Date;
 	metadata?: Record<string, any>;
+	/**
+	 * Model reasoning ("thinking") captured for this turn, when the model is a
+	 * thinking model and emitted thought summaries. Persisted to session history
+	 * as a collapsed `[!reasoning]` callout and rendered as a collapsible section
+	 * below the message. A model entry may carry `thoughts` with an empty
+	 * `message` — that represents reasoning the model produced before deciding to
+	 * call tools (a "reasoning-only" turn).
+	 */
+	thoughts?: string;
 }

--- a/src/ui/agent-view/agent-view-messages.ts
+++ b/src/ui/agent-view/agent-view-messages.ts
@@ -84,6 +84,18 @@ export class AgentViewMessages {
 			emptyState.remove();
 		}
 
+		// Reasoning-only turn (the model thought but produced no text — e.g. before
+		// calling tools). Render it as a bare collapsible line in the conversation
+		// flow, with no "Agent" message header, so reasoning steps don't each spawn
+		// a new attribution.
+		if (entry.role === 'model' && !entry.message.trim() && entry.thoughts?.trim()) {
+			const sourcePath = currentSession?.historyPath || '';
+			await this.renderReasoningSection(this.chatContainer, entry.thoughts, sourcePath);
+			this.scrollToBottom();
+			this.chatContainer.scrollTop = this.chatContainer.scrollHeight;
+			return;
+		}
+
 		const messageDiv = this.chatContainer.createDiv({
 			cls: `gemini-agent-message gemini-agent-message-${entry.role}`,
 		});
@@ -236,17 +248,16 @@ export class AgentViewMessages {
 	}
 
 	/**
-	 * Render model reasoning ("thinking") as a collapsed, expandable block that
-	 * mirrors the tool-execution rows — a bordered box with a 🧠 header that
-	 * toggles open. Shared by the live-stream finalizer and history re-rendering
-	 * so reasoning looks the same whether it just arrived or was loaded from a
-	 * session file.
+	 * Render model reasoning ("thinking") as a single collapsible line that
+	 * mirrors a tool-execution row — a 🧠 header that toggles open — but without
+	 * the surrounding group box. Shared by the live-stream finalizer, the
+	 * reasoning-only renderer, and history re-rendering so reasoning looks the
+	 * same whether it just arrived or was loaded from a session file.
 	 */
 	private async renderReasoningSection(parent: HTMLElement, thoughts: string, sourcePath: string): Promise<void> {
-		// Reuse the tool-group/tool-row structure and styling so reasoning reads
-		// as the same kind of collapsible element as a tool call.
-		const block = parent.createDiv({ cls: 'gemini-tool-group gemini-reasoning-block' });
-		const row = block.createDiv({ cls: 'gemini-tool-row gemini-reasoning-row' });
+		// Reuse the tool-row structure/styling (no group wrapper) so reasoning
+		// reads as the same kind of collapsible line as a tool call.
+		const row = parent.createDiv({ cls: 'gemini-tool-row gemini-reasoning-row' });
 
 		const header = row.createDiv({ cls: 'gemini-tool-row-header' });
 		header.setAttribute('role', 'button');

--- a/src/ui/agent-view/agent-view-messages.ts
+++ b/src/ui/agent-view/agent-view-messages.ts
@@ -782,8 +782,15 @@ export class AgentViewMessages {
 				allowBtn.removeEventListener('click', allowHandler);
 				cancelBtn.removeEventListener('click', cancelHandler);
 
-				// Update message to show result
-				this.updateConfirmationResult(messageDiv, confirmed, tool.displayName || tool.name);
+				// On grant, drop the request card from the main flow — the caller
+				// renders a "permission granted" row into the tool stack instead, so
+				// the acknowledgment lives next to the tool it authorized. Denials
+				// stay in the main flow as a visible interruption.
+				if (confirmed) {
+					messageDiv.remove();
+				} else {
+					this.updateConfirmationResult(messageDiv, confirmed, tool.displayName || tool.name);
+				}
 
 				// Resolve Promise
 				resolve({

--- a/src/ui/agent-view/agent-view-messages.ts
+++ b/src/ui/agent-view/agent-view-messages.ts
@@ -199,14 +199,19 @@ export class AgentViewMessages {
 			await MarkdownRenderer.render(this.app, formattedMessage, content, sourcePath, this.viewContext);
 		}
 
+		// Render model reasoning as a collapsible section below the message.
+		if (entry.role === 'model' && entry.thoughts?.trim()) {
+			await this.renderReasoningSection(content, entry.thoughts, sourcePath);
+		}
+
 		// Scroll to bottom after displaying message
 		this.scrollToBottom();
 
 		// Setup image click handlers
 		this.setupImageClickHandlers(content, sourcePath);
 
-		// Add a copy button for both user and model messages
-		if (entry.role === 'model' || entry.role === 'user') {
+		// Add a copy button for messages with visible text (skip reasoning-only turns).
+		if ((entry.role === 'model' || entry.role === 'user') && renderMessage.trim()) {
 			const copyButton = content.createEl('button', {
 				cls: 'gemini-agent-copy-button',
 			});
@@ -228,6 +233,29 @@ export class AgentViewMessages {
 
 		// Auto-scroll to bottom
 		this.chatContainer.scrollTop = this.chatContainer.scrollHeight;
+	}
+
+	/**
+	 * Render model reasoning ("thinking") as a collapsed, expandable section.
+	 * Shared by the live-stream finalizer and history re-rendering so reasoning
+	 * looks the same whether it just arrived or was loaded from a session file.
+	 */
+	private async renderReasoningSection(parent: HTMLElement, thoughts: string, sourcePath: string): Promise<void> {
+		const section = parent.createDiv({ cls: 'gemini-agent-reasoning' });
+
+		const header = section.createDiv({ cls: 'gemini-agent-reasoning-header' });
+		const icon = header.createEl('span', { cls: 'gemini-agent-reasoning-icon' });
+		setIcon(icon, 'chevron-right');
+		header.createEl('span', { text: 'Reasoning', cls: 'gemini-agent-reasoning-label' });
+
+		const body = section.createDiv({ cls: 'gemini-agent-reasoning-content is-collapsed' });
+		await MarkdownRenderer.render(this.app, formatModelMessage(thoughts), body, sourcePath, this.viewContext);
+
+		header.addEventListener('click', () => {
+			const collapsed = body.hasClass('is-collapsed');
+			body.toggleClass('is-collapsed', !collapsed);
+			setIcon(icon, collapsed ? 'chevron-down' : 'chevron-right');
+		});
 	}
 
 	/**
@@ -294,6 +322,11 @@ export class AgentViewMessages {
 
 			const sourcePath = currentSession?.historyPath || '';
 			await MarkdownRenderer.render(this.app, formattedMessage, messageDiv, sourcePath, this.viewContext);
+
+			// Render model reasoning as a collapsible section below the message.
+			if (entry.role === 'model' && entry.thoughts?.trim()) {
+				await this.renderReasoningSection(messageDiv, entry.thoughts, sourcePath);
+			}
 
 			// Add a copy button for model messages
 			if (entry.role === 'model') {

--- a/src/ui/agent-view/agent-view-messages.ts
+++ b/src/ui/agent-view/agent-view-messages.ts
@@ -248,6 +248,15 @@ export class AgentViewMessages {
 	}
 
 	/**
+	 * Public entry point to render a reasoning line into an arbitrary container —
+	 * e.g. the tool group body, so reasoning interleaves with tool rows. Shares
+	 * the single row renderer so live and reload reasoning look identical.
+	 */
+	async renderReasoningInto(container: HTMLElement, thoughts: string, sourcePath: string): Promise<void> {
+		await this.renderReasoningSection(container, thoughts, sourcePath);
+	}
+
+	/**
 	 * Render model reasoning ("thinking") as a single collapsible line that
 	 * mirrors a tool-execution row — a 🧠 header that toggles open — but without
 	 * the surrounding group box. Shared by the live-stream finalizer, the

--- a/src/ui/agent-view/agent-view-messages.ts
+++ b/src/ui/agent-view/agent-view-messages.ts
@@ -371,8 +371,9 @@ export class AgentViewMessages {
 				await this.renderReasoningSection(messageDiv, entry.thoughts, sourcePath);
 			}
 
-			// Add a copy button for model messages
-			if (entry.role === 'model') {
+			// Add a copy button only when there's visible message text — mirrors the
+			// reasoning-only suppression in displayMessage.
+			if (entry.role === 'model' && fullMarkdown.trim()) {
 				const copyButton = messageDiv.createEl('button', {
 					cls: 'gemini-agent-copy-button',
 				});

--- a/src/ui/agent-view/agent-view-messages.ts
+++ b/src/ui/agent-view/agent-view-messages.ts
@@ -236,25 +236,48 @@ export class AgentViewMessages {
 	}
 
 	/**
-	 * Render model reasoning ("thinking") as a collapsed, expandable section.
-	 * Shared by the live-stream finalizer and history re-rendering so reasoning
-	 * looks the same whether it just arrived or was loaded from a session file.
+	 * Render model reasoning ("thinking") as a collapsed, expandable block that
+	 * mirrors the tool-execution rows — a bordered box with a 🧠 header that
+	 * toggles open. Shared by the live-stream finalizer and history re-rendering
+	 * so reasoning looks the same whether it just arrived or was loaded from a
+	 * session file.
 	 */
 	private async renderReasoningSection(parent: HTMLElement, thoughts: string, sourcePath: string): Promise<void> {
-		const section = parent.createDiv({ cls: 'gemini-agent-reasoning' });
+		// Reuse the tool-group/tool-row structure and styling so reasoning reads
+		// as the same kind of collapsible element as a tool call.
+		const block = parent.createDiv({ cls: 'gemini-tool-group gemini-reasoning-block' });
+		const row = block.createDiv({ cls: 'gemini-tool-row gemini-reasoning-row' });
 
-		const header = section.createDiv({ cls: 'gemini-agent-reasoning-header' });
-		const icon = header.createEl('span', { cls: 'gemini-agent-reasoning-icon' });
-		setIcon(icon, 'chevron-right');
-		header.createEl('span', { text: 'Reasoning', cls: 'gemini-agent-reasoning-label' });
+		const header = row.createDiv({ cls: 'gemini-tool-row-header' });
+		header.setAttribute('role', 'button');
+		header.setAttribute('tabindex', '0');
+		header.setAttribute('aria-expanded', 'false');
 
-		const body = section.createDiv({ cls: 'gemini-agent-reasoning-content is-collapsed' });
-		await MarkdownRenderer.render(this.app, formatModelMessage(thoughts), body, sourcePath, this.viewContext);
+		const icon = header.createSpan({ cls: 'gemini-tool-row-icon gemini-reasoning-row-icon' });
+		icon.setText('🧠');
 
-		header.addEventListener('click', () => {
-			const collapsed = body.hasClass('is-collapsed');
-			body.toggleClass('is-collapsed', !collapsed);
-			setIcon(icon, collapsed ? 'chevron-down' : 'chevron-right');
+		header.createSpan({ text: 'Reasoning', cls: 'gemini-tool-row-name' });
+
+		const chevron = header.createSpan({ cls: 'gemini-tool-row-chevron' });
+		setIcon(chevron, 'chevron-right');
+
+		const details = row.createDiv({ cls: 'gemini-tool-row-details gemini-reasoning-row-details' });
+		details.style.display = 'none';
+		await MarkdownRenderer.render(this.app, formatModelMessage(thoughts), details, sourcePath, this.viewContext);
+
+		const toggle = () => {
+			const nowExpanded = header.getAttribute('aria-expanded') !== 'true';
+			details.style.display = nowExpanded ? 'block' : 'none';
+			setIcon(chevron, nowExpanded ? 'chevron-down' : 'chevron-right');
+			row.toggleClass('gemini-tool-row-expanded', nowExpanded);
+			header.setAttribute('aria-expanded', String(nowExpanded));
+		};
+		header.addEventListener('click', toggle);
+		header.addEventListener('keydown', (e: KeyboardEvent) => {
+			if (e.key === 'Enter' || e.key === ' ') {
+				e.preventDefault();
+				toggle();
+			}
 		});
 	}
 

--- a/src/ui/agent-view/agent-view-send.ts
+++ b/src/ui/agent-view/agent-view-send.ts
@@ -431,7 +431,8 @@ To reference an attachment in your response, use the path shown above.`;
 							// User message already saved early in sendMessage()
 
 							// If there was any streamed text before tool calls, finalize it
-							if (modelMessageContainer && accumulatedMarkdown.trim()) {
+							const hadPartialText = !!(modelMessageContainer && accumulatedMarkdown.trim());
+							if (hadPartialText) {
 								const aiEntry: GeminiConversationEntry = {
 									role: 'model',
 									message: accumulatedMarkdown,
@@ -441,7 +442,7 @@ To reference an attachment in your response, use the path shown above.`;
 									...(turnThoughts ? { thoughts: turnThoughts } : {}),
 								};
 								await this.ctx.messages.finalizeStreamingMessage(
-									modelMessageContainer,
+									modelMessageContainer!,
 									accumulatedMarkdown,
 									aiEntry,
 									currentSession
@@ -449,30 +450,19 @@ To reference an attachment in your response, use the path shown above.`;
 
 								// Save partial response to history before executing tools
 								await this.ctx.plugin.sessionHistory.addEntryToSession(currentSession, aiEntry);
-							} else if (turnThoughts) {
-								// Reasoning-only turn: the model thought before deciding to
-								// call tools but produced no text. Persist it so the
-								// pre-tool reasoning isn't lost from the session record.
-								const reasoningEntry: GeminiConversationEntry = {
-									role: 'model',
-									message: '',
-									notePath: '',
-									created_at: new Date(),
-									model: modelName,
-									thoughts: turnThoughts,
-								};
-								await this.ctx.messages.displayMessage(reasoningEntry, currentSession);
-								await this.ctx.plugin.sessionHistory.addEntryToSession(currentSession, reasoningEntry);
 							}
 
-							// Execute tools and handle results
+							// Pre-tool reasoning with no accompanying text is handed to the
+							// tool handler, which renders it as the first row of the tool
+							// group (interleaved with the tools) and persists it.
 							await this.ctx.tools.handleToolCalls(
 								response.toolCalls,
 								message,
 								compactionResult.compactedHistory,
 								userEntry,
 								customPrompt,
-								perTurn
+								perTurn,
+								hadPartialText ? undefined : turnThoughts
 							);
 						} else {
 							// Normal response without tool calls
@@ -561,28 +551,16 @@ To reference an attachment in your response, use the path shown above.`;
 
 					// Check if the model requested tool calls
 					if (response.toolCalls && response.toolCalls.length > 0) {
-						// Persist any pre-tool reasoning before executing tools.
-						if (turnThoughts) {
-							const reasoningEntry: GeminiConversationEntry = {
-								role: 'model',
-								message: '',
-								notePath: '',
-								created_at: new Date(),
-								model: modelName,
-								thoughts: turnThoughts,
-							};
-							await this.ctx.displayMessage(reasoningEntry);
-							await this.ctx.plugin.sessionHistory.addEntryToSession(currentSession, reasoningEntry);
-						}
-
-						// Execute tools and handle results
+						// Pre-tool reasoning is handed to the tool handler, which renders
+						// it as the first row of the tool group and persists it.
 						await this.ctx.tools.handleToolCalls(
 							response.toolCalls,
 							message,
 							compactionResult.compactedHistory,
 							userEntry,
 							customPrompt,
-							perTurn
+							perTurn,
+							turnThoughts
 						);
 					} else {
 						// Normal response without tool calls

--- a/src/ui/agent-view/agent-view-send.ts
+++ b/src/ui/agent-view/agent-view-send.ts
@@ -420,6 +420,12 @@ To reference an attachment in your response, use the path shown above.`;
 							this.ctx.plugin.logger.debug('[AgentView] Streaming response had no usageMetadata');
 						}
 
+						// Model reasoning for this turn — prefer the completed response's
+						// thoughts; fall back to whatever streamed into the progress bar.
+						const turnThoughts = response.thoughts?.trim()
+							? response.thoughts
+							: accumulatedThoughts.trim() || undefined;
+
 						// Check if the model requested tool calls
 						if (response.toolCalls && response.toolCalls.length > 0) {
 							// User message already saved early in sendMessage()
@@ -432,6 +438,7 @@ To reference an attachment in your response, use the path shown above.`;
 									notePath: '',
 									created_at: new Date(),
 									model: modelName,
+									...(turnThoughts ? { thoughts: turnThoughts } : {}),
 								};
 								await this.ctx.messages.finalizeStreamingMessage(
 									modelMessageContainer,
@@ -442,6 +449,20 @@ To reference an attachment in your response, use the path shown above.`;
 
 								// Save partial response to history before executing tools
 								await this.ctx.plugin.sessionHistory.addEntryToSession(currentSession, aiEntry);
+							} else if (turnThoughts) {
+								// Reasoning-only turn: the model thought before deciding to
+								// call tools but produced no text. Persist it so the
+								// pre-tool reasoning isn't lost from the session record.
+								const reasoningEntry: GeminiConversationEntry = {
+									role: 'model',
+									message: '',
+									notePath: '',
+									created_at: new Date(),
+									model: modelName,
+									thoughts: turnThoughts,
+								};
+								await this.ctx.messages.displayMessage(reasoningEntry, currentSession);
+								await this.ctx.plugin.sessionHistory.addEntryToSession(currentSession, reasoningEntry);
 							}
 
 							// Execute tools and handle results
@@ -463,6 +484,7 @@ To reference an attachment in your response, use the path shown above.`;
 									notePath: '',
 									created_at: new Date(),
 									model: modelName,
+									...(turnThoughts ? { thoughts: turnThoughts } : {}),
 								};
 
 								// Finalize the streaming message with proper rendering
@@ -482,6 +504,21 @@ To reference an attachment in your response, use the path shown above.`;
 								this.ctx.messages.scrollToBottom();
 
 								// Hide progress bar after successful response
+								this.ctx.progress.hide();
+							} else if (turnThoughts) {
+								// No answer text, but the model did reason — show and persist
+								// the reasoning instead of a bare "empty response" notice.
+								const reasoningEntry: GeminiConversationEntry = {
+									role: 'model',
+									message: '',
+									notePath: '',
+									created_at: new Date(),
+									model: modelName,
+									thoughts: turnThoughts,
+								};
+								await this.ctx.messages.displayMessage(reasoningEntry, currentSession);
+								await this.ctx.plugin.sessionHistory.addEntryToSession(currentSession, reasoningEntry);
+								this.ctx.messages.scrollToBottom();
 								this.ctx.progress.hide();
 							} else {
 								// Empty response - might be thinking tokens
@@ -519,8 +556,25 @@ To reference an attachment in your response, use the path shown above.`;
 					// Update progress to show response received
 					this.ctx.progress.update('Processing response...', 'waiting');
 
+					// Model reasoning for this turn (non-streaming exposes it directly).
+					const turnThoughts = response.thoughts?.trim() ? response.thoughts : undefined;
+
 					// Check if the model requested tool calls
 					if (response.toolCalls && response.toolCalls.length > 0) {
+						// Persist any pre-tool reasoning before executing tools.
+						if (turnThoughts) {
+							const reasoningEntry: GeminiConversationEntry = {
+								role: 'model',
+								message: '',
+								notePath: '',
+								created_at: new Date(),
+								model: modelName,
+								thoughts: turnThoughts,
+							};
+							await this.ctx.displayMessage(reasoningEntry);
+							await this.ctx.plugin.sessionHistory.addEntryToSession(currentSession, reasoningEntry);
+						}
+
 						// Execute tools and handle results
 						await this.ctx.tools.handleToolCalls(
 							response.toolCalls,
@@ -541,6 +595,7 @@ To reference an attachment in your response, use the path shown above.`;
 								notePath: '',
 								created_at: new Date(),
 								model: modelName,
+								...(turnThoughts ? { thoughts: turnThoughts } : {}),
 							};
 							await this.ctx.displayMessage(aiEntry);
 
@@ -548,6 +603,19 @@ To reference an attachment in your response, use the path shown above.`;
 							await this.ctx.plugin.sessionHistory.addEntryToSession(currentSession, aiEntry);
 
 							// Hide progress bar after successful response
+							this.ctx.progress.hide();
+						} else if (turnThoughts) {
+							// No answer text, but the model reasoned — show and persist it.
+							const reasoningEntry: GeminiConversationEntry = {
+								role: 'model',
+								message: '',
+								notePath: '',
+								created_at: new Date(),
+								model: modelName,
+								thoughts: turnThoughts,
+							};
+							await this.ctx.displayMessage(reasoningEntry);
+							await this.ctx.plugin.sessionHistory.addEntryToSession(currentSession, reasoningEntry);
 							this.ctx.progress.hide();
 						} else {
 							// Empty response - might be thinking tokens

--- a/src/ui/agent-view/agent-view-tool-display.ts
+++ b/src/ui/agent-view/agent-view-tool-display.ts
@@ -224,6 +224,26 @@ export class AgentViewToolDisplay {
 	 * Show tool execution in the UI as a compact row inside a group container.
 	 * If no group container is active, creates a standalone fallback.
 	 */
+	/**
+	 * Render a compact "permission granted" row into the tool group, next to the
+	 * tool it authorized. Falls back to the main flow only if no group is active.
+	 */
+	public showPermissionGranted(toolName: string, groupContainer?: HTMLElement | null): void {
+		const body = groupContainer?.querySelector('.gemini-tool-group-body') as HTMLElement | null;
+		const target = body || this.chatContainer;
+
+		const row = target.createDiv({ cls: 'gemini-tool-row gemini-permission-row' });
+		const header = row.createDiv({ cls: 'gemini-tool-row-header' });
+
+		const icon = header.createSpan({ cls: 'gemini-tool-row-icon gemini-permission-row-icon' });
+		setIcon(icon, 'shield-check');
+
+		header.createSpan({
+			text: `Permission granted: ${toolName}`,
+			cls: 'gemini-tool-row-name',
+		});
+	}
+
 	public async showToolExecution(
 		toolName: string,
 		parameters: any,

--- a/src/ui/agent-view/agent-view-tools.ts
+++ b/src/ui/agent-view/agent-view-tools.ts
@@ -18,6 +18,8 @@ export interface AgentViewContext {
 	updateProgress(statusText: string, state?: 'thinking' | 'tool' | 'waiting' | 'streaming'): void;
 	hideProgress(): void;
 	displayMessage(entry: GeminiConversationEntry): Promise<void>;
+	/** Render a reasoning line into an arbitrary container (e.g. the tool group body). */
+	renderReasoning(container: HTMLElement, thoughts: string, sourcePath: string): Promise<void>;
 	incrementToolCallCount?(count: number): void;
 	/** Who approves tool calls that require confirmation — AgentView implements this. */
 	confirmationProvider: IConfirmationProvider;
@@ -41,6 +43,8 @@ export class AgentViewTools {
 	private lastCompletedTool: string | null = null;
 	private currentGroupContainer: HTMLElement | null = null;
 	private display: AgentViewToolDisplay;
+	/** Reasoning produced before the first tool batch, rendered into the group once it exists. */
+	private pendingReasoning: string | null = null;
 
 	constructor(
 		chatContainer: HTMLElement,
@@ -60,10 +64,25 @@ export class AgentViewTools {
 		conversationHistory: Content[],
 		_userEntry: GeminiConversationEntry,
 		customPrompt?: CustomPrompt,
-		perTurn?: PerTurnContext
+		perTurn?: PerTurnContext,
+		precedingThoughts?: string
 	) {
 		const currentSession = this.context.getCurrentSession();
 		if (!currentSession) return;
+
+		// Reasoning the model produced before this first tool batch. Render it as
+		// the first row of the tool group (once the group exists) and persist it.
+		this.pendingReasoning = precedingThoughts?.trim() ? precedingThoughts : null;
+		if (this.pendingReasoning) {
+			await this.plugin.sessionHistory.addEntryToSession(currentSession, {
+				role: 'model',
+				message: '',
+				notePath: '',
+				created_at: new Date(),
+				model: currentSession.modelConfig?.model || this.plugin.settings.chatModelName,
+				thoughts: this.pendingReasoning,
+			});
+		}
 
 		const activeProject = currentSession.projectPath
 			? await this.plugin.projectManager?.getProject(currentSession.projectPath)
@@ -86,8 +105,13 @@ export class AgentViewTools {
 					viewActions: this.context.viewActions,
 					perTurn,
 					hooks: {
-						onToolBatchStart: (batch) => {
+						onToolBatchStart: async (batch) => {
 							this.ensureGroupContainer(batch.length);
+							// Flush any pre-tool reasoning as the first row of the group.
+							if (this.pendingReasoning) {
+								await this.renderReasoningInGroup(this.pendingReasoning);
+								this.pendingReasoning = null;
+							}
 						},
 						onToolCallStart: async (toolCall, executionId, description) => {
 							this.context.updateProgress(description, 'tool');
@@ -112,18 +136,17 @@ export class AgentViewTools {
 						},
 						onModelReasoning: async (thoughts) => {
 							// Reasoning the model produced before deciding to call the
-							// next tool batch — persist it as a reasoning-only model turn
-							// and render it so the full session is captured.
-							const reasoningEntry: GeminiConversationEntry = {
+							// next tool batch — render it as a row inside the current tool
+							// group (interleaved with the tool calls) and persist it.
+							await this.renderReasoningInGroup(thoughts);
+							await this.plugin.sessionHistory.addEntryToSession(currentSession, {
 								role: 'model',
 								message: '',
 								notePath: '',
 								created_at: new Date(),
 								model: currentSession.modelConfig?.model || this.plugin.settings.chatModelName,
 								thoughts,
-							};
-							await this.context.displayMessage(reasoningEntry);
-							await this.plugin.sessionHistory.addEntryToSession(currentSession, reasoningEntry);
+							});
 						},
 					},
 				},
@@ -168,6 +191,18 @@ export class AgentViewTools {
 			this.currentGroupContainer = null;
 			this.context.hideProgress();
 		}
+	}
+
+	/**
+	 * Render a reasoning line into the current tool group's body so it interleaves
+	 * with the tool rows in execution order. No-op if there's no active group.
+	 */
+	private async renderReasoningInGroup(thoughts: string): Promise<void> {
+		if (!this.currentGroupContainer) return;
+		const body = this.currentGroupContainer.querySelector('.gemini-tool-group-body') as HTMLElement | null;
+		if (!body) return;
+		const sourcePath = this.context.getCurrentSession()?.historyPath || '';
+		await this.context.renderReasoning(body, thoughts, sourcePath);
 	}
 
 	/**

--- a/src/ui/agent-view/agent-view-tools.ts
+++ b/src/ui/agent-view/agent-view-tools.ts
@@ -110,6 +110,21 @@ export class AgentViewTools {
 						onFollowUpRequestStart: () => {
 							this.context.updateProgress('Thinking...', 'thinking');
 						},
+						onModelReasoning: async (thoughts) => {
+							// Reasoning the model produced before deciding to call the
+							// next tool batch — persist it as a reasoning-only model turn
+							// and render it so the full session is captured.
+							const reasoningEntry: GeminiConversationEntry = {
+								role: 'model',
+								message: '',
+								notePath: '',
+								created_at: new Date(),
+								model: currentSession.modelConfig?.model || this.plugin.settings.chatModelName,
+								thoughts,
+							};
+							await this.context.displayMessage(reasoningEntry);
+							await this.plugin.sessionHistory.addEntryToSession(currentSession, reasoningEntry);
+						},
 					},
 				},
 			});
@@ -135,6 +150,7 @@ export class AgentViewTools {
 				notePath: '',
 				created_at: new Date(),
 				model: currentSession.modelConfig?.model || this.plugin.settings.chatModelName,
+				...(result.thoughts ? { thoughts: result.thoughts } : {}),
 			};
 
 			await this.context.displayMessage(aiEntry);

--- a/src/ui/agent-view/agent-view-tools.ts
+++ b/src/ui/agent-view/agent-view-tools.ts
@@ -194,6 +194,16 @@ export class AgentViewTools {
 	}
 
 	/**
+	 * Render a "permission granted" acknowledgment into the current tool group,
+	 * interleaved with the tool rows. Called by the view after the user approves
+	 * a confirmation, so the acknowledgment sits in the activity stack instead of
+	 * stacking up in the main conversation flow.
+	 */
+	public showPermissionGranted(toolName: string): void {
+		this.display.showPermissionGranted(toolName, this.currentGroupContainer);
+	}
+
+	/**
 	 * Render a reasoning line into the current tool group's body so it interleaves
 	 * with the tool rows in execution order. No-op if there's no active group.
 	 */

--- a/src/ui/agent-view/agent-view.ts
+++ b/src/ui/agent-view/agent-view.ts
@@ -727,6 +727,8 @@ export class AgentView extends ItemView {
 				this.progress.update(statusText, state),
 			hideProgress: () => this.progress.hide(),
 			displayMessage: (entry: GeminiConversationEntry) => this.displayMessage(entry),
+			renderReasoning: (container: HTMLElement, thoughts: string, sourcePath: string) =>
+				this.messages.renderReasoningInto(container, thoughts, sourcePath),
 			incrementToolCallCount: (count: number) => {
 				this.send?.incrementToolCallCount(count);
 			},

--- a/src/ui/agent-view/agent-view.ts
+++ b/src/ui/agent-view/agent-view.ts
@@ -669,8 +669,14 @@ export class AgentView extends ItemView {
 		executionId: string,
 		diffContext?: import('../../tools/types').DiffContext
 	): Promise<import('../../tools/types').ConfirmationResult> {
-		// Delegate to messages component
-		return this.messages.displayConfirmationRequest(tool, parameters, executionId, diffContext);
+		// Delegate to messages component for the request card (main flow).
+		const result = await this.messages.displayConfirmationRequest(tool, parameters, executionId, diffContext);
+		// On grant, record the acknowledgment in the tool stack rather than the
+		// main flow, next to the tool it authorized.
+		if (result.confirmed) {
+			this.tools?.showPermissionGranted(tool.displayName || tool.name);
+		}
+		return result;
 	}
 
 	/**

--- a/styles.css
+++ b/styles.css
@@ -2116,6 +2116,21 @@ If your plugin does not need CSS, delete this file.
 	border-bottom: 1px solid var(--background-modifier-border);
 }
 
+/* "Permission granted" acknowledgment row — sits in the tool stack next to the
+   tool it authorized. Non-collapsible (no chevron); a muted info line. */
+.gemini-permission-row .gemini-tool-row-header {
+	cursor: default;
+}
+
+.gemini-permission-row .gemini-tool-row-name {
+	font-weight: 400;
+	color: var(--text-muted);
+}
+
+.gemini-permission-row-icon {
+	color: var(--color-green);
+}
+
 .gemini-reasoning-row .gemini-tool-row-icon {
 	font-size: 13px;
 	line-height: 1;

--- a/styles.css
+++ b/styles.css
@@ -2102,10 +2102,18 @@ If your plugin does not need CSS, delete this file.
 }
 
 /* Model reasoning ("thinking") — a single collapsible line that reuses the
-   tool-row structure but stands on its own (no group box). */
+   tool-row structure. Standalone (below an answer / on reload) it stands on its
+   own; inside a tool group it sits flush with the tool rows. */
 .gemini-reasoning-row {
 	border-bottom: none;
 	margin: var(--size-2-2) 0;
+}
+
+/* Inside the tool group, interleave flush with tool rows (border separators,
+   no extra margin) so reasoning and tool calls read as one activity stream. */
+.gemini-tool-group-body .gemini-reasoning-row {
+	margin: 0;
+	border-bottom: 1px solid var(--background-modifier-border);
 }
 
 .gemini-reasoning-row .gemini-tool-row-icon {

--- a/styles.css
+++ b/styles.css
@@ -2101,8 +2101,13 @@ If your plugin does not need CSS, delete this file.
 	color: white;
 }
 
-/* Model reasoning ("thinking") — reuses the tool-group/row structure so it
-   reads as the same kind of collapsible element as a tool call. */
+/* Model reasoning ("thinking") — a single collapsible line that reuses the
+   tool-row structure but stands on its own (no group box). */
+.gemini-reasoning-row {
+	border-bottom: none;
+	margin: var(--size-2-2) 0;
+}
+
 .gemini-reasoning-row .gemini-tool-row-icon {
 	font-size: 13px;
 	line-height: 1;

--- a/styles.css
+++ b/styles.css
@@ -2101,6 +2101,52 @@ If your plugin does not need CSS, delete this file.
 	color: white;
 }
 
+/* Model reasoning ("thinking") — collapsible section below a model message. */
+.gemini-agent-reasoning {
+	margin-top: var(--size-4-2);
+	border-left: 2px solid var(--background-modifier-border);
+	padding-left: var(--size-4-2);
+}
+
+.gemini-agent-reasoning-header {
+	display: flex;
+	align-items: center;
+	gap: var(--size-2-2);
+	cursor: pointer;
+	user-select: none;
+	color: var(--text-muted);
+	font-size: var(--font-ui-small);
+}
+
+.gemini-agent-reasoning-header:hover {
+	color: var(--text-normal);
+}
+
+.gemini-agent-reasoning-icon {
+	display: flex;
+	align-items: center;
+}
+
+.gemini-agent-reasoning-icon svg {
+	width: 14px;
+	height: 14px;
+}
+
+.gemini-agent-reasoning-label {
+	font-weight: 500;
+	font-style: italic;
+}
+
+.gemini-agent-reasoning-content {
+	margin-top: var(--size-2-2);
+	color: var(--text-muted);
+	font-size: var(--font-ui-smaller);
+}
+
+.gemini-agent-reasoning-content.is-collapsed {
+	display: none;
+}
+
 @keyframes pulse {
 	0% {
 		opacity: 1;

--- a/styles.css
+++ b/styles.css
@@ -2101,50 +2101,21 @@ If your plugin does not need CSS, delete this file.
 	color: white;
 }
 
-/* Model reasoning ("thinking") — collapsible section below a model message. */
-.gemini-agent-reasoning {
-	margin-top: var(--size-4-2);
-	border-left: 2px solid var(--background-modifier-border);
-	padding-left: var(--size-4-2);
+/* Model reasoning ("thinking") — reuses the tool-group/row structure so it
+   reads as the same kind of collapsible element as a tool call. */
+.gemini-reasoning-row .gemini-tool-row-icon {
+	font-size: 13px;
+	line-height: 1;
 }
 
-.gemini-agent-reasoning-header {
-	display: flex;
-	align-items: center;
-	gap: var(--size-2-2);
-	cursor: pointer;
-	user-select: none;
-	color: var(--text-muted);
-	font-size: var(--font-ui-small);
+/* No status badge on a reasoning row, so push the chevron to the right edge. */
+.gemini-reasoning-row .gemini-tool-row-chevron {
+	margin-left: auto;
 }
 
-.gemini-agent-reasoning-header:hover {
-	color: var(--text-normal);
-}
-
-.gemini-agent-reasoning-icon {
-	display: flex;
-	align-items: center;
-}
-
-.gemini-agent-reasoning-icon svg {
-	width: 14px;
-	height: 14px;
-}
-
-.gemini-agent-reasoning-label {
-	font-weight: 500;
-	font-style: italic;
-}
-
-.gemini-agent-reasoning-content {
-	margin-top: var(--size-2-2);
-	color: var(--text-muted);
+.gemini-reasoning-row-details {
 	font-size: var(--font-ui-smaller);
-}
-
-.gemini-agent-reasoning-content.is-collapsed {
-	display: none;
+	color: var(--text-muted);
 }
 
 @keyframes pulse {

--- a/test/agent/agent-loop.test.ts
+++ b/test/agent/agent-loop.test.ts
@@ -194,7 +194,11 @@ describe('AgentLoop', () => {
 					confirmationProvider,
 					isCancelled: () => false,
 					createModelApi: () => api,
-					hooks: { onModelReasoning: (t) => reasoning.push(t) },
+					hooks: {
+						onModelReasoning: (t) => {
+							reasoning.push(t);
+						},
+					},
 				},
 			});
 
@@ -224,7 +228,11 @@ describe('AgentLoop', () => {
 					confirmationProvider,
 					isCancelled: () => false,
 					createModelApi: () => api,
-					hooks: { onModelReasoning: (t) => reasoning.push(t) },
+					hooks: {
+						onModelReasoning: (t) => {
+							reasoning.push(t);
+						},
+					},
 				},
 			});
 

--- a/test/agent/agent-loop.test.ts
+++ b/test/agent/agent-loop.test.ts
@@ -148,6 +148,90 @@ describe('AgentLoop', () => {
 		});
 	});
 
+	describe('model reasoning (thoughts)', () => {
+		test('terminal text response surfaces its thoughts on the result', async () => {
+			const plugin = buildPlugin();
+			const session = buildSession();
+			const api = makeScriptedModelApi([
+				{ markdown: 'the final answer', rendered: '', thoughts: 'I reasoned about it' },
+			]);
+
+			const loop = new AgentLoop();
+			const result = await loop.run({
+				initialResponse: toolResponse([tc('read_file', { path: 'a.md' })]),
+				initialUserMessage: 'q',
+				initialHistory: [],
+				options: { plugin, session, confirmationProvider, isCancelled: () => false, createModelApi: () => api },
+			});
+
+			expect(result.markdown).toBe('the final answer');
+			expect(result.thoughts).toBe('I reasoned about it');
+		});
+
+		test('intermediate reasoning fires onModelReasoning before the next tool batch', async () => {
+			const plugin = buildPlugin();
+			const session = buildSession();
+			// First follow-up: reasoning + more tools. Second follow-up: terminal text.
+			const api = makeScriptedModelApi([
+				{
+					markdown: '',
+					rendered: '',
+					toolCalls: [tc('write_file', { path: 'b.md', content: 'x' })],
+					thoughts: 'why I call write_file',
+				},
+				{ markdown: 'done', rendered: '', thoughts: 'final reasoning' },
+			]);
+
+			const reasoning: string[] = [];
+			const loop = new AgentLoop();
+			const result = await loop.run({
+				initialResponse: toolResponse([tc('read_file', { path: 'a.md' })]),
+				initialUserMessage: 'q',
+				initialHistory: [],
+				options: {
+					plugin,
+					session,
+					confirmationProvider,
+					isCancelled: () => false,
+					createModelApi: () => api,
+					hooks: { onModelReasoning: (t) => reasoning.push(t) },
+				},
+			});
+
+			// The intermediate (tools-continuing) reasoning goes through the hook;
+			// the terminal reasoning comes back on the result.
+			expect(reasoning).toEqual(['why I call write_file']);
+			expect(result.thoughts).toBe('final reasoning');
+		});
+
+		test('does not fire onModelReasoning when intermediate response has no thoughts', async () => {
+			const plugin = buildPlugin();
+			const session = buildSession();
+			const api = makeScriptedModelApi([
+				toolResponse([tc('write_file', { path: 'b.md', content: 'x' })]),
+				textResponse('done'),
+			]);
+
+			const reasoning: string[] = [];
+			const loop = new AgentLoop();
+			await loop.run({
+				initialResponse: toolResponse([tc('read_file', { path: 'a.md' })]),
+				initialUserMessage: 'q',
+				initialHistory: [],
+				options: {
+					plugin,
+					session,
+					confirmationProvider,
+					isCancelled: () => false,
+					createModelApi: () => api,
+					hooks: { onModelReasoning: (t) => reasoning.push(t) },
+				},
+			});
+
+			expect(reasoning).toEqual([]);
+		});
+	});
+
 	describe('tool sorting', () => {
 		test('reads execute before writes within a batch', async () => {
 			const plugin = buildPlugin();

--- a/test/agent/session-history.test.ts
+++ b/test/agent/session-history.test.ts
@@ -1199,6 +1199,70 @@ describe('SessionHistory', () => {
 			expect(result[2].thoughts).toBe('The headings were inconsistent, so I normalized them.');
 		});
 
+		it('parses an interleaved activity run (reasoning + tool callouts, no --- between)', async () => {
+			const mockFile = makeTFile('gemini-scribe/Agent-Sessions/Test.md');
+			(mockFile as any).extension = 'md';
+			mockPlugin.app.vault.getAbstractFileByPath.mockReturnValue(mockFile);
+			mockPlugin.app.metadataCache.getFileCache.mockReturnValue(null);
+
+			// Mirrors the streamlined on-disk shape: the activity stream is reasoning
+			// and tool callouts flowing together with no horizontal rules; only the
+			// user message and the final answer are `---`-separated sections.
+			const content = [
+				'## Allen',
+				'',
+				'> [!metadata]- Message Info',
+				'> | Property | Value |',
+				'> | -------- | ----- |',
+				'> | Time | 2026-01-01T00:00:00Z |',
+				'',
+				'> [!user]+',
+				'> Find live jazz near my hotel.',
+				'',
+				'---',
+				'',
+				'> [!reasoning]- Reasoning',
+				'> The vault has nothing; I should search.',
+				'',
+				'> [!tools]- Tool Execution',
+				'> 🔧 `vault_semantic_search` query="jazz" → success (10ms)',
+				'',
+				'> [!reasoning]- Reasoning',
+				'> Now confirm distances.',
+				'',
+				'> [!tools]- Tool Execution',
+				'> 🔧 `google_search` query="jazz hotel" → success (20ms)',
+				'',
+				'## Model',
+				'',
+				'> [!metadata]- Message Info',
+				'> | Property | Value |',
+				'> | -------- | ----- |',
+				'> | Time | 2026-01-01T00:01:00Z |',
+				'> | Model | gemini-3.5-flash |',
+				'',
+				'> [!assistant]+',
+				'> Here are two options.',
+				'',
+				'> [!reasoning]- Reasoning',
+				'> Organize by proximity.',
+				'',
+				'---',
+			].join('\n');
+			mockPlugin.app.vault.read.mockResolvedValue(content);
+
+			const result = await sessionHistory.getHistoryForSession(createMockSession());
+
+			expect(result).toHaveLength(4);
+			expect(result[0]).toMatchObject({ role: 'user', message: 'Find live jazz near my hotel.' });
+			expect(result[1]).toMatchObject({ role: 'model', message: '' });
+			expect(result[1].thoughts).toBe('The vault has nothing; I should search.');
+			expect(result[2]).toMatchObject({ role: 'model', message: '' });
+			expect(result[2].thoughts).toBe('Now confirm distances.');
+			expect(result[3]).toMatchObject({ role: 'model', message: 'Here are two options.' });
+			expect(result[3].thoughts).toBe('Organize by proximity.');
+		});
+
 		it('leaves thoughts undefined for legacy entries without a reasoning callout', async () => {
 			mockFile = makeTFile('gemini-scribe/Agent-Sessions/Test.md');
 			(mockFile as any).extension = 'md';

--- a/test/agent/session-history.test.ts
+++ b/test/agent/session-history.test.ts
@@ -1032,4 +1032,161 @@ describe('SessionHistory', () => {
 			);
 		});
 	});
+
+	describe('model reasoning (thoughts) round-trip', () => {
+		let mockFile: TFile;
+
+		// Wire a real write→read round-trip: addEntryToSession appends via
+		// vault.modify; getHistoryForSession reads the accumulated buffer back.
+		function wireRoundTripFile(initial = ''): { read: () => string } {
+			let fileContent = initial;
+			mockFile = makeTFile('gemini-scribe/Agent-Sessions/Test.md');
+			(mockFile as any).extension = 'md';
+			mockPlugin.app.vault.getAbstractFileByPath.mockReturnValue(mockFile);
+			mockPlugin.app.metadataCache.getFileCache.mockReturnValue(null);
+			mockPlugin.app.vault.read.mockImplementation(async () => fileContent);
+			mockPlugin.app.vault.modify.mockImplementation(async (_f: TFile, content: string) => {
+				fileContent = content;
+			});
+			return { read: () => fileContent };
+		}
+
+		it('round-trips a model entry that has both a message and thoughts', async () => {
+			wireRoundTripFile();
+			const session = createMockSession();
+
+			await sessionHistory.addEntryToSession(session, {
+				role: 'model',
+				message: 'The answer is 42.',
+				notePath: '',
+				created_at: new Date('2026-01-01T00:00:00Z'),
+				thoughts: 'The user asked about the meaning of life.\nConsidering the references...',
+			});
+
+			const result = await sessionHistory.getHistoryForSession(session);
+			expect(result).toHaveLength(1);
+			expect(result[0].role).toBe('model');
+			expect(result[0].message).toBe('The answer is 42.');
+			expect(result[0].thoughts).toBe('The user asked about the meaning of life.\nConsidering the references...');
+		});
+
+		it('round-trips a reasoning-only model turn (thoughts, empty message)', async () => {
+			wireRoundTripFile();
+			const session = createMockSession();
+
+			await sessionHistory.addEntryToSession(session, {
+				role: 'model',
+				message: '',
+				notePath: '',
+				created_at: new Date('2026-01-01T00:00:00Z'),
+				thoughts: 'I should read the file before editing it.',
+			});
+
+			const result = await sessionHistory.getHistoryForSession(session);
+			expect(result).toHaveLength(1);
+			expect(result[0].role).toBe('model');
+			expect(result[0].message).toBe('');
+			expect(result[0].thoughts).toBe('I should read the file before editing it.');
+		});
+
+		it('does not let the reasoning callout leak into the message body', async () => {
+			wireRoundTripFile();
+			const session = createMockSession();
+
+			await sessionHistory.addEntryToSession(session, {
+				role: 'model',
+				message: 'Final answer.',
+				notePath: '',
+				created_at: new Date('2026-01-01T00:00:00Z'),
+				thoughts: 'Reasoning text here.',
+			});
+
+			const result = await sessionHistory.getHistoryForSession(session);
+			expect(result[0].message).toBe('Final answer.');
+			expect(result[0].message).not.toContain('reasoning');
+			expect(result[0].message).not.toContain('Reasoning');
+		});
+
+		it('preserves multi-paragraph thoughts with blank lines', async () => {
+			wireRoundTripFile();
+			const session = createMockSession();
+			const thoughts = 'First paragraph of reasoning.\n\nSecond paragraph after a blank line.';
+
+			await sessionHistory.addEntryToSession(session, {
+				role: 'model',
+				message: 'Done.',
+				notePath: '',
+				created_at: new Date('2026-01-01T00:00:00Z'),
+				thoughts,
+			});
+
+			const result = await sessionHistory.getHistoryForSession(session);
+			expect(result[0].thoughts).toBe(thoughts);
+		});
+
+		it('round-trips a full user → reasoning-only → answer sequence', async () => {
+			wireRoundTripFile();
+			const session = createMockSession();
+
+			await sessionHistory.addEntryToSession(session, {
+				role: 'user',
+				message: 'Refactor my note.',
+				notePath: '',
+				created_at: new Date('2026-01-01T00:00:00Z'),
+			});
+			await sessionHistory.addEntryToSession(session, {
+				role: 'model',
+				message: '',
+				notePath: '',
+				created_at: new Date('2026-01-01T00:00:01Z'),
+				thoughts: 'I need to read the note first.',
+			});
+			await sessionHistory.addEntryToSession(session, {
+				role: 'model',
+				message: 'Done — I tidied the headings.',
+				notePath: '',
+				created_at: new Date('2026-01-01T00:00:02Z'),
+				thoughts: 'The headings were inconsistent, so I normalized them.',
+			});
+
+			const result = await sessionHistory.getHistoryForSession(session);
+			expect(result).toHaveLength(3);
+			expect(result[0]).toMatchObject({ role: 'user', message: 'Refactor my note.' });
+			expect(result[0].thoughts).toBeUndefined();
+			expect(result[1]).toMatchObject({ role: 'model', message: '' });
+			expect(result[1].thoughts).toBe('I need to read the note first.');
+			expect(result[2]).toMatchObject({ role: 'model', message: 'Done — I tidied the headings.' });
+			expect(result[2].thoughts).toBe('The headings were inconsistent, so I normalized them.');
+		});
+
+		it('leaves thoughts undefined for legacy entries without a reasoning callout', async () => {
+			mockFile = makeTFile('gemini-scribe/Agent-Sessions/Test.md');
+			(mockFile as any).extension = 'md';
+			mockPlugin.app.vault.getAbstractFileByPath.mockReturnValue(mockFile);
+			mockPlugin.app.metadataCache.getFileCache.mockReturnValue(null);
+
+			// Pre-reasoning history format — message callout only, no reasoning.
+			const legacy = [
+				'## Model',
+				'',
+				'> [!assistant]+',
+				'> Here is the legacy answer.',
+				'',
+				'> [!metadata]- Message Info',
+				'> | Property | Value |',
+				'> | -------- | ----- |',
+				'> | Time | 2026-01-01T00:00:00Z |',
+				'',
+				'---',
+			].join('\n');
+			mockPlugin.app.vault.read.mockResolvedValue(legacy);
+
+			const session = createMockSession();
+			const result = await sessionHistory.getHistoryForSession(session);
+
+			expect(result).toHaveLength(1);
+			expect(result[0].message).toBe('Here is the legacy answer.');
+			expect(result[0].thoughts).toBeUndefined();
+		});
+	});
 });

--- a/test/agent/session-history.test.ts
+++ b/test/agent/session-history.test.ts
@@ -1089,6 +1089,46 @@ describe('SessionHistory', () => {
 			expect(result[0].thoughts).toBe('I should read the file before editing it.');
 		});
 
+		it('writes reasoning-only turns without a header or metadata block (streamlined)', async () => {
+			const file = wireRoundTripFile();
+			const session = createMockSession();
+
+			await sessionHistory.addEntryToSession(session, {
+				role: 'model',
+				message: '',
+				notePath: '',
+				created_at: new Date('2026-01-01T00:00:00Z'),
+				model: 'gemini-3.5-flash',
+				thoughts: 'Pre-tool reasoning.',
+			});
+
+			const raw = file.read();
+			expect(raw).toContain('> [!reasoning]- Reasoning');
+			// No heavy `## Model` header / Message Info table for a bare reasoning step.
+			expect(raw).not.toContain('## Model');
+			expect(raw).not.toContain('Message Info');
+		});
+
+		it('keeps the header + metadata for model turns that have an answer', async () => {
+			const file = wireRoundTripFile();
+			const session = createMockSession();
+
+			await sessionHistory.addEntryToSession(session, {
+				role: 'model',
+				message: 'Here is the answer.',
+				notePath: '',
+				created_at: new Date('2026-01-01T00:00:00Z'),
+				model: 'gemini-3.5-flash',
+				thoughts: 'Reasoning behind it.',
+			});
+
+			const raw = file.read();
+			expect(raw).toContain('## Model');
+			expect(raw).toContain('Message Info');
+			expect(raw).toContain('> [!assistant]+');
+			expect(raw).toContain('> [!reasoning]- Reasoning');
+		});
+
 		it('does not let the reasoning callout leak into the message body', async () => {
 			wireRoundTripFile();
 			const session = createMockSession();


### PR DESCRIPTION
## Summary

Fixes #428. Thinking-model reasoning was shown live in the progress bar but **discarded when the turn completed**. This captures it for every turn, renders it as a collapsed **Reasoning** section below the model message, and round-trips it through the markdown session history — so a session file faithfully records the whole arc: **user request → model reasoning → tool calls → answer (and the reasoning behind it)**. That also makes session files a richer source for training/eval data.

Per discussion on the issue, this goes all-in: it captures **every reasoning step** (including the pre-tool "why I'm calling these tools" reasoning, persisted as reasoning-only turns) and is **always on** (no setting).

## Changes

- **Types**: `thoughts?: string` on `GeminiConversationEntry` and `AgentLoopResult`.
- **History writer** (`historyEntry.hbs`, `session-history.ts`): emit a collapsed `> [!reasoning]-` callout when thoughts exist; message callout is conditional so a reasoning-only model turn renders reasoning alone.
- **History parser**: shared `extractCalloutBody` helper; extracts reasoning, supports reasoning-only model entries (no message callout), pushes when `message || thoughts`. **Legacy files (no reasoning callout) round-trip unchanged** — `thoughts` stays `undefined`.
- **Capture** (`agent-view-send.ts`, streaming + non-streaming): attach `response.thoughts` to model entries; persist pre-tool reasoning-only turns; show reasoning instead of the bare "empty response" notice when a thinking model returns only reasoning.
- **AgentLoop**: return terminal thoughts on `result.thoughts`; new `onModelReasoning` hook for intermediate (pre-next-batch) reasoning. `agent-view-tools.ts` persists/displays those as reasoning-only turns and attaches `result.thoughts` to the final entry.
- **UI** (`agent-view-messages.ts` + `styles.css`): collapsible **Reasoning** section, shared by the stream finalizer and history re-render, collapsed by default.
- **Tests**: history round-trip incl. reasoning-only + legacy back-compat (6); AgentLoop `thoughts` + `onModelReasoning` (3).
- **Docs**: "Model Reasoning" section in the agent-mode guide.

## Verification

- **3042 unit tests pass** (3033 + 9 new); build, format, lint, knip all clean.
- **Live round-trip** through the running plugin: wrote a `user → reasoning-only → answer+reasoning` sequence, read it back — all entries and multi-line thoughts preserved; raw file contains clean `[!reasoning]-` callouts.
- **Live UI**: rendered a message-with-reasoning and a reasoning-only turn in the agent view; the collapsed **Reasoning** chevron appears and expands to show the reasoning. (Screenshots captured locally.)

## Screenshots / Screencast

Collapsed and expanded **Reasoning** sections verified in the agent view (message-with-reasoning and reasoning-only turns). Screenshots available on request.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A: no platform-specific APIs; pure history/UI logic shared across platforms
- [x] Documentation has been updated (if applicable)
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Collapsible "Reasoning" blocks show model thinking inline, interleaved with tool groups, and during streaming.
  * Reasoning-only turns are displayed, saved to session history as collapsed callouts, and restored when reopening sessions.
  * Permission-granted acknowledgement row added; copy-button and progress UI adjusted for reasoning turns; styling added for reasoning and permission rows.

* **Documentation**
  * Added "Model Reasoning" section to the Agent Mode Guide.

* **Tests**
  * Added tests covering reasoning parsing, preservation, round-tripping, and display behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->