### PR TITLE
refactor: extract shared HeadlessConfirmationProvider for headless runners

### DIFF
--- a/src/services/headless-confirmation-provider.ts
+++ b/src/services/headless-confirmation-provider.ts
@@ -1,0 +1,33 @@
+import type { ConfirmationResult, DiffContext, IConfirmationProvider, Tool } from '../tools/types';
+
+/**
+ * Auto-approve all tool confirmations for headless agent runs.
+ *
+ * Shared by `HookRunner` and `ScheduledTaskRunner`: both run unattended with an
+ * explicit `enabledTools` allowlist authored by the user, so there's no surface
+ * on which to display a mid-run confirmation dialog. ASK_USER tools are filtered
+ * out upstream via `toolRegistry.getAutoApprovedTools()` before reaching the
+ * loop, so this provider only ever sees APPROVE-class tools.
+ */
+export class HeadlessConfirmationProvider implements IConfirmationProvider {
+	// Full signatures (rather than zero-arg stubs) pin this class to the real
+	// IConfirmationProvider contract — future additions to the interface will
+	// break compilation here instead of silently passing.
+	async showConfirmationInChat(
+		_tool: Tool,
+		_parameters: unknown,
+		_executionId: string,
+		_diffContext?: DiffContext
+	): Promise<ConfirmationResult> {
+		return { confirmed: true, allowWithoutConfirmation: false };
+	}
+	isToolAllowedWithoutConfirmation(_toolName: string): boolean {
+		return true;
+	}
+	allowToolWithoutConfirmation(_toolName: string): void {
+		/* no-op */
+	}
+	updateProgress(_message: string, _status: string): void {
+		/* no-op */
+	}
+}

--- a/src/services/hook-runner.ts
+++ b/src/services/hook-runner.ts
@@ -1,7 +1,6 @@
 import { App, TFile, normalizePath } from 'obsidian';
 import type ObsidianGemini from '../main';
 import { DestructiveAction } from '../types/agent';
-import type { ConfirmationResult, DiffContext, IConfirmationProvider, Tool } from '../tools/types';
 import { ToolExecutionContext } from '../tools/types';
 import { ModelClientFactory } from '../api';
 import { ExtendedModelRequest } from '../api/interfaces/model-api';
@@ -12,32 +11,7 @@ import { AgentLoop, DEFAULT_HEADLESS_MAX_ITERATIONS } from '../agent/agent-loop'
 import { GeminiSummary } from '../summary';
 import { SelectionRewriter } from '../rewrite-selection';
 import { HookFireContext, renderPrompt } from './hook-manager';
-
-/**
- * Auto-approve all tool confirmations for headless hook fires. The user
- * authored the hook definition with an explicit `enabledTools` allowlist —
- * there is no UI surface during a vault-event-triggered run on which to
- * surface a mid-run confirmation.
- */
-class HeadlessConfirmationProvider implements IConfirmationProvider {
-	async showConfirmationInChat(
-		_tool: Tool,
-		_parameters: unknown,
-		_executionId: string,
-		_diffContext?: DiffContext
-	): Promise<ConfirmationResult> {
-		return { confirmed: true, allowWithoutConfirmation: false };
-	}
-	isToolAllowedWithoutConfirmation(_toolName: string): boolean {
-		return true;
-	}
-	allowToolWithoutConfirmation(_toolName: string): void {
-		/* no-op */
-	}
-	updateProgress(_message: string, _status: string): void {
-		/* no-op */
-	}
-}
+import { HeadlessConfirmationProvider } from './headless-confirmation-provider';
 
 /**
  * Runs a single hook fire headlessly:

--- a/src/services/scheduled-task-runner.ts
+++ b/src/services/scheduled-task-runner.ts
@@ -2,7 +2,6 @@ import { normalizePath } from 'obsidian';
 import type ObsidianGemini from '../main';
 import type { ScheduledTask } from './scheduled-task-manager';
 import { DestructiveAction } from '../types/agent';
-import type { ConfirmationResult, DiffContext, IConfirmationProvider, Tool } from '../tools/types';
 import { ToolExecutionContext } from '../tools/types';
 import { ModelClientFactory } from '../api';
 import { ExtendedModelRequest } from '../api/interfaces/model-api';
@@ -10,35 +9,7 @@ import { ensureFolderExists } from '../utils/file-utils';
 import { formatLocalDate, formatLocalTimestamp } from '../utils/format-utils';
 import { buildTurnPreamble } from '../utils/turn-preamble';
 import { AgentLoop, DEFAULT_HEADLESS_MAX_ITERATIONS } from '../agent/agent-loop';
-
-/**
- * Auto-approve all tool confirmations for headless scheduled-task runs.
- * Scheduled tasks run unattended with an explicit `enabledTools` frontmatter
- * allowlist — the user has already opted in by authoring the task file, so
- * there's no surface on which to surface a mid-run confirmation dialog.
- */
-class HeadlessConfirmationProvider implements IConfirmationProvider {
-	// Full signatures (rather than zero-arg stubs) pin this class to the real
-	// IConfirmationProvider contract — future additions to the interface will
-	// break compilation here instead of silently passing.
-	async showConfirmationInChat(
-		_tool: Tool,
-		_parameters: unknown,
-		_executionId: string,
-		_diffContext?: DiffContext
-	): Promise<ConfirmationResult> {
-		return { confirmed: true, allowWithoutConfirmation: false };
-	}
-	isToolAllowedWithoutConfirmation(_toolName: string): boolean {
-		return true;
-	}
-	allowToolWithoutConfirmation(_toolName: string): void {
-		/* no-op */
-	}
-	updateProgress(_message: string, _status: string): void {
-		/* no-op */
-	}
-}
+import { HeadlessConfirmationProvider } from './headless-confirmation-provider';
 
 /**
  * Runs a single scheduled task headlessly:


### PR DESCRIPTION
## Summary

Architecture-audit nightly sweep flagged: **dry-violation** in `src/services/hook-runner.ts` and `src/services/scheduled-task-runner.ts`.

Both files carried byte-identical `HeadlessConfirmationProvider` classes — same `IConfirmationProvider` implementation (auto-approve every confirmation, report every tool as pre-allowed) with the same no-op `allowToolWithoutConfirmation` / `updateProgress`. The classes existed because both runners need an auto-approve provider for unattended runs where there's no UI to surface a confirmation modal on; the duplication was just historical — `HookRunner` was modelled on `ScheduledTaskRunner`'s pattern when it was added.

The fix is a pure code-motion extraction into `src/services/headless-confirmation-provider.ts`. Both runners now import the same class. A third headless runner (the next one is likely whatever comes out of #631's `PromptRunner` consolidation) won't grow a third copy.

## Changes

- **New** `src/services/headless-confirmation-provider.ts` — the shared `HeadlessConfirmationProvider` class, with the contract-pinning full signatures preserved and the rationale comment expanded to cover both call sites and explain why this stub is safe (ASK_USER tools are filtered out upstream by `toolRegistry.getAutoApprovedTools()`).
- **`src/services/hook-runner.ts`** — delete the local copy, import from the shared module. Drop now-unused `ConfirmationResult`/`DiffContext`/`IConfirmationProvider`/`Tool` imports.
- **`src/services/scheduled-task-runner.ts`** — delete the local copy, import from the shared module. Drop now-unused `ConfirmationResult`/`DiffContext`/`IConfirmationProvider`/`Tool` imports.

Net diff: +35 / −57 lines (one new file, two callers shrink). Behavior is identical — same class, same auto-approve semantics, same contract.

## Test plan

- [x] `npm run format-check`
- [x] `npm run build`
- [x] `npm test` (133 files / 3067 tests pass — the existing `HeadlessConfirmationProvider` suite in `test/services/scheduled-task-runner.test.ts` inspects the provider through the `AgentLoop.run` mock, so no test change was needed)
- [x] `npm run typecheck:test`
- [x] `npm run lint`
- [x] `npm run knip`

## Checklist

### Required

- [x] All CI checks pass
- [x] No documentation updates required (no user-visible change)
- [x] No Mobile-breaking changes (pure code motion)

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude (architecture-audit skill)
- [x] I have reviewed and understand all AI-generated code in this PR

---

Filed by the `architecture-audit` nightly sweep.

---
_Generated by [Claude Code](https://claude.ai/code/session_013exUH1qdd6pJjXtPjRYTKU)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated duplicate confirmation provider implementations across the codebase for improved code organization and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->