### PR TITLE
fix(auto-dev): key parked-issue unblock off label-application time

### DIFF
--- a/.agents/skills/auto-dev/SKILL.md
+++ b/.agents/skills/auto-dev/SKILL.md
@@ -24,15 +24,15 @@ This skill automates the path from open issue to reviewed PR while keeping the m
 
 ## Label state machine
 
-| Label               | Meaning                                                                                                                       | Who sets it                                           |
-| ------------------- | ----------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
-| (no `auto:*` label) | Not yet triaged by auto-dev                                                                                                   | —                                                     |
-| `auto:needs-info`   | Skill asked a clarifying question; waiting on a human reply                                                                   | skill                                                 |
-| `auto:planned`      | Skill posted an implementation plan; waiting on approval                                                                      | skill                                                 |
-| `auto:ready`        | Plan approved; eligible to build                                                                                              | skill (on detected approval) or human (directly)      |
-| `auto:in-progress`  | Being built / has an open automated PR                                                                                        | skill                                                 |
-| `auto:parked`       | Assessed; the maintainer chose to hold it. Skill does not re-triage until the label is removed or a new human comment appears | human (directly), or skill on a human "park it" reply |
-| `auto:skip`         | Opt-out — auto-dev never touches this issue                                                                                   | human                                                 |
+| Label               | Meaning                                                                                                                                     | Who sets it                                           |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
+| (no `auto:*` label) | Not yet triaged by auto-dev                                                                                                                 | —                                                     |
+| `auto:needs-info`   | Skill asked a clarifying question; waiting on a human reply                                                                                 | skill                                                 |
+| `auto:planned`      | Skill posted an implementation plan; waiting on approval                                                                                    | skill                                                 |
+| `auto:ready`        | Plan approved; eligible to build                                                                                                            | skill (on detected approval) or human (directly)      |
+| `auto:in-progress`  | Being built / has an open automated PR                                                                                                      | skill                                                 |
+| `auto:parked`       | Assessed; the maintainer chose to hold it. Skill does not re-triage until the label is removed or a human comment is added _after_ the park | human (directly), or skill on a human "park it" reply |
+| `auto:skip`         | Opt-out — auto-dev never touches this issue                                                                                                 | human                                                 |
 
 **Eligibility:** all open issues, oldest first, EXCEPT issues labeled `auto:skip`, `epic`, `question`, `wontfix`, `duplicate`, or `invalid`. Pull requests are never triaged as issues.
 
@@ -109,7 +109,7 @@ If the build cannot complete inside this tick's budget, push the WIP commits and
 
 ### Step 4 — Triage pass (bounded)
 
-Walk eligible open issues oldest→newest. Act on at most **5** issues per tick (count only issues where you actually post/relabel; skipped issues are free). To stay cheap on idle ticks, only deep-read an issue's thread when it might have changed: an `auto:*`-labelled issue whose `updatedAt` is no newer than the skill's own last marker comment on it has nothing new — skip it without re-reading. For each issue that needs a look, read the full thread, then branch on its current `auto:*` state:
+Walk eligible open issues oldest→newest. Act on at most **5** issues per tick (count only issues where you actually post/relabel; skipped issues are free). To stay cheap on idle ticks, only deep-read an issue's thread when it might have changed: an `auto:*`-labelled issue whose `updatedAt` is no newer than the skill's own last marker comment on it has nothing new — skip it without re-reading (for `auto:parked`, the baseline is the park-time label event, not a marker comment). For each issue that needs a look, read the full thread, then branch on its current `auto:*` state:
 
 - **No `auto:*` label** — assess whether the issue contains enough to plan from (clear problem, scoped outcome, no unresolved design fork):
   - _Plannable_ → draft an implementation plan (format below), post it as a comment, add `auto:planned`.
@@ -126,10 +126,18 @@ Walk eligible open issues oldest→newest. Act on at most **5** issues per tick 
   - _A request to park_ ("not now", "let's hold this") → swap label to `auto:parked`.
   - _No reply_ → skip silently.
   - The human adding `auto:ready` directly is always approval, reply or not.
-- **`auto:parked`** — the maintainer chose to hold this; it rests until they re-engage. Two unblock signals:
-  - _A new human comment since the skill's last marker comment_ (the maintainer added detail or direction) → unblocked: remove `auto:parked` and re-triage it this tick as if freshly labelled (plan if now plannable, otherwise ask / re-propose).
+- **`auto:parked`** — the maintainer chose to hold this; it rests until they re-engage. The unblock baseline is **when `auto:parked` was applied**, _not_ the skill's last marker comment — so a rationale the maintainer records _at park time_ doesn't bounce the issue straight back out. Read the park time from the most recent `auto:parked` `labeled` event on the issue timeline:
+
+  ```bash
+  gh api "repos/{owner}/{repo}/issues/<N>/timeline" --paginate \
+    | jq -r '[.[] | select(.event=="labeled" and .label.name=="auto:parked")] | last | .created_at'
+  ```
+
+  Two unblock signals:
+  - _A human comment (no marker, not a third-party bot) newer than the park time_ (the maintainer came back with detail or direction) → unblocked: remove `auto:parked` and re-triage it this tick as if freshly labelled (plan if now plannable, otherwise ask / re-propose).
   - _The human removed the label_ → it reappears with no `auto:*` label and re-enters triage through the no-label branch; nothing special to do.
-  - _Otherwise_ (still parked, no new human comment) → skip silently. **Never re-propose parking, re-ask, or re-plan a parked issue.**
+  - _Otherwise_ (still parked, no human comment after the park) → skip silently. **Never re-propose parking, re-ask, or re-plan a parked issue.**
+
 - **`auto:ready` / `auto:in-progress`** — leave for steps 1 and 3.
 
 ### Step 5 — Nothing to do
@@ -190,7 +198,7 @@ This isn't blocked on missing detail — it's waiting on a call that's yours to 
 Want me to **park** it for now? Reply "park it" (or add the `auto:parked` label) and I'll leave it untouched until you remove the label or add more detail to the issue. If you'd rather move it forward, here's what would unblock it: <the specific decision or input needed>.
 ```
 
-A parked issue is durable rest, not abandonment: the skill picks it back up the moment the maintainer removes `auto:parked` or adds a new comment.
+A parked issue is durable rest, not abandonment: the skill picks it back up the moment the maintainer removes `auto:parked` or adds a comment _after_ the park (a rationale left at park time is recorded but does not re-activate it — see the `auto:parked` triage branch).
 
 ## Exit report
 
@@ -218,7 +226,7 @@ errors: <none | details>
 - Don't start a second build while an automated PR is open.
 - Don't post a second question/plan when the previous one is still unanswered.
 - Don't park an issue on your own initiative — only _propose_ parking; the maintainer parks by replying "park it" or adding the label. (`auto:parked` is set by the skill solely on a human park reply, or by the human directly.)
-- Don't re-propose parking, re-ask, or re-plan an `auto:parked` issue — it rests until the maintainer removes the label or adds a new comment. Don't remove `auto:parked` yourself except when re-triaging it because the maintainer just commented.
+- Don't re-propose parking, re-ask, or re-plan an `auto:parked` issue — it rests until the maintainer removes the label or adds a comment _after_ the park. Don't remove `auto:parked` yourself except when re-triaging it because the maintainer commented after parking.
 - Don't touch `auto:skip`, `epic`, `question`, `wontfix`, `duplicate`, or `invalid` issues, and don't remove `auto:skip` ever.
 - Don't apply or change non-`auto:*` labels — categorization belongs to the `triage-issues` skill.
 - Don't close issues, edit issue bodies, or modify human comments.

--- a/.agents/skills/review-queue/SKILL.md
+++ b/.agents/skills/review-queue/SKILL.md
@@ -92,13 +92,13 @@ When drained or dismissed, print a short session summary: what you decided, what
 - **Approve** ("approved", "lgtm", "go", "ship it") → add `auto:ready`. The oldest `auto:ready` builds on the next tick with no PR in flight.
 - **Approve with a tweak** ("approved, but use X") → post your tweak as a plain comment, then add `auto:ready` (the build adapts to the latest comment). If the change is large enough to reshape the plan, instead post the change and leave `auto:planned` so the next tick re-plans — ask which you want if it's unclear.
 - **Request changes** → post your feedback as a comment; leave `auto:planned` (next tick revises the plan).
-- **Not now** → `auto:parked` (hold, revisit later) or `auto:skip` (opt out entirely), per your words.
+- **Not now** → `auto:parked` (hold, revisit later) or `auto:skip` (opt out entirely), per your words. If you give a reason, record it the park-safe way (below).
 - **I'll do this one** → `auto:skip` (so a tick won't build it concurrently); you implement it normally and remove `auto:skip` later to hand it back, or close it via your PR.
 
 **A question or park proposal (`auto:needs-info`):**
 
 - **Answer it** → post your answer as a comment; the next tick incorporates it (plans, or asks a follow-up).
-- **Park it** → add `auto:parked` (it rests until you remove the label or add a new comment).
+- **Park it** → add `auto:parked` (it rests until you remove the label or add a comment _after_ the park). If you give a reason, record it the park-safe way (below).
 - **Skip** → `auto:skip`.
 
 **A parked issue (`auto:parked`):**
@@ -106,6 +106,8 @@ When drained or dismissed, print a short session summary: what you decided, what
 - **Unpark with direction** → remove `auto:parked` and post the new detail/decision as a comment; it re-enters triage with your input.
 - **Decide the design** → post your decision; either remove `auto:parked` to let the bot re-plan, or, if you've fully specced it, write the plan yourself and set the label you want (`auto:planned` for the bot to confirm, or straight to `auto:ready`).
 - **Keep holding** → leave it; move on.
+
+> **Parking with a reason — order matters.** auto-dev keys a parked issue's unblock off **when `auto:parked` was applied** (the label event on the timeline). So when you park _with_ a rationale, post the reason as a plain comment **first, then apply the label** — the comment ends up older than the park event, so it's recorded without bouncing the issue back into triage. Apply the label first and comment after, and the next tick reads that comment as "the maintainer came back" and un-parks it. (Unparking later is exactly this: a comment _after_ the park, or removing the label.)
 
 **A new / untriaged issue:**
 


### PR DESCRIPTION
## Summary

Fixes a self-unblock bug in the `auto-dev` parked-issue workflow, surfaced while parking #447 via `review-queue`.

The `auto:parked` branch unblocked an issue when it saw *"a human comment newer than the skill's last marker comment."* But parking posts **no** marker comment, so any rationale the maintainer records at park time is — by definition — newer than the last marker, and the very next cron tick reads it as "the maintainer came back," un-parks the issue, and re-proposes parking. Result: you can't park an issue *with a reason* without it bouncing back into triage within the hour.

**Fix:** re-baseline the unblock on **when `auto:parked` was applied** (the `labeled` event on the issue timeline) instead of the last marker comment. A reason left at park time is now older than the park event and is correctly ignored; only a comment added *after* the park (or removing the label) re-activates the issue.

This is why, in the current session, #447 was parked label-only with its rationale ("migrate to the Interactions API once it's GA") held back — once this merges, that rationale can be recorded on the issue safely.

## Changes

- `.agents/skills/auto-dev/SKILL.md`:
  - `auto:parked` triage branch now reads the park time from the timeline (`gh api .../issues/<N>/timeline` → most recent `auto:parked` `labeled` event) and unblocks only on a human comment newer than that.
  - Aligned the label-table description, the park-proposal closing note, the "what not to do" rule, and the cheap-skip baseline to the "comment *after* the park" semantics.
- `.agents/skills/review-queue/SKILL.md`:
  - Added a "parking with a reason — order matters" rule: post the rationale comment **first**, then apply `auto:parked`, so the comment predates the park event. Cross-referenced from the plan-"not now" and question-"park it" actions.

## Notes

- Docs/skill-only change; no plugin runtime code touched. `format-check`, `build`, and `npm test` (3067) all pass.
- The timeline lookup is a recipe the tick adapts at runtime, consistent with the rest of the skill's `gh` snippets.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: bug in the pipeline tooling, found and fixed in-session with the maintainer
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop — N/A (no runtime code); verified `format-check` / `build` / `npm test` pass and re-read both skills for internal consistency
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A: documentation/tooling only
- [x] Documentation has been updated (if applicable) — the skills are the documentation
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR