### PR TITLE
chore(daily): 2026-06-14 daily update

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Let the AI actively work with your vault through tool calling capabilities.
 - **Create Folders:** Organize your vault with new folder structures
 - **List Files:** Browse vault directories and their contents
 - **Web Search:** Search Google for current information (if enabled)
+- **Google Maps:** Look up real-world places, addresses, opening hours, and ratings grounded in Google Maps (Gemini provider only)
 - **Fetch URLs:** Retrieve and analyze web content
 - **Deep Research:** Conduct comprehensive multi-source research with citations
 - **Agent Skills:** Activate specialized skill packages for domain-specific tasks

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -411,7 +411,7 @@ Controls which agent tools execute automatically, which require user confirmatio
 - **Setting**: `toolPolicy.toolPermissions`
 - **Type**: Object (tool name → permission)
 - **Default**: `{}` (empty — preset governs all tools)
-- **Description**: Each registered tool can be individually set to `deny` (blocked), `ask_user` (confirmation required), or `approve` (runs automatically). Overrides take precedence over the active preset. Setting an override causes the preset to switch to `custom`.
+- **Description**: Each registered tool can be individually set to `deny` (blocked), `ask` (confirmation required), or `allow` (runs automatically). Overrides take precedence over the active preset. Setting an override causes the preset to switch to `custom`. Legacy aliases `ask_user` and `approve` still parse correctly but `ask` and `allow` are the canonical forms.
 
 ### MCP servers
 

--- a/planning/changelog/2026-06-13.md
+++ b/planning/changelog/2026-06-13.md
@@ -1,0 +1,20 @@
+# Daily changelog — June 13, 2026
+
+**Date:** 2026-06-13
+**PRs merged:** 2
+
+---
+
+## Summary
+
+Quiet maintenance day. A Dependabot security patch updated esbuild to 0.28.1, and the automated daily housekeeping PR closed out the previous day's changelog and triage work. No feature work shipped.
+
+## What shipped
+
+### [#979 chore(deps-dev): bump esbuild from 0.28.0 to 0.28.1](https://github.com/allenhutchison/obsidian-gemini/pull/979)
+
+Security patch for the esbuild dev dependency. The 0.28.1 release fixes a path-traversal vulnerability in esbuild's local development server on Windows (backslash bypass via `path.Clean`), and adds integrity checks to the Deno API install script. No user-facing behavior change; this is a build-toolchain update only.
+
+### [#980 chore(daily): 2026-06-13 daily update](https://github.com/allenhutchison/obsidian-gemini/pull/980)
+
+Automated daily housekeeping. Wrote `planning/changelog/2026-06-12.md` covering the June 12 i18n completion and auto-dev pipeline launch day (4 PRs: #973, #975, #976, #978). Docs audit found no drift. Triage found no unlabeled issues.


### PR DESCRIPTION
## Summary

Automated daily housekeeping for 2026-06-14. Quiet maintenance day on June 13 — one esbuild security patch and the daily housekeeping PR. Docs audit found two drift items: the per-tool permission value names in settings.md used the old internal names (`ask_user`/`approve`) rather than the canonical serialized forms (`ask`/`allow`), and the Google Maps tool was missing from README's Available Tools list. Triage found no unlabeled issues.

## Changes

- **Add `planning/changelog/2026-06-13.md`**: Documents June 13 — 2 PRs: esbuild 0.28.1 security patch (#979) and daily housekeeping (#980). Quiet maintenance day.
- **Fix `docs/reference/settings.md`**: Per-Tool Overrides description corrected — `ask_user` → `ask` and `approve` → `allow` (canonical serialized forms; aliases still parse, but these are what the code writes). Added note that legacy aliases remain accepted.
- **Fix `README.md`**: Added Google Maps tool to the Available Tools list in the Agent mode section (was fully documented in `docs/guide/agent-mode.md` but omitted from the README summary).

## Sub-skill outcomes

- **daily-changelog**: wrote `planning/changelog/2026-06-13.md`, 2 PRs (quiet maintenance day — esbuild security patch #979 + daily housekeeping #980)
- **audit-docs**: fixed 2 drift items — `docs/reference/settings.md` permission value names (`ask_user`→`ask`, `approve`→`allow`); `README.md` missing Google Maps tool in Available Tools list
- **triage-issues**: no unlabeled open issues (0 processed, 0 labeled)

## Screenshots / Screencast

N/A — changelog and docs fixes only.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: daily housekeeping
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop — N/A: docs and changelog only
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A: docs only
- [x] Documentation has been updated (if applicable) — this PR IS the documentation update
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01FyLxGcJCSqmmM5fHvTvNHV)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **Google Maps** tool entry for **Gemini-provider-only** usage.

* **Documentation**
  * Clarified per-tool permission override behavior, including canonical values (**deny**, **ask** for confirmation, **allow** for automatic execution), preset switching to **custom**, and support for legacy aliases.

* **Chores**
  * Added a new daily changelog entry for **2026-06-13** summarizing merged PR activity and housekeeping updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->