### PR TITLE
refactor(services): extract shared FailurePauseTracker (#994)

### DIFF
--- a/src/services/failure-pause-tracker.ts
+++ b/src/services/failure-pause-tracker.ts
@@ -1,0 +1,135 @@
+import { getRawErrorMessage } from '../utils/error-utils';
+import type { Logger } from '../utils/logger';
+
+/**
+ * Shared "auto-pause after N consecutive failures" behavior for the markdown-defined
+ * feature managers — HookManager and ScheduledTaskManager. Both walk the identical
+ * prev-state → bump counter → derive `pausedDueToErrors` → save → log ladder over their
+ * per-entry JSON sidecar state, and both expose the same "clear the failure state" reset.
+ * This is the error-recovery layer on top of the sidecar scaffolding in `feature-definition.ts`:
+ * that file owns the state I/O, this file owns the failure/pause policy that mutates it.
+ */
+
+/** Pause an entity after this many consecutive failures. Shared by every subsystem that auto-pauses. */
+export const MAX_CONSECUTIVE_FAILURES = 3;
+
+/**
+ * The slice of per-entity sidecar state the failure-pause ladder reads and writes.
+ * Managers embed these fields in their own state shape (HookState, TaskState, …).
+ */
+export interface FailurePauseState {
+	/** Error message from the most recent failed run, if any. */
+	lastError?: string;
+	/** Number of consecutive failures since the last success. */
+	consecutiveFailures?: number;
+	/** When true the entity is auto-paused until manually reset. */
+	pausedDueToErrors?: boolean;
+}
+
+/** Outcome of {@link FailurePauseTracker.recordFailure}. */
+export interface FailureOutcome {
+	consecutiveFailures: number;
+	pausedDueToErrors: boolean;
+}
+
+export interface FailurePauseTrackerOptions<TState extends FailurePauseState> {
+	/** Read the current in-memory record for a slug (undefined if none yet). */
+	getState: (slug: string) => TState | undefined;
+	/** Persist the next record for a slug — callers wire this to `this.state[slug] = next; saveState()`. */
+	setState: (slug: string, next: TState) => void | Promise<void>;
+	logger: Logger;
+	/** Message prefix, e.g. `[HookManager]`. */
+	label: string;
+	/** Entity noun used in log messages, e.g. `Hook` or `Task`. */
+	entityNoun: string;
+	/** Failures before pausing. Defaults to {@link MAX_CONSECUTIVE_FAILURES}. */
+	maxFailures?: number;
+	/**
+	 * When true, a non-pausing failure is logged at error level (the hook manager's
+	 * behavior). When false, the caller owns failure logging — e.g. the scheduled-task
+	 * manager re-throws and lets the background runner surface the error. Defaults to false.
+	 */
+	logFailures?: boolean;
+}
+
+/**
+ * Owns the shared "auto-pause after N consecutive failures" ladder over a manager's
+ * per-entity sidecar state: bump the counter, derive `pausedDueToErrors`, persist, log.
+ *
+ * Pure delegation — the tracker never touches the state file directly. Callers wire
+ * `getState`/`setState` to their existing in-memory record + `saveState()` plumbing, so
+ * each manager keeps its own sidecar format. Entity-specific fields (a fresh `lastRunAt`
+ * on success, a fresh `nextRunAt` on reset, …) flow in through the optional `patch`
+ * argument without the tracker needing to know about them.
+ */
+export class FailurePauseTracker<TState extends FailurePauseState> {
+	private readonly maxFailures: number;
+	private readonly logFailures: boolean;
+
+	constructor(private readonly options: FailurePauseTrackerOptions<TState>) {
+		this.maxFailures = options.maxFailures ?? MAX_CONSECUTIVE_FAILURES;
+		this.logFailures = options.logFailures ?? false;
+	}
+
+	/** True when the entity is currently auto-paused. */
+	isPaused(slug: string): boolean {
+		return this.options.getState(slug)?.pausedDueToErrors ?? false;
+	}
+
+	/** Clear the failure counters after a successful run. `patch` carries entity-specific fields. */
+	async recordSuccess(slug: string, patch?: Partial<TState>): Promise<void> {
+		const prev = this.options.getState(slug);
+		const next = {
+			...(prev ?? {}),
+			...patch,
+			lastError: undefined,
+			consecutiveFailures: 0,
+			pausedDueToErrors: false,
+		} as TState;
+		await this.options.setState(slug, next);
+	}
+
+	/**
+	 * Record a failed run: bump the counter, pause once it reaches the threshold, persist,
+	 * and warn when newly paused. `patch` carries entity-specific fields.
+	 */
+	async recordFailure(slug: string, error: unknown, patch?: Partial<TState>): Promise<FailureOutcome> {
+		const prev = this.options.getState(slug);
+		const consecutiveFailures = (prev?.consecutiveFailures ?? 0) + 1;
+		const pausedDueToErrors = consecutiveFailures >= this.maxFailures;
+		const next = {
+			...(prev ?? {}),
+			...patch,
+			lastError: getRawErrorMessage(error),
+			consecutiveFailures,
+			pausedDueToErrors,
+		} as TState;
+		await this.options.setState(slug, next);
+
+		const { logger, label, entityNoun } = this.options;
+		if (pausedDueToErrors) {
+			logger.warn(`${label} ${entityNoun} "${slug}" paused after ${this.maxFailures} consecutive failures`);
+		} else if (this.logFailures) {
+			logger.error(`${label} ${entityNoun} "${slug}" failed:`, error);
+		}
+
+		return { consecutiveFailures, pausedDueToErrors };
+	}
+
+	/**
+	 * Manually clear the failure/pause state so a paused entity can run again. No-op when no
+	 * record exists. `patch` carries entity-specific fields (e.g. a fresh `nextRunAt`).
+	 */
+	async reset(slug: string, patch?: Partial<TState>): Promise<void> {
+		const prev = this.options.getState(slug);
+		if (!prev) return;
+		const next = {
+			...prev,
+			...patch,
+			lastError: undefined,
+			consecutiveFailures: 0,
+			pausedDueToErrors: false,
+		} as TState;
+		await this.options.setState(slug, next);
+	}
+}

--- a/src/services/failure-pause-tracker.ts
+++ b/src/services/failure-pause-tracker.ts
@@ -32,6 +32,14 @@ export interface FailureOutcome {
 	pausedDueToErrors: boolean;
 }
 
+/**
+ * Entity-specific fields a caller may merge into the state on success/failure/reset
+ * (e.g. `lastRunAt`, `nextRunAt`). The fields the ladder owns — the {@link FailureOutcome}
+ * counters and `lastError` — are excluded so a patch can't even express an override the
+ * tracker would silently discard (it always re-derives those after spreading the patch).
+ */
+export type EntityPatch<TState extends FailurePauseState> = Partial<Omit<TState, keyof FailureOutcome | 'lastError'>>;
+
 export interface FailurePauseTrackerOptions<TState extends FailurePauseState> {
 	/** Read the current in-memory record for a slug (undefined if none yet). */
 	getState: (slug: string) => TState | undefined;
@@ -77,10 +85,17 @@ export class FailurePauseTracker<TState extends FailurePauseState> {
 	}
 
 	/** Clear the failure counters after a successful run. `patch` carries entity-specific fields. */
-	async recordSuccess(slug: string, patch?: Partial<TState>): Promise<void> {
+	async recordSuccess(slug: string, patch?: EntityPatch<TState>): Promise<void> {
 		const prev = this.options.getState(slug);
+		// Precondition: a record already exists for this slug. The ladder only ever
+		// clears/derives the failure fields on top of state the manager has already
+		// seeded (advanceState for tasks, recordFire for hooks). Fabricating a record
+		// for an unknown slug would cast away required fields the patch doesn't supply
+		// (e.g. TaskState.nextRunAt) and persist `undefined`, so no-op instead — mirroring
+		// `reset`. A missing record on success is harmless (nothing to clear) so it's silent.
+		if (!prev) return;
 		const next = {
-			...(prev ?? {}),
+			...prev,
 			...patch,
 			lastError: undefined,
 			consecutiveFailures: 0,
@@ -93,12 +108,19 @@ export class FailurePauseTracker<TState extends FailurePauseState> {
 	 * Record a failed run: bump the counter, pause once it reaches the threshold, persist,
 	 * and warn when newly paused. `patch` carries entity-specific fields.
 	 */
-	async recordFailure(slug: string, error: unknown, patch?: Partial<TState>): Promise<FailureOutcome> {
+	async recordFailure(slug: string, error: unknown, patch?: EntityPatch<TState>): Promise<FailureOutcome> {
 		const prev = this.options.getState(slug);
-		const consecutiveFailures = (prev?.consecutiveFailures ?? 0) + 1;
+		// See recordSuccess: the failure ladder builds on an existing record. Unlike
+		// success, a missing record here is a wiring bug (the manager should have seeded
+		// state before the run), so fail loudly rather than persist a record with required
+		// fields cast away. The caller re-throws into the background runner regardless.
+		if (!prev) {
+			throw new Error(`${this.options.label} cannot record a failure for unknown ${this.options.entityNoun} "${slug}"`);
+		}
+		const consecutiveFailures = (prev.consecutiveFailures ?? 0) + 1;
 		const pausedDueToErrors = consecutiveFailures >= this.maxFailures;
 		const next = {
-			...(prev ?? {}),
+			...prev,
 			...patch,
 			lastError: getRawErrorMessage(error),
 			consecutiveFailures,
@@ -120,7 +142,7 @@ export class FailurePauseTracker<TState extends FailurePauseState> {
 	 * Manually clear the failure/pause state so a paused entity can run again. No-op when no
 	 * record exists. `patch` carries entity-specific fields (e.g. a fresh `nextRunAt`).
 	 */
-	async reset(slug: string, patch?: Partial<TState>): Promise<void> {
+	async reset(slug: string, patch?: EntityPatch<TState>): Promise<void> {
 		const prev = this.options.getState(slug);
 		if (!prev) return;
 		const next = {

--- a/src/services/hook-manager.ts
+++ b/src/services/hook-manager.ts
@@ -1,7 +1,6 @@
 import { Platform, TAbstractFile, TFile, normalizePath } from 'obsidian';
 import type ObsidianGemini from '../main';
 import { ensureFolderExists } from '../utils/file-utils';
-import { getRawErrorMessage } from '../utils/error-utils';
 import { FeatureToolPolicy } from '../types/tool-policy';
 import { formatToolPolicyYaml } from './feature-policy-yaml';
 import {
@@ -12,6 +11,7 @@ import {
 	purgeOrphanState,
 	resolveFeatureToolPolicy,
 } from './feature-definition';
+import { FailurePauseTracker, MAX_CONSECUTIVE_FAILURES } from './failure-pause-tracker';
 
 // ─── Folder / file layout ─────────────────────────────────────────────────────
 
@@ -32,9 +32,6 @@ const DEFAULT_COOLDOWN_MS = 30_000;
 /** Hard loop ceiling: max fires per (hook, file) inside the loop window. */
 const HARD_LOOP_LIMIT = 5;
 const HARD_LOOP_WINDOW_MS = 60_000;
-
-/** Pause the hook after this many consecutive failures. */
-const MAX_CONSECUTIVE_FAILURES = 3;
 
 // ─── Public types ─────────────────────────────────────────────────────────────
 
@@ -290,9 +287,22 @@ export class HookManager {
 	private inflight = new Set<string>();
 	/** Vault event handlers registered via plugin.registerEvent — kept for off(). */
 	private eventRefs: { off: () => void }[] = [];
+	/** Shared auto-pause-after-N-failures ladder over the per-hook sidecar state. */
+	private readonly failureTracker: FailurePauseTracker<HookState>;
 
 	constructor(private plugin: ObsidianGemini) {
 		this.stateStore = new JsonSidecarStateStore<HooksState>(plugin, () => this.stateFilePath, '[HookManager]');
+		this.failureTracker = new FailurePauseTracker<HookState>({
+			getState: (slug) => this.state[slug],
+			setState: (slug, next) => {
+				this.state[slug] = next;
+				return this.saveState();
+			},
+			logger: this.plugin.logger,
+			label: '[HookManager]',
+			entityNoun: 'Hook',
+			logFailures: true,
+		});
 	}
 
 	// ── Folder path helpers ──────────────────────────────────────────────────
@@ -375,15 +385,7 @@ export class HookManager {
 	 * Manually clear `pausedDueToErrors` so a paused hook can fire again.
 	 */
 	async resetHook(slug: string): Promise<void> {
-		const entry = this.state[slug];
-		if (!entry) return;
-		this.state[slug] = {
-			...entry,
-			lastError: undefined,
-			consecutiveFailures: 0,
-			pausedDueToErrors: false,
-		};
-		await this.saveState();
+		await this.failureTracker.reset(slug);
 	}
 
 	// ── CRUD operations ─────────────────────────────────────────────────────
@@ -769,34 +771,11 @@ export class HookManager {
 	}
 
 	private async recordSuccess(slug: string): Promise<void> {
-		const prev = this.state[slug] ?? {};
-		this.state[slug] = {
-			...prev,
-			lastError: undefined,
-			consecutiveFailures: 0,
-			pausedDueToErrors: false,
-		};
-		await this.saveState();
+		await this.failureTracker.recordSuccess(slug);
 	}
 
 	private async recordFailure(slug: string, error: unknown): Promise<void> {
-		const prev = this.state[slug] ?? {};
-		const consecutiveFailures = (prev.consecutiveFailures ?? 0) + 1;
-		const pausedDueToErrors = consecutiveFailures >= MAX_CONSECUTIVE_FAILURES;
-		this.state[slug] = {
-			...prev,
-			lastError: getRawErrorMessage(error),
-			consecutiveFailures,
-			pausedDueToErrors,
-		};
-		await this.saveState();
-		if (pausedDueToErrors) {
-			this.plugin.logger.warn(
-				`[HookManager] Hook "${slug}" paused after ${MAX_CONSECUTIVE_FAILURES} consecutive failures`
-			);
-		} else {
-			this.plugin.logger.error(`[HookManager] Hook "${slug}" failed:`, error);
-		}
+		await this.failureTracker.recordFailure(slug, error);
 	}
 
 	private async recordPausedDueToLoop(slug: string): Promise<void> {

--- a/src/services/scheduled-task-manager.ts
+++ b/src/services/scheduled-task-manager.ts
@@ -1,7 +1,6 @@
 import { TFile, normalizePath } from 'obsidian';
 import type ObsidianGemini from '../main';
 import { ensureFolderExists } from '../utils/file-utils';
-import { getRawErrorMessage } from '../utils/error-utils';
 import { FeatureToolPolicy } from '../types/tool-policy';
 import { formatToolPolicyYaml } from './feature-policy-yaml';
 import {
@@ -12,6 +11,7 @@ import {
 	purgeOrphanState,
 	resolveFeatureToolPolicy,
 } from './feature-definition';
+import { FailurePauseTracker, MAX_CONSECUTIVE_FAILURES } from './failure-pause-tracker';
 
 // ─── Folder / file layout ─────────────────────────────────────────────────────
 
@@ -21,9 +21,6 @@ const STATE_FILE = 'scheduled-tasks-state.json';
 
 /** Milliseconds between scheduler ticks (60 s). Same cadence as ChatTimer. */
 const TICK_INTERVAL_MS = 60_000;
-
-/** Pause the task after this many consecutive failures. */
-const MAX_CONSECUTIVE_FAILURES = 3;
 
 // ─── Public types ─────────────────────────────────────────────────────────────
 
@@ -286,6 +283,8 @@ export class ScheduledTaskManager {
 	/** Slugs reserved for catch-up approval — tick skips these until approved or skipped. */
 	private catchUpPending = new Set<string>();
 	private readonly stateStore: JsonSidecarStateStore<ScheduledTasksState>;
+	/** Shared auto-pause-after-N-failures ladder over the per-task sidecar state. */
+	private readonly failureTracker: FailurePauseTracker<TaskState>;
 
 	constructor(private plugin: ObsidianGemini) {
 		this.stateStore = new JsonSidecarStateStore<ScheduledTasksState>(
@@ -293,6 +292,16 @@ export class ScheduledTaskManager {
 			() => this.stateFilePath,
 			'[ScheduledTaskManager]'
 		);
+		this.failureTracker = new FailurePauseTracker<TaskState>({
+			getState: (slug) => this.state[slug],
+			setState: (slug, next) => {
+				this.state[slug] = next;
+				return this.saveState();
+			},
+			logger: this.plugin.logger,
+			label: '[ScheduledTaskManager]',
+			entityNoun: 'Task',
+		});
 	}
 
 	// ── Folder path helpers ──────────────────────────────────────────────────
@@ -629,15 +638,7 @@ export class ScheduledTaskManager {
 	 * Called from the UI "Reset" button after a user fixes the underlying problem.
 	 */
 	async resetTask(slug: string): Promise<void> {
-		if (!this.state[slug]) return;
-		this.state[slug] = {
-			...this.state[slug],
-			nextRunAt: new Date().toISOString(),
-			lastError: undefined,
-			consecutiveFailures: 0,
-			pausedDueToErrors: false,
-		};
-		await this.saveState();
+		await this.failureTracker.reset(slug, { nextRunAt: new Date().toISOString() });
 	}
 
 	/**
@@ -776,35 +777,11 @@ export class ScheduledTaskManager {
 			// undefined means the run was cancelled — don't record as a successful
 			// completion so lastRunAt only reflects genuine completions.
 			if (outputPath !== undefined) {
-				this.state[task.slug] = {
-					...this.state[task.slug],
-					lastRunAt: new Date().toISOString(),
-					lastError: undefined,
-					consecutiveFailures: 0,
-					pausedDueToErrors: false,
-				};
-				await this.saveState();
+				await this.failureTracker.recordSuccess(task.slug, { lastRunAt: new Date().toISOString() });
 			}
 			return outputPath;
 		} catch (error) {
-			const msg = getRawErrorMessage(error);
-			const prev = this.state[task.slug];
-			const consecutiveFailures = (prev?.consecutiveFailures ?? 0) + 1;
-			const pausedDueToErrors = consecutiveFailures >= MAX_CONSECUTIVE_FAILURES;
-
-			if (pausedDueToErrors) {
-				this.plugin.logger.warn(
-					`[ScheduledTaskManager] Task "${task.slug}" paused after ${MAX_CONSECUTIVE_FAILURES} consecutive failures`
-				);
-			}
-
-			this.state[task.slug] = {
-				...prev,
-				lastError: msg,
-				consecutiveFailures,
-				pausedDueToErrors,
-			};
-			await this.saveState();
+			await this.failureTracker.recordFailure(task.slug, error);
 			throw error;
 		}
 	}

--- a/test/services/failure-pause-tracker.test.ts
+++ b/test/services/failure-pause-tracker.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+	FailurePauseTracker,
+	MAX_CONSECUTIVE_FAILURES,
+	type FailurePauseState,
+} from '../../src/services/failure-pause-tracker';
+import type { Logger } from '../../src/utils/logger';
+
+interface TestState extends FailurePauseState {
+	lastRunAt?: string;
+	nextRunAt?: string;
+}
+
+function makeLogger() {
+	return { log: vi.fn(), debug: vi.fn(), error: vi.fn(), warn: vi.fn() } as unknown as Logger;
+}
+
+function makeTracker(
+	overrides: Partial<ConstructorParameters<typeof FailurePauseTracker<TestState>>[0]> = {},
+	initial: Record<string, TestState> = {}
+) {
+	const store: Record<string, TestState> = { ...initial };
+	const setState = vi.fn((slug: string, next: TestState) => {
+		store[slug] = next;
+	});
+	const logger = makeLogger();
+	const tracker = new FailurePauseTracker<TestState>({
+		getState: (slug) => store[slug],
+		setState,
+		logger,
+		label: '[TestManager]',
+		entityNoun: 'Thing',
+		...overrides,
+	});
+	return { tracker, store, setState, logger };
+}
+
+describe('FailurePauseTracker', () => {
+	beforeEach(() => vi.clearAllMocks());
+
+	it('exports a shared default threshold of 3', () => {
+		expect(MAX_CONSECUTIVE_FAILURES).toBe(3);
+	});
+
+	describe('recordFailure ladder', () => {
+		it('first failure sets counter to 1 without pausing', async () => {
+			const { tracker, store, logger } = makeTracker();
+			const outcome = await tracker.recordFailure('a', new Error('boom'));
+			expect(outcome).toEqual({ consecutiveFailures: 1, pausedDueToErrors: false });
+			expect(store.a).toMatchObject({
+				lastError: 'boom',
+				consecutiveFailures: 1,
+				pausedDueToErrors: false,
+			});
+			expect(logger.warn).not.toHaveBeenCalled();
+		});
+
+		it('accumulates consecutive failures across calls', async () => {
+			const { tracker, store } = makeTracker();
+			await tracker.recordFailure('a', new Error('1'));
+			const second = await tracker.recordFailure('a', new Error('2'));
+			expect(second.consecutiveFailures).toBe(2);
+			expect(store.a.lastError).toBe('2');
+			expect(store.a.pausedDueToErrors).toBe(false);
+		});
+
+		it('pauses and warns once the threshold is reached', async () => {
+			const { tracker, store, logger } = makeTracker();
+			await tracker.recordFailure('a', new Error('1'));
+			await tracker.recordFailure('a', new Error('2'));
+			const outcome = await tracker.recordFailure('a', new Error('3'));
+			expect(outcome).toEqual({ consecutiveFailures: 3, pausedDueToErrors: true });
+			expect(store.a.pausedDueToErrors).toBe(true);
+			expect(logger.warn).toHaveBeenCalledWith('[TestManager] Thing "a" paused after 3 consecutive failures');
+		});
+
+		it('respects a custom maxFailures threshold', async () => {
+			const { tracker } = makeTracker({ maxFailures: 1 });
+			const outcome = await tracker.recordFailure('a', new Error('boom'));
+			expect(outcome.pausedDueToErrors).toBe(true);
+		});
+
+		it('only error-logs non-pausing failures when logFailures is true', async () => {
+			const { tracker: quiet, logger: quietLog } = makeTracker();
+			await quiet.recordFailure('a', new Error('boom'));
+			expect(quietLog.error).not.toHaveBeenCalled();
+
+			const { tracker: loud, logger: loudLog } = makeTracker({ logFailures: true });
+			const err = new Error('boom');
+			await loud.recordFailure('a', err);
+			expect(loudLog.error).toHaveBeenCalledWith('[TestManager] Thing "a" failed:', err);
+		});
+
+		it('merges an entity-specific patch into the failed state', async () => {
+			const { tracker, store } = makeTracker();
+			await tracker.recordFailure('a', new Error('boom'), { nextRunAt: 'later' });
+			expect(store.a.nextRunAt).toBe('later');
+			expect(store.a.consecutiveFailures).toBe(1);
+		});
+	});
+
+	describe('recordSuccess', () => {
+		it('clears failure state and unpauses', async () => {
+			const { tracker, store } = makeTracker(
+				{},
+				{
+					a: { lastError: 'boom', consecutiveFailures: 3, pausedDueToErrors: true },
+				}
+			);
+			await tracker.recordSuccess('a');
+			expect(store.a).toMatchObject({
+				lastError: undefined,
+				consecutiveFailures: 0,
+				pausedDueToErrors: false,
+			});
+		});
+
+		it('applies an entity-specific patch while clearing failures', async () => {
+			const { tracker, store } = makeTracker(
+				{},
+				{
+					a: { consecutiveFailures: 2, nextRunAt: 'keep-me' },
+				}
+			);
+			await tracker.recordSuccess('a', { lastRunAt: 'now' });
+			expect(store.a.lastRunAt).toBe('now');
+			expect(store.a.nextRunAt).toBe('keep-me');
+			expect(store.a.consecutiveFailures).toBe(0);
+		});
+
+		it('does not let a patch override the success invariants', async () => {
+			const { tracker, store } = makeTracker();
+			await tracker.recordSuccess('a', { pausedDueToErrors: true, consecutiveFailures: 9 } as Partial<TestState>);
+			expect(store.a.pausedDueToErrors).toBe(false);
+			expect(store.a.consecutiveFailures).toBe(0);
+		});
+	});
+
+	describe('reset', () => {
+		it('clears failure state for an existing entry', async () => {
+			const { tracker, store, setState } = makeTracker(
+				{},
+				{
+					a: { lastError: 'boom', consecutiveFailures: 3, pausedDueToErrors: true },
+				}
+			);
+			await tracker.reset('a');
+			expect(setState).toHaveBeenCalledOnce();
+			expect(store.a).toMatchObject({
+				lastError: undefined,
+				consecutiveFailures: 0,
+				pausedDueToErrors: false,
+			});
+		});
+
+		it('applies an entity-specific patch on reset', async () => {
+			const { tracker, store } = makeTracker({}, { a: { pausedDueToErrors: true } });
+			await tracker.reset('a', { nextRunAt: 'rescheduled' });
+			expect(store.a.nextRunAt).toBe('rescheduled');
+			expect(store.a.pausedDueToErrors).toBe(false);
+		});
+
+		it('is a no-op when no record exists', async () => {
+			const { tracker, setState } = makeTracker();
+			await tracker.reset('missing');
+			expect(setState).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('isPaused', () => {
+		it('reflects the stored pause flag', () => {
+			const { tracker } = makeTracker(
+				{},
+				{
+					paused: { pausedDueToErrors: true },
+					ok: { pausedDueToErrors: false },
+				}
+			);
+			expect(tracker.isPaused('paused')).toBe(true);
+			expect(tracker.isPaused('ok')).toBe(false);
+			expect(tracker.isPaused('missing')).toBe(false);
+		});
+	});
+
+	it('awaits an async setState (persistence) before resolving', async () => {
+		const order: string[] = [];
+		const setState = vi.fn(async () => {
+			await Promise.resolve();
+			order.push('saved');
+		});
+		const tracker = new FailurePauseTracker<TestState>({
+			getState: () => undefined,
+			setState,
+			logger: makeLogger(),
+			label: '[TestManager]',
+			entityNoun: 'Thing',
+		});
+		await tracker.recordFailure('a', new Error('boom'));
+		order.push('after');
+		expect(order).toEqual(['saved', 'after']);
+	});
+});

--- a/test/services/failure-pause-tracker.test.ts
+++ b/test/services/failure-pause-tracker.test.ts
@@ -3,6 +3,7 @@ import {
 	FailurePauseTracker,
 	MAX_CONSECUTIVE_FAILURES,
 	type FailurePauseState,
+	type EntityPatch,
 } from '../../src/services/failure-pause-tracker';
 import type { Logger } from '../../src/utils/logger';
 
@@ -43,8 +44,10 @@ describe('FailurePauseTracker', () => {
 	});
 
 	describe('recordFailure ladder', () => {
+		// The ladder builds on an existing record (seeded by the manager before the run),
+		// so these cases start from an empty-but-present entry rather than a fresh slug.
 		it('first failure sets counter to 1 without pausing', async () => {
-			const { tracker, store, logger } = makeTracker();
+			const { tracker, store, logger } = makeTracker({}, { a: {} });
 			const outcome = await tracker.recordFailure('a', new Error('boom'));
 			expect(outcome).toEqual({ consecutiveFailures: 1, pausedDueToErrors: false });
 			expect(store.a).toMatchObject({
@@ -56,7 +59,7 @@ describe('FailurePauseTracker', () => {
 		});
 
 		it('accumulates consecutive failures across calls', async () => {
-			const { tracker, store } = makeTracker();
+			const { tracker, store } = makeTracker({}, { a: {} });
 			await tracker.recordFailure('a', new Error('1'));
 			const second = await tracker.recordFailure('a', new Error('2'));
 			expect(second.consecutiveFailures).toBe(2);
@@ -65,7 +68,7 @@ describe('FailurePauseTracker', () => {
 		});
 
 		it('pauses and warns once the threshold is reached', async () => {
-			const { tracker, store, logger } = makeTracker();
+			const { tracker, store, logger } = makeTracker({}, { a: {} });
 			await tracker.recordFailure('a', new Error('1'));
 			await tracker.recordFailure('a', new Error('2'));
 			const outcome = await tracker.recordFailure('a', new Error('3'));
@@ -75,27 +78,35 @@ describe('FailurePauseTracker', () => {
 		});
 
 		it('respects a custom maxFailures threshold', async () => {
-			const { tracker } = makeTracker({ maxFailures: 1 });
+			const { tracker } = makeTracker({ maxFailures: 1 }, { a: {} });
 			const outcome = await tracker.recordFailure('a', new Error('boom'));
 			expect(outcome.pausedDueToErrors).toBe(true);
 		});
 
 		it('only error-logs non-pausing failures when logFailures is true', async () => {
-			const { tracker: quiet, logger: quietLog } = makeTracker();
+			const { tracker: quiet, logger: quietLog } = makeTracker({}, { a: {} });
 			await quiet.recordFailure('a', new Error('boom'));
 			expect(quietLog.error).not.toHaveBeenCalled();
 
-			const { tracker: loud, logger: loudLog } = makeTracker({ logFailures: true });
+			const { tracker: loud, logger: loudLog } = makeTracker({ logFailures: true }, { a: {} });
 			const err = new Error('boom');
 			await loud.recordFailure('a', err);
 			expect(loudLog.error).toHaveBeenCalledWith('[TestManager] Thing "a" failed:', err);
 		});
 
 		it('merges an entity-specific patch into the failed state', async () => {
-			const { tracker, store } = makeTracker();
+			const { tracker, store } = makeTracker({}, { a: {} });
 			await tracker.recordFailure('a', new Error('boom'), { nextRunAt: 'later' });
 			expect(store.a.nextRunAt).toBe('later');
 			expect(store.a.consecutiveFailures).toBe(1);
+		});
+
+		it('throws (rather than fabricating a record) for an unknown slug', async () => {
+			const { tracker, setState } = makeTracker();
+			await expect(tracker.recordFailure('missing', new Error('boom'))).rejects.toThrow(
+				'[TestManager] cannot record a failure for unknown Thing "missing"'
+			);
+			expect(setState).not.toHaveBeenCalled();
 		});
 	});
 
@@ -129,10 +140,21 @@ describe('FailurePauseTracker', () => {
 		});
 
 		it('does not let a patch override the success invariants', async () => {
-			const { tracker, store } = makeTracker();
-			await tracker.recordSuccess('a', { pausedDueToErrors: true, consecutiveFailures: 9 } as Partial<TestState>);
+			const { tracker, store } = makeTracker({}, { a: { consecutiveFailures: 1 } });
+			// EntityPatch excludes the tracker-owned fields at compile time; the cast forces
+			// them through to prove the runtime re-derivation also wins as a belt-and-suspenders.
+			await tracker.recordSuccess('a', {
+				pausedDueToErrors: true,
+				consecutiveFailures: 9,
+			} as unknown as EntityPatch<TestState>);
 			expect(store.a.pausedDueToErrors).toBe(false);
 			expect(store.a.consecutiveFailures).toBe(0);
+		});
+
+		it('is a no-op for an unknown slug (nothing to clear)', async () => {
+			const { tracker, setState } = makeTracker();
+			await tracker.recordSuccess('missing', { lastRunAt: 'now' });
+			expect(setState).not.toHaveBeenCalled();
 		});
 	});
 
@@ -189,7 +211,7 @@ describe('FailurePauseTracker', () => {
 			order.push('saved');
 		});
 		const tracker = new FailurePauseTracker<TestState>({
-			getState: () => undefined,
+			getState: () => ({}),
 			setState,
 			logger: makeLogger(),
 			label: '[TestManager]',

--- a/test/services/scheduled-task-manager.test.ts
+++ b/test/services/scheduled-task-manager.test.ts
@@ -1,7 +1,17 @@
 import type { Mock } from 'vitest';
 import { TFile as MockTFile } from 'obsidian';
 import { ScheduledTaskManager, computeNextRunAt, ScheduledTask } from '../../src/services/scheduled-task-manager';
+import { MAX_CONSECUTIVE_FAILURES } from '../../src/services/failure-pause-tracker';
 import { PolicyPreset, ToolPermission } from '../../src/types/tool-policy';
+
+// executeTask dynamically imports ScheduledTaskRunner; stub it with a controllable
+// run() so the wiring tests can drive resolve (success) and reject (failure) paths.
+const { runnerRun } = vi.hoisted(() => ({ runnerRun: vi.fn() }));
+vi.mock('../../src/services/scheduled-task-runner', () => ({
+	ScheduledTaskRunner: class {
+		run = runnerRun;
+	},
+}));
 
 // ─── Mocks ────────────────────────────────────────────────────────────────────
 
@@ -806,6 +816,106 @@ describe('ScheduledTaskManager', () => {
 			const nextRunAt = new Date(state['advance-test'].nextRunAt);
 			// Should now be ~24 h in the future, not in the past
 			expect(nextRunAt.getTime()).toBeGreaterThan(Date.now());
+		});
+	});
+
+	// ── executeTask wiring (success / failure through the manager) ─────────────
+	//
+	// The tick tests above stop at submit(): the default backgroundTaskManager.submit
+	// mock returns an ID without ever invoking the work callback, so executeTask —
+	// where the FailurePauseTracker is wired — never runs. These tests make submit
+	// actually invoke the captured work function so the recordSuccess/recordFailure
+	// plumbing (getState/setState closures, the lastRunAt patch, the re-throw contract)
+	// is exercised at the manager level, not just the tracker in isolation.
+
+	describe('executeTask failure/success wiring', () => {
+		async function makeRunnableManager(slug: string) {
+			const plugin = createMockPlugin();
+			plugin.app.vault.getMarkdownFiles.mockReturnValue([
+				{ path: `gemini-scribe/Scheduled-Tasks/${slug}.md`, basename: slug },
+			]);
+			plugin.app.metadataCache.getFileCache.mockReturnValue({
+				frontmatter: { schedule: 'daily', enabled: true },
+			});
+			plugin.app.vault.read = vi.fn().mockResolvedValue('Do work');
+			// Seed a due (past) state entry so tick() submits.
+			plugin.app.vault.adapter.exists.mockResolvedValue(true);
+			plugin.app.vault.adapter.read.mockResolvedValue(
+				JSON.stringify({ [slug]: { nextRunAt: new Date(Date.now() - 60_000).toISOString() } })
+			);
+
+			// Capture the work callback instead of running it fire-and-forget so the
+			// test can await executeTask and inspect the resulting state.
+			let capturedWork: ((isCancelled: () => boolean) => Promise<unknown>) | undefined;
+			plugin.backgroundTaskManager.submit = vi.fn((_type: string, _label: string, work: any) => {
+				capturedWork = work;
+				return 'bg-task-1';
+			});
+
+			const manager = new ScheduledTaskManager(plugin);
+			await manager.initialize();
+			return {
+				manager,
+				plugin,
+				runWork: () => {
+					if (!capturedWork) throw new Error('submit was never called');
+					return capturedWork(() => false);
+				},
+			};
+		}
+
+		it('records success and clears failure counters when the runner resolves an output path', async () => {
+			const { manager, runWork } = await makeRunnableManager('ok-task');
+			const outputPath = 'gemini-scribe/Scheduled-Tasks/Runs/ok-task/2026-04-17.md';
+			runnerRun.mockResolvedValue(outputPath);
+
+			await manager.tick();
+			const result = await runWork();
+
+			expect(result).toBe(outputPath);
+			const state = manager.getState()['ok-task'];
+			expect(state.lastRunAt).toBeDefined();
+			expect(Number.isNaN(new Date(state.lastRunAt as string).getTime())).toBe(false);
+			expect(state.consecutiveFailures).toBe(0);
+			expect(state.pausedDueToErrors).toBe(false);
+			expect(state.lastError).toBeUndefined();
+		});
+
+		it('bumps the failure counter, pauses at the threshold, and re-throws when the runner rejects', async () => {
+			const { manager, runWork } = await makeRunnableManager('fail-task');
+			runnerRun.mockRejectedValue(new Error('runner exploded'));
+
+			const snapshots: Array<{ consecutiveFailures?: number; lastError?: string; pausedDueToErrors?: boolean }> = [];
+			for (let i = 0; i < MAX_CONSECUTIVE_FAILURES; i++) {
+				// runNow ignores the due-time check, so each iteration re-submits the
+				// same slug (advanceState pushes nextRunAt into the future after run 1).
+				await manager.runNow('fail-task');
+				// The error must propagate out of the work callback (the bg manager relies
+				// on it to emit backgroundTaskFailed) rather than being swallowed.
+				await expect(runWork()).rejects.toThrow('runner exploded');
+				snapshots.push({ ...manager.getState()['fail-task'] });
+			}
+
+			// First failure: counter bumped to 1, error captured, not yet paused.
+			expect(snapshots[0].consecutiveFailures).toBe(1);
+			expect(snapshots[0].lastError).toBe('runner exploded');
+			expect(snapshots[0].pausedDueToErrors).toBe(false);
+
+			// Threshold reached on the third consecutive failure.
+			expect(snapshots[MAX_CONSECUTIVE_FAILURES - 1].consecutiveFailures).toBe(MAX_CONSECUTIVE_FAILURES);
+			expect(snapshots[MAX_CONSECUTIVE_FAILURES - 1].pausedDueToErrors).toBe(true);
+		});
+
+		it('does not record success when the runner returns undefined (cancelled run)', async () => {
+			const { manager, runWork } = await makeRunnableManager('cancel-task');
+			runnerRun.mockResolvedValue(undefined);
+
+			await manager.tick();
+			const result = await runWork();
+
+			expect(result).toBeUndefined();
+			// lastRunAt only reflects genuine completions — a cancelled run leaves it unset.
+			expect(manager.getState()['cancel-task'].lastRunAt).toBeUndefined();
 		});
 	});
 


### PR DESCRIPTION
## Summary

`HookManager` and `ScheduledTaskManager` both implemented the same
"auto-pause after N consecutive failures" state machine over their
per-entry JSON sidecar state, with `MAX_CONSECUTIVE_FAILURES = 3`
declared twice and parallel `recordFailure` / `recordSuccess` /
`resetHook` vs `resetTask` logic. This extracts that error-recovery
behavior into a single shared helper so the pause/log policy lives in
one place. Closes #994.

## Changes

- `src/services/failure-pause-tracker.ts` — new
  `FailurePauseTracker<TState extends FailurePauseState>` that owns the
  prev-state -> bump counter -> derive `pausedDueToErrors` -> save -> log
  ladder, plus `recordSuccess` / `reset` / `isPaused`. Exports a single
  `MAX_CONSECUTIVE_FAILURES`. Pure delegation — callers wire
  `getState`/`setState` to their existing `saveState` plumbing, so each
  manager keeps its own sidecar format. Entity-specific fields
  (`lastRunAt` on success, `nextRunAt` on reset) flow through an optional
  `patch` argument.
- `src/services/hook-manager.ts` — deletes the local
  `MAX_CONSECUTIVE_FAILURES`, constructs a `FailurePauseTracker`, and
  delegates `recordSuccess` / `recordFailure` / `resetHook` to it.
- `src/services/scheduled-task-manager.ts` — deletes the local
  `MAX_CONSECUTIVE_FAILURES`, constructs a `FailurePauseTracker`, and
  delegates the inline `executeTask` success/failure blocks and
  `resetTask` to it (passing the `lastRunAt` / `nextRunAt` patches).
- `test/services/failure-pause-tracker.test.ts` — 15 new tests covering
  the ladder transitions (first-failure -> counter=1, threshold ->
  `pausedDueToErrors`, success -> reset), the per-manager log divergence
  (`logFailures`), reset-with-patch, `isPaused`, and async persistence.

Behavior is unchanged: the loop-detection path (`recordPausedDueToLoop`)
and the "is paused, skipping" early-exit log sites are left in place, and
per-manager log prefixes (`[HookManager]` / `[ScheduledTaskManager]`) are
preserved via the `label` parameter. Net -44 lines across the two
managers.

## Screenshots / Screencast

No UI changes — backend/internal refactor only. Verified live against a
test vault: forced 3 consecutive failing scheduled-task runs (bogus
model) -> `consecutiveFailures` 1 -> 2 -> 3 with `pausedDueToErrors`
flipping true at the threshold; `resetTask` cleared the failure state and
set a fresh `nextRunAt`; a successful run cleared the counter and set a
fresh `lastRunAt`.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards)
- [x] Documentation has been updated (n/a — no user-facing or settings changes)
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude (claude-opus-4-8 via Claude Code)
- [x] I have reviewed and understand all AI-generated code in this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized consecutive-failure tracking and automatic pause/resume logic so both hook handling and scheduled tasks behave consistently.
  * Failure outcomes now uniformly clear on success, pause when the threshold is reached, and optionally log failure details.
* **Tests**
  * Added/expanded automated coverage for the shared failure tracker and for scheduled task execution behavior (success, failure, and cancelled runs).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->