### PR TITLE
chore(daily): 2026-06-21 daily update

### DIFF
--- a/planning/changelog/2026-06-21.md
+++ b/planning/changelog/2026-06-21.md
@@ -1,0 +1,41 @@
+# Daily changelog — June 21, 2026
+
+**Date:** 2026-06-21
+**PRs merged:** 10
+
+---
+
+## Summary
+
+Feature-plus-security day: the standout is a soft turn budget for the agent loop — the first slice of issue #622, giving the agent a heads-up as it approaches its iteration cap and a one-time extension if it's still mid-task. A cleanup refactor collapsed seven more redundant error-extraction patterns. Two daily-update catchups (#1002 and #1006) landed, and six Dependabot dependency bumps closed out the day; two of them were security releases (undici patched seven CVEs, ws fixed a remote OOM DoS).
+
+## What shipped
+
+### [#996 feat(agent): soft turn budget with reminder and one-shot extension](https://github.com/allenhutchison/obsidian-gemini/pull/996)
+
+Adds a soft turn budget on top of the agent loop's existing hard iteration cap. Rather than killing a run the instant it hits `maxIterations`, the loop now (1) injects a "N turns remaining" reminder into the tool-response turn as the budget runs low so the model can wrap up cleanly, and (2) grants a one-time extension if the budget expires while tool calls are still in flight. A second expiry falls through to the existing hard-stop `exhausted` path. Interactive sessions get a generous default budget (`DEFAULT_INTERACTIVE_MAX_ITERATIONS = 50`), bounding genuinely runaway loops without breaking normal use.
+
+This is the first slice of #622. The cache-aware extension heuristic is explicitly deferred to a follow-up; its `getCachedRatio` callback ships unused so the signature won't need to change. New `onBudgetUpdate` hook exposed for UI callers.
+
+### [#1000 refactor: collapse 7 leftover error-extraction sites to getRawErrorMessage](https://github.com/allenhutchison/obsidian-gemini/pull/1000)
+
+Architecture-audit nightly sweep found seven sites that still inlined `error instanceof Error ? error.message : String(error)` since the original 24-site cleanup in #912. Routes all seven through the shared `getRawErrorMessage()` helper: two in `src/services/hook-runner.ts`, one each in `src/services/rag-cache.ts`, `src/services/rag-vault-scanner.ts`, `src/ui/hook-management-modal.ts`, `src/ui/scheduler-management-modal.ts`, and `src/ui/settings-mcp.ts`. Pure refactor, no behavior change.
+
+### [#1002 chore(daily): 2026-06-19 daily update](https://github.com/allenhutchison/obsidian-gemini/pull/1002)
+
+Catchup daily housekeeping for June 19: added `planning/changelog/2026-06-19.md` (two PRs) and fixed the stale "Can I use Ollama?" FAQ entry in `docs/guide/faq.md` (the old answer said "No" — wrong since v4.x introduced the Ollama provider).
+
+### [#1006 chore(daily): 2026-06-20 daily update](https://github.com/allenhutchison/obsidian-gemini/pull/1006)
+
+Daily housekeeping for June 20: added `planning/changelog/2026-06-20.md` (quiet day, no PRs). Full docs audit found no drift; triage found no unlabeled issues.
+
+### Dependency bumps: #999, #1001, #1003, #1004, #1007, #1008
+
+Six Dependabot updates, two carrying security fixes:
+
+- **#1001 undici 7.25.0 → 7.28.0** — security release patching seven advisories, including three High-severity CVEs (GHSA-vxpw-j846-p89q, GHSA-vmh5-mc38-953g, GHSA-hm92-r4w5-c3mj). Upgrade required; the v7 line is unaffected by a separate 8.x-only regression.
+- **#1008 ws 8.20.1 → 8.21.0** — fixes a remote memory-exhaustion DoS where a peer could crash a ws server or client by sending a high volume of tiny fragments at modest bandwidth. Introduces `maxBufferedChunks` and `maxFragments` options to bound the risk.
+- **#999** hono 4.12.23 → 4.12.26 (minor/patch)
+- **#1003** actions/checkout from v6 to v7 (blocks fork PR checkout for `pull_request_target` — security hardening in CI)
+- **#1007** js-yaml 4.1.1 → 4.2.0 (adds `maxDepth` and `maxMergeSeqLength` safety limits)
+- **#1004** dev-dependencies group bump: `@google/genai` 2.8.0 → 2.9.0, `@types/node` 25.9.3 → 26.0.0, `@vitest/coverage-v8` 4.1.8 → 4.1.9, `knip` 6.16.1 → 6.17.1, `lint-staged` 17.0.7 → 17.0.8, `typescript-eslint` 8.61.0 → 8.61.1


### PR DESCRIPTION
## Summary

Automated daily housekeeping run for 2026-06-21. All pre-flight checks pass (format, build, 3086 tests).

## Changes

- **daily-changelog**: Added `planning/changelog/2026-06-21.md` — 10 PRs merged, led by the soft turn budget feature (#996), an error-extraction refactor (#1000), two daily-update catchups (#1002, #1006), and six dependency bumps (two security releases: undici with 7 CVEs, ws OOM DoS fix).

## Sub-skill outcomes

- **daily-changelog**: wrote `planning/changelog/2026-06-21.md`, 10 PRs merged on 2026-06-21
  - [#996](https://github.com/allenhutchison/obsidian-gemini/pull/996) — feat(agent): soft turn budget with reminder and one-shot extension (first slice of #622)
  - [#999](https://github.com/allenhutchison/obsidian-gemini/pull/999) — chore(deps): bump hono 4.12.23→4.12.26
  - [#1000](https://github.com/allenhutchison/obsidian-gemini/pull/1000) — refactor: collapse 7 leftover error-extraction sites to getRawErrorMessage
  - [#1001](https://github.com/allenhutchison/obsidian-gemini/pull/1001) — chore(deps-dev): bump undici 7.25.0→7.28.0 (**security**: 7 CVEs including 3 High)
  - [#1002](https://github.com/allenhutchison/obsidian-gemini/pull/1002) — chore(daily): 2026-06-19 daily update
  - [#1003](https://github.com/allenhutchison/obsidian-gemini/pull/1003) — chore(deps): bump actions/checkout 6→7
  - [#1006](https://github.com/allenhutchison/obsidian-gemini/pull/1006) — chore(daily): 2026-06-20 daily update
  - [#1007](https://github.com/allenhutchison/obsidian-gemini/pull/1007) — chore(deps-dev): bump js-yaml 4.1.1→4.2.0
  - [#1004](https://github.com/allenhutchison/obsidian-gemini/pull/1004) — chore(deps-dev): bump dev-dependencies group (8 packages, incl. @google/genai 2.8→2.9)
  - [#1008](https://github.com/allenhutchison/obsidian-gemini/pull/1008) — chore(deps): bump ws 8.20.1→8.21.0 (**security**: remote OOM DoS fix)
- **audit-docs**: full audit of docs/guide/, docs/reference/, README.md, AGENTS.md — all settings defaults, command IDs, tool names, schedule formats, loop-detection thresholds, hook defaults, and attachment limits verified correct against code. No drift found, no new docs warranted.
- **triage-issues**: no unlabeled open issues (0 processed, 0 labeled)

## Screenshots / Screencast

N/A — changelog file only.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: automated daily housekeeping
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [ ] I have tested this change on Desktop — N/A: changelog file only
- [ ] I have verified this change does not break Mobile — N/A: changelog file only
- [x] Documentation has been updated (if applicable) — N/A: no user-facing code changes
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01WfSRyZbikuKR3pHgok8zTh)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a soft turn budget with reminder notifications and one-time extension capability for improved agent performance.

* **Bug Fixes**
  * Security patches deployed addressing critical vulnerabilities in undici (multiple CVEs resolved) and ws library (DoS attack mitigation with enhanced buffering).

* **Documentation**
  * Two documentation maintenance updates completed.

* **Chores**
  * Six dependency updates applied through automated tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->