### PR TITLE
feat(gemini): per-use-case thinkingLevel in the Gemini client

### DIFF
--- a/src/api/factory.ts
+++ b/src/api/factory.ts
@@ -15,17 +15,11 @@ import { GeminiPrompts } from '../prompts';
 import { RetryDecorator } from './retry-decorator';
 import { getDefaultModelForRole } from '../models';
 import type ObsidianGemini from '../main';
+import { ModelUseCase } from './model-use-case';
 
-/**
- * Model use cases for the plugin
- */
-export enum ModelUseCase {
-	CHAT = 'chat',
-	SUMMARY = 'summary',
-	COMPLETIONS = 'completions',
-	REWRITE = 'rewrite',
-	SEARCH = 'search',
-}
+// Re-exported so existing `import { ModelUseCase } from '.../api/factory'` call
+// sites keep working after the enum moved to its own (import-free) module.
+export { ModelUseCase } from './model-use-case';
 
 /**
  * Factory for creating provider-appropriate ModelApi clients.
@@ -72,6 +66,7 @@ export class ModelClientFactory {
 		const config: GeminiClientConfig = {
 			apiKey: plugin.apiKey,
 			model: modelName,
+			useCase,
 			temperature: settings.temperature ?? 1.0,
 			topP: settings.topP ?? 0.95,
 			streamingEnabled: settings.streamingEnabled ?? true,

--- a/src/api/model-use-case.ts
+++ b/src/api/model-use-case.ts
@@ -1,0 +1,15 @@
+/**
+ * The use case a model client is created for.
+ *
+ * Drives model selection in `ModelClientFactory` and per-use-case request
+ * tuning in the providers (e.g. the Gemini `thinkingLevel` map). Kept in its
+ * own module — with no imports — so providers can depend on it without forming
+ * an import cycle with `factory.ts` (which imports the provider clients).
+ */
+export enum ModelUseCase {
+	CHAT = 'chat',
+	SUMMARY = 'summary',
+	COMPLETIONS = 'completions',
+	REWRITE = 'rewrite',
+	SEARCH = 'search',
+}

--- a/src/api/providers/gemini/client.ts
+++ b/src/api/providers/gemini/client.ts
@@ -13,6 +13,7 @@ import {
 	GenerateContentResponse,
 	GenerateContentResponseUsageMetadata,
 } from '@google/genai';
+import type { ThinkingLevel } from '@google/genai';
 import {
 	ModelApi,
 	BaseModelRequest,
@@ -28,6 +29,34 @@ import type ObsidianGemini from '../../../main';
 import { getDefaultModelForRole } from '../../../models';
 import { decodeHtmlEntities } from '../../../utils/html-entities';
 import type { GeminiClientConfig } from './config';
+import { ModelUseCase } from '../../model-use-case';
+
+/**
+ * Per-use-case reasoning depth for Gemini 3.x `thinkingConfig.thinkingLevel`,
+ * replacing the legacy global `thinkingBudget: -1`. These are starting points
+ * (see #621; tune against the eval suite in #619): latency-sensitive paths
+ * think the least, while CHAT — which is the agent loop — thinks the most.
+ *
+ * | Use case    | level    | why                                            |
+ * | ----------- | -------- | ---------------------------------------------- |
+ * | Completions | MINIMAL  | latency-sensitive, simple next-token output    |
+ * | Summary     | LOW      | bounded, templated output                      |
+ * | Rewrite     | LOW      | short, focused edits                           |
+ * | Search      | MEDIUM   | query understanding + synthesis                |
+ * | Chat        | HIGH     | agent mode: multi-step tool use, benefits most |
+ */
+// The literal strings are the `ThinkingLevel` enum's own runtime values, used
+// directly (with a single cast) instead of the imported enum members so this
+// module never touches the SDK's runtime namespace — keeping it load-safe under
+// tests that mock `@google/genai`. The per-use-case values are covered by unit
+// tests, which catch any typo here.
+const THINKING_LEVEL_BY_USE_CASE: Record<ModelUseCase, ThinkingLevel> = {
+	[ModelUseCase.COMPLETIONS]: 'MINIMAL',
+	[ModelUseCase.SUMMARY]: 'LOW',
+	[ModelUseCase.REWRITE]: 'LOW',
+	[ModelUseCase.SEARCH]: 'MEDIUM',
+	[ModelUseCase.CHAT]: 'HIGH',
+} as Record<ModelUseCase, ThinkingLevel>;
 
 /**
  * Extends Part to include the optional thought property
@@ -227,11 +256,14 @@ export class GeminiClient implements ModelApi {
 			...(systemInstruction && { systemInstruction }),
 		};
 
-		// Add thinking config if model supports it
+		// Add thinking config if model supports it. We steer reasoning depth with
+		// `thinkingLevel` (Gemini 3.x) per use case — never the legacy
+		// `thinkingBudget`, and never both knobs in one request. `includeThoughts`
+		// stays true so reasoning persistence (#965) keeps receiving thought parts.
 		if (this.supportsThinking(model)) {
 			config.thinkingConfig = {
 				includeThoughts: true,
-				thinkingBudget: -1, // -1 = automatic budget
+				thinkingLevel: THINKING_LEVEL_BY_USE_CASE[this.config.useCase ?? ModelUseCase.CHAT],
 			};
 		}
 

--- a/src/api/providers/gemini/config.ts
+++ b/src/api/providers/gemini/config.ts
@@ -1,9 +1,17 @@
+import type { ModelUseCase } from '../../model-use-case';
+
 /**
  * Configuration for GeminiClient
  */
 export interface GeminiClientConfig {
 	apiKey: string;
 	model?: string;
+	/**
+	 * The use case this client was created for. Drives per-use-case request
+	 * tuning (e.g. `thinkingLevel`). Optional — `createCustom` callers leave it
+	 * unset and fall back to the CHAT defaults.
+	 */
+	useCase?: ModelUseCase;
 	temperature?: number;
 	topP?: number;
 	maxOutputTokens?: number;

--- a/test/api/providers/gemini/client.test.ts
+++ b/test/api/providers/gemini/client.test.ts
@@ -4,6 +4,7 @@ import { GeminiClient } from '../../../../src/api/providers/gemini/client';
 import type { GeminiClientConfig } from '../../../../src/api/providers/gemini/config';
 import { GeminiPrompts } from '../../../../src/prompts';
 import type { ExtendedModelRequest } from '../../../../src/api/interfaces/model-api';
+import { ModelUseCase } from '../../../../src/api/model-use-case';
 
 // Capture every call to `client.models.generateContent` so tests can assert on
 // the params (system instruction, contents, etc.) the SDK sees. vi.hoisted lets
@@ -297,6 +298,67 @@ describe('GeminiClient', () => {
 			expect(userTurn).toBeDefined();
 			expect(userTurn.parts).toHaveLength(1);
 			expect(userTurn.parts[0].text).toBe('just chat');
+		});
+	});
+
+	// Per-use-case thinkingLevel (#621): the client maps the ModelUseCase it was
+	// created for to a thinkingConfig.thinkingLevel, replacing the old global
+	// thinkingBudget. Reasoning persistence (#965) relies on includeThoughts, and
+	// the API rejects sending both knobs — so assert exactly one is present.
+	describe('per-use-case thinkingLevel', () => {
+		const THINKING_MODEL = 'gemini-3-pro';
+
+		beforeEach(() => {
+			generateContentMock.mockReset();
+			generateContentMock.mockResolvedValue({
+				candidates: [{ content: { parts: [{ text: 'ok' }] } }],
+				usageMetadata: { promptTokenCount: 1, candidatesTokenCount: 1, totalTokenCount: 2 },
+			});
+		});
+
+		// Captures the thinkingConfig the SDK is handed for a client created with
+		// the given use case against a thinking-capable model.
+		const thinkingConfigFor = async (useCase?: ModelUseCase): Promise<any> => {
+			const client = new GeminiClient(
+				{ apiKey: 'test-api-key', model: THINKING_MODEL, useCase },
+				new GeminiPrompts(mockPlugin),
+				mockPlugin
+			);
+			await client.generateModelResponse({ kind: 'base', prompt: 'hi' });
+			const params = (generateContentMock as Mock).mock.calls[0][0];
+			return params.config.thinkingConfig;
+		};
+
+		test.each([
+			[ModelUseCase.COMPLETIONS, 'MINIMAL'],
+			[ModelUseCase.SUMMARY, 'LOW'],
+			[ModelUseCase.REWRITE, 'LOW'],
+			[ModelUseCase.SEARCH, 'MEDIUM'],
+			[ModelUseCase.CHAT, 'HIGH'],
+		])('%s maps to thinkingLevel %s', async (useCase, expectedLevel) => {
+			const thinkingConfig = await thinkingConfigFor(useCase as ModelUseCase);
+			expect(thinkingConfig.thinkingLevel).toBe(expectedLevel);
+			expect(thinkingConfig.includeThoughts).toBe(true);
+			// Never send both knobs — thinkingLevel only.
+			expect(thinkingConfig.thinkingBudget).toBeUndefined();
+		});
+
+		test('defaults to HIGH when no use case is set (e.g. createCustom callers)', async () => {
+			const thinkingConfig = await thinkingConfigFor(undefined);
+			expect(thinkingConfig.thinkingLevel).toBe('HIGH');
+			expect(thinkingConfig.includeThoughts).toBe(true);
+			expect(thinkingConfig.thinkingBudget).toBeUndefined();
+		});
+
+		test('omits thinkingConfig entirely for non-thinking models', async () => {
+			const client = new GeminiClient(
+				{ apiKey: 'test-api-key', model: 'gemini-pro', useCase: ModelUseCase.CHAT },
+				new GeminiPrompts(mockPlugin),
+				mockPlugin
+			);
+			await client.generateModelResponse({ kind: 'base', prompt: 'hi' });
+			const params = (generateContentMock as Mock).mock.calls[0][0];
+			expect(params.config.thinkingConfig).toBeUndefined();
 		});
 	});
 


### PR DESCRIPTION
<!-- auto-dev -->

## Summary

Fixes #621. Steers Gemini 3.x reasoning depth per use case via `thinkingConfig.thinkingLevel`, replacing the single global `thinkingBudget: -1` that gave every path — including latency-sensitive completions — automatic/unbounded thinking. `includeThoughts: true` is preserved so reasoning persistence (#965) keeps receiving thought parts, and only one thinking knob is ever sent (`thinkingLevel`, never `thinkingBudget`).

This PR was produced by the auto-dev pipeline from the plan approved on #621.

**Level map** (starting points; tune against the eval suite in #619):

| Use case    | `thinkingLevel` | Why                                            |
| ----------- | --------------- | ---------------------------------------------- |
| Completions | `MINIMAL`       | latency-sensitive, simple next-token output    |
| Summary     | `LOW`           | bounded, templated output                      |
| Rewrite     | `LOW`           | short, focused edits                           |
| Search      | `MEDIUM`        | query understanding + synthesis                |
| Chat        | `HIGH`          | agent mode: multi-step tool use, benefits most |

Clients created without a use case (e.g. `createCustom`) default to `HIGH`.

## Changes

- `src/api/model-use-case.ts` (new) — extracts the `ModelUseCase` enum into its own import-free module so providers can depend on it without forming a `factory.ts` ↔ `client.ts` import cycle.
- `src/api/factory.ts` — imports `ModelUseCase` from the new module and re-exports it (back-compat for existing `import { ModelUseCase } from '.../api/factory'` call sites); `createFromPlugin` now sets `useCase` on the constructed `GeminiClientConfig` (overridable via the existing `overrides` spread).
- `src/api/providers/gemini/config.ts` — adds optional `useCase?: ModelUseCase` to `GeminiClientConfig`.
- `src/api/providers/gemini/client.ts` — replaces the `thinkingBudget: -1` block with a documented `ModelUseCase → ThinkingLevel` lookup; keeps `includeThoughts: true`. The level map uses the SDK enum's string values via a type-only import + single cast, so the module never touches the SDK's runtime namespace and stays load-safe under suites that mock `@google/genai`.
- `test/api/providers/gemini/client.test.ts` — new `thinkingLevel` coverage: each use case maps to the expected level, `includeThoughts` stays true, `thinkingBudget` is never sent, the no-use-case default is `HIGH`, and non-thinking models get no `thinkingConfig` at all.

## Notes

- **`supportsThinking` left unchanged.** Per the approved plan and issue (2.5 is deprecated; design targets `thinkingLevel` only), the capability gate is untouched — thinking-capable models, including legacy 2.5, now receive `thinkingLevel`. Gating to 3.x-only would be a separate, out-of-scope change.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer — #621, plan approved
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop — verified via `npm test` (3067 tests, incl. new thinkingLevel coverage), `npm run build`, `npm run format-check`, `npm run typecheck:test`
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A: provider-layer request config, no platform-specific code
- [ ] Documentation has been updated (if applicable) — N/A: internal request-tuning change with no user-facing setting or UI; no docs reference thinking config
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (auto-dev pipeline)
- [x] I have reviewed and understand all AI-generated code in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Gemini models now support per-use-case optimization of thinking levels, tailoring AI behavior for chat, summaries, completions, rewrites, and search tasks.

* **Refactoring**
  * Reorganized model use case definitions and internal configuration structure.

* **Tests**
  * Added test coverage verifying Gemini thinking configurations respond correctly to different use cases and model types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->