### PR TITLE
refactor(agent): type session listing with TFolder instead of any cast

### DIFF
--- a/src/agent/session-history.ts
+++ b/src/agent/session-history.ts
@@ -1,4 +1,4 @@
-import { TFile, normalizePath } from 'obsidian';
+import { TFile, TFolder, normalizePath } from 'obsidian';
 import { ChatSession } from '../types/agent';
 import { GeminiConversationEntry } from '../types/conversation';
 import type ObsidianGemini from '../main';
@@ -178,11 +178,11 @@ export class SessionHistory {
 
 		try {
 			const folder = this.plugin.app.vault.getAbstractFileByPath(agentSessionsPath);
-			if (!folder || !('children' in folder)) return [];
+			if (!(folder instanceof TFolder)) return [];
 
-			return (folder as any).children
-				.filter((file: any): file is TFile => file instanceof TFile && file.extension === 'md')
-				.sort((a: TFile, b: TFile) => b.stat.mtime - a.stat.mtime); // Most recent first
+			return folder.children
+				.filter((file): file is TFile => file instanceof TFile && file.extension === 'md')
+				.sort((a, b) => b.stat.mtime - a.stat.mtime); // Most recent first
 		} catch (error) {
 			this.plugin.logger.error(`Error listing agent sessions:`, error);
 			return [];

--- a/test/agent/session-history.test.ts
+++ b/test/agent/session-history.test.ts
@@ -1,5 +1,5 @@
 import { SessionHistory } from '../../src/agent/session-history';
-import { TFile } from 'obsidian';
+import { TFile, TFolder } from 'obsidian';
 import type { GeminiConversationEntry } from '../../src/types/conversation';
 import type { ChatSession } from '../../src/types/agent';
 import { SessionType } from '../../src/types/agent';
@@ -932,7 +932,7 @@ describe('SessionHistory', () => {
 			expect(result).toEqual([]);
 		});
 
-		it('should return empty array when folder has no children property', async () => {
+		it('should return empty array when path resolves to a non-folder', async () => {
 			mockPlugin.app.vault.getAbstractFileByPath.mockReturnValue({ path: 'some-path' });
 
 			const result = await sessionHistory.getAllAgentSessions();
@@ -950,9 +950,9 @@ describe('SessionHistory', () => {
 				extension: 'txt',
 				stat: { ctime: now, mtime: now },
 			});
-			const folder = {
+			const folder = Object.assign(new TFolder(), {
 				children: [mdFile, txtFile, { path: 'not-a-tfile' }],
-			};
+			});
 			mockPlugin.app.vault.getAbstractFileByPath.mockReturnValue(folder);
 
 			const result = await sessionHistory.getAllAgentSessions();
@@ -971,9 +971,9 @@ describe('SessionHistory', () => {
 				extension: 'md',
 				stat: { ctime: now - 1000, mtime: now - 1000 },
 			});
-			const folder = {
+			const folder = Object.assign(new TFolder(), {
 				children: [olderFile, newerFile],
-			};
+			});
 			mockPlugin.app.vault.getAbstractFileByPath.mockReturnValue(folder);
 
 			const result = await sessionHistory.getAllAgentSessions();


### PR DESCRIPTION
## Summary

Architecture-audit nightly sweep flagged: **`any` overuse / improper typing** in `src/agent/session-history.ts:183-184`.

`getAllAgentSessions` was using a structural `'children' in folder` check plus `(folder as any).children` to access the folder's child list, then re-annotating the `filter`/`sort` callbacks with explicit `any`. Switching to `instanceof TFolder` narrows the abstract file properly so the cast and the callback annotations disappear — TypeScript infers them from `TFolder.children: TAbstractFile[]`.

Behaviorally identical: both checks reject anything that isn't a folder, and the `file instanceof TFile && file.extension === 'md'` filter is unchanged.

## Changes

- `src/agent/session-history.ts` — import `TFolder`, replace `'children' in folder` + `as any` with `instanceof TFolder`, drop `any` annotations on filter/sort params.
- `test/agent/session-history.test.ts` — construct folder fixtures via `new TFolder()` so `instanceof TFolder` holds; rename "no children property" test to "non-folder" to match the narrowing.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A, surfaced by the architecture-audit nightly sweep
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop — covered by unit tests; no runtime behavior change
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — pure type/narrowing change, no platform-specific code
- [x] Documentation has been updated (if applicable) — N/A, internal refactor with no user-visible change
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01637wGv7pSC3xPmWZszGqvb)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of session history retrieval with stricter validation checks.
  * Enhanced handling of edge cases when accessing session folders.

* **Tests**
  * Expanded test coverage for session history edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->