### PR TITLE
feat(agent): soft turn budget with reminder and one-shot extension

### DIFF
--- a/docs/guide/lifecycle-hooks.md
+++ b/docs/guide/lifecycle-hooks.md
@@ -115,10 +115,10 @@ toolPolicy:
 
 An `agent-task` fire drives an agent loop that calls tools, reads the results, and calls more tools until it produces a final response. To guard against runaway loops in unattended fires, that loop is capped at **20 tool-call batches** by default. A batch is one round of tool calls (which may run several tools in parallel), not a single tool call.
 
-When a fire exhausts the cap without producing a response, it fails with an error like:
+The cap is a **soft budget**: the agent is warned as it nears the limit, and granted a **one-time extension** (half the original budget, rounded up) if it runs out mid-task, so it can wrap up instead of being cut off. Only when that extension is also spent does the fire fail:
 
 ```text
-Hook "<slug>" exhausted 20 tool iterations without producing a response
+Hook "<slug>" exhausted its tool-iteration budget (cap 20, ran 30) without producing a response
 ```
 
 If a legitimately long hook keeps hitting this, raise the cap with the `maxIterations` frontmatter key (or the **Max tool iterations** field under **Advanced options** in the hook editor):
@@ -131,7 +131,7 @@ maxIterations: 50
 ---
 ```
 
-`maxIterations` must be a positive whole number; blank or invalid values fall back to the default of 20. It only affects `agent-task` hooks — the other actions don't drive the agent loop. This is the same limit (and the same default) used by [scheduled tasks](./scheduled-tasks.md#tool-iteration-limit); the interactive agent chat has no such cap.
+`maxIterations` must be a positive whole number; blank or invalid values fall back to the default of 20. It only affects `agent-task` hooks — the other actions don't drive the agent loop. This is the same soft budget (and the same default) used by [scheduled tasks](./scheduled-tasks.md#tool-iteration-limit); the interactive agent chat applies it too, with a higher default of 50.
 
 ### `summarize`
 

--- a/docs/guide/scheduled-tasks.md
+++ b/docs/guide/scheduled-tasks.md
@@ -105,10 +105,10 @@ Omitting `toolPolicy` (or setting it to an empty object) means **inherit the glo
 
 Each run drives an agent loop that calls tools, reads the results, and calls more tools until it produces a final response. To guard against runaway loops in unattended runs, that loop is capped at **20 tool-call batches** by default. A batch is one round of tool calls (which may run several tools in parallel), not a single tool call — so a task doing parallel work fits more real calls into 20 batches than a strictly sequential one.
 
-When a task exhausts the cap without producing a response, the run fails with an error like:
+The cap is a **soft budget**, not a hard cliff. As the run nears its limit, the agent is told how many turns it has left so it can wrap up cleanly instead of being cut off mid-thought. And if it runs out while still mid-task, it's granted a **one-time extension** (half the original budget, rounded up) with a nudge to finish — so a task that needs "just a couple more" turns isn't killed at the cap. Only when that extension is also spent does the run fail:
 
 ```text
-Task "<slug>" exhausted 20 tool iterations without producing a response
+Task "<slug>" exhausted its tool-iteration budget (cap 20, ran 30) without producing a response
 ```
 
 If a legitimately long task keeps hitting this, raise the cap with the `maxIterations` frontmatter key (or the **Max tool iterations** field under **Advanced options** in the Scheduler):
@@ -120,7 +120,7 @@ maxIterations: 50
 ---
 ```
 
-`maxIterations` must be a positive whole number; blank or invalid values fall back to the default of 20. The interactive agent chat has no such cap — this limit applies only to unattended runs (scheduled tasks and lifecycle hooks).
+`maxIterations` must be a positive whole number; blank or invalid values fall back to the default of 20. The interactive agent chat applies the same soft-budget machinery with a much higher default (50 batches), so the reminder and one-time extension also protect long interactive turns from runaway loops without getting in the way of normal multi-step work.
 
 ## Managing Tasks
 

--- a/src/agent/agent-loop-helpers.ts
+++ b/src/agent/agent-loop-helpers.ts
@@ -162,8 +162,15 @@ export function buildToolHistoryTurns(args: {
 	perTurnContext?: string;
 	toolCalls: ToolCall[];
 	toolResults: ToolCallResultPair[];
+	/**
+	 * Optional text appended to the tool-response (user) turn as a trailing
+	 * text part — used by the soft turn budget to inject the budget reminder or
+	 * extension grant alongside the tool results, so the model sees it on its
+	 * next follow-up without a separate history entry.
+	 */
+	appendText?: string;
 }): Content[] {
-	const { conversationHistory, userMessage, perTurnContext, toolCalls, toolResults } = args;
+	const { conversationHistory, userMessage, perTurnContext, toolCalls, toolResults, appendText } = args;
 
 	const userParts: Part[] = [];
 	if (userMessage && userMessage.trim()) {
@@ -173,10 +180,15 @@ export function buildToolHistoryTurns(args: {
 		userParts.push({ text: perTurnContext });
 	}
 
+	const responseParts = buildFunctionResponseParts(toolResults);
+	if (appendText && appendText.trim()) {
+		responseParts.push({ text: appendText });
+	}
+
 	const updated: Content[] = [
 		...conversationHistory,
 		{ role: 'model', parts: buildFunctionCallParts(toolCalls) },
-		{ role: 'user', parts: buildFunctionResponseParts(toolResults) },
+		{ role: 'user', parts: responseParts },
 	];
 
 	if (userParts.length > 0) {
@@ -286,4 +298,29 @@ export function truncateOldToolResults(
 		});
 		return { ...turn, parts: newParts };
 	});
+}
+
+/**
+ * Format the soft-budget reminder injected into the tool-response turn when the
+ * agent has only a few turns left. Model-facing (stays English; not localized).
+ * Pluralizes "turn"/"turns" so the single-turn case reads naturally.
+ */
+export function formatBudgetReminder(remaining: number): string {
+	const turns = `${remaining} ${remaining === 1 ? 'turn' : 'turns'}`;
+	return (
+		`ENVIRONMENT REMINDER: You have ${turns} remaining in this task. ` +
+		`Wrap up your work and give your final answer before the budget runs out.`
+	);
+}
+
+/**
+ * Format the one-shot extension grant injected when the budget is spent but the
+ * agent still wants to call tools. Model-facing (stays English; not localized).
+ */
+export function formatBudgetExtension(granted: number): string {
+	const turns = `${granted} more ${granted === 1 ? 'turn' : 'turns'}`;
+	return (
+		`ENVIRONMENT REMINDER: You have used your initial turn budget. You are granted ${turns} — ` +
+		`wrap up your work now, or explain what you still need to finish.`
+	);
 }

--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -6,7 +6,14 @@ import type { ToolCall, ModelResponse, ModelApi } from '../api/interfaces/model-
 import type { CustomPrompt } from '../prompts/types';
 import type { IConfirmationProvider, IToolHostView, ToolExecutionContext, ToolResult } from '../tools/types';
 import { generateToolDescription } from '../utils/text-generation';
-import { sortToolCallsByPriority, buildToolHistoryTurns, type ToolCallResultPair } from './agent-loop-helpers';
+import {
+	sortToolCallsByPriority,
+	buildToolHistoryTurns,
+	formatBudgetReminder,
+	formatBudgetExtension,
+	type ToolCallResultPair,
+} from './agent-loop-helpers';
+import { TurnBudget } from './turn-budget';
 import {
 	buildFollowUpRequest,
 	buildRetryRequest,
@@ -56,6 +63,14 @@ export interface AgentLoopHooks {
 	 * returned on `AgentLoopResult.thoughts` instead, not via this hook.
 	 */
 	onModelReasoning?(thoughts: string): void | Promise<void>;
+	/**
+	 * Fired once per iteration after a tool batch runs, with the soft turn
+	 * budget's state. `remaining` is `Infinity` for an unlimited (no-cap)
+	 * budget; `limit` is `undefined` in that case. `extended` is true once the
+	 * one-shot extension has been granted. UI uses this to render a small
+	 * remaining-turns counter as the budget runs low.
+	 */
+	onBudgetUpdate?(state: { remaining: number; limit: number | undefined; extended: boolean }): void | Promise<void>;
 }
 
 export interface AgentLoopOptions {
@@ -173,6 +188,18 @@ const AGENT_LOOP_ABORT_THRESHOLD = 3;
 export const DEFAULT_HEADLESS_MAX_ITERATIONS = 20;
 
 /**
+ * Default soft turn budget for interactive agent-view sessions. Unlike the
+ * headless cap this is deliberately high — it exists so the soft-budget
+ * machinery (reminder + one-shot extension) applies to the path users actually
+ * watch, bounding genuinely runaway loops without getting in the way of normal
+ * multi-step work. Per the cache-aware framing on #622, a long focused loop is
+ * relatively cheap once the prefix cache is warm, so the right interactive cap
+ * is higher than the paper's cost-tuned numbers suggest. `AgentViewTools`
+ * passes this as `maxIterations`; tune against the eval suite (#619).
+ */
+export const DEFAULT_INTERACTIVE_MAX_ITERATIONS = 50;
+
+/**
  * Drives the tool-execution loop after the initial model response. Iterates
  * until the model returns a text response (or cancellation / iteration cap /
  * empty-fallback fires). UI-agnostic — callers attach behavior via hooks.
@@ -236,6 +263,13 @@ export class AgentLoop {
 		// rest of the iteration budget.
 		let loopFireCount = 0;
 
+		// Soft turn budget layered on the hard `maxIterations` cap. An undefined
+		// cap yields an unlimited (inert) budget, preserving the no-cap default.
+		// `pendingBudgetNotice` carries an extension-grant string from the top of
+		// one iteration to the tool-response turn built later in the same pass.
+		const budget = new TurnBudget(maxIterations);
+		let pendingBudgetNotice: string | undefined;
+
 		// Lazily resolve the model API factory once — same instance is reused
 		// for every follow-up and retry request in this loop.
 		const createModel =
@@ -251,17 +285,31 @@ export class AgentLoop {
 				return this.cancelledResult(conversationHistory, iterations);
 			}
 
-			if (maxIterations !== undefined && iterations >= maxIterations) {
-				return {
-					markdown: '',
-					history: conversationHistory,
-					cancelled: false,
-					retried: false,
-					fellBack: false,
-					exhausted: true,
-					loopAborted: false,
-					iterations,
-				};
+			// Budget gate. We only reach here with pending tool calls, so an
+			// exhausted budget means the model is out of turns but not done. Grant
+			// the one-shot extension if it's still available — the grant text is
+			// injected into this batch's tool-response turn so the model sees it
+			// and can wrap up. A second exhaustion (extension already spent) falls
+			// through to the hard-stop `exhausted` path.
+			if (budget.isExhausted(iterations)) {
+				if (budget.canExtend()) {
+					const granted = budget.grantExtension();
+					plugin.logger.log(
+						`[AgentLoop] Turn budget spent at ${iterations} iterations; granting one-time extension of ${granted} turns`
+					);
+					pendingBudgetNotice = formatBudgetExtension(granted);
+				} else {
+					return {
+						markdown: '',
+						history: conversationHistory,
+						cancelled: false,
+						retried: false,
+						fellBack: false,
+						exhausted: true,
+						loopAborted: false,
+						iterations,
+					};
+				}
 			}
 
 			// Sort and execute this batch
@@ -308,12 +356,30 @@ export class AgentLoop {
 					`${currentToolCalls.filter((tc) => tc.thoughtSignature).length} with signatures`
 			);
 
+			// Resolve the soft-budget notice for this tool-response turn. An
+			// extension grant (set above) takes priority; otherwise inject the
+			// low-turns reminder when the threshold is crossed. The model sees
+			// whichever applies on its next follow-up.
+			let budgetNotice = pendingBudgetNotice;
+			pendingBudgetNotice = undefined;
+			if (!budgetNotice && budget.shouldRemind(iterations)) {
+				budgetNotice = formatBudgetReminder(budget.remaining(iterations));
+			}
+			await this.safeHook('onBudgetUpdate', plugin, () =>
+				hooks?.onBudgetUpdate?.({
+					remaining: budget.remaining(iterations),
+					limit: budget.limit,
+					extended: budget.wasExtended,
+				})
+			);
+
 			const updatedHistory = buildToolHistoryTurns({
 				conversationHistory,
 				userMessage,
 				perTurnContext,
 				toolCalls: currentToolCalls,
 				toolResults,
+				appendText: budgetNotice,
 			});
 
 			if (isCancelled()) {

--- a/src/agent/turn-budget.ts
+++ b/src/agent/turn-budget.ts
@@ -105,9 +105,14 @@ export class TurnBudget {
 		return left > 0 && left <= this.remindAt;
 	}
 
-	/** True when a one-shot extension is still available to grant. */
+	/**
+	 * True when a one-shot extension is still available to grant. A
+	 * zero-turn extension (`extensionTurns: 0`) is never grantable — otherwise
+	 * the budget would be marked extended and an extension notice emitted
+	 * without actually adding any turns.
+	 */
 	canExtend(): boolean {
-		return this.currentLimit !== undefined && !this.extensionGranted;
+		return this.currentLimit !== undefined && !this.extensionGranted && this.extensionTurns > 0;
 	}
 
 	/**

--- a/src/agent/turn-budget.ts
+++ b/src/agent/turn-budget.ts
@@ -1,0 +1,138 @@
+/**
+ * Soft turn budget for the agent tool-execution loop.
+ *
+ * Layers a *soft* budget on top of the loop's existing hard iteration cap
+ * (`AgentLoopOptions.maxIterations`). Where the hard cap is a dumb stop — the
+ * run just dies with `exhausted: true` the moment it's hit — this helper adds
+ * two behaviours the paper "More with Less: An Empirical Study of Turn-Control
+ * Strategies for Efficient Coding Agents" (arXiv 2510.16786) found beat a fixed
+ * cap by 12–24%:
+ *
+ *  1. **Reminder** — when only a few turns remain, the loop injects an
+ *     "ENVIRONMENT REMINDER: you have N turns left" line so the model can wrap
+ *     up instead of being cut off mid-thought.
+ *  2. **One-shot extension** — when the budget is spent but the model still
+ *     wants to call tools (i.e. it hasn't produced a final answer), the budget
+ *     grants a single extra allotment so a task that needs "just a couple more"
+ *     turns isn't killed at the cap. A second expiry falls through to the
+ *     hard-stop `exhausted` path.
+ *
+ * This class owns only the *bookkeeping*: it does not know about the loop, the
+ * model, or history. The loop drives it (`isExhausted`, `shouldRemind`,
+ * `grantExtension`) and performs the actual injection.
+ *
+ * An *unlimited* budget (constructed from `undefined`) is inert: it never
+ * reminds, never exhausts, and never extends — matching the loop's "no cap"
+ * default for callers that pass no `maxIterations`.
+ */
+
+/** Default number of remaining turns at or below which the reminder fires. */
+export const DEFAULT_TURN_BUDGET_REMIND_AT = 3;
+
+export interface TurnBudgetOptions {
+	/** Inject the reminder when remaining turns falls to this many or fewer. */
+	remindAt?: number;
+	/**
+	 * Turns added by the one-shot extension. Defaults to half the initial
+	 * limit (rounded up, minimum 1) — enough to let a nearly-done task finish
+	 * without doubling the cost of a runaway one.
+	 */
+	extensionTurns?: number;
+	/**
+	 * Optional view onto the current prefix-cache hit ratio (0–1). Reserved for
+	 * the cache-aware extension heuristic (#622 follow-up): granting turns is
+	 * cheap when the cache is warm and far costlier right after a compaction
+	 * that wiped the cached prefix. Stored and exposed but **not** yet consulted
+	 * by `grantExtension` — wiring it in needs no signature change.
+	 */
+	getCachedRatio?: () => number | undefined;
+}
+
+export class TurnBudget {
+	private currentLimit: number | undefined;
+	private readonly remindAt: number;
+	private readonly extensionTurns: number;
+	private readonly getCachedRatioFn?: () => number | undefined;
+	private extensionGranted = false;
+
+	/**
+	 * @param limit Total tool-execution batches allowed before the budget is
+	 *   spent. `undefined` means unlimited (the loop's no-cap default).
+	 */
+	constructor(limit: number | undefined, options: TurnBudgetOptions = {}) {
+		this.currentLimit = limit;
+		this.remindAt = options.remindAt ?? DEFAULT_TURN_BUDGET_REMIND_AT;
+		this.extensionTurns = options.extensionTurns ?? (limit !== undefined ? Math.max(1, Math.ceil(limit / 2)) : 0);
+		this.getCachedRatioFn = options.getCachedRatio;
+	}
+
+	/** True when this budget imposes no cap (constructed from `undefined`). */
+	isUnlimited(): boolean {
+		return this.currentLimit === undefined;
+	}
+
+	/** The current limit including any granted extension (`undefined` = unlimited). */
+	get limit(): number | undefined {
+		return this.currentLimit;
+	}
+
+	/**
+	 * Turns left after `used` batches have run. `Infinity` for an unlimited
+	 * budget. Never negative.
+	 */
+	remaining(used: number): number {
+		if (this.currentLimit === undefined) return Infinity;
+		return Math.max(0, this.currentLimit - used);
+	}
+
+	/**
+	 * True once `used` batches have consumed the entire current limit. The loop
+	 * checks this at the top of each iteration: if the model still has pending
+	 * tool calls at that point, the budget is spent but the work isn't done.
+	 */
+	isExhausted(used: number): boolean {
+		return this.currentLimit !== undefined && used >= this.currentLimit;
+	}
+
+	/**
+	 * True when the reminder should be injected: a finite budget with between 1
+	 * and `remindAt` turns left (inclusive). Returns false at 0 remaining — by
+	 * then the extension/exhaustion path takes over.
+	 */
+	shouldRemind(used: number): boolean {
+		if (this.currentLimit === undefined) return false;
+		const left = this.remaining(used);
+		return left > 0 && left <= this.remindAt;
+	}
+
+	/** True when a one-shot extension is still available to grant. */
+	canExtend(): boolean {
+		return this.currentLimit !== undefined && !this.extensionGranted;
+	}
+
+	/**
+	 * Grant the one-shot extension, raising the limit by `extensionTurns`.
+	 * Returns the number of turns added, or 0 if an extension was already
+	 * granted or the budget is unlimited. Idempotent after the first grant.
+	 */
+	grantExtension(): number {
+		if (!this.canExtend()) return 0;
+		this.extensionGranted = true;
+		this.currentLimit = (this.currentLimit as number) + this.extensionTurns;
+		return this.extensionTurns;
+	}
+
+	/** Whether the one-shot extension has been granted. */
+	get wasExtended(): boolean {
+		return this.extensionGranted;
+	}
+
+	/**
+	 * Current prefix-cache hit ratio via the injected callback, or `undefined`
+	 * when no callback was provided. Reserved for the cache-aware extension
+	 * follow-up; see {@link TurnBudgetOptions.getCachedRatio}.
+	 */
+	getCachedRatio(): number | undefined {
+		return this.getCachedRatioFn?.();
+	}
+}

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -2340,6 +2340,11 @@ export const en = {
 		message: 'Thinking...',
 		context: 'Progress-bar status while the AI model is processing a request.',
 	},
+	'agent.progress.thinkingWithBudget': {
+		message: '{thinking} ({remaining} turns left)',
+		context:
+			'Progress-bar status while the AI model is processing, shown when the agent is running low on its turn budget. {thinking} is the localized "Thinking..." label; {remaining} is the number of tool-execution turns remaining.',
+	},
 	'agent.progress.generating': {
 		message: 'Generating response...',
 		context: 'Progress-bar status while the AI response is streaming in.',

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -2341,9 +2341,9 @@ export const en = {
 		context: 'Progress-bar status while the AI model is processing a request.',
 	},
 	'agent.progress.thinkingWithBudget': {
-		message: '{thinking} ({remaining} turns left)',
+		message: '{thinking} ({remaining} remaining)',
 		context:
-			'Progress-bar status while the AI model is processing, shown when the agent is running low on its turn budget. {thinking} is the localized "Thinking..." label; {remaining} is the number of tool-execution turns remaining.',
+			'Progress-bar status while the AI model is processing, shown when the agent is running low on its turn budget. {thinking} is the localized "Thinking..." label; {remaining} is the number of tool-execution turns remaining. Plural-neutral wording ("remaining") so it reads correctly for a count of 1.',
 	},
 	'agent.progress.generating': {
 		message: 'Generating response...',

--- a/src/services/hook-runner.ts
+++ b/src/services/hook-runner.ts
@@ -123,8 +123,12 @@ export class HookRunner {
 			});
 			if (result.cancelled) return undefined;
 			if (result.exhausted) {
+				// Exhaustion now fires only after the soft budget's one-shot
+				// extension was also spent, so the actual iteration count exceeds
+				// the configured cap — report both.
 				throw new Error(
-					`[HookRunner] Hook "${hook.slug}" exhausted ${maxIterations} tool iterations without producing a response`
+					`[HookRunner] Hook "${hook.slug}" exhausted its tool-iteration budget ` +
+						`(cap ${maxIterations}, ran ${result.iterations}) without producing a response`
 				);
 			}
 			finalText = result.markdown;

--- a/src/services/scheduled-task-runner.ts
+++ b/src/services/scheduled-task-runner.ts
@@ -108,8 +108,12 @@ export class ScheduledTaskRunner {
 			if (result.cancelled) return undefined;
 
 			if (result.exhausted) {
+				// Exhaustion now fires only after the soft budget's one-shot
+				// extension was also spent, so the actual iteration count exceeds
+				// the configured cap — report both.
 				throw new Error(
-					`[ScheduledTaskRunner] Task "${this.task.slug}" exhausted ${maxIterations} tool iterations without producing a response`
+					`[ScheduledTaskRunner] Task "${this.task.slug}" exhausted its tool-iteration budget ` +
+						`(cap ${maxIterations}, ran ${result.iterations}) without producing a response`
 				);
 			}
 

--- a/src/ui/agent-view/agent-view-tools.ts
+++ b/src/ui/agent-view/agent-view-tools.ts
@@ -4,7 +4,8 @@ import { ChatSession } from '../../types/agent';
 import { GeminiConversationEntry } from '../../types/conversation';
 import { IConfirmationProvider, IToolHostView, ToolResult } from '../../tools/types';
 import { CustomPrompt } from '../../prompts/types';
-import { AgentLoop } from '../../agent/agent-loop';
+import { AgentLoop, DEFAULT_INTERACTIVE_MAX_ITERATIONS } from '../../agent/agent-loop';
+import { DEFAULT_TURN_BUDGET_REMIND_AT } from '../../agent/turn-budget';
 import type { ToolCall } from '../../api/interfaces/model-api';
 import { AgentViewToolDisplay } from './agent-view-tool-display';
 import type { PerTurnContext } from './agent-view-tool-followup';
@@ -46,6 +47,12 @@ export class AgentViewTools {
 	private display: AgentViewToolDisplay;
 	/** Reasoning produced before the first tool batch, rendered into the group once it exists. */
 	private pendingReasoning: string | null = null;
+	/**
+	 * Latest remaining turns from the soft budget (via `onBudgetUpdate`), used to
+	 * surface a small counter in the "Thinking…" progress label as the budget
+	 * runs low. `Infinity` (or undefined) means no finite budget — no counter.
+	 */
+	private budgetRemaining: number | undefined;
 
 	constructor(
 		chatContainer: HTMLElement,
@@ -70,6 +77,9 @@ export class AgentViewTools {
 	) {
 		const currentSession = this.context.getCurrentSession();
 		if (!currentSession) return;
+
+		// Fresh budget counter per user turn (this instance is reused across turns).
+		this.budgetRemaining = undefined;
 
 		// Reasoning the model produced before this first tool batch. Render it as
 		// the first row of the tool group (once the group exists) and persist it.
@@ -100,6 +110,10 @@ export class AgentViewTools {
 					session: currentSession,
 					isCancelled: () => this.context.isCancellationRequested(),
 					confirmationProvider: this.context.confirmationProvider,
+					// Give interactive sessions a high soft budget so the reminder +
+					// one-shot extension machinery applies here too, bounding runaway
+					// loops on the path users watch without capping normal work.
+					maxIterations: DEFAULT_INTERACTIVE_MAX_ITERATIONS,
 					customPrompt,
 					projectRootPath: activeProject?.rootPath,
 					featureToolPolicy: activeProject?.config.toolPolicy,
@@ -132,8 +146,13 @@ export class AgentViewTools {
 						onToolCounted: () => {
 							this.context.incrementToolCallCount?.(1);
 						},
+						onBudgetUpdate: ({ remaining }) => {
+							// Remember the latest count so the next "Thinking…" label can
+							// surface it once the budget runs low.
+							this.budgetRemaining = remaining;
+						},
 						onFollowUpRequestStart: () => {
-							this.context.updateProgress(t('agent.progress.thinking'), 'thinking');
+							this.context.updateProgress(this.thinkingLabel(), 'thinking');
 						},
 						onModelReasoning: async (thoughts) => {
 							// Reasoning the model produced before deciding to call the
@@ -192,6 +211,22 @@ export class AgentViewTools {
 			this.currentGroupContainer = null;
 			this.context.hideProgress();
 		}
+	}
+
+	/**
+	 * The "Thinking…" progress label, suffixed with a small remaining-turns
+	 * counter once the soft budget runs low (≤ the reminder threshold). A
+	 * non-finite or absent budget shows the plain label.
+	 */
+	private thinkingLabel(): string {
+		const remaining = this.budgetRemaining;
+		if (remaining !== undefined && Number.isFinite(remaining) && remaining <= DEFAULT_TURN_BUDGET_REMIND_AT) {
+			return t('agent.progress.thinkingWithBudget', {
+				thinking: t('agent.progress.thinking'),
+				remaining,
+			});
+		}
+		return t('agent.progress.thinking');
 	}
 
 	/**

--- a/test/agent/agent-loop-helpers.test.ts
+++ b/test/agent/agent-loop-helpers.test.ts
@@ -4,6 +4,8 @@ import {
 	buildFunctionResponseParts,
 	buildToolHistoryTurns,
 	truncateOldToolResults,
+	formatBudgetReminder,
+	formatBudgetExtension,
 	DEFAULT_TOOL_RESPONSE_TRUNCATE_BYTES,
 	ToolCallResultPair,
 } from '../../src/agent/agent-loop-helpers';
@@ -478,6 +480,52 @@ describe('buildToolHistoryTurns', () => {
 		expect(userResponseTurn.parts).toHaveLength(2);
 		expect(userResponseTurn.parts![0].functionResponse).toBeDefined();
 		expect(userResponseTurn.parts![1].inlineData).toEqual({ mimeType: 'image/png', data: 'imgbytes' });
+	});
+
+	test('appends appendText as a trailing text part on the tool-response turn', () => {
+		const updated = buildToolHistoryTurns({
+			conversationHistory: [],
+			userMessage: 'q',
+			toolCalls: [sampleToolCall],
+			toolResults: [sampleResult],
+			appendText: 'ENVIRONMENT REMINDER: You have 2 turns remaining.',
+		});
+
+		const userResponseTurn = updated[updated.length - 1];
+		expect(userResponseTurn.role).toBe('user');
+		expect(userResponseTurn.parts).toHaveLength(2); // functionResponse + appended text
+		expect(userResponseTurn.parts![0].functionResponse).toBeDefined();
+		expect(userResponseTurn.parts![1]).toEqual({ text: 'ENVIRONMENT REMINDER: You have 2 turns remaining.' });
+	});
+
+	test('omits the trailing text part when appendText is empty or whitespace', () => {
+		const updated = buildToolHistoryTurns({
+			conversationHistory: [],
+			userMessage: 'q',
+			toolCalls: [sampleToolCall],
+			toolResults: [sampleResult],
+			appendText: '   ',
+		});
+
+		const userResponseTurn = updated[updated.length - 1];
+		expect(userResponseTurn.parts).toHaveLength(1);
+		expect(userResponseTurn.parts![0].functionResponse).toBeDefined();
+	});
+});
+
+describe('formatBudgetReminder', () => {
+	test('includes the remaining count and pluralizes correctly', () => {
+		expect(formatBudgetReminder(3)).toContain('You have 3 turns remaining');
+		expect(formatBudgetReminder(1)).toContain('You have 1 turn remaining');
+		expect(formatBudgetReminder(2)).toMatch(/^ENVIRONMENT REMINDER:/);
+	});
+});
+
+describe('formatBudgetExtension', () => {
+	test('states the granted turns and pluralizes correctly', () => {
+		expect(formatBudgetExtension(5)).toContain('granted 5 more turns');
+		expect(formatBudgetExtension(1)).toContain('granted 1 more turn');
+		expect(formatBudgetExtension(2)).toMatch(/^ENVIRONMENT REMINDER:/);
 	});
 });
 

--- a/test/agent/agent-loop.test.ts
+++ b/test/agent/agent-loop.test.ts
@@ -405,7 +405,7 @@ describe('AgentLoop', () => {
 	});
 
 	describe('iteration cap', () => {
-		test('exhausts when maxIterations is reached without terminal text', async () => {
+		test('exhausts after the one-shot extension when the model never produces text', async () => {
 			const plugin = buildPlugin();
 			const session = buildSession();
 			// Model always returns more tool calls — would loop forever without a cap
@@ -428,10 +428,12 @@ describe('AgentLoop', () => {
 				},
 			});
 
+			// Hard cap 3 + one-shot extension of ceil(3/2)=2 = 5 total iterations
+			// before the budget finally hard-stops.
 			expect(result.exhausted).toBe(true);
-			expect(result.iterations).toBe(3);
+			expect(result.iterations).toBe(5);
 			expect(result.markdown).toBe('');
-			expect(plugin.toolExecutionEngine.executeTool).toHaveBeenCalledTimes(3);
+			expect(plugin.toolExecutionEngine.executeTool).toHaveBeenCalledTimes(5);
 		});
 
 		test('no cap by default — runs until model produces text', async () => {
@@ -457,6 +459,183 @@ describe('AgentLoop', () => {
 			expect(result.markdown).toBe('finally done');
 			expect(result.iterations).toBe(6);
 			expect(result.exhausted).toBe(false);
+		});
+	});
+
+	describe('soft turn budget', () => {
+		// Collect every text part across the history (tool-response turns carry the
+		// injected budget reminder/extension strings as trailing text parts).
+		const allText = (history: any[]): string[] =>
+			history.flatMap((turn) => (turn.parts || []).map((p: any) => p.text).filter((t: any): t is string => !!t));
+
+		test('injects a reminder once ≤3 turns remain, with the live remaining count', async () => {
+			const plugin = buildPlugin();
+			const session = buildSession();
+			// limit 5 → reminder fires at remaining 3 and 2, then the model finishes.
+			const api = makeScriptedModelApi([
+				toolResponse([tc('read_file')]),
+				toolResponse([tc('read_file')]),
+				textResponse('done'),
+			]);
+
+			const loop = new AgentLoop();
+			const result = await loop.run({
+				initialResponse: toolResponse([tc('read_file')]),
+				initialUserMessage: 'q',
+				initialHistory: [],
+				options: {
+					plugin,
+					session,
+					confirmationProvider,
+					isCancelled: () => false,
+					maxIterations: 5,
+					createModelApi: () => api,
+				},
+			});
+
+			expect(result.exhausted).toBe(false);
+			expect(result.markdown).toBe('done');
+			const texts = allText(result.history);
+			expect(texts.some((t) => t.includes('You have 3 turns remaining'))).toBe(true);
+			expect(texts.some((t) => t.includes('You have 2 turns remaining'))).toBe(true);
+			// No reminder while the budget was still comfortable (4 remaining).
+			expect(texts.some((t) => t.includes('You have 4 turns remaining'))).toBe(false);
+		});
+
+		test('grants exactly one extension when the budget expires mid-tool-call, then lets the model finish', async () => {
+			const plugin = buildPlugin();
+			const session = buildSession();
+			// limit 2 (+1 extension) → model keeps calling tools until the grant,
+			// then wraps up on the extra turn.
+			const api = makeScriptedModelApi([
+				toolResponse([tc('read_file')]),
+				toolResponse([tc('read_file')]),
+				textResponse('wrapped up'),
+			]);
+
+			const loop = new AgentLoop();
+			const result = await loop.run({
+				initialResponse: toolResponse([tc('read_file')]),
+				initialUserMessage: 'q',
+				initialHistory: [],
+				options: {
+					plugin,
+					session,
+					confirmationProvider,
+					isCancelled: () => false,
+					maxIterations: 2,
+					createModelApi: () => api,
+				},
+			});
+
+			expect(result.exhausted).toBe(false);
+			expect(result.markdown).toBe('wrapped up');
+			expect(result.iterations).toBe(3); // 2 + one-shot extension of ceil(2/2)=1
+			const texts = allText(result.history);
+			const grants = texts.filter((t) => t.includes('granted'));
+			expect(grants).toHaveLength(1);
+			expect(grants[0]).toContain('1 more turn');
+		});
+
+		test('fires onBudgetUpdate each iteration with the remaining count', async () => {
+			const plugin = buildPlugin();
+			const session = buildSession();
+			const api = makeScriptedModelApi([toolResponse([tc('read_file')]), textResponse('done')]);
+
+			const updates: Array<{ remaining: number; limit: number | undefined; extended: boolean }> = [];
+			const loop = new AgentLoop();
+			await loop.run({
+				initialResponse: toolResponse([tc('read_file')]),
+				initialUserMessage: 'q',
+				initialHistory: [],
+				options: {
+					plugin,
+					session,
+					confirmationProvider,
+					isCancelled: () => false,
+					maxIterations: 5,
+					createModelApi: () => api,
+					hooks: {
+						onBudgetUpdate: (state) => {
+							updates.push(state);
+						},
+					},
+				},
+			});
+
+			expect(updates).toEqual([
+				{ remaining: 4, limit: 5, extended: false },
+				{ remaining: 3, limit: 5, extended: false },
+			]);
+		});
+
+		test('an unlimited budget (no maxIterations) never reminds or extends', async () => {
+			const plugin = buildPlugin();
+			const session = buildSession();
+			const api = makeScriptedModelApi([
+				toolResponse([tc('read_file')]),
+				toolResponse([tc('read_file')]),
+				textResponse('done'),
+			]);
+
+			const updates: Array<{ remaining: number }> = [];
+			const loop = new AgentLoop();
+			const result = await loop.run({
+				initialResponse: toolResponse([tc('read_file')]),
+				initialUserMessage: 'q',
+				initialHistory: [],
+				options: {
+					plugin,
+					session,
+					confirmationProvider,
+					isCancelled: () => false,
+					createModelApi: () => api,
+					hooks: {
+						onBudgetUpdate: (s) => {
+							updates.push(s);
+						},
+					},
+				},
+			});
+
+			expect(result.exhausted).toBe(false);
+			expect(allText(result.history).some((t) => t.includes('ENVIRONMENT REMINDER'))).toBe(false);
+			expect(updates.every((u) => u.remaining === Infinity)).toBe(true);
+		});
+
+		test('loop-abort still preempts the budget when both would fire', async () => {
+			const plugin = buildPlugin();
+			plugin.toolExecutionEngine.executeTool = vi
+				.fn()
+				.mockResolvedValue({ success: false, loopDetected: true, error: 'Execution loop detected' });
+
+			const session = buildSession();
+			// Three blocked calls per batch trip the loop-abort threshold (3) within
+			// the very first batch — before the budget gate (checked at the top of
+			// the next iteration) ever gets the chance to exhaust.
+			const batch = [tc('read_file', { path: 'a' }), tc('read_file', { path: 'b' }), tc('read_file', { path: 'c' })];
+			const api = {
+				generateModelResponse: vi.fn().mockResolvedValue(toolResponse(batch)),
+			} as any;
+
+			const loop = new AgentLoop();
+			const result = await loop.run({
+				initialResponse: toolResponse(batch),
+				initialUserMessage: 'q',
+				initialHistory: [],
+				options: {
+					plugin,
+					session,
+					confirmationProvider,
+					isCancelled: () => false,
+					maxIterations: 1,
+					createModelApi: () => api,
+				},
+			});
+
+			expect(result.loopAborted).toBe(true);
+			expect(result.exhausted).toBe(false);
+			expect(result.iterations).toBe(1);
 		});
 	});
 

--- a/test/agent/turn-budget.test.ts
+++ b/test/agent/turn-budget.test.ts
@@ -65,6 +65,14 @@ describe('TurnBudget', () => {
 			expect(budget.grantExtension()).toBe(5);
 			expect(budget.limit).toBe(15);
 		});
+
+		test('a zero-turn extension is never grantable', () => {
+			const budget = new TurnBudget(10, { extensionTurns: 0 });
+			expect(budget.canExtend()).toBe(false);
+			expect(budget.grantExtension()).toBe(0);
+			expect(budget.wasExtended).toBe(false);
+			expect(budget.limit).toBe(10);
+		});
 	});
 
 	describe('unlimited budget', () => {

--- a/test/agent/turn-budget.test.ts
+++ b/test/agent/turn-budget.test.ts
@@ -1,0 +1,91 @@
+import { TurnBudget, DEFAULT_TURN_BUDGET_REMIND_AT } from '../../src/agent/turn-budget';
+
+describe('TurnBudget', () => {
+	describe('finite budget', () => {
+		test('tracks remaining turns and exhaustion against the limit', () => {
+			const budget = new TurnBudget(5);
+			expect(budget.isUnlimited()).toBe(false);
+			expect(budget.limit).toBe(5);
+			expect(budget.remaining(0)).toBe(5);
+			expect(budget.remaining(2)).toBe(3);
+			expect(budget.remaining(5)).toBe(0);
+			expect(budget.isExhausted(4)).toBe(false);
+			expect(budget.isExhausted(5)).toBe(true);
+			expect(budget.isExhausted(6)).toBe(true);
+		});
+
+		test('remaining never goes negative', () => {
+			const budget = new TurnBudget(3);
+			expect(budget.remaining(10)).toBe(0);
+		});
+
+		test('reminds only within the default threshold window (1..remindAt)', () => {
+			const budget = new TurnBudget(10);
+			// remindAt defaults to 3 → reminds at remaining 3, 2, 1
+			expect(budget.shouldRemind(6)).toBe(false); // 4 left
+			expect(budget.shouldRemind(7)).toBe(true); // 3 left
+			expect(budget.shouldRemind(8)).toBe(true); // 2 left
+			expect(budget.shouldRemind(9)).toBe(true); // 1 left
+			expect(budget.shouldRemind(10)).toBe(false); // 0 left — extension/exhaust takes over
+			expect(DEFAULT_TURN_BUDGET_REMIND_AT).toBe(3);
+		});
+
+		test('honours a custom remindAt', () => {
+			const budget = new TurnBudget(10, { remindAt: 1 });
+			expect(budget.shouldRemind(8)).toBe(false); // 2 left
+			expect(budget.shouldRemind(9)).toBe(true); // 1 left
+		});
+	});
+
+	describe('one-shot extension', () => {
+		test('default extension is half the initial limit (rounded up, min 1)', () => {
+			expect(new TurnBudget(20).grantExtension()).toBe(10);
+			expect(new TurnBudget(3).grantExtension()).toBe(2);
+			expect(new TurnBudget(1).grantExtension()).toBe(1);
+		});
+
+		test('grant raises the limit and only fires once', () => {
+			const budget = new TurnBudget(4);
+			expect(budget.canExtend()).toBe(true);
+			expect(budget.wasExtended).toBe(false);
+
+			const granted = budget.grantExtension();
+			expect(granted).toBe(2);
+			expect(budget.limit).toBe(6);
+			expect(budget.wasExtended).toBe(true);
+			expect(budget.canExtend()).toBe(false);
+
+			// Second attempt is a no-op.
+			expect(budget.grantExtension()).toBe(0);
+			expect(budget.limit).toBe(6);
+		});
+
+		test('honours a custom extensionTurns', () => {
+			const budget = new TurnBudget(10, { extensionTurns: 5 });
+			expect(budget.grantExtension()).toBe(5);
+			expect(budget.limit).toBe(15);
+		});
+	});
+
+	describe('unlimited budget', () => {
+		test('is inert: never reminds, exhausts, or extends', () => {
+			const budget = new TurnBudget(undefined);
+			expect(budget.isUnlimited()).toBe(true);
+			expect(budget.limit).toBeUndefined();
+			expect(budget.remaining(1000)).toBe(Infinity);
+			expect(budget.isExhausted(1000)).toBe(false);
+			expect(budget.shouldRemind(1000)).toBe(false);
+			expect(budget.canExtend()).toBe(false);
+			expect(budget.grantExtension()).toBe(0);
+			expect(budget.limit).toBeUndefined();
+		});
+	});
+
+	describe('cache ratio callback', () => {
+		test('exposes the injected ratio, or undefined when absent', () => {
+			expect(new TurnBudget(5).getCachedRatio()).toBeUndefined();
+			const budget = new TurnBudget(5, { getCachedRatio: () => 0.75 });
+			expect(budget.getCachedRatio()).toBe(0.75);
+		});
+	});
+});

--- a/test/services/hook-runner.test.ts
+++ b/test/services/hook-runner.test.ts
@@ -668,7 +668,7 @@ describe('HookRunner agent-task: exhausted iterations', () => {
 		const hook = makeHook();
 		const runner = new HookRunner(plugin as any, makeContext(hook));
 
-		await expect(runner.run()).rejects.toThrow(/exhausted its tool-iteration budget \(cap 20/);
+		await expect(runner.run()).rejects.toThrow(/exhausted its tool-iteration budget \(cap 20, ran \d+\)/);
 	});
 
 	it('forwards a per-hook maxIterations override to AgentLoop', async () => {
@@ -705,7 +705,7 @@ describe('HookRunner agent-task: exhausted iterations', () => {
 		const plugin = createMockPlugin();
 		const runner = new HookRunner(plugin as any, makeContext(makeHook({ maxIterations: 50 })));
 
-		await expect(runner.run()).rejects.toThrow(/exhausted its tool-iteration budget \(cap 50/);
+		await expect(runner.run()).rejects.toThrow(/exhausted its tool-iteration budget \(cap 50, ran \d+\)/);
 	});
 });
 

--- a/test/services/hook-runner.test.ts
+++ b/test/services/hook-runner.test.ts
@@ -668,7 +668,7 @@ describe('HookRunner agent-task: exhausted iterations', () => {
 		const hook = makeHook();
 		const runner = new HookRunner(plugin as any, makeContext(hook));
 
-		await expect(runner.run()).rejects.toThrow(/exhausted 20 tool iterations/);
+		await expect(runner.run()).rejects.toThrow(/exhausted its tool-iteration budget \(cap 20/);
 	});
 
 	it('forwards a per-hook maxIterations override to AgentLoop', async () => {
@@ -705,7 +705,7 @@ describe('HookRunner agent-task: exhausted iterations', () => {
 		const plugin = createMockPlugin();
 		const runner = new HookRunner(plugin as any, makeContext(makeHook({ maxIterations: 50 })));
 
-		await expect(runner.run()).rejects.toThrow(/exhausted 50 tool iterations/);
+		await expect(runner.run()).rejects.toThrow(/exhausted its tool-iteration budget \(cap 50/);
 	});
 });
 

--- a/test/services/scheduled-task-runner.test.ts
+++ b/test/services/scheduled-task-runner.test.ts
@@ -251,7 +251,7 @@ describe('ScheduledTaskRunner', () => {
 		const plugin = createMockPlugin();
 		const runner = new ScheduledTaskRunner(plugin, makeTask({ maxIterations: 50 }));
 
-		await expect(runner.run(() => false)).rejects.toThrow(/exhausted its tool-iteration budget \(cap 50/);
+		await expect(runner.run(() => false)).rejects.toThrow(/exhausted its tool-iteration budget \(cap 50, ran \d+\)/);
 	});
 
 	it('returns undefined when AgentLoop reports cancellation', async () => {

--- a/test/services/scheduled-task-runner.test.ts
+++ b/test/services/scheduled-task-runner.test.ts
@@ -251,7 +251,7 @@ describe('ScheduledTaskRunner', () => {
 		const plugin = createMockPlugin();
 		const runner = new ScheduledTaskRunner(plugin, makeTask({ maxIterations: 50 }));
 
-		await expect(runner.run(() => false)).rejects.toThrow('exhausted 50 tool iterations');
+		await expect(runner.run(() => false)).rejects.toThrow(/exhausted its tool-iteration budget \(cap 50/);
 	});
 
 	it('returns undefined when AgentLoop reports cancellation', async () => {


### PR DESCRIPTION
<!-- auto-dev -->

## Summary

Layers a **soft turn budget** on top of the agent loop's existing hard iteration cap (`maxIterations`). Where the hard cap was a dumb stop — the run died with `exhausted: true` the instant it was hit — the loop now (1) warns the model as the budget runs low so it can wrap up cleanly, and (2) grants a **one-time extension** if it runs out while still mid-task, so a run that needs "just a couple more" turns isn't killed at the cap. A second expiry falls through to the existing hard-stop `exhausted` path. Interactive sessions now get this machinery too, with a high default budget, bounding genuinely runaway loops on the path users watch.

This is the **first slice** of #622 (the approved plan). The cache-aware extension heuristic and eval-suite tuning of the default caps are explicitly deferred to a follow-up — the `getCachedRatio` callback ships in place but unused so the follow-up needs no signature change.

Fixes #622

## Changes

- **`src/agent/turn-budget.ts` (new)** — `TurnBudget` helper: tracks used/remaining turns, the reminder threshold, and the one-shot extension grant (defaults to half the initial budget, rounded up). An unlimited budget (from `undefined`) is inert. Carries a reserved, unused `getCachedRatio` hook for the cache-aware follow-up.
- **`src/agent/agent-loop.ts`** — constructs a `TurnBudget` from `maxIterations`; injects the reminder ("ENVIRONMENT REMINDER: You have N turns remaining…") or one-shot extension grant into the tool-response turn; grants the extension on expiry-with-pending-tool-calls; keeps `AGENT_LOOP_ABORT_THRESHOLD` taking precedence. New `onBudgetUpdate` hook and `DEFAULT_INTERACTIVE_MAX_ITERATIONS = 50` constant.
- **`src/agent/agent-loop-helpers.ts`** — pure `formatBudgetReminder` / `formatBudgetExtension` formatters; `buildToolHistoryTurns` gains an optional `appendText` trailing text part.
- **`src/ui/agent-view/agent-view-tools.ts`** — passes the interactive default budget; surfaces a small remaining-turns counter in the "Thinking…" progress label as the budget runs low.
- **`src/services/hook-runner.ts` / `scheduled-task-runner.ts`** — exhaustion error now reports the configured cap and actual iterations run (the run extends past the cap before the final hard stop).
- **`src/i18n/en.ts`** — new `agent.progress.thinkingWithBudget` key.
- **Docs** — `scheduled-tasks.md` and `lifecycle-hooks.md` "Tool Iteration Limit" sections rewritten to describe the soft budget, reminder, and one-shot extension.
- **Tests** — new `test/agent/turn-budget.test.ts`; new soft-budget suite in `agent-loop.test.ts` (reminder injection, one-shot extension, `onBudgetUpdate`, unlimited budget, loop-abort precedence); formatter + `appendText` coverage in `agent-loop-helpers.test.ts`; updated runner exhaustion-message assertions.

## Notes

- `npm run translate` was **not** run (no `GOOGLE_API_KEY` in this environment), so non-English locales fall back to English for the new `agent.progress.thinkingWithBudget` key at runtime until a translation pass is run. The key is present in `en.ts` (source of truth) so the feature works in all locales.
- The `test-scripts/*.mjs` agent integration runners require a live API key and were not run here; the agent-loop behavior is covered by the unit suite (3085 tests green).

## Checklist

### Required

- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`, `npm run typecheck:test`, `npm run knip`)
- [x] Documentation has been updated
- [ ] Tested on Desktop (interactive smoke test pending maintainer)
- [x] No Mobile-breaking changes (pure loop/logic, no platform APIs)

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude (auto-dev pipeline)
- [x] I have reviewed and understand all AI-generated code in this PR

---

This PR was produced by the **auto-dev** pipeline from the approved plan on #622.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tool iteration limits now use a soft budget with a one-time extension (50% of the original limit, rounded up) if the agent runs out mid-task.
  * Added low-budget guidance and updated interactive progress to show remaining turns (“thinking with budget”).
  * New budget state hook updates UI/headless flows with remaining/extension status.
* **Bug Fixes**
  * Exhaustion errors now report both the configured cap and the actual iterations, reflecting the one-time extension behavior.
* **Documentation**
  * Updated lifecycle hooks and scheduled tasks docs to match the soft-budget/extension semantics and defaults.
* **Tests**
  * Added TurnBudget coverage and updated existing iteration-cap expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->