### PR TITLE
chore(daily): 2026-06-16 daily update

### DIFF
--- a/planning/changelog/2026-06-16.md
+++ b/planning/changelog/2026-06-16.md
@@ -7,7 +7,7 @@
 
 ## Summary
 
-Quiet Monday — the only merge was the automated daily housekeeping PR for June 15. No feature work or fixes landed; the day's activity was maintenance infrastructure keeping the changelog and docs audit cadence current.
+Quiet Tuesday — the only merge was the automated daily housekeeping PR for June 15. No feature work or fixes landed; the day's activity was maintenance infrastructure keeping the changelog and docs audit cadence current.
 
 ## What shipped
 

--- a/planning/changelog/2026-06-16.md
+++ b/planning/changelog/2026-06-16.md
@@ -1,0 +1,16 @@
+# Daily changelog — June 16, 2026
+
+**Date:** 2026-06-16
+**PRs merged:** 1
+
+---
+
+## Summary
+
+Quiet Monday — the only merge was the automated daily housekeeping PR for June 15. No feature work or fixes landed; the day's activity was maintenance infrastructure keeping the changelog and docs audit cadence current.
+
+## What shipped
+
+### [#990 chore(daily): 2026-06-15 daily update](https://github.com/allenhutchison/obsidian-gemini/pull/990)
+
+Automated daily housekeeping for June 15. Wrote `planning/changelog/2026-06-15.md` documenting that day's single merged PR (the June 14 daily update, #989). Docs audit found no drift; triage found no unlabeled open issues.


### PR DESCRIPTION
## Summary

Automated daily housekeeping for 2026-06-16. Quiet Monday — one PR merged (the June 15 daily update). Docs audit found no drift; triage found no unlabeled issues.

## Changes

- **Add `planning/changelog/2026-06-16.md`**: Documents June 16 — 1 PR (#990, the previous daily housekeeping run covering June 15).

## Sub-skill outcomes

- **daily-changelog**: wrote `planning/changelog/2026-06-16.md`, 1 PR (quiet Monday — daily housekeeping only)
- **audit-docs**: no drift found, no new docs warranted
- **triage-issues**: no unlabeled open issues (0 processed, 0 labeled)

## Screenshots / Screencast

N/A — changelog only.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: daily housekeeping
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop — N/A: changelog only
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A: docs only
- [x] Documentation has been updated (if applicable) — this PR IS the documentation update
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01RatyzdEAeLerbCMEPSu5kf)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an updated daily changelog entry for June 16, 2026, documenting the previous cycle’s housekeeping work and the resulting documentation audit/triage outcome (no drift found and no unlabeled open issues).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->