### PR TITLE
chore(daily): 2026-06-19 daily update

### DIFF
--- a/docs/guide/faq.md
+++ b/docs/guide/faq.md
@@ -85,7 +85,17 @@ If privacy is the concern, the paid AI Studio tier's no-training terms are the i
 
 ### Can I use a local LLM via Ollama or llama.cpp?
 
-No. Gemini Scribe is built around the Gemini API and its SDK — swapping in a local inference server would be a full rewrite, not a configuration change, and many of the plugin's features (Deep Research, semantic vault search, Google Search grounding, URL Context) have no local equivalent. If local-first inference is your priority, another plugin will serve you better. ([#576](https://github.com/allenhutchison/obsidian-gemini/discussions/576))
+**Ollama is supported.** Switch the provider to **Ollama** in Settings → Gemini Scribe → Provider, point the base URL at your Ollama instance, and enter the model name you have pulled. See the [Ollama Setup guide](./ollama-setup.md) for a step-by-step walkthrough.
+
+A few Gemini-specific features are unavailable on Ollama — these all depend on Google's cloud APIs and have no local equivalent:
+
+- **Deep Research** (requires Google Search grounding)
+- **Semantic vault search / RAG** (requires the Gemini File Search API)
+- **Google Search grounding** in agent mode
+- **URL Context** web-fetch tool
+- **Image generation** (Imagen API)
+
+Agent mode, tool calling, scheduled tasks, lifecycle hooks, custom prompts, completions, summarization, and rewriting all work with Ollama. ([#576](https://github.com/allenhutchison/obsidian-gemini/discussions/576))
 
 ## Language & Localization
 

--- a/planning/changelog/2026-06-19.md
+++ b/planning/changelog/2026-06-19.md
@@ -1,0 +1,20 @@
+# Daily changelog — June 19, 2026
+
+**Date:** 2026-06-19
+**PRs merged:** 2
+
+---
+
+## Summary
+
+Quiet housekeeping day: the previous day's daily update PR landed first, followed by an architecture-audit refactor that eliminated a DRY violation in the headless-runner layer. No user-visible changes shipped.
+
+## What shipped
+
+### [#998 chore(daily): 2026-06-18 daily update](https://github.com/allenhutchison/obsidian-gemini/pull/998)
+
+Automated daily housekeeping for June 18: added `planning/changelog/2026-06-18.md` documenting three PRs (two nightly architecture-audit refactors and the prior day's daily update). Docs audit found no drift; triage found no unlabeled issues.
+
+### [#997 refactor: extract shared HeadlessConfirmationProvider for headless runners](https://github.com/allenhutchison/obsidian-gemini/pull/997)
+
+Architecture-audit sweep surfaced byte-identical `HeadlessConfirmationProvider` classes in `src/services/hook-runner.ts` and `src/services/scheduled-task-runner.ts` — both auto-approve every confirmation for unattended runs where no UI confirmation modal is available. The fix extracts the shared class into `src/services/headless-confirmation-provider.ts` and updates both runners to import it. Net diff: +35 / −57 lines, behavior unchanged. A third headless runner won't need to copy the class again.


### PR DESCRIPTION
## Summary

Automated daily housekeeping for 2026-06-19. Two PRs merged — an architecture-audit refactor eliminating a DRY violation in the headless-runner layer, plus the prior day's daily update. Docs audit caught one stale FAQ answer (Ollama marked as unsupported when it has been a fully-supported provider since v4.x); triage found no unlabeled issues.

## Changes

- **Add `planning/changelog/2026-06-19.md`**: Documents June 19 — 2 PRs (#997, #998).
- **Fix `docs/guide/faq.md`**: Rewrite the "Can I use Ollama?" FAQ entry. The old answer flatly said "No" — that was true before v4.x but is now wrong. The new answer confirms Ollama is supported, points to the Ollama Setup guide, and lists the features that remain Gemini-only (Deep Research, semantic vault search, Google Search grounding, URL Context, image generation).

## Sub-skill outcomes

- **daily-changelog**: wrote `planning/changelog/2026-06-19.md`, 2 PRs
  - [#998](https://github.com/allenhutchison/obsidian-gemini/pull/998) — chore(daily): 2026-06-18 daily update
  - [#997](https://github.com/allenhutchison/obsidian-gemini/pull/997) — refactor: extract shared HeadlessConfirmationProvider for headless runners
- **audit-docs**: fixed one drift item — `docs/guide/faq.md` "Can I use Ollama?" answer was stale (said "No", Ollama provider has been fully supported since v4.x; updated to confirm support and list Gemini-only features)
- **triage-issues**: no unlabeled open issues (0 processed, 0 labeled)

## Screenshots / Screencast

N/A — changelog and doc fix only.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: daily housekeeping
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop — N/A: docs and changelog only
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A: docs only
- [x] Documentation has been updated (if applicable) — this PR IS the documentation update
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

---
_Generated by [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HyDvNHFe4QotgT2F9ipiua)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated FAQ with comprehensive instructions for configuring Ollama as a local LLM provider, including setup guidance and clarification on which features are available with local inference versus those requiring cloud connectivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->