### PR TITLE
refactor: type-guard file-picker fuzzy-search filter

### DIFF
--- a/src/ui/agent-view/file-picker-modal.ts
+++ b/src/ui/agent-view/file-picker-modal.ts
@@ -65,8 +65,10 @@ export class FilePickerModal extends SuggestModal<TAbstractFile> {
 		const search = prepareFuzzySearch(trimmed);
 		this.lastSuggestions = this.allItems
 			.map((item) => ({ item, result: search(item.path) }))
-			.filter(({ result }) => result !== null)
-			.sort((a, b) => b.result!.score - a.result!.score)
+			.filter(
+				(entry): entry is { item: TAbstractFile; result: NonNullable<typeof entry.result> } => entry.result !== null
+			)
+			.sort((a, b) => b.result.score - a.result.score)
 			.map(({ item }) => item);
 		return this.lastSuggestions;
 	}


### PR DESCRIPTION
## Summary

Architecture-audit nightly sweep flagged: **improper typing** in `src/ui/agent-view/file-picker-modal.ts`.

`FilePickerModal.getSuggestions` builds `{ item, result }` pairs, drops the ones with `result === null`, then sorts by `b.result!.score - a.result!.score`. The two non-null assertions exist because plain `.filter(({ result }) => result !== null)` doesn't narrow the inner type — TypeScript still thinks `result` could be null on the next line.

Replace the runtime filter with a user-defined type guard that asserts `result is NonNullable<typeof entry.result>`. The sort accesses `b.result.score` directly afterwards; no `!` needed.

Behavior is identical (same predicate, same ordering). Pure typing tightening — no UX change, no test changes required.

## Changes

- `src/ui/agent-view/file-picker-modal.ts` — replace `.filter(({ result }) => result !== null)` with a type-guarded `.filter((entry): entry is { item: TAbstractFile; result: NonNullable<typeof entry.result> } => entry.result !== null)`, and drop the two `result!` non-null assertions in the subsequent `.sort()`.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer — _filed by the nightly architecture-audit sweep; no human issue, the sweep itself is the standing approval per `.agents/skills/architecture-audit/SKILL.md`._
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop — _build + 3067 tests pass; pure typing tightening with no runtime change._
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — _no platform-specific code touched._
- [x] Documentation has been updated (if applicable) — N/A, internal typing refinement.
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR


---
_Generated by [Claude Code](https://claude.ai/code/session_01GCedv4BJKTSonyYLvJYTgi)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved code maintainability in the file picker suggestion system through better filtering logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->