### PR TITLE
feat: auto-dev skill — autonomous issue-to-PR pipeline

### DIFF
--- a/.agents/skills/auto-dev/SKILL.md
+++ b/.agents/skills/auto-dev/SKILL.md
@@ -1,0 +1,190 @@
+---
+name: auto-dev
+description: Execute one tick of the autonomous issue-to-PR pipeline — triage open issues for readiness, draft implementation plans for maintainer approval, build the oldest approved issue into a PR, and address review feedback on the open automated PR. Designed for unattended scheduled runs (`scripts/auto-dev.sh`); also invocable interactively as "/auto-dev" or "run an auto-dev tick", and as "/auto-dev dry-run" for a read-only report of what a tick would do. Never merges PRs. State lives in `auto:*` GitHub labels.
+---
+
+# Auto-dev: one tick of the issue-to-PR pipeline
+
+This skill automates the path from open issue to reviewed PR while keeping the maintainer in control of two gates: **plan approval** (nothing is built without an approved plan) and **merge** (the skill never merges — ever). It is designed to run unattended every 15–30 minutes; each invocation is **one tick of a state machine**, does the single highest-priority piece of work, and exits. "Waiting" (for a reply, an approval, a review, a merge) is simply what happens between ticks.
+
+## Invariants — read these first
+
+1. **Never merge a PR.** Not with `gh pr merge`, not via the API, not by enabling auto-merge. Merging is exclusively the maintainer's act, and a merge is what unblocks the pipeline for the next issue.
+2. **At most one automated PR in flight.** While any auto-dev PR is open, no new issue gets built. Ticks spent in that state only advance the open PR.
+3. **All runs happen under the maintainer's own GitHub identity**, so authorship cannot distinguish this pipeline from the human. Every comment this skill posts MUST begin with the marker line `<!-- auto-dev -->` (invisible in rendered Markdown). Classify comments into three buckets: **pipeline** (has the marker), **third-party bot** (author login ends in `[bot]` or `app/` — e.g. `coderabbitai`, `dependabot`; CodeRabbit posts auto-enrichment boilerplate on issues), and **human** (everything else). Only _human_ comments count as replies, answers, or approvals; third-party bot comments never satisfy "the human replied" and never gate-keep anything — read them for technical signal at most.
+4. **Labels are the cross-run memory, and humans always win.** If a human has changed an `auto:*` label since the last tick (e.g. removed `auto:ready`, added `auto:skip`), respect the label as found — never "correct" it back.
+5. **Never force-push**, never push to `master` directly, never run the release process, never create or delete labels, never close issues, never edit or delete human comments.
+6. **Stay inside the repo's own conventions**: pre-flight checks, documentation policy, and the PR template all come from the `create-pr` skill and AGENTS.md, exactly as for human-driven work.
+
+## Invocation modes
+
+- **Scheduled** (`scripts/auto-dev.sh`): headless, in the dedicated clone, against the curated allowlist. The runner guarantees a clean tree on fresh master.
+- **Interactive** (`/auto-dev` in a Claude Code session): identical behavior, but under normal permission prompts and possibly in the maintainer's working checkout. A dirty working tree or non-master branch does NOT block the GitHub-only steps (1-reconcile, 3-triage) — it only blocks steps that touch the working tree (2's CI/feedback fixes, 4-build). If a working-tree step is what the tick needs and the tree is dirty, report that and stop rather than stashing or resetting anything.
+- **Dry run** (`/auto-dev dry-run`, or the user asks for a dry run): execute the full tick logic **read-only**. Gather all state, decide exactly what a live tick would do, and print it as the exit report with every action prefixed `would:` — but post no comments, change no labels, create no branches/commits/PRs, and push nothing. This is the recommended first test and is always safe to run.
+
+## Label state machine
+
+| Label               | Meaning                                                     | Who sets it                                      |
+| ------------------- | ----------------------------------------------------------- | ------------------------------------------------ |
+| (no `auto:*` label) | Not yet triaged by auto-dev                                 | —                                                |
+| `auto:needs-info`   | Skill asked a clarifying question; waiting on a human reply | skill                                            |
+| `auto:planned`      | Skill posted an implementation plan; waiting on approval    | skill                                            |
+| `auto:ready`        | Plan approved; eligible to build                            | skill (on detected approval) or human (directly) |
+| `auto:in-progress`  | Being built / has an open automated PR                      | skill                                            |
+| `auto:skip`         | Opt-out — auto-dev never touches this issue                 | human                                            |
+
+**Eligibility:** all open issues, oldest first, EXCEPT issues labeled `auto:skip`, `epic`, `question`, `wontfix`, `duplicate`, or `invalid`. Pull requests are never triaged as issues.
+
+## The tick algorithm
+
+Work through these steps in order. Execute the **first step that has work**, finish it, print the exit report, and stop. Do not fall through to later steps after completing one (exception: step 2 falls through to step 3 when the open PR needs nothing).
+
+### Step 0 — Preflight
+
+```bash
+gh auth status                      # must be authenticated
+gh repo view --json nameWithOwner   # confirm the repo
+git status --porcelain              # clean in scheduled runs; in interactive runs a dirty tree only blocks working-tree steps
+```
+
+Gather the current state in parallel:
+
+```bash
+# Open automated PRs (branch prefix is the identity signal)
+gh pr list --state open --json number,headRefName,title,reviewDecision,mergeable \
+  | jq '[.[] | select(.headRefName | startswith("auto/"))]'
+
+# All open issues, oldest first
+gh issue list --state open --limit 200 \
+  --json number,title,labels,createdAt,updatedAt --search "sort:created-asc"
+
+# Recently closed automated PRs (for step 1's orphan/closure handling)
+gh pr list --state closed --limit 10 --json number,headRefName,mergedAt,closedAt \
+  | jq '[.[] | select(.headRefName | startswith("auto/"))]'
+```
+
+If `gh` auth or repo resolution fails, print the failure in the exit report and stop — do not attempt repairs.
+
+### Step 1 — Reconcile finished work
+
+For issues labeled `auto:in-progress`:
+
+- **PR merged** (or issue closed by `Fixes #N`): remove `auto:in-progress`. If the issue is somehow still open after its PR merged, comment (with marker) linking the merged PR and noting it may be closable — but leave closing to the human.
+- **PR closed without merging**: treat as rejection of the approach. Remove `auto:in-progress`, add `auto:skip`, and comment (with marker) that the PR was closed unmerged and the issue needs human direction before auto-dev will touch it again.
+- **No PR exists at all** (a previous tick crashed between labeling and PR creation): treat the issue as `auto:ready` in step 4 — its plan is already approved.
+
+### Step 2 — Advance the open automated PR
+
+If an automated PR is open, this tick belongs to it. Follow the `coderabbit-review` skill's loop if it is available; the essentials:
+
+1. Fetch all four feedback surfaces: PR metadata + CI rollup, review summaries, inline review comments, and issue-style comments (`gh pr view`, `gh api .../pulls/N/reviews`, `.../pulls/N/comments`, `.../issues/N/comments`).
+2. **CI red?** Fix CI first — check out the `auto/` branch, fix, run the repo pre-flight (`npm run format-check`, `npm run build`, `npm test`, `npm run typecheck:test`), push.
+3. **New feedback since the skill's last reply?** A thread is unaddressed if its newest comment lacks the `<!-- auto-dev -->` marker. Triage each item on its merits (CodeRabbit is not always right), fix valid items with **focused commits** (one logical fix per commit, conventional subjects), push, then **reply to every thread** — including ones you decline, with a one-sentence reason. Replies carry the marker.
+4. **Human feedback** outranks bot feedback. If a human reviewer and CodeRabbit conflict, follow the human and say so in the reply to the bot.
+5. **Scope creep requested in review?** Acknowledge in a reply, file a follow-up issue (it enters this same pipeline untriaged), link it, and keep the PR scoped.
+6. **Nothing new** (no new comments, CI green, all threads answered): the PR is waiting on review or merge. Print that in the exit report and **fall through to step 3 (triage only)** — never to step 4.
+
+### Step 3 — Triage pass (bounded)
+
+Walk eligible open issues oldest→newest. Act on at most **5** issues per tick (count only issues where you actually post/relabel; skipped issues are free). For each issue, read the full thread, then branch on its current `auto:*` state:
+
+- **No `auto:*` label** — assess whether the issue contains enough to plan from (clear problem, scoped outcome, no unresolved design fork):
+  - _Plannable_ → draft an implementation plan (format below), post it as a comment, add `auto:planned`.
+  - _Not plannable_ → post one comment asking the specific missing questions (numbered, concrete — not "please clarify"), add `auto:needs-info`.
+- **`auto:needs-info`** — is there a _human_ comment (no marker, not a third-party bot) newer than the skill's last marker comment?
+  - _No_ → skip silently. This is the "already asked, no reply" rule.
+  - _Yes_ → incorporate the reply. If it resolves the questions, draft and post the plan, swap label to `auto:planned`. If it raises new ambiguity, ask the follow-up (stay `auto:needs-info`) — but if this would be the third unanswered round-trip, stop asking and leave a final note that the issue needs maintainer attention.
+- **`auto:planned`** — is there a _human_ comment (not a third-party bot) newer than the plan?
+  - _Approval_ (e.g. "approved", "LGTM", "go ahead", "yes do it", a 👍-only reply) → swap label to `auto:ready`. "Approved, but change X" counts as approval: update the plan comment-thread with the revision first, then mark ready.
+  - _Substantive feedback / objections_ → revise, post the updated plan (marker), stay `auto:planned`.
+  - _No reply_ → skip silently.
+  - The human adding `auto:ready` directly is always approval, reply or not.
+- **`auto:ready` / `auto:in-progress`** — leave for steps 1 and 4.
+
+### Step 4 — Build (only if NO automated PR is open)
+
+Take the **oldest** `auto:ready` issue (or a step-1 orphan). Then:
+
+1. Swap labels: remove `auto:ready`, add `auto:in-progress`.
+2. Branch from fresh master: `git checkout master && git pull --ff-only && git checkout -b auto/issue-<N>-<short-slug>`.
+3. Implement the approved plan as posted on the issue — the plan comment is the spec. Where reality diverges from the plan (an approach doesn't work, a file moved), prefer small sensible adaptation and document the deviation in the PR body; for a fundamental divergence, stop, comment on the issue explaining the blocker (marker), revert the label to `auto:planned`, and exit.
+4. Follow the repo's documentation policy — docs updates ship in the same PR.
+5. Run the full pre-flight: `npm run format-check`, `npm run build`, `npm test`, `npm run typecheck:test`. All green before pushing.
+6. Create the PR with the **create-pr** skill (template, checklist, AI-disclosure section). The body must include `Fixes #<N>`, the marker line, and a note that this PR was produced by the auto-dev pipeline from the approved plan.
+7. Comment on the issue (marker) linking the PR.
+
+If the build cannot complete inside this tick's budget, push the branch with WIP commits and exit reporting partial progress — the next tick's step 1/2 will find the branch. Do **not** open a PR that fails pre-flight checks.
+
+### Step 5 — Nothing to do
+
+If no step had work: print "no work to be done" with the counts (open PRs awaiting human review/merge, issues awaiting replies, issues awaiting approval) and exit.
+
+## Plan comment format
+
+```markdown
+<!-- auto-dev -->
+
+## Proposed implementation plan
+
+**Approach:** <2–4 sentences: what will change and why this approach>
+
+**Changes:**
+
+- `path/to/file.ts` — <what>
+- <new files, tests, docs to update>
+
+**Testing:** <unit tests to add/extend; manual verification if UI>
+
+**Out of scope:** <explicitly excluded, if anything notable>
+
+---
+
+Reply with an approval ("approved", "LGTM", "go ahead") to queue this for implementation, reply with changes to revise the plan, or add the `auto:skip` label to opt this issue out of automation.
+```
+
+Plans follow the repo's "Implementation Planning" convention (plans live in the issue). Keep them honest about size — if an issue is too large to land as one reviewable PR, the plan should say so and propose the first slice only.
+
+## Question comment format
+
+```markdown
+<!-- auto-dev -->
+
+Before this can be planned for implementation, a few things need clarification:
+
+1. <specific question>
+2. <specific question>
+
+---
+
+Reply here and the next automation pass will pick it up, or add the `auto:skip` label to opt this issue out of automation.
+```
+
+## Exit report
+
+Every tick ends by printing a structured report to stdout (the runner appends it to the log):
+
+```text
+auto-dev tick — <ISO timestamp>
+step executed: <0-failed | 1-reconcile | 2-pr-advance | 3-triage | 4-build | 5-idle>
+open auto PR: #<n> (<status>) | none
+actions:
+- #123: asked 2 clarifying questions → auto:needs-info
+- #145: plan approved by reply → auto:ready
+- PR #210: fixed 2 CodeRabbit findings, replied to 4 threads, pushed <sha>
+blocked on human:
+- PR #210 awaiting review/merge
+- #145 ready to build once #210 merges
+errors: <none | details>
+```
+
+## What not to do
+
+- Don't merge, approve, or enable auto-merge on any PR.
+- Don't start a second build while an automated PR is open.
+- Don't post a second question/plan when the previous one is still unanswered.
+- Don't touch `auto:skip`, `epic`, `question`, `wontfix`, `duplicate`, or `invalid` issues, and don't remove `auto:skip` ever.
+- Don't apply or change non-`auto:*` labels — categorization belongs to the `triage-issues` skill.
+- Don't close issues, edit issue bodies, or modify human comments.
+- Don't expand a PR's scope in response to review; file a follow-up issue instead.
+- Don't bypass failing checks (`--no-verify`, skipping tests) to get a PR out.
+- Don't work around permission denials from the runner's allowlist — report them in the exit report so the allowlist can be tuned deliberately.

--- a/.agents/skills/auto-dev/SKILL.md
+++ b/.agents/skills/auto-dev/SKILL.md
@@ -75,7 +75,11 @@ For issues labeled `auto:in-progress`:
 
 ### Step 2 — Advance the open automated PR
 
-If an automated PR is open, this tick belongs to it. Follow the `coderabbit-review` skill's loop if it is available; the essentials:
+If an automated PR is open, this tick belongs to it.
+
+**Draft PR** (a yielded partial build from step 4): resume the implementation first — finish the plan, run the full pre-flight, push, and mark it ready with `gh pr ready`. Only then does the review loop below apply.
+
+**Ready PR**: run one round of the review loop. The maintainer's user-level `coderabbit-review` skill describes the same loop in more depth — follow it when it is available (it is not part of this repo, so scheduled runs may not have it); the essentials below stand alone:
 
 1. Fetch all four feedback surfaces: PR metadata + CI rollup, review summaries, inline review comments, and issue-style comments (`gh pr view`, `gh api .../pulls/N/reviews`, `.../pulls/N/comments`, `.../issues/N/comments`).
 2. **CI red?** Fix CI first — check out the `auto/` branch, fix, run the repo pre-flight (`npm run format-check`, `npm run build`, `npm test`, `npm run typecheck:test`), push.
@@ -113,7 +117,7 @@ Take the **oldest** `auto:ready` issue (or a step-1 orphan). Then:
 6. Create the PR with the **create-pr** skill (template, checklist, AI-disclosure section). The body must include `Fixes #<N>`, the marker line, and a note that this PR was produced by the auto-dev pipeline from the approved plan.
 7. Comment on the issue (marker) linking the PR.
 
-If the build cannot complete inside this tick's budget, push the branch with WIP commits and exit reporting partial progress — the next tick's step 1/2 will find the branch. Do **not** open a PR that fails pre-flight checks.
+If the build cannot complete inside this tick's budget, push the WIP commits and open a **draft** PR (`gh pr create --draft`) before exiting — a bare pushed branch is invisible to the next tick, whose discovery queries only look at PRs and issues. The draft body still carries `Fixes #<N>` and the marker, plus a note that the build is incomplete and will be resumed. Never mark a PR ready for review (`gh pr ready`) while pre-flight checks fail.
 
 ### Step 5 — Nothing to do
 

--- a/.claude/skills/auto-dev
+++ b/.claude/skills/auto-dev
@@ -1,0 +1,1 @@
+../../.agents/skills/auto-dev

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -300,6 +300,25 @@ Example: See issue #90 for the custom prompt system implementation plan.
 
 This keeps technical planning centralized and accessible for all contributors.
 
+### Autonomous issue pipeline (auto-dev)
+
+The **auto-dev** skill (`.agents/skills/auto-dev/SKILL.md`) runs one tick of an unattended issue-to-PR pipeline: it triages open issues for readiness (asking clarifying questions where needed), posts implementation plans for maintainer approval, builds the oldest approved issue into a PR, and addresses CodeRabbit/human review feedback on the open automated PR. It **never merges** — merging is always the maintainer's act — and at most one automated PR is in flight at a time.
+
+- State lives in the `auto:*` GitHub labels (`auto:needs-info`, `auto:planned`, `auto:ready`, `auto:in-progress`, `auto:skip`). Add `auto:skip` to any issue the pipeline should never touch; add `auto:ready` to approve a posted plan directly (an approving reply on the plan comment also works).
+- Comments posted by the pipeline run under the maintainer's own GitHub account and are identified by a hidden `<!-- auto-dev -->` marker — that marker, not authorship, distinguishes automated comments from human ones.
+- Scheduled runs go through `scripts/auto-dev.sh` (cron/launchd every 15–30 min), which operates in a **dedicated clone** (default `~/src/obsidian-gemini-autodev`) so it never disturbs interactive checkouts, holds a lockfile so ticks can't overlap, caps per-tick spend (`--max-budget-usd`) and wall-clock time, and runs headless Claude Code against the curated permissions allowlist in `scripts/auto-dev-settings.json` (which hard-denies `gh pr merge`, force pushes, direct pushes to master, and releases). Logs land in `~/.local/state/auto-dev/`.
+
+#### Driving the maintainer side from a Claude Code session
+
+The maintainer's half of the pipeline (reviewing plans, approving, answering questions) is usually done through an interactive Claude Code session. When asked to "review the pipeline", "check what auto-dev is waiting on", "approve the plan on #N", or similar:
+
+- **See the pipeline state**: `gh issue list --label "auto:planned"` (plans awaiting approval), `--label "auto:needs-info"` (questions awaiting answers), `--label "auto:ready"` (build queue), `--label "auto:in-progress"` (being built), plus `gh pr list --state open` filtered to `auto/` branches for the PR in flight. Pipeline comments are the ones starting with the hidden `<!-- auto-dev -->` marker; third-party bot comments (`coderabbitai`, `dependabot`, …) are ignored for state decisions; everything else is human input.
+- **Approve a plan**: reply on the issue with an explicit approval ("Approved.", optionally with amendments — "Approved, but use X instead of Y" counts and the pipeline incorporates the change), or add the `auto:ready` label directly. **Request changes**: reply with the changes; the next tick revises the plan. **Answer questions** on `auto:needs-info` issues with an ordinary comment; the next tick incorporates it.
+- **Never include the `<!-- auto-dev -->` marker in comments posted on the maintainer's behalf.** The pipeline classifies marker comments as its own output — a marked reply would be invisible to it as human input. Don't imitate the pipeline's comment templates either.
+- **Taking an issue over manually**: before implementing an issue yourself that carries `auto:planned`/`auto:ready` (or answering its plan with "I'll do this one"), add `auto:skip` (or at minimum remove `auto:ready`) so a scheduled tick doesn't build it concurrently. Remove `auto:skip` later to hand it back.
+- **Reviewing the automated PR** works like any PR review: comment on the PR; the next tick addresses the feedback and replies. Merging is always the human's call — the pipeline never merges, and a merge is what unblocks the next build.
+- **Testing / manual ticks**: `/auto-dev dry-run` prints what a tick would do with zero side effects; `/auto-dev` runs one live tick interactively under normal permission prompts.
+
 ## Commit & Pull Request Guidelines
 
 For creating pull requests, use the **create-pr** skill which enforces the PR template and runs all pre-flight checks.

--- a/scripts/auto-dev-settings.json
+++ b/scripts/auto-dev-settings.json
@@ -35,6 +35,12 @@
 		],
 		"deny": [
 			"Bash(gh pr merge*)",
+			"Bash(gh pr close*)",
+			"Bash(gh issue close*)",
+			"Bash(gh issue delete*)",
+			"Bash(gh label create*)",
+			"Bash(gh label delete*)",
+			"Bash(gh label edit*)",
 			"Bash(gh release *)",
 			"Bash(gh repo delete*)",
 			"Bash(gh api -X DELETE*)",

--- a/scripts/auto-dev-settings.json
+++ b/scripts/auto-dev-settings.json
@@ -1,0 +1,53 @@
+{
+	"permissions": {
+		"allow": [
+			"Read",
+			"Glob",
+			"Grep",
+			"Edit",
+			"Write",
+			"TodoWrite",
+			"Skill",
+			"Bash(git *)",
+			"Bash(gh *)",
+			"Bash(npm *)",
+			"Bash(npx *)",
+			"Bash(node *)",
+			"Bash(jq *)",
+			"Bash(ls *)",
+			"Bash(cat *)",
+			"Bash(head *)",
+			"Bash(tail *)",
+			"Bash(wc *)",
+			"Bash(grep *)",
+			"Bash(rg *)",
+			"Bash(find *)",
+			"Bash(diff *)",
+			"Bash(sort *)",
+			"Bash(uniq *)",
+			"Bash(sed *)",
+			"Bash(awk *)",
+			"Bash(date *)",
+			"Bash(echo *)",
+			"Bash(mkdir *)",
+			"Bash(cp *)",
+			"Bash(mv *)"
+		],
+		"deny": [
+			"Bash(gh pr merge*)",
+			"Bash(gh release *)",
+			"Bash(gh repo delete*)",
+			"Bash(gh api -X DELETE*)",
+			"Bash(git push --force*)",
+			"Bash(git push -f*)",
+			"Bash(git push origin master*)",
+			"Bash(git push origin main*)",
+			"Bash(npm publish*)",
+			"Bash(npm run version*)",
+			"Bash(rm *)",
+			"Bash(sudo *)",
+			"Bash(curl *)",
+			"Bash(wget *)"
+		]
+	}
+}

--- a/scripts/auto-dev.sh
+++ b/scripts/auto-dev.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Scheduled runner for the auto-dev skill (.agents/skills/auto-dev/SKILL.md).
+#
+# Each invocation runs ONE tick of the autonomous issue-to-PR pipeline in a
+# DEDICATED clone — never in the interactive checkout — so unattended runs
+# cannot disturb work in progress in ~/src/obsidian-gemini.
+#
+# Install (every 30 minutes) with crontab -e:
+#   */30 * * * * /Users/allen/src/obsidian-gemini/scripts/auto-dev.sh
+#
+# Overridable environment:
+#   AUTO_DEV_DIR             dedicated clone location (default: ~/src/obsidian-gemini-autodev)
+#   AUTO_DEV_LOG_DIR         log directory (default: ~/.local/state/auto-dev)
+#   AUTO_DEV_MAX_BUDGET_USD  per-tick API spend cap (default: 10)
+#   AUTO_DEV_MAX_SECONDS     per-tick wall-clock cap (default: 2700)
+
+set -euo pipefail
+
+# cron provides a minimal PATH; make sure claude, gh, git, node are reachable.
+export PATH="$HOME/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
+
+REPO_URL="https://github.com/allenhutchison/obsidian-gemini.git"
+WORK_DIR="${AUTO_DEV_DIR:-$HOME/src/obsidian-gemini-autodev}"
+LOG_DIR="${AUTO_DEV_LOG_DIR:-$HOME/.local/state/auto-dev}"
+LOCK_DIR="${TMPDIR:-/tmp}/obsidian-gemini-auto-dev.lock"
+MAX_BUDGET_USD="${AUTO_DEV_MAX_BUDGET_USD:-10}"
+MAX_SECONDS="${AUTO_DEV_MAX_SECONDS:-2700}"
+
+mkdir -p "$LOG_DIR"
+LOG_FILE="$LOG_DIR/auto-dev-$(date +%Y-%m-%d).log"
+exec >>"$LOG_FILE" 2>&1
+
+echo ""
+echo "=== auto-dev tick start $(date '+%Y-%m-%dT%H:%M:%S%z') ==="
+
+# --- Lock: skip the tick entirely if a previous one is still running. ---
+if ! mkdir "$LOCK_DIR" 2>/dev/null; then
+	HELD_PID="$(cat "$LOCK_DIR/pid" 2>/dev/null || true)"
+	if [ -n "$HELD_PID" ] && kill -0 "$HELD_PID" 2>/dev/null; then
+		echo "lock held by running pid $HELD_PID; skipping this tick"
+		exit 0
+	fi
+	echo "reclaiming stale lock (pid ${HELD_PID:-unknown} not running)"
+	rm -rf "$LOCK_DIR"
+	mkdir "$LOCK_DIR"
+fi
+echo "$$" >"$LOCK_DIR/pid"
+trap 'rm -rf "$LOCK_DIR"' EXIT
+
+# --- Dedicated clone, reset to a clean master each tick. ---
+if [ ! -d "$WORK_DIR/.git" ]; then
+	echo "creating dedicated clone at $WORK_DIR"
+	git clone "$REPO_URL" "$WORK_DIR"
+fi
+cd "$WORK_DIR"
+git fetch origin --prune
+git reset --hard
+git clean -fd
+git checkout master
+git pull --ff-only origin master
+npm install --no-audit --no-fund >/dev/null
+
+# --- One tick, with a budget cap and a wall-clock watchdog. ---
+claude -p "/auto-dev" \
+	--settings "$WORK_DIR/scripts/auto-dev-settings.json" \
+	--permission-mode dontAsk \
+	--max-budget-usd "$MAX_BUDGET_USD" &
+CLAUDE_PID=$!
+
+(
+	sleep "$MAX_SECONDS"
+	if kill -0 "$CLAUDE_PID" 2>/dev/null; then
+		echo "watchdog: tick exceeded ${MAX_SECONDS}s; killing pid $CLAUDE_PID"
+		kill "$CLAUDE_PID" 2>/dev/null || true
+	fi
+) &
+WATCHDOG_PID=$!
+
+STATUS=0
+wait "$CLAUDE_PID" || STATUS=$?
+kill "$WATCHDOG_PID" 2>/dev/null || true
+
+echo "=== auto-dev tick end $(date '+%Y-%m-%dT%H:%M:%S%z') status=$STATUS ==="
+exit "$STATUS"

--- a/scripts/auto-dev.sh
+++ b/scripts/auto-dev.sh
@@ -12,7 +12,7 @@
 #   AUTO_DEV_DIR             dedicated clone location (default: ~/src/obsidian-gemini-autodev)
 #   AUTO_DEV_LOG_DIR         log directory (default: ~/.local/state/auto-dev)
 #   AUTO_DEV_MAX_BUDGET_USD  per-tick API spend cap (default: 10)
-#   AUTO_DEV_MAX_SECONDS     per-tick wall-clock cap (default: 2700)
+#   AUTO_DEV_MAX_SECONDS     per-tick wall-clock cap, covering clone/install/claude (default: 2700)
 
 set -euo pipefail
 
@@ -22,7 +22,7 @@ export PATH="$HOME/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
 REPO_URL="https://github.com/allenhutchison/obsidian-gemini.git"
 WORK_DIR="${AUTO_DEV_DIR:-$HOME/src/obsidian-gemini-autodev}"
 LOG_DIR="${AUTO_DEV_LOG_DIR:-$HOME/.local/state/auto-dev}"
-LOCK_DIR="${TMPDIR:-/tmp}/obsidian-gemini-auto-dev.lock"
+LOCK_FILE="${TMPDIR:-/tmp}/obsidian-gemini-auto-dev.lock"
 MAX_BUDGET_USD="${AUTO_DEV_MAX_BUDGET_USD:-10}"
 MAX_SECONDS="${AUTO_DEV_MAX_SECONDS:-2700}"
 
@@ -33,52 +33,78 @@ exec >>"$LOG_FILE" 2>&1
 echo ""
 echo "=== auto-dev tick start $(date '+%Y-%m-%dT%H:%M:%S%z') ==="
 
-# --- Lock: skip the tick entirely if a previous one is still running. ---
-if ! mkdir "$LOCK_DIR" 2>/dev/null; then
-	HELD_PID="$(cat "$LOCK_DIR/pid" 2>/dev/null || true)"
+# The EXIT trap guarantees a structured end-of-tick line even when set -e
+# aborts setup early, and releases the lock only if this tick owns it.
+LOCK_HELD=0
+WATCHDOG_PID=""
+cleanup() {
+	local code=$?
+	if [ -n "$WATCHDOG_PID" ]; then
+		kill "$WATCHDOG_PID" 2>/dev/null || true
+	fi
+	if [ "$LOCK_HELD" = 1 ]; then
+		rm -f "$LOCK_FILE"
+	fi
+	echo "=== auto-dev tick end $(date '+%Y-%m-%dT%H:%M:%S%z') status=$code ==="
+}
+trap cleanup EXIT
+
+# --- Lock: atomic create-with-PID via noclobber; skip if a live tick holds it. ---
+acquire_lock() {
+	(
+		set -o noclobber
+		echo "$$" >"$LOCK_FILE"
+	) 2>/dev/null
+}
+if ! acquire_lock; then
+	HELD_PID="$(cat "$LOCK_FILE" 2>/dev/null || true)"
 	if [ -n "$HELD_PID" ] && kill -0 "$HELD_PID" 2>/dev/null; then
 		echo "lock held by running pid $HELD_PID; skipping this tick"
 		exit 0
 	fi
 	echo "reclaiming stale lock (pid ${HELD_PID:-unknown} not running)"
-	rm -rf "$LOCK_DIR"
-	mkdir "$LOCK_DIR"
+	rm -f "$LOCK_FILE"
+	if ! acquire_lock; then
+		echo "lost the reclaim race to another tick; skipping"
+		exit 0
+	fi
 fi
-echo "$$" >"$LOCK_DIR/pid"
-trap 'rm -rf "$LOCK_DIR"' EXIT
+LOCK_HELD=1
 
-# --- Dedicated clone, reset to a clean master each tick. ---
-if [ ! -d "$WORK_DIR/.git" ]; then
-	echo "creating dedicated clone at $WORK_DIR"
-	git clone "$REPO_URL" "$WORK_DIR"
-fi
-cd "$WORK_DIR"
-git fetch origin --prune
-git reset --hard
-git clean -fd
-git checkout master
-git pull --ff-only origin master
-npm install --no-audit --no-fund >/dev/null
+# --- The whole tick (clone, npm install, claude) runs in a background
+# --- subshell so a single watchdog can cap its total wall-clock time.
+run_tick() {
+	if [ ! -d "$WORK_DIR/.git" ]; then
+		echo "creating dedicated clone at $WORK_DIR"
+		git clone "$REPO_URL" "$WORK_DIR"
+	fi
+	cd "$WORK_DIR"
+	git fetch origin --prune
+	git reset --hard
+	git clean -fd
+	git checkout master
+	git pull --ff-only origin master
+	npm install --no-audit --no-fund >/dev/null
 
-# --- One tick, with a budget cap and a wall-clock watchdog. ---
-claude -p "/auto-dev" \
-	--settings "$WORK_DIR/scripts/auto-dev-settings.json" \
-	--permission-mode dontAsk \
-	--max-budget-usd "$MAX_BUDGET_USD" &
-CLAUDE_PID=$!
+	claude -p "/auto-dev" \
+		--settings "$WORK_DIR/scripts/auto-dev-settings.json" \
+		--permission-mode dontAsk \
+		--max-budget-usd "$MAX_BUDGET_USD"
+}
+
+run_tick &
+TICK_PID=$!
 
 (
 	sleep "$MAX_SECONDS"
-	if kill -0 "$CLAUDE_PID" 2>/dev/null; then
-		echo "watchdog: tick exceeded ${MAX_SECONDS}s; killing pid $CLAUDE_PID"
-		kill "$CLAUDE_PID" 2>/dev/null || true
+	if kill -0 "$TICK_PID" 2>/dev/null; then
+		echo "watchdog: tick exceeded ${MAX_SECONDS}s; terminating pid $TICK_PID"
+		pkill -P "$TICK_PID" 2>/dev/null || true
+		kill "$TICK_PID" 2>/dev/null || true
 	fi
 ) &
 WATCHDOG_PID=$!
 
 STATUS=0
-wait "$CLAUDE_PID" || STATUS=$?
-kill "$WATCHDOG_PID" 2>/dev/null || true
-
-echo "=== auto-dev tick end $(date '+%Y-%m-%dT%H:%M:%S%z') status=$STATUS ==="
+wait "$TICK_PID" || STATUS=$?
 exit "$STATUS"


### PR DESCRIPTION
## Summary

Adds the **auto-dev** skill: an autonomous issue-to-PR pipeline designed to run unattended on a 15–30 minute schedule. Each invocation is one tick of a label-driven state machine: it triages open issues for readiness (asking clarifying questions where needed), posts implementation plans for maintainer approval, builds the oldest approved issue into a PR, and addresses CodeRabbit/human review feedback on the open automated PR. Two control gates stay exclusively human: **plan approval** (nothing is built without it) and **merge** (the pipeline never merges).

## Changes

- `.agents/skills/auto-dev/SKILL.md` (+ `.claude/skills/auto-dev` symlink) — the skill: invariants, label state machine (`auto:needs-info` / `auto:planned` / `auto:ready` / `auto:in-progress` / `auto:skip`), the five-step tick algorithm, plan/question comment templates, dry-run mode, and a what-not-to-do list
- `scripts/auto-dev.sh` — scheduled runner: operates in a dedicated clone (never the interactive checkout), PID lockfile so ticks can't overlap, per-tick spend cap (`--max-budget-usd`, default \$10) and wall-clock watchdog (default 45 min), logs to `~/.local/state/auto-dev/`
- `scripts/auto-dev-settings.json` — curated permissions allowlist for headless runs; hard-denies `gh pr merge`, `gh release`, force pushes, direct pushes to master/main, `npm publish`, `npm run version`, `rm`, `sudo`, and network fetch tools
- `AGENTS.md` — new "Autonomous issue pipeline (auto-dev)" section documenting the labels, the `<!-- auto-dev -->` comment marker, the runner, and the maintainer-side workflow for driving approvals from an interactive Claude Code session

## Design notes

- Pipeline comments post under the maintainer's own GitHub identity, so a hidden `<!-- auto-dev -->` marker (not authorship) distinguishes pipeline comments from human ones; third-party bot comments (`coderabbitai`, `dependabot`) are a third bucket ignored for state decisions — a dry-run against the live issue backlog caught CodeRabbit's auto-enrichment comments masquerading as human replies, hence the three-bucket rule
- At most one automated PR in flight; a merge (always human) is what unblocks the next build
- The five `auto:*` labels were created on the repo; a dry-run tick validated the triage logic against the five oldest eligible issues (3 plannable, 2 needing clarification)

## Testing

- `npm run format-check`, `npm run build`, `npm test` (3060 passing) — no production code touched
- `bash -n scripts/auto-dev.sh` and `jq` validation of the settings JSON
- `/auto-dev dry-run` executed against the live repo state: correct step selection (fresh pipeline → triage), correct epic/label exclusions, sensible plannable-vs-needs-info verdicts

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer (N/A — maintainer-driven tooling change, design discussed directly with maintainer)
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop (dry-run tick against live repo state)
- [x] I have verified this change does not break Mobile (N/A — no plugin code touched; dev tooling only)
- [x] Documentation has been updated (AGENTS.md)
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced an autonomous issue-to-PR pipeline that triages issues, posts implementation plans/questions for maintainer approval, and builds approved issues into pull requests with label-based state tracking and interactive commands.

* **Documentation**
  * Added comprehensive docs describing pipeline states, invocation modes (scheduled, interactive, dry-run), maintainer workflows, and required comment/label formats.

* **Chores**
  * Added a scheduled runner and configuration settings to run and safely gate automated ticks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->