### PR TITLE
chore(daily): 2026-06-10 daily update

### DIFF
--- a/planning/changelog/2026-06-09.md
+++ b/planning/changelog/2026-06-09.md
@@ -1,0 +1,36 @@
+# Daily changelog — June 09, 2026
+
+**Date:** 2026-06-09
+**PRs merged:** 6
+
+---
+
+## Summary
+
+A feature-heavy day dominated by two substantial additions: reasoning persistence (thinking model thoughts captured to session history and rendered in the UI) and the Google Maps grounding tool. Two new bundled skills shipped alongside, rounding out the agent's format knowledge. The day also included the regular daily housekeeping PR and a nightly architecture-audit type fix.
+
+## What shipped
+
+### [#961 refactor: replace `any` in agent-view modal constructors with proper types](https://github.com/allenhutchison/obsidian-gemini/pull/961)
+
+Nightly architecture-audit sweep fixed improper `any` typing in two agent-view modal constructors (`file-mention-modal.ts`, `session-settings-modal.ts`). The constructor `app` parameters now use Obsidian's `App` type, and a `models.forEach` callback was tightened from `any` to `GeminiModel`. Pure typing fix — no behavior change.
+
+### [#962 chore(daily): 2026-06-09 daily update](https://github.com/allenhutchison/obsidian-gemini/pull/962)
+
+Automated daily housekeeping: June 8 changelog (9 PRs) and a single docs drift fix — `docs/reference/evals.md` task count updated from 54 to 59 to reflect the 5 eval tasks added in PR #929.
+
+### [#963 feat(skills): bundle obsidian-markdown and json-canvas, enrich obsidian-bases](https://github.com/allenhutchison/obsidian-gemini/pull/963)
+
+Addresses #564. Adds two new bundled agent skills: `obsidian-markdown` (Obsidian Flavored Markdown: wikilinks, embeds, callouts, block references, tags, math) and `json-canvas` (JSON Canvas spec with a worked example). The existing `obsidian-bases` skill gets a new Troubleshooting section covering YAML quoting, formula errors, undefined refs, and render gotchas. These adapt the genuinely-missing format/spec knowledge from the kepano/obsidian-skills library to the plugin's in-Obsidian tooling model, rather than a wholesale port that assumes shell access.
+
+### [#964 feat(tools): add google_maps grounding tool](https://github.com/allenhutchison/obsidian-gemini/pull/964)
+
+Fixes #585. Adds a `google_maps` agent tool using the same pattern as `google_search`: a separate Gemini model instance with the `googleMaps` grounding tool enabled. The agent can now answer place/location questions — businesses, points of interest, addresses, hours, ratings — with inline citations linking to referenced places. Registered under `getWebTools()` so it's automatically available for the Gemini provider; skipped on Ollama like the other web tools. No new settings.
+
+### [#965 feat(agent): persist and display model reasoning (thoughts)](https://github.com/allenhutchison/obsidian-gemini/pull/965)
+
+Fixes #428. Thinking-model reasoning was previously shown live in the progress bar but discarded when the turn completed. This captures reasoning at every step, renders it as a collapsed **Reasoning** section in the agent view, and round-trips it through markdown session history via a `> [!reasoning]-` callout. Pre-tool "why I'm calling these" reasoning is captured as reasoning-only turns; terminal reasoning attaches to the final answer entry. Always on — no setting. Legacy session files round-trip unchanged. The change makes session history a richer eval/training record.
+
+### [#967 docs(agents): document reasoning persistence, onModelReasoning hook, and typecheck:test](https://github.com/allenhutchison/obsidian-gemini/pull/967)
+
+Docs-only follow-up to #965. Records three durable learnings in `AGENTS.md`: the `npm run typecheck:test` requirement (CI's lint job runs `tsc --project tsconfig.test.json` and catches errors the production build misses — the sole CI failure on #965 was an expression-bodied arrow returning `number` instead of `void`), the `onModelReasoning` hook semantics (intermediate vs. terminal reasoning), and the history parser invariant (entries keyed by callout, not `## ` headers; multiple callouts per `---` section).


### PR DESCRIPTION
## Summary

Automated daily housekeeping for 2026-06-10. Covers the June 9 changelog (6 PRs — a feature-heavy day: bundled skills, Google Maps grounding tool, and reasoning persistence). Docs audit found no drift. No unlabeled open issues.

## Changes

- **Add `planning/changelog/2026-06-09.md`**: Documents June 9 — 6 PRs: nightly architecture-audit type fix (#961), daily housekeeping (#962), bundled obsidian-markdown and json-canvas skills (#963), Google Maps grounding tool (#964), reasoning persistence (#965), and AGENTS.md docs follow-up (#967).

## Sub-skill outcomes

- **daily-changelog**: wrote `planning/changelog/2026-06-09.md`, 6 PRs (bundled skills, Google Maps tool, reasoning persistence — feature-heavy day)
- **audit-docs**: no drift found — settings defaults, model names, tool names, schedule formats, bundled skills list (all 10 match code), and loop detection thresholds all accurate; `google_maps` and reasoning already documented in `docs/guide/agent-mode.md` from their feature PRs; no new docs warranted
- **triage-issues**: no unlabeled open issues — 0 issues processed

## Screenshots / Screencast

N/A — changelog only.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: daily housekeeping
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop — N/A: changelog only
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A: changelog only
- [x] Documentation has been updated (if applicable) — this PR IS the documentation update
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01FkmUkZHk5BHxqF842dnB9K)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added daily changelog documenting recent product updates, including new tools, AI reasoning enhancements, and various improvements
* **Chores**
  * Recorded June 09, 2026 changelog entries

<!-- end of auto-generated comment: release notes by coderabbit.ai -->