### PR TITLE
feat: stateless Interactions API transport for Gemini (Phase 1)

### DIFF
--- a/__mocks__/@google/genai.js
+++ b/__mocks__/@google/genai.js
@@ -23,5 +23,14 @@ export const GoogleGenAI = vi.fn().mockImplementation(function () {
 				},
 			}),
 		},
+		interactions: {
+			create: vi.fn().mockResolvedValue({
+				id: 'int_mock',
+				status: 'completed',
+				output_text: 'Mock interaction text',
+				steps: [{ type: 'model_output', content: [{ type: 'text', text: 'Mock interaction text' }] }],
+				usage: { total_input_tokens: 1, total_output_tokens: 1, total_tokens: 2 },
+			}),
+		},
 	};
 });

--- a/docs/reference/advanced-settings.md
+++ b/docs/reference/advanced-settings.md
@@ -53,6 +53,16 @@ Gemini Scribe automatically discovers the parameter limits for your available mo
 
 ## API configuration
 
+### Use Interactions API
+
+Route Gemini requests through Google's newer [Interactions API](https://ai.google.dev/gemini-api/docs/interactions) (`interactions.create`) instead of the legacy `generateContent` API. Google has made the Interactions API generally available and is steering new development toward it.
+
+- **Setting name**: Use Interactions API
+- **Default**: off (uses `generateContent`)
+- **Scope**: Gemini provider only — the toggle is hidden when the provider is Ollama.
+- **Privacy**: The plugin runs the Interactions API **statelessly** (`store: false`). Your conversation history stays on your device and is replayed with each request; nothing is retained on Google's servers between turns.
+- **Status**: Experimental while the SDK surface settles. If you hit problems, turn it off to fall back to the proven `generateContent` path. When enabled, responses are currently delivered non-streaming (incremental streaming for this transport is planned).
+
 ### Custom API Endpoint
 
 Route all Google API requests through a proxy or gateway instead of hitting the public endpoint directly.

--- a/docs/reference/advanced-settings.md
+++ b/docs/reference/advanced-settings.md
@@ -60,7 +60,7 @@ Route Gemini requests through Google's newer [Interactions API](https://ai.googl
 - **Setting name**: Use Interactions API
 - **Default**: off (uses `generateContent`)
 - **Scope**: Gemini provider only — the toggle is hidden when the provider is Ollama.
-- **Privacy**: The plugin runs the Interactions API **statelessly** (`store: false`). Your conversation history stays on your device and is replayed with each request; nothing is retained on Google's servers between turns.
+- **Privacy**: The plugin runs the Interactions API **statelessly** (`store: false`). Conversation history is replayed with each request, and the plugin does not persist Interactions state on Google's side between turns. (Requests are still sent to Google to generate each response, subject to Google's standard API data-handling terms.)
 - **Status**: Experimental while the SDK surface settles. If you hit problems, turn it off to fall back to the proven `generateContent` path. When enabled, responses are currently delivered non-streaming (incremental streaming for this transport is planned).
 
 ### Custom API Endpoint

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -288,6 +288,16 @@ Advanced settings for developers and power users. Access by clicking "Show advan
 
 ### API configuration
 
+#### Use Interactions API
+
+- **Setting**: `useInteractionsApi`
+- **Type**: Boolean
+- **Default**: `false`
+- **Only applies when**: Provider is `gemini`
+- **Description**: Routes Gemini requests through Google's GA [Interactions API](https://ai.google.dev/gemini-api/docs/interactions) (`interactions.create`) instead of the legacy `generateContent` API.
+- **Privacy**: Runs statelessly (`store: false`) — conversation history stays on your device and is replayed each turn; nothing is retained server-side between turns.
+- **Status**: Experimental. Responses are non-streaming for now; turn it off to fall back to `generateContent` if you hit issues.
+
 #### Custom API Endpoint
 
 - **Setting**: `customBaseUrl`

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -295,7 +295,7 @@ Advanced settings for developers and power users. Access by clicking "Show advan
 - **Default**: `false`
 - **Only applies when**: Provider is `gemini`
 - **Description**: Routes Gemini requests through Google's GA [Interactions API](https://ai.google.dev/gemini-api/docs/interactions) (`interactions.create`) instead of the legacy `generateContent` API.
-- **Privacy**: Runs statelessly (`store: false`) — conversation history stays on your device and is replayed each turn; nothing is retained server-side between turns.
+- **Privacy**: Runs statelessly (`store: false`) — conversation history is replayed with each request, and the plugin does not persist Interactions state on Google's side between turns. (Requests are still sent to Google to generate each response, subject to Google's standard API data-handling terms.)
 - **Status**: Experimental. Responses are non-streaming for now; turn it off to fall back to `generateContent` if you hit issues.
 
 #### Custom API Endpoint

--- a/src/api/factory.ts
+++ b/src/api/factory.ts
@@ -70,6 +70,7 @@ export class ModelClientFactory {
 			temperature: settings.temperature ?? 1.0,
 			topP: settings.topP ?? 0.95,
 			streamingEnabled: settings.streamingEnabled ?? true,
+			useInteractionsApi: settings.useInteractionsApi ?? false,
 			...overrides,
 		};
 		const client = new GeminiClient(config, prompts, plugin);

--- a/src/api/providers/gemini/client.ts
+++ b/src/api/providers/gemini/client.ts
@@ -37,6 +37,7 @@ import {
 	toolsToInteractionTools,
 	type InteractionStep,
 } from './interactions-mapper';
+import { installObsidianFetch } from './obsidian-fetch';
 
 /**
  * Per-use-case reasoning depth for Gemini 3.x `thinkingConfig.thinkingLevel`,
@@ -129,6 +130,15 @@ export class GeminiClient implements ModelApi {
 	 */
 	private async generateViaInteractions(request: BaseModelRequest | ExtendedModelRequest): Promise<ModelResponse> {
 		const params = await this.buildInteractionParams(request);
+
+		// Route the Interactions (Next-Gen) client through Obsidian's requestUrl
+		// so its requests bypass renderer CORS — the SDK otherwise uses the global
+		// fetch, whose preflight to the Interactions endpoint fails in Obsidian.
+		if (!installObsidianFetch(this.ai)) {
+			this.plugin?.logger.warn(
+				'[GeminiClient] Could not route Interactions client through Obsidian requestUrl; requests may fail due to CORS.'
+			);
+		}
 
 		try {
 			const interaction = await (this.ai as any).interactions.create(params);

--- a/src/api/providers/gemini/client.ts
+++ b/src/api/providers/gemini/client.ts
@@ -30,6 +30,13 @@ import { getDefaultModelForRole } from '../../../models';
 import { decodeHtmlEntities } from '../../../utils/html-entities';
 import type { GeminiClientConfig } from './config';
 import { ModelUseCase } from '../../model-use-case';
+import {
+	buildUserInputStep,
+	contentToSteps,
+	extractModelResponseFromInteraction,
+	toolsToInteractionTools,
+	type InteractionStep,
+} from './interactions-mapper';
 
 /**
  * Per-use-case reasoning depth for Gemini 3.x `thinkingConfig.thinkingLevel`,
@@ -90,9 +97,22 @@ export class GeminiClient implements ModelApi {
 	}
 
 	/**
+	 * Whether this client routes through the GA Interactions API. Reads the
+	 * per-client config first (set by the factory), falling back to live plugin
+	 * settings for `createCustom` callers that don't thread the flag through.
+	 */
+	private get useInteractions(): boolean {
+		return this.config.useInteractionsApi ?? this.plugin?.settings?.useInteractionsApi ?? false;
+	}
+
+	/**
 	 * Generate a non-streaming response
 	 */
 	async generateModelResponse(request: BaseModelRequest | ExtendedModelRequest): Promise<ModelResponse> {
+		if (this.useInteractions) {
+			return this.generateViaInteractions(request);
+		}
+
 		const params = await this.buildGenerateContentParams(request);
 
 		try {
@@ -105,12 +125,125 @@ export class GeminiClient implements ModelApi {
 	}
 
 	/**
+	 * Non-streaming generation via the Interactions API (stateless transport).
+	 */
+	private async generateViaInteractions(request: BaseModelRequest | ExtendedModelRequest): Promise<ModelResponse> {
+		const params = await this.buildInteractionParams(request);
+
+		try {
+			const interaction = await (this.ai as any).interactions.create(params);
+			return extractModelResponseFromInteraction(interaction);
+		} catch (error) {
+			this.plugin?.logger.error('[GeminiClient] Error creating interaction:', error);
+			throw error;
+		}
+	}
+
+	/**
+	 * Build Interactions `create` params from our request format, mirroring
+	 * `buildGenerateContentParams` but emitting the snake_case Interactions
+	 * surface. Stateless: full history is replayed in `input` and `store` is
+	 * false, so no `previous_interaction_id` is used.
+	 */
+	private async buildInteractionParams(
+		request: BaseModelRequest | ExtendedModelRequest
+	): Promise<Record<string, unknown>> {
+		const isExtended = isExtendedRequest(request);
+		const model = request.model || this.config.model || getDefaultModelForRole('chat');
+
+		const generationConfig: Record<string, unknown> = {
+			temperature: request.temperature ?? this.config.temperature,
+			top_p: request.topP ?? this.config.topP,
+			...(this.config.maxOutputTokens && { max_output_tokens: this.config.maxOutputTokens }),
+		};
+		// Interactions uses lowercase thinking levels; reuse the per-use-case map.
+		if (this.supportsThinking(model)) {
+			generationConfig.thinking_level =
+				THINKING_LEVEL_BY_USE_CASE[this.config.useCase ?? ModelUseCase.CHAT].toLowerCase();
+			generationConfig.thinking_summaries = 'auto';
+		}
+
+		const params: Record<string, unknown> = {
+			model,
+			store: false,
+			generation_config: generationConfig,
+		};
+
+		if (!isExtended) {
+			// One-shot request: the prompt is the entire input.
+			params.input = request.prompt || '';
+			return params;
+		}
+
+		const systemInstruction = await this.prompts.buildExtendedSystemInstruction(request);
+		if (systemInstruction) params.system_instruction = systemInstruction;
+
+		if (request.availableTools?.length) {
+			params.tools = toolsToInteractionTools(request.availableTools);
+		}
+
+		const input = this.buildInteractionInput(request);
+		params.input = input.length > 0 ? input : request.userMessage || '';
+		return params;
+	}
+
+	/**
+	 * Build the Interactions `input` step array: replayed history followed by the
+	 * current user turn (message + per-turn context + inline attachments).
+	 */
+	private buildInteractionInput(request: ExtendedModelRequest): InteractionStep[] {
+		const steps: InteractionStep[] = [];
+
+		for (const entry of request.conversationHistory ?? []) {
+			if ('role' in entry && 'parts' in entry) {
+				steps.push(...contentToSteps(entry as Content));
+			} else if ('role' in entry && 'text' in entry) {
+				const legacy = entry as Content & { text: string };
+				steps.push(
+					...contentToSteps({ role: legacy.role === 'user' ? 'user' : 'model', parts: [{ text: legacy.text }] })
+				);
+			} else if ('role' in entry && 'message' in entry) {
+				const legacy = entry as Content & { role: string; message: string };
+				steps.push(
+					...contentToSteps({ role: legacy.role === 'user' ? 'user' : 'model', parts: [{ text: legacy.message }] })
+				);
+			}
+		}
+
+		const attachments = [...(request.inlineAttachments || []), ...(request.imageAttachments || [])];
+		const userStep = buildUserInputStep(request.userMessage, request.perTurnContext, attachments);
+		if (userStep) steps.push(userStep);
+
+		return steps;
+	}
+
+	/**
 	 * Generate a streaming response
 	 */
 	generateStreamingResponse(
 		request: BaseModelRequest | ExtendedModelRequest,
 		onChunk: StreamCallback
 	): StreamingModelResponse {
+		// Phase 1: the Interactions transport is non-streaming only. Honour the
+		// ModelApi fallback contract — run the non-streaming path and emit the
+		// full response as a single chunk. Real step-based streaming is #1015.
+		if (this.useInteractions) {
+			let cancelledNonStream = false;
+			const complete = this.generateViaInteractions(request).then((response) => {
+				if (!cancelledNonStream) {
+					if (response.thoughts) onChunk({ text: '', thought: response.thoughts });
+					if (response.markdown) onChunk({ text: response.markdown });
+				}
+				return response;
+			});
+			return {
+				complete,
+				cancel: () => {
+					cancelledNonStream = true;
+				},
+			};
+		}
+
 		let cancelled = false;
 		let accumulatedText = '';
 		let accumulatedRendered = '';

--- a/src/api/providers/gemini/client.ts
+++ b/src/api/providers/gemini/client.ts
@@ -229,13 +229,14 @@ export class GeminiClient implements ModelApi {
 		// full response as a single chunk. Real step-based streaming is #1015.
 		if (this.useInteractions) {
 			let cancelledNonStream = false;
-			const complete = this.generateViaInteractions(request).then((response) => {
+			const complete = (async (): Promise<ModelResponse> => {
+				const response = await this.generateViaInteractions(request);
 				if (!cancelledNonStream) {
 					if (response.thoughts) onChunk({ text: '', thought: response.thoughts });
 					if (response.markdown) onChunk({ text: response.markdown });
 				}
 				return response;
-			});
+			})();
 			return {
 				complete,
 				cancel: () => {

--- a/src/api/providers/gemini/config.ts
+++ b/src/api/providers/gemini/config.ts
@@ -16,4 +16,10 @@ export interface GeminiClientConfig {
 	topP?: number;
 	maxOutputTokens?: number;
 	streamingEnabled?: boolean;
+	/**
+	 * Route requests through the GA Interactions API (`interactions.create`)
+	 * instead of the legacy `generateContent`. Stateless (`store: false`) — the
+	 * plugin still owns and replays conversation history. Opt-in; see epic #1013.
+	 */
+	useInteractionsApi?: boolean;
 }

--- a/src/api/providers/gemini/interactions-mapper.ts
+++ b/src/api/providers/gemini/interactions-mapper.ts
@@ -1,0 +1,200 @@
+/**
+ * Translation layer between the plugin's `generateContent`-shaped request/response
+ * model and Google's GA Interactions API (`client.interactions.create`).
+ *
+ * The plugin owns conversation history (persisted as Markdown) and replays it on
+ * every turn, so we drive the Interactions API **statelessly** (`store: false`,
+ * no `previous_interaction_id`): the full conversation is rebuilt into the
+ * `input` array of typed steps each call. See epic #1013.
+ *
+ * The Interactions request/response surface is snake_case (`call_id`,
+ * `system_instruction`, `generation_config`, `total_input_tokens`, …), distinct
+ * from the camelCase `Content` model the rest of the client uses — this module is
+ * the single place that bridge lives, so the conversions stay testable in
+ * isolation. Shapes are typed loosely (`Record<string, unknown>` / local
+ * interfaces) on purpose: the SDK marks `interactions` experimental and several
+ * step types are not exported, so we avoid hard-coupling to unstable type names.
+ */
+import type { Content, Part } from '@google/genai';
+import type { ModelResponse, ToolCall, ToolDefinition } from '../../interfaces/model-api';
+import { decodeHtmlEntities } from '../../../utils/html-entities';
+
+/** A `Part` that may carry Gemini's thought metadata. */
+interface PartWithThought extends Part {
+	thought?: boolean;
+	thoughtSignature?: string;
+}
+
+/** A typed step in an Interactions `input` array or response `steps` array. */
+export type InteractionStep = Record<string, unknown>;
+
+/** A typed content item (text/image/…) inside a `user_input`/`model_output` step. */
+export type InteractionContentItem = Record<string, unknown>;
+
+/**
+ * MIME types the Interactions content model accepts as first-class media. Other
+ * inline data is degraded to a text note so the model still sees that an
+ * attachment existed rather than silently dropping it.
+ */
+function mediaTypeForMime(mime: string): 'image' | 'audio' | 'video' | 'document' | null {
+	if (mime.startsWith('image/')) return 'image';
+	if (mime.startsWith('audio/')) return 'audio';
+	if (mime.startsWith('video/')) return 'video';
+	if (mime === 'application/pdf' || mime === 'text/csv') return 'document';
+	return null;
+}
+
+/** Convert an inline-data part (base64 + mime) into an Interactions content item. */
+function inlineDataToContentItem(mimeType: string, data: string): InteractionContentItem {
+	const mediaType = mediaTypeForMime(mimeType);
+	if (!mediaType) {
+		return { type: 'text', text: `[attachment: ${mimeType}]` };
+	}
+	return { type: mediaType, data, mime_type: mimeType };
+}
+
+/** Serialize a tool's `functionResponse.response` into the `function_result.result` shape. */
+function functionResponseToResult(response: unknown): InteractionContentItem[] {
+	const text = typeof response === 'string' ? response : JSON.stringify(response ?? {});
+	return [{ type: 'text', text }];
+}
+
+/**
+ * Convert one history `Content` entry into zero or more Interactions steps.
+ *
+ * A single entry may contain a mix of text, inline media, function calls, and
+ * function responses. Text/media collapse into one `user_input` or `model_output`
+ * step (preserving the model's "say something, then call a tool" ordering by
+ * emitting the content step before any call steps), while function calls/results
+ * each become their own step. Model "thought" text parts are intentionally
+ * dropped from replay — reasoning is reconstructed server-side and re-sending it
+ * as plain output would distort the transcript.
+ */
+export function contentToSteps(content: Content): InteractionStep[] {
+	const role = content.role === 'user' ? 'user' : 'model';
+	const mediaItems: InteractionContentItem[] = [];
+	const callSteps: InteractionStep[] = [];
+
+	for (const part of content.parts ?? []) {
+		const p = part as PartWithThought;
+		if (p.functionCall) {
+			const step: InteractionStep = {
+				type: 'function_call',
+				id: p.functionCall.id ?? p.functionCall.name ?? 'call',
+				name: p.functionCall.name,
+				arguments: p.functionCall.args ?? {},
+			};
+			if (p.thoughtSignature) step.signature = p.thoughtSignature;
+			callSteps.push(step);
+		} else if (p.functionResponse) {
+			callSteps.push({
+				type: 'function_result',
+				call_id: p.functionResponse.id ?? p.functionResponse.name ?? 'call',
+				name: p.functionResponse.name,
+				result: functionResponseToResult(p.functionResponse.response),
+			});
+		} else if (p.inlineData?.data) {
+			mediaItems.push(inlineDataToContentItem(p.inlineData.mimeType ?? 'application/octet-stream', p.inlineData.data));
+		} else if (typeof p.text === 'string' && p.text.length > 0 && !p.thought) {
+			mediaItems.push({ type: 'text', text: p.text });
+		}
+	}
+
+	const steps: InteractionStep[] = [];
+	if (mediaItems.length > 0) {
+		steps.push({ type: role === 'user' ? 'user_input' : 'model_output', content: mediaItems });
+	}
+	steps.push(...callSteps);
+	return steps;
+}
+
+/** Build a `user_input` step for the current turn (message + per-turn context + attachments). */
+export function buildUserInputStep(
+	userMessage: string | undefined,
+	perTurnContext: string | undefined,
+	attachments: Array<{ base64: string; mimeType: string }>
+): InteractionStep | null {
+	const content: InteractionContentItem[] = [];
+	if (userMessage && userMessage.trim()) content.push({ type: 'text', text: userMessage });
+	if (perTurnContext && perTurnContext.trim()) content.push({ type: 'text', text: perTurnContext });
+	for (const attachment of attachments) {
+		content.push(inlineDataToContentItem(attachment.mimeType, attachment.base64));
+	}
+	return content.length > 0 ? { type: 'user_input', content } : null;
+}
+
+/** Map our tool definitions to flat Interactions `function` tool declarations. */
+export function toolsToInteractionTools(tools: ToolDefinition[]): InteractionStep[] {
+	return tools.map((tool) => ({
+		type: 'function',
+		name: tool.name,
+		description: tool.description,
+		parameters: {
+			type: 'object',
+			properties: tool.parameters.properties || {},
+			required: tool.parameters.required || [],
+		},
+	}));
+}
+
+/** Pull the concatenated text out of a step's `content` array. */
+function textFromContentArray(content: unknown): string {
+	if (!Array.isArray(content)) return '';
+	return content
+		.filter((item): item is { type: string; text: string } => {
+			const i = item as { type?: string; text?: unknown };
+			return i.type === 'text' && typeof i.text === 'string';
+		})
+		.map((item) => item.text)
+		.join('');
+}
+
+/**
+ * Extract a `ModelResponse` from a completed `Interaction`.
+ *
+ * Prefers the SDK's `output_text` convenience for the final answer, falling back
+ * to scanning trailing `model_output` steps. Thought summaries, tool calls, and
+ * token usage are read directly off the `steps`/`usage` surface.
+ */
+export function extractModelResponseFromInteraction(interaction: Record<string, unknown>): ModelResponse {
+	const steps = Array.isArray(interaction.steps) ? (interaction.steps as InteractionStep[]) : [];
+
+	let markdown = typeof interaction.output_text === 'string' ? interaction.output_text : '';
+	let thoughts = '';
+	const toolCalls: ToolCall[] = [];
+
+	for (const step of steps) {
+		const type = step.type as string;
+		if (type === 'model_output' && !markdown) {
+			markdown += textFromContentArray(step.content);
+		} else if (type === 'thought') {
+			thoughts += textFromContentArray(step.summary);
+		} else if (type === 'function_call') {
+			toolCalls.push({
+				name: String(step.name ?? ''),
+				arguments: (step.arguments as Record<string, unknown>) ?? {},
+				id: typeof step.id === 'string' ? step.id : undefined,
+				thoughtSignature: typeof step.signature === 'string' ? step.signature : undefined,
+			});
+		}
+	}
+
+	markdown = decodeHtmlEntities(markdown);
+
+	const usage = interaction.usage as Record<string, number> | undefined;
+	const response: ModelResponse = {
+		markdown,
+		rendered: '', // search grounding is Phase 3 (#1016)
+	};
+	if (thoughts) response.thoughts = thoughts;
+	if (toolCalls.length > 0) response.toolCalls = toolCalls;
+	if (usage) {
+		response.usageMetadata = {
+			promptTokenCount: usage.total_input_tokens,
+			candidatesTokenCount: usage.total_output_tokens,
+			totalTokenCount: usage.total_tokens,
+			cachedContentTokenCount: usage.total_cached_tokens,
+		};
+	}
+	return response;
+}

--- a/src/api/providers/gemini/obsidian-fetch.ts
+++ b/src/api/providers/gemini/obsidian-fetch.ts
@@ -1,0 +1,105 @@
+/**
+ * A WHATWG-`fetch`-compatible adapter backed by Obsidian's `requestUrl`.
+ *
+ * Why this exists: the `@google/genai` Interactions client (the "Next-Gen" API
+ * client behind `client.interactions.*`) issues requests with the renderer's
+ * global `fetch`. In Obsidian's Electron renderer that is subject to CORS, and
+ * the Interactions endpoint's preflight fails ("Failed to fetch"). Obsidian's
+ * `requestUrl` runs in the main process and is not CORS-constrained, so routing
+ * the SDK through it makes the calls succeed — the same reason other network
+ * tools in this plugin use `requestUrl`.
+ *
+ * Upstream root cause: the Next-Gen client sends an `Api-Revision` request
+ * header that `generativelanguage.googleapis.com` does not list in its
+ * `Access-Control-Allow-Headers`, so the browser preflight returns 403 with no
+ * `Access-Control-Allow-Origin`. (`models.generateContent` works in the browser
+ * because it never sets that header.) Tracked upstream at
+ * https://github.com/googleapis/js-genai/issues/1723, where a Google maintainer
+ * proposed removing the header from the SDK. There is also no public hook to
+ * supply a custom `fetch` to the Next-Gen client (feature requests
+ * https://github.com/googleapis/js-genai/issues/999 and /1215), which is why
+ * `installObsidianFetch` patches `fetch` onto the lazily constructed client
+ * instance (see `GeminiClient.generateViaInteractions`).
+ *
+ * Revisit when the upstream fix ships — tracked in #1023 (includes a recipe for
+ * checking whether Google has fixed it). Even once fixed, routing through
+ * `requestUrl` remains harmless and consistent with the plugin's other network
+ * calls.
+ */
+import { requestUrl, type RequestUrlParam } from 'obsidian';
+
+/** Normalize `HeadersInit` (Headers | [k,v][] | record) into a plain record. */
+function normalizeHeaders(headers: HeadersInit | undefined): Record<string, string> {
+	const out: Record<string, string> = {};
+	if (!headers) return out;
+	if (headers instanceof Headers) {
+		headers.forEach((value, key) => {
+			out[key] = value;
+		});
+	} else if (Array.isArray(headers)) {
+		for (const [key, value] of headers) out[key] = value;
+	} else {
+		Object.assign(out, headers);
+	}
+	return out;
+}
+
+/** Coerce a `fetch` body (string | ArrayBuffer | undefined) into what `requestUrl` accepts. */
+function normalizeBody(body: BodyInit | null | undefined): string | ArrayBuffer | undefined {
+	if (body == null) return undefined;
+	if (typeof body === 'string') return body;
+	if (body instanceof ArrayBuffer) return body;
+	// The Interactions client only sends JSON string bodies in the non-streaming
+	// path; anything else is unexpected, so stringify defensively.
+	return String(body);
+}
+
+/**
+ * `fetch`-shaped function that proxies through Obsidian's `requestUrl` and
+ * returns a real `Response`, so the SDK's response handling (`.json()`,
+ * `.status`, `.headers`) works unchanged.
+ */
+export async function obsidianFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+	const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+
+	const param: RequestUrlParam = {
+		url,
+		method: (init?.method ?? 'GET').toUpperCase(),
+		headers: normalizeHeaders(init?.headers),
+		// Return the response regardless of status so the SDK maps HTTP errors
+		// itself instead of requestUrl throwing on non-2xx.
+		throw: false,
+	};
+	const body = normalizeBody(init?.body);
+	if (body !== undefined) param.body = body;
+
+	const response = await requestUrl(param);
+	return new Response(response.arrayBuffer, {
+		status: response.status,
+		headers: response.headers,
+	});
+}
+
+/**
+ * Patch `obsidianFetch` onto a `GoogleGenAI` instance's Next-Gen (Interactions)
+ * client so its requests bypass renderer CORS. Idempotent and defensive: if the
+ * SDK internals change shape, it silently no-ops and the caller falls back to the
+ * SDK's global-`fetch` behaviour. Returns true if the patch was applied (or was
+ * already in place).
+ */
+export function installObsidianFetch(ai: unknown): boolean {
+	const getNextGenClient = (ai as { getNextGenClient?: () => { fetch?: unknown; __obsidianFetch?: boolean } })
+		?.getNextGenClient;
+	if (typeof getNextGenClient !== 'function') return false;
+
+	try {
+		const client = getNextGenClient.call(ai);
+		if (!client) return false;
+		if (client.__obsidianFetch) return true;
+		client.fetch = obsidianFetch;
+		client.__obsidianFetch = true;
+		return true;
+	} catch {
+		return false;
+	}
+}

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -464,7 +464,7 @@ export const en = {
 	},
 	'settings.agentConfig.useInteractionsApiDesc': {
 		message:
-			'Route Gemini requests through Google’s newer Interactions API instead of the legacy generateContent API. Conversation history stays on your device. Experimental — leave off if you hit issues.',
+			'Route Gemini requests through Google’s newer Interactions API instead of the legacy generateContent API. Runs statelessly — conversation history is replayed each turn and not persisted on Google’s side between turns. Experimental — leave off if you hit issues.',
 		context:
 			'Settings toggle description for the Interactions API. "Interactions API" and "generateContent" are Google API names; keep them in English.',
 	},

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -458,6 +458,16 @@ export const en = {
 		context:
 			'Settings toggle description for file logging. "Debug Mode" refers to the setting named by settings.debug.debugModeName; translate consistently.',
 	},
+	'settings.agentConfig.useInteractionsApiName': {
+		message: 'Use Interactions API',
+		context: 'Settings toggle name for routing Gemini requests through the GA Interactions API.',
+	},
+	'settings.agentConfig.useInteractionsApiDesc': {
+		message:
+			'Route Gemini requests through Google’s newer Interactions API instead of the legacy generateContent API. Conversation history stays on your device. Experimental — leave off if you hit issues.',
+		context:
+			'Settings toggle description for the Interactions API. "Interactions API" and "generateContent" are Google API names; keep them in English.',
+	},
 	'settings.agentConfig.customEndpointName': {
 		message: 'Custom API endpoint',
 		context: 'Settings field name for overriding the Google API base URL.',

--- a/src/main.ts
+++ b/src/main.ts
@@ -74,6 +74,13 @@ export interface ObsidianGeminiSettings {
 	maxRetries: number;
 	initialBackoffDelay: number;
 	streamingEnabled: boolean;
+	/**
+	 * Use Google's GA Interactions API (`client.interactions.create`) as the
+	 * Gemini transport instead of the legacy `generateContent`. Runs stateless
+	 * (`store: false`); we still own and replay conversation history. Opt-in
+	 * while the SDK surface settles — see epic #1013.
+	 */
+	useInteractionsApi: boolean;
 	allowSystemPromptOverride: boolean;
 	temperature: number;
 	topP: number;
@@ -128,6 +135,7 @@ const DEFAULT_SETTINGS: ObsidianGeminiSettings = {
 	maxRetries: 3,
 	initialBackoffDelay: 1000,
 	streamingEnabled: true,
+	useInteractionsApi: false,
 	allowSystemPromptOverride: false,
 	temperature: 0.7,
 	topP: 1,

--- a/src/ui/settings-agent-config.ts
+++ b/src/ui/settings-agent-config.ts
@@ -72,6 +72,20 @@ export async function renderAgentConfigSettings(
 			})
 		);
 
+	// The Interactions API is a Gemini-only transport; hide the toggle entirely
+	// on Ollama, which has no equivalent.
+	if (plugin.settings.provider === 'gemini') {
+		new Setting(sectionEl)
+			.setName(t('settings.agentConfig.useInteractionsApiName'))
+			.setDesc(t('settings.agentConfig.useInteractionsApiDesc'))
+			.addToggle((toggle) =>
+				toggle.setValue(plugin.settings.useInteractionsApi).onChange(async (value) => {
+					plugin.settings.useInteractionsApi = value;
+					await plugin.saveSettings();
+				})
+			);
+	}
+
 	// Only the Gemini provider honours customBaseUrl — the Ollama path has its
 	// own ollamaBaseUrl setting and ignores this value. Hide the row entirely
 	// on Ollama so users don't type a URL that silently does nothing.

--- a/test/api/providers/gemini/client.test.ts
+++ b/test/api/providers/gemini/client.test.ts
@@ -9,8 +9,9 @@ import { ModelUseCase } from '../../../../src/api/model-use-case';
 // Capture every call to `client.models.generateContent` so tests can assert on
 // the params (system instruction, contents, etc.) the SDK sees. vi.hoisted lets
 // us share the spy with the factory while keeping vitest's mock-hoisting safe.
-const { generateContentMock } = vi.hoisted(() => ({
+const { generateContentMock, interactionsCreateMock } = vi.hoisted(() => ({
 	generateContentMock: vi.fn(),
+	interactionsCreateMock: vi.fn(),
 }));
 
 vi.mock('@google/genai', () => ({
@@ -20,6 +21,9 @@ vi.mock('@google/genai', () => ({
 			models: {
 				generateContent: generateContentMock,
 				generateContentStream: vi.fn(),
+			},
+			interactions: {
+				create: interactionsCreateMock,
 			},
 		};
 	}),
@@ -967,6 +971,193 @@ describe('GeminiClient', () => {
 
 			const params = (generateContentMock as Mock).mock.calls[0][0];
 			expect(params.config.maxOutputTokens).toBe(4096);
+		});
+	});
+
+	describe('Interactions API transport (useInteractionsApi)', () => {
+		const makeInteractionsClient = (extra: Partial<GeminiClientConfig> = {}) =>
+			new GeminiClient(
+				{ apiKey: 'test-api-key', model: 'gemini-3-flash', useInteractionsApi: true, ...extra },
+				new GeminiPrompts(mockPlugin),
+				mockPlugin
+			);
+
+		beforeEach(() => {
+			interactionsCreateMock.mockReset();
+			interactionsCreateMock.mockResolvedValue({
+				id: 'int_1',
+				status: 'completed',
+				output_text: 'Hello from interactions',
+				steps: [{ type: 'model_output', content: [{ type: 'text', text: 'Hello from interactions' }] }],
+				usage: { total_input_tokens: 10, total_output_tokens: 5, total_tokens: 15, total_cached_tokens: 2 },
+			});
+
+			// Stub the plugin surface buildExtendedSystemInstruction depends on.
+			(mockPlugin as any).agentsMemory = { read: vi.fn().mockResolvedValue('') };
+			(mockPlugin as any).skillManager = { getSkillSummaries: vi.fn().mockResolvedValue([]) };
+			(mockPlugin as any).settings = { userName: 'Tester', ragIndexing: { enabled: false } };
+		});
+
+		test('routes generateModelResponse to interactions.create, not generateContent', async () => {
+			const client = makeInteractionsClient();
+			const response = await client.generateModelResponse({
+				prompt: '',
+				userMessage: 'hi',
+				kind: 'extended',
+				conversationHistory: [],
+			} as ExtendedModelRequest);
+
+			expect(interactionsCreateMock).toHaveBeenCalledTimes(1);
+			expect(generateContentMock).not.toHaveBeenCalled();
+			expect(response.markdown).toBe('Hello from interactions');
+		});
+
+		test('sends stateless params: store=false and snake_case generation_config', async () => {
+			const client = makeInteractionsClient();
+			await client.generateModelResponse({
+				prompt: '',
+				userMessage: 'hi',
+				kind: 'extended',
+				conversationHistory: [],
+				temperature: 0.4,
+				topP: 0.8,
+			} as ExtendedModelRequest);
+
+			const params = interactionsCreateMock.mock.calls[0][0];
+			expect(params.store).toBe(false);
+			expect(params.previous_interaction_id).toBeUndefined();
+			expect(params.generation_config.temperature).toBe(0.4);
+			expect(params.generation_config.top_p).toBe(0.8);
+			// gemini-3-flash supports thinking → lowercase thinking_level for CHAT use case
+			expect(params.generation_config.thinking_level).toBe('high');
+		});
+
+		test('maps tools to flat function declarations', async () => {
+			const client = makeInteractionsClient();
+			await client.generateModelResponse({
+				prompt: '',
+				userMessage: 'use a tool',
+				kind: 'extended',
+				conversationHistory: [],
+				availableTools: [
+					{
+						name: 'read_file',
+						description: 'Read a file',
+						parameters: { type: 'object', properties: { path: { type: 'string' } }, required: ['path'] },
+					},
+				],
+			} as ExtendedModelRequest);
+
+			const params = interactionsCreateMock.mock.calls[0][0];
+			expect(params.tools).toEqual([
+				{
+					type: 'function',
+					name: 'read_file',
+					description: 'Read a file',
+					parameters: { type: 'object', properties: { path: { type: 'string' } }, required: ['path'] },
+				},
+			]);
+		});
+
+		test('replays history as typed steps incl. function call/result round-trip', async () => {
+			const client = makeInteractionsClient();
+			await client.generateModelResponse({
+				prompt: '',
+				userMessage: 'and now?',
+				kind: 'extended',
+				conversationHistory: [
+					{ role: 'user', parts: [{ text: 'read foo.md' }] },
+					{ role: 'model', parts: [{ functionCall: { id: 'c1', name: 'read_file', args: { path: 'foo.md' } } }] },
+					{ role: 'user', parts: [{ functionResponse: { id: 'c1', name: 'read_file', response: { content: 'hi' } } }] },
+					{ role: 'model', parts: [{ text: 'foo.md says hi' }] },
+				] as any,
+			} as ExtendedModelRequest);
+
+			const params = interactionsCreateMock.mock.calls[0][0];
+			expect(params.input).toEqual([
+				{ type: 'user_input', content: [{ type: 'text', text: 'read foo.md' }] },
+				{ type: 'function_call', id: 'c1', name: 'read_file', arguments: { path: 'foo.md' } },
+				{
+					type: 'function_result',
+					call_id: 'c1',
+					name: 'read_file',
+					result: [{ type: 'text', text: JSON.stringify({ content: 'hi' }) }],
+				},
+				{ type: 'model_output', content: [{ type: 'text', text: 'foo.md says hi' }] },
+				{ type: 'user_input', content: [{ type: 'text', text: 'and now?' }] },
+			]);
+		});
+
+		test('maps inline image attachments to image content items', async () => {
+			const client = makeInteractionsClient();
+			await client.generateModelResponse({
+				prompt: '',
+				userMessage: 'what is this?',
+				kind: 'extended',
+				conversationHistory: [],
+				inlineAttachments: [{ base64: 'AAAA', mimeType: 'image/png' }],
+			} as ExtendedModelRequest);
+
+			const params = interactionsCreateMock.mock.calls[0][0];
+			const lastStep = params.input[params.input.length - 1];
+			expect(lastStep.content).toEqual([
+				{ type: 'text', text: 'what is this?' },
+				{ type: 'image', data: 'AAAA', mime_type: 'image/png' },
+			]);
+		});
+
+		test('extracts tool calls, thoughts, and usage from the interaction', async () => {
+			interactionsCreateMock.mockResolvedValue({
+				id: 'int_2',
+				status: 'requires_action',
+				output_text: '',
+				steps: [
+					{ type: 'thought', summary: [{ type: 'text', text: 'thinking...' }] },
+					{ type: 'function_call', id: 'c9', name: 'list_files', arguments: { dir: '.' }, signature: 'sig9' },
+				],
+				usage: { total_input_tokens: 7, total_output_tokens: 3, total_tokens: 10 },
+			});
+			const client = makeInteractionsClient();
+			const response = await client.generateModelResponse({
+				prompt: '',
+				userMessage: 'list files',
+				kind: 'extended',
+				conversationHistory: [],
+			} as ExtendedModelRequest);
+
+			expect(response.thoughts).toBe('thinking...');
+			expect(response.toolCalls).toEqual([
+				{ name: 'list_files', arguments: { dir: '.' }, id: 'c9', thoughtSignature: 'sig9' },
+			]);
+			expect(response.usageMetadata).toEqual({
+				promptTokenCount: 7,
+				candidatesTokenCount: 3,
+				totalTokenCount: 10,
+				cachedContentTokenCount: undefined,
+			});
+		});
+
+		test('streaming falls back to a single chunk via the non-streaming path', async () => {
+			const client = makeInteractionsClient();
+			const chunks: Array<{ text: string; thought?: string }> = [];
+			const stream = client.generateStreamingResponse!(
+				{ prompt: '', userMessage: 'hi', kind: 'extended', conversationHistory: [] } as ExtendedModelRequest,
+				(chunk) => chunks.push(chunk)
+			);
+			const result = await stream.complete;
+
+			expect(interactionsCreateMock).toHaveBeenCalledTimes(1);
+			expect(result.markdown).toBe('Hello from interactions');
+			expect(chunks.some((c) => c.text === 'Hello from interactions')).toBe(true);
+		});
+
+		test('one-shot base requests pass the prompt as input', async () => {
+			const client = makeInteractionsClient();
+			await client.generateModelResponse({ prompt: 'just answer', kind: 'base' } as any);
+
+			const params = interactionsCreateMock.mock.calls[0][0];
+			expect(params.input).toBe('just answer');
+			expect(params.system_instruction).toBeUndefined();
 		});
 	});
 });

--- a/test/api/providers/gemini/client.test.ts
+++ b/test/api/providers/gemini/client.test.ts
@@ -9,15 +9,19 @@ import { ModelUseCase } from '../../../../src/api/model-use-case';
 // Capture every call to `client.models.generateContent` so tests can assert on
 // the params (system instruction, contents, etc.) the SDK sees. vi.hoisted lets
 // us share the spy with the factory while keeping vitest's mock-hoisting safe.
-const { generateContentMock, interactionsCreateMock } = vi.hoisted(() => ({
+const { generateContentMock, interactionsCreateMock, nextGenClient } = vi.hoisted(() => ({
 	generateContentMock: vi.fn(),
 	interactionsCreateMock: vi.fn(),
+	// Stands in for the SDK's internal Next-Gen client so installObsidianFetch
+	// has a `getNextGenClient()` + patchable `.fetch` to bind to.
+	nextGenClient: { fetch: undefined as unknown },
 }));
 
 vi.mock('@google/genai', () => ({
 	GoogleGenAI: vi.fn().mockImplementation(function () {
 		return {
 			getModel: vi.fn(),
+			getNextGenClient: () => nextGenClient,
 			models: {
 				generateContent: generateContentMock,
 				generateContentStream: vi.fn(),
@@ -1010,6 +1014,9 @@ describe('GeminiClient', () => {
 			expect(interactionsCreateMock).toHaveBeenCalledTimes(1);
 			expect(generateContentMock).not.toHaveBeenCalled();
 			expect(response.markdown).toBe('Hello from interactions');
+			// Next-Gen client routed through Obsidian's requestUrl (CORS bypass).
+			expect(typeof nextGenClient.fetch).toBe('function');
+			expect((nextGenClient as any).__obsidianFetch).toBe(true);
 		});
 
 		test('sends stateless params: store=false and snake_case generation_config', async () => {

--- a/test/api/providers/gemini/obsidian-fetch.test.ts
+++ b/test/api/providers/gemini/obsidian-fetch.test.ts
@@ -1,0 +1,89 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+
+// Control Obsidian's requestUrl precisely for these tests.
+const { requestUrlMock } = vi.hoisted(() => ({ requestUrlMock: vi.fn() }));
+vi.mock('obsidian', () => ({ requestUrl: requestUrlMock }));
+
+import { obsidianFetch, installObsidianFetch } from '../../../../src/api/providers/gemini/obsidian-fetch';
+
+describe('obsidianFetch', () => {
+	beforeEach(() => {
+		requestUrlMock.mockReset();
+		requestUrlMock.mockResolvedValue({
+			status: 200,
+			headers: { 'content-type': 'application/json' },
+			arrayBuffer: new TextEncoder().encode(JSON.stringify({ ok: true })).buffer,
+		});
+	});
+
+	test('proxies a POST through requestUrl and returns a real Response', async () => {
+		const res = await obsidianFetch('https://example.com/v1beta/interactions', {
+			method: 'post',
+			headers: { 'x-goog-api-key': 'k', 'content-type': 'application/json' },
+			body: JSON.stringify({ model: 'gemini-3.5-flash' }),
+		});
+
+		expect(requestUrlMock).toHaveBeenCalledTimes(1);
+		const param = requestUrlMock.mock.calls[0][0];
+		expect(param.url).toBe('https://example.com/v1beta/interactions');
+		expect(param.method).toBe('POST'); // upper-cased
+		expect(param.headers['x-goog-api-key']).toBe('k');
+		expect(param.body).toBe(JSON.stringify({ model: 'gemini-3.5-flash' }));
+		expect(param.throw).toBe(false); // let the SDK map HTTP errors itself
+
+		expect(res).toBeInstanceOf(Response);
+		expect(res.status).toBe(200);
+		await expect(res.json()).resolves.toEqual({ ok: true });
+	});
+
+	test('normalizes a Headers instance into a plain record', async () => {
+		const headers = new Headers();
+		headers.set('authorization', 'Bearer t');
+		await obsidianFetch(new URL('https://example.com/x'), { headers });
+
+		const param = requestUrlMock.mock.calls[0][0];
+		expect(param.headers.authorization).toBe('Bearer t');
+		expect(param.url).toBe('https://example.com/x');
+	});
+
+	test('non-2xx responses are returned (not thrown) for the SDK to handle', async () => {
+		requestUrlMock.mockResolvedValue({
+			status: 429,
+			headers: {},
+			arrayBuffer: new TextEncoder().encode('rate limited').buffer,
+		});
+		const res = await obsidianFetch('https://example.com/x', { method: 'GET' });
+		expect(res.status).toBe(429);
+		expect(res.ok).toBe(false);
+	});
+});
+
+describe('installObsidianFetch', () => {
+	test('patches the Next-Gen client fetch and is idempotent', () => {
+		const client: { fetch?: unknown; __obsidianFetch?: boolean } = { fetch: window.fetch };
+		const ai = { getNextGenClient: () => client };
+
+		expect(installObsidianFetch(ai)).toBe(true);
+		expect(client.fetch).toBe(obsidianFetch);
+		expect(client.__obsidianFetch).toBe(true);
+
+		// Second call is a no-op that still reports success.
+		const prev = client.fetch;
+		expect(installObsidianFetch(ai)).toBe(true);
+		expect(client.fetch).toBe(prev);
+	});
+
+	test('returns false when the SDK lacks getNextGenClient', () => {
+		expect(installObsidianFetch({})).toBe(false);
+		expect(installObsidianFetch(null)).toBe(false);
+	});
+
+	test('returns false (no throw) when getNextGenClient throws', () => {
+		const ai = {
+			getNextGenClient: () => {
+				throw new Error('internal');
+			},
+		};
+		expect(installObsidianFetch(ai)).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary

Phase 1 of the Gemini **Interactions API** migration (epic #1013). Adds an opt-in, **stateless** Interactions transport (`client.interactions.create`) to `GeminiClient`, behind a new `useInteractionsApi` setting (default **off**). The plugin keeps owning and replaying conversation history (Markdown-backed), so we run with `store: false` and no `previous_interaction_id` — the `ModelApi` interface and everything above it (agent loop, factory, retry decorator, Ollama provider) are unchanged. `generateContent` stays as the untouched fallback path.

Non-streaming only in this phase; when the flag is on, the streaming method falls back to a single-chunk emission via the non-streaming call (honoring the `ModelApi` fallback contract). Real step-based streaming is Phase 2 (#1015).

Fixes #1014. Part of #1013.

## Changes

- **New** `src/api/providers/gemini/interactions-mapper.ts` — the `Content` ⇄ Interactions translation layer (history → typed `input` steps, tools → flat `{type:'function',…}` declarations, `Interaction` → `ModelResponse`), isolated for unit testing.
- `GeminiClient.generateModelResponse` routes to `interactions.create` when the flag is on; builds snake_case params (`system_instruction`, `generation_config` with lowercase `thinking_level`, `store: false`) and replays full history into `input`.
- Streaming path falls back to non-streaming when the flag is on.
- `useInteractionsApi` added to settings (`main.ts`), `GeminiClientConfig`, and threaded through the factory.
- Gemini-only toggle in Settings → Agent config → API configuration, with `en.ts` i18n keys.
- Extended the `@google/genai` test mock with `interactions.create`; 7 new unit tests (routing, stateless params, tool mapping, function call/result round-trip, attachment mapping, response extraction incl. thoughts/usage, streaming fallback, base request).
- Docs: `docs/reference/settings.md` and `docs/reference/advanced-settings.md`.

## Notes for reviewers

- Field shapes (snake_case params, flat `function` tools, lowercase `thinking_level`) were taken from the SDK's own `genai.d.ts`, not the prose docs (which were wrong on casing).
- The SDK marks `client.interactions` **experimental** and there is a live "breaking changes May 2026" doc — this is exactly why the flag defaults off and `generateContent` is retained as a fallback rather than removed.
- Two new i18n keys are English-only here; `npm run translate` (needs `GOOGLE_API_KEY`) should be run before merge to regenerate locale files. Missing keys fall back to English, so nothing breaks meanwhile.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop
- [ ] I have verified this change does not break Mobile — N/A: no platform-specific APIs; transport swap behind a default-off flag
- [x] Documentation has been updated (if applicable)
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an experimental **“Use Interactions API”** toggle for the **Gemini** provider (disabled by default).
  * When enabled, Gemini requests route through Google’s Interactions API with stateless history replay; streaming uses a non-streaming interaction flow (cancel suppresses output only after completion).
  * Added an Obsidian-safe fetch adapter to support the Interactions transport.
* **Documentation**
  * Updated settings reference and advanced settings guide with the toggle details, limitations, and fallback behavior.
* **Tests**
  * Expanded Gemini tests and mocks to cover Interactions routing, request/response mapping, and the Obsidian fetch adapter behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->