### PR TITLE
feat: step-based streaming for the Interactions transport (Phase 2)

### DIFF
--- a/docs/reference/advanced-settings.md
+++ b/docs/reference/advanced-settings.md
@@ -61,7 +61,7 @@ Route Gemini requests through Google's newer [Interactions API](https://ai.googl
 - **Default**: off (uses `generateContent`)
 - **Scope**: Gemini provider only — the toggle is hidden when the provider is Ollama.
 - **Privacy**: The plugin runs the Interactions API **statelessly** (`store: false`). Conversation history is replayed with each request, and the plugin does not persist Interactions state on Google's side between turns. (Requests are still sent to Google to generate each response, subject to Google's standard API data-handling terms.)
-- **Status**: Experimental while the SDK surface settles. If you hit problems, turn it off to fall back to the proven `generateContent` path. When enabled, responses are currently delivered non-streaming (incremental streaming for this transport is planned).
+- **Status**: Experimental while the SDK surface settles. If you hit problems, turn it off to fall back to the proven `generateContent` path. Responses stream incrementally, including reasoning and tool calls.
 
 ### Custom API Endpoint
 

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -296,7 +296,7 @@ Advanced settings for developers and power users. Access by clicking "Show advan
 - **Only applies when**: Provider is `gemini`
 - **Description**: Routes Gemini requests through Google's GA [Interactions API](https://ai.google.dev/gemini-api/docs/interactions) (`interactions.create`) instead of the legacy `generateContent` API.
 - **Privacy**: Runs statelessly (`store: false`) — conversation history is replayed with each request, and the plugin does not persist Interactions state on Google's side between turns. (Requests are still sent to Google to generate each response, subject to Google's standard API data-handling terms.)
-- **Status**: Experimental. Responses are non-streaming for now; turn it off to fall back to `generateContent` if you hit issues.
+- **Status**: Experimental. Responses stream incrementally (text, reasoning, and tool calls); turn it off to fall back to `generateContent` if you hit issues.
 
 #### Custom API Endpoint
 

--- a/src/api/providers/gemini/client.ts
+++ b/src/api/providers/gemini/client.ts
@@ -35,6 +35,7 @@ import {
 	contentToSteps,
 	extractModelResponseFromInteraction,
 	toolsToInteractionTools,
+	InteractionStreamAccumulator,
 	type InteractionStep,
 } from './interactions-mapper';
 import { installObsidianFetch } from './obsidian-fetch';
@@ -126,19 +127,24 @@ export class GeminiClient implements ModelApi {
 	}
 
 	/**
-	 * Non-streaming generation via the Interactions API (stateless transport).
+	 * Route the Interactions (Next-Gen) client through Obsidian's requestUrl so its
+	 * requests bypass renderer CORS — the SDK otherwise uses the global fetch,
+	 * whose preflight to the Interactions endpoint fails in Obsidian (see #1023).
 	 */
-	private async generateViaInteractions(request: BaseModelRequest | ExtendedModelRequest): Promise<ModelResponse> {
-		const params = await this.buildInteractionParams(request);
-
-		// Route the Interactions (Next-Gen) client through Obsidian's requestUrl
-		// so its requests bypass renderer CORS — the SDK otherwise uses the global
-		// fetch, whose preflight to the Interactions endpoint fails in Obsidian.
+	private ensureInteractionsFetch(): void {
 		if (!installObsidianFetch(this.ai)) {
 			this.plugin?.logger.warn(
 				'[GeminiClient] Could not route Interactions client through Obsidian requestUrl; requests may fail due to CORS.'
 			);
 		}
+	}
+
+	/**
+	 * Non-streaming generation via the Interactions API (stateless transport).
+	 */
+	private async generateViaInteractions(request: BaseModelRequest | ExtendedModelRequest): Promise<ModelResponse> {
+		const params = await this.buildInteractionParams(request);
+		this.ensureInteractionsFetch();
 
 		try {
 			const interaction = await (this.ai as any).interactions.create(params);
@@ -147,6 +153,52 @@ export class GeminiClient implements ModelApi {
 			this.plugin?.logger.error('[GeminiClient] Error creating interaction:', error);
 			throw error;
 		}
+	}
+
+	/**
+	 * Streaming generation via the Interactions API. Consumes the step-based SSE
+	 * stream (`stream: true`) through an InteractionStreamAccumulator, emitting
+	 * text/reasoning chunks as they arrive and returning the assembled response
+	 * (text, thoughts, tool calls, usage) on completion. Cancellation stops
+	 * consuming and returns whatever has accumulated so far.
+	 */
+	private streamViaInteractions(
+		request: BaseModelRequest | ExtendedModelRequest,
+		onChunk: StreamCallback
+	): StreamingModelResponse {
+		let cancelled = false;
+		const accumulator = new InteractionStreamAccumulator();
+
+		const complete = (async (): Promise<ModelResponse> => {
+			const params = await this.buildInteractionParams(request);
+			params.stream = true;
+			this.ensureInteractionsFetch();
+
+			try {
+				const stream = await (this.ai as any).interactions.create(params);
+				for await (const event of stream) {
+					if (cancelled) break;
+					const chunk = accumulator.handleEvent(event);
+					if (chunk && (chunk.text || chunk.thought)) {
+						onChunk(chunk);
+					}
+				}
+				return accumulator.finalize();
+			} catch (error) {
+				if (cancelled) {
+					return accumulator.finalize();
+				}
+				this.plugin?.logger.error('[GeminiClient] Error streaming interaction:', error);
+				throw error;
+			}
+		})();
+
+		return {
+			complete,
+			cancel: () => {
+				cancelled = true;
+			},
+		};
 	}
 
 	/**
@@ -234,25 +286,8 @@ export class GeminiClient implements ModelApi {
 		request: BaseModelRequest | ExtendedModelRequest,
 		onChunk: StreamCallback
 	): StreamingModelResponse {
-		// Phase 1: the Interactions transport is non-streaming only. Honour the
-		// ModelApi fallback contract — run the non-streaming path and emit the
-		// full response as a single chunk. Real step-based streaming is #1015.
 		if (this.useInteractions) {
-			let cancelledNonStream = false;
-			const complete = (async (): Promise<ModelResponse> => {
-				const response = await this.generateViaInteractions(request);
-				if (!cancelledNonStream) {
-					if (response.thoughts) onChunk({ text: '', thought: response.thoughts });
-					if (response.markdown) onChunk({ text: response.markdown });
-				}
-				return response;
-			})();
-			return {
-				complete,
-				cancel: () => {
-					cancelledNonStream = true;
-				},
-			};
+			return this.streamViaInteractions(request, onChunk);
 		}
 
 		let cancelled = false;

--- a/src/api/providers/gemini/client.ts
+++ b/src/api/providers/gemini/client.ts
@@ -167,7 +167,20 @@ export class GeminiClient implements ModelApi {
 		onChunk: StreamCallback
 	): StreamingModelResponse {
 		let cancelled = false;
+		// The SDK's Stream exposes an AbortController; aborting it actively
+		// interrupts an in-flight SSE read so cancel() doesn't have to wait for the
+		// next frame (or the server) to unblock the `for await`.
+		let activeStream: { controller?: AbortController } | undefined;
 		const accumulator = new InteractionStreamAccumulator();
+
+		const cancel = () => {
+			cancelled = true;
+			try {
+				activeStream?.controller?.abort();
+			} catch {
+				// Best-effort: an SDK stream without a controller still stops via the flag.
+			}
+		};
 
 		const complete = (async (): Promise<ModelResponse> => {
 			const params = await this.buildInteractionParams(request);
@@ -176,6 +189,12 @@ export class GeminiClient implements ModelApi {
 
 			try {
 				const stream = await (this.ai as any).interactions.create(params);
+				activeStream = stream;
+				// Cancelled during request setup, before iteration began.
+				if (cancelled) {
+					cancel();
+					return accumulator.finalize();
+				}
 				for await (const event of stream) {
 					if (cancelled) break;
 					const chunk = accumulator.handleEvent(event);
@@ -195,9 +214,7 @@ export class GeminiClient implements ModelApi {
 
 		return {
 			complete,
-			cancel: () => {
-				cancelled = true;
-			},
+			cancel,
 		};
 	}
 

--- a/src/api/providers/gemini/interactions-mapper.ts
+++ b/src/api/providers/gemini/interactions-mapper.ts
@@ -181,20 +181,177 @@ export function extractModelResponseFromInteraction(interaction: Record<string, 
 
 	markdown = decodeHtmlEntities(markdown);
 
-	const usage = interaction.usage as Record<string, number> | undefined;
 	const response: ModelResponse = {
 		markdown,
 		rendered: '', // search grounding is Phase 3 (#1016)
 	};
 	if (thoughts) response.thoughts = thoughts;
 	if (toolCalls.length > 0) response.toolCalls = toolCalls;
-	if (usage) {
-		response.usageMetadata = {
-			promptTokenCount: usage.total_input_tokens,
-			candidatesTokenCount: usage.total_output_tokens,
-			totalTokenCount: usage.total_tokens,
-			cachedContentTokenCount: usage.total_cached_tokens,
-		};
-	}
+	const usageMetadata = mapInteractionUsage(interaction.usage);
+	if (usageMetadata) response.usageMetadata = usageMetadata;
 	return response;
+}
+
+/** Map an Interactions `usage` object to our `ModelResponse.usageMetadata` shape. */
+function mapInteractionUsage(usage: unknown): ModelResponse['usageMetadata'] | undefined {
+	if (!usage || typeof usage !== 'object') return undefined;
+	const u = usage as Record<string, number>;
+	return {
+		promptTokenCount: u.total_input_tokens,
+		candidatesTokenCount: u.total_output_tokens,
+		totalTokenCount: u.total_tokens,
+		cachedContentTokenCount: u.total_cached_tokens,
+	};
+}
+
+/** A streamed Interactions SSE event (loosely typed; see `StepDelta`/`InteractionCompletedEvent`). */
+export type InteractionStreamEvent = Record<string, unknown>;
+
+/** A chunk to surface to the streaming callback (mirrors `StreamChunk`). */
+export interface InteractionStreamChunk {
+	text: string;
+	thought?: string;
+}
+
+/** In-flight function-call step being assembled from `step.start` + `arguments_delta` fragments. */
+interface PendingToolCall {
+	id?: string;
+	name: string;
+	signature?: string;
+	/** Concatenated `arguments_delta` fragments (a JSON string once complete). */
+	argsBuffer: string;
+	/** Whole arguments object from `step.start`, used when no `arguments_delta` arrives. */
+	seedArgs?: Record<string, unknown>;
+}
+
+/**
+ * Accumulates Interactions streaming events into a final `ModelResponse`.
+ *
+ * The step-based stream interleaves: `step.start` (carries the full `Step`, so a
+ * `function_call` step's id/name/signature land here), `step.delta` (incremental
+ * `text`, `thought_summary`, or `arguments_delta`), `step.stop` (finalizes a
+ * step), and `interaction.completed` (final `usage`). Function-call arguments
+ * arrive as `arguments_delta` string fragments keyed by step `index` and are
+ * JSON-parsed once the step stops.
+ *
+ * Kept free of SDK/DOM dependencies so it is unit-testable with plain event
+ * objects. `handleEvent` returns the chunk to emit (or null); `finalize` builds
+ * the response once the stream ends.
+ */
+export class InteractionStreamAccumulator {
+	private text = '';
+	private thoughts = '';
+	private usage: ModelResponse['usageMetadata'] | undefined;
+	private readonly pending = new Map<number, PendingToolCall>();
+	private readonly toolCalls: ToolCall[] = [];
+
+	/** Process one streamed event; returns a chunk to emit, or null if nothing to surface. */
+	handleEvent(event: InteractionStreamEvent): InteractionStreamChunk | null {
+		const eventType = event.event_type as string | undefined;
+
+		if (eventType === 'step.start') {
+			const step = event.step as Record<string, unknown> | undefined;
+			if (step?.type === 'function_call') {
+				const index = event.index as number;
+				this.pending.set(index, {
+					id: typeof step.id === 'string' ? step.id : undefined,
+					name: String(step.name ?? ''),
+					signature: typeof step.signature === 'string' ? step.signature : undefined,
+					argsBuffer: '',
+					seedArgs:
+						step.arguments && typeof step.arguments === 'object'
+							? (step.arguments as Record<string, unknown>)
+							: undefined,
+				});
+			}
+			return null;
+		}
+
+		if (eventType === 'step.delta') {
+			return this.handleDelta(event);
+		}
+
+		if (eventType === 'step.stop') {
+			this.finalizeStep(event.index as number);
+			return null;
+		}
+
+		if (eventType === 'interaction.completed') {
+			const interaction = event.interaction as Record<string, unknown> | undefined;
+			const usage = mapInteractionUsage(interaction?.usage);
+			if (usage) this.usage = usage;
+			return null;
+		}
+
+		return null;
+	}
+
+	private handleDelta(event: InteractionStreamEvent): InteractionStreamChunk | null {
+		const delta = event.delta as Record<string, unknown> | undefined;
+		if (!delta) return null;
+
+		switch (delta.type) {
+			case 'text': {
+				const text = decodeHtmlEntities(String(delta.text ?? ''));
+				if (!text) return null;
+				this.text += text;
+				return { text };
+			}
+			case 'thought_summary': {
+				const content = delta.content as { text?: string } | undefined;
+				const thought = content?.text ?? '';
+				if (!thought) return null;
+				this.thoughts += thought;
+				return { text: '', thought };
+			}
+			case 'arguments_delta': {
+				const pending = this.pending.get(event.index as number);
+				if (pending && typeof delta.arguments === 'string') {
+					pending.argsBuffer += delta.arguments;
+				}
+				return null;
+			}
+			default:
+				return null;
+		}
+	}
+
+	/** Finalize a function-call step into a `ToolCall` when its step stops. */
+	private finalizeStep(index: number): void {
+		const pending = this.pending.get(index);
+		if (!pending) return;
+		this.pending.delete(index);
+
+		let args: Record<string, unknown> = pending.seedArgs ?? {};
+		if (pending.argsBuffer) {
+			try {
+				args = JSON.parse(pending.argsBuffer);
+			} catch {
+				// Keep the seed args (or empty) if the streamed fragments aren't valid JSON.
+			}
+		}
+
+		this.toolCalls.push({
+			name: pending.name,
+			arguments: args,
+			id: pending.id,
+			thoughtSignature: pending.signature,
+		});
+	}
+
+	/** Build the final response once the stream is exhausted (flushing any unstopped steps). */
+	finalize(): ModelResponse {
+		for (const index of [...this.pending.keys()]) {
+			this.finalizeStep(index);
+		}
+
+		const response: ModelResponse = {
+			markdown: this.text,
+			rendered: '', // search grounding is Phase 3 (#1016)
+		};
+		if (this.thoughts) response.thoughts = this.thoughts;
+		if (this.toolCalls.length > 0) response.toolCalls = this.toolCalls;
+		if (this.usage) response.usageMetadata = this.usage;
+		return response;
+	}
 }

--- a/test/api/providers/gemini/client.test.ts
+++ b/test/api/providers/gemini/client.test.ts
@@ -1211,6 +1211,36 @@ describe('GeminiClient', () => {
 			expect(result.markdown).not.toContain('MORE');
 		});
 
+		test('cancel() aborts a stalled SSE read (does not wait for the next frame)', async () => {
+			// A Stream that yields one frame, then blocks on the next read until its
+			// AbortController fires — modelling a server that has gone quiet. Without
+			// aborting the controller, `complete` would hang here.
+			interactionsCreateMock.mockImplementation(async () => {
+				const controller = new AbortController();
+				return {
+					controller,
+					async *[Symbol.asyncIterator]() {
+						yield { event_type: 'step.delta', index: 0, delta: { type: 'text', text: 'partial' } };
+						await new Promise((_resolve, reject) => {
+							if (controller.signal.aborted) return reject(new Error('aborted'));
+							controller.signal.addEventListener('abort', () => reject(new Error('aborted')));
+						});
+						yield { event_type: 'step.delta', index: 0, delta: { type: 'text', text: ' NEVER' } };
+					},
+				};
+			});
+
+			const client = makeInteractionsClient();
+			const stream = client.generateStreamingResponse!(
+				{ prompt: '', userMessage: 'hi', kind: 'extended', conversationHistory: [] } as ExtendedModelRequest,
+				() => stream.cancel() // cancel mid-read, while the second read is blocked
+			);
+			const result = await stream.complete; // resolves only because cancel() aborts the read
+
+			expect(result.markdown).toBe('partial');
+			expect(result.markdown).not.toContain('NEVER');
+		});
+
 		test('one-shot base requests pass the prompt as input', async () => {
 			const client = makeInteractionsClient();
 			await client.generateModelResponse({ prompt: 'just answer', kind: 'base' } as any);

--- a/test/api/providers/gemini/client.test.ts
+++ b/test/api/providers/gemini/client.test.ts
@@ -1144,18 +1144,71 @@ describe('GeminiClient', () => {
 			});
 		});
 
-		test('streaming falls back to a single chunk via the non-streaming path', async () => {
+		test('streams step-based events: text chunks, tool call, and usage', async () => {
+			const events = [
+				{ event_type: 'interaction.created', interaction: { id: 'int_s' } },
+				{ event_type: 'step.start', index: 0, step: { type: 'model_output' } },
+				{ event_type: 'step.delta', index: 0, delta: { type: 'text', text: 'Read' } },
+				{ event_type: 'step.delta', index: 0, delta: { type: 'text', text: 'ing…' } },
+				{ event_type: 'step.stop', index: 0 },
+				{ event_type: 'step.start', index: 1, step: { type: 'function_call', id: 'c1', name: 'read_file' } },
+				{ event_type: 'step.delta', index: 1, delta: { type: 'arguments_delta', arguments: '{"path":"a.md"}' } },
+				{ event_type: 'step.stop', index: 1 },
+				{
+					event_type: 'interaction.completed',
+					interaction: { usage: { total_input_tokens: 9, total_output_tokens: 3, total_tokens: 12 } },
+				},
+			];
+			interactionsCreateMock.mockImplementation(async () => {
+				return (async function* () {
+					for (const event of events) yield event;
+				})();
+			});
+
 			const client = makeInteractionsClient();
 			const chunks: Array<{ text: string; thought?: string }> = [];
 			const stream = client.generateStreamingResponse!(
-				{ prompt: '', userMessage: 'hi', kind: 'extended', conversationHistory: [] } as ExtendedModelRequest,
+				{ prompt: '', userMessage: 'read a.md', kind: 'extended', conversationHistory: [] } as ExtendedModelRequest,
 				(chunk) => chunks.push(chunk)
 			);
 			const result = await stream.complete;
 
-			expect(interactionsCreateMock).toHaveBeenCalledTimes(1);
-			expect(result.markdown).toBe('Hello from interactions');
-			expect(chunks.some((c) => c.text === 'Hello from interactions')).toBe(true);
+			// stream: true was requested
+			expect(interactionsCreateMock.mock.calls[0][0].stream).toBe(true);
+			// text streamed incrementally
+			expect(chunks).toEqual([{ text: 'Read' }, { text: 'ing…' }]);
+			expect(result.markdown).toBe('Reading…');
+			// tool call assembled from start + arguments_delta
+			expect(result.toolCalls).toEqual([
+				{ name: 'read_file', arguments: { path: 'a.md' }, id: 'c1', thoughtSignature: undefined },
+			]);
+			expect(result.usageMetadata?.totalTokenCount).toBe(12);
+		});
+
+		test('cancel() stops processing and returns the partial response', async () => {
+			interactionsCreateMock.mockImplementation(async () => {
+				return (async function* () {
+					yield { event_type: 'step.start', index: 0, step: { type: 'model_output' } };
+					yield { event_type: 'step.delta', index: 0, delta: { type: 'text', text: 'partial' } };
+					yield { event_type: 'step.delta', index: 0, delta: { type: 'text', text: ' MORE' } };
+				})();
+			});
+
+			const client = makeInteractionsClient();
+			const chunks: Array<{ text: string }> = [];
+			const stream = client.generateStreamingResponse!(
+				{ prompt: '', userMessage: 'hi', kind: 'extended', conversationHistory: [] } as ExtendedModelRequest,
+				(chunk) => {
+					chunks.push(chunk as { text: string });
+					stream.cancel(); // cancel after the first emitted chunk
+				}
+			);
+			const result = await stream.complete;
+
+			// Only the pre-cancel chunk is emitted and processed; later events are ignored.
+			expect(chunks).toEqual([{ text: 'partial' }]);
+			expect(result.markdown).toBe('partial');
+			expect(result.markdown).not.toContain('MORE');
 		});
 
 		test('one-shot base requests pass the prompt as input', async () => {

--- a/test/api/providers/gemini/interactions-mapper.test.ts
+++ b/test/api/providers/gemini/interactions-mapper.test.ts
@@ -1,0 +1,139 @@
+import { describe, test, expect } from 'vitest';
+import { InteractionStreamAccumulator } from '../../../../src/api/providers/gemini/interactions-mapper';
+
+/** Feed a list of events through the accumulator, collecting emitted chunks. */
+function run(events: Array<Record<string, unknown>>) {
+	const acc = new InteractionStreamAccumulator();
+	const chunks: Array<{ text: string; thought?: string }> = [];
+	for (const event of events) {
+		const chunk = acc.handleEvent(event);
+		if (chunk) chunks.push(chunk);
+	}
+	return { response: acc.finalize(), chunks };
+}
+
+describe('InteractionStreamAccumulator', () => {
+	test('accumulates streamed text into markdown and emits text chunks', () => {
+		const { response, chunks } = run([
+			{ event_type: 'interaction.created', interaction: { id: 'int_1' } },
+			{ event_type: 'step.start', index: 0, step: { type: 'model_output' } },
+			{ event_type: 'step.delta', index: 0, delta: { type: 'text', text: 'Hello' } },
+			{ event_type: 'step.delta', index: 0, delta: { type: 'text', text: ', world' } },
+			{ event_type: 'step.stop', index: 0 },
+			{
+				event_type: 'interaction.completed',
+				interaction: { usage: { total_input_tokens: 4, total_output_tokens: 2, total_tokens: 6 } },
+			},
+		]);
+
+		expect(chunks).toEqual([{ text: 'Hello' }, { text: ', world' }]);
+		expect(response.markdown).toBe('Hello, world');
+		expect(response.usageMetadata).toEqual({
+			promptTokenCount: 4,
+			candidatesTokenCount: 2,
+			totalTokenCount: 6,
+			cachedContentTokenCount: undefined,
+		});
+		expect(response.toolCalls).toBeUndefined();
+	});
+
+	test('surfaces thought_summary deltas as thought chunks and accumulates thoughts', () => {
+		const { response, chunks } = run([
+			{ event_type: 'step.start', index: 0, step: { type: 'thought' } },
+			{
+				event_type: 'step.delta',
+				index: 0,
+				delta: { type: 'thought_summary', content: { type: 'text', text: 'Hmm ' } },
+			},
+			{
+				event_type: 'step.delta',
+				index: 0,
+				delta: { type: 'thought_summary', content: { type: 'text', text: 'let me think' } },
+			},
+			{ event_type: 'step.stop', index: 0 },
+		]);
+
+		expect(chunks).toEqual([
+			{ text: '', thought: 'Hmm ' },
+			{ text: '', thought: 'let me think' },
+		]);
+		expect(response.thoughts).toBe('Hmm let me think');
+	});
+
+	test('assembles a tool call from step.start + multi-fragment arguments_delta', () => {
+		const { response, chunks } = run([
+			{
+				event_type: 'step.start',
+				index: 0,
+				step: { type: 'function_call', id: 'c1', name: 'read_file', signature: 'sig1' },
+			},
+			{ event_type: 'step.delta', index: 0, delta: { type: 'arguments_delta', arguments: '{"path":' } },
+			{ event_type: 'step.delta', index: 0, delta: { type: 'arguments_delta', arguments: '"foo.md"}' } },
+			{ event_type: 'step.stop', index: 0 },
+		]);
+
+		expect(chunks).toEqual([]); // tool-call assembly emits nothing to the UI text stream
+		expect(response.toolCalls).toEqual([
+			{ name: 'read_file', arguments: { path: 'foo.md' }, id: 'c1', thoughtSignature: 'sig1' },
+		]);
+	});
+
+	test('falls back to seed arguments when no arguments_delta arrives', () => {
+		const { response } = run([
+			{
+				event_type: 'step.start',
+				index: 0,
+				step: { type: 'function_call', id: 'c2', name: 'list_files', arguments: { dir: '.' } },
+			},
+			{ event_type: 'step.stop', index: 0 },
+		]);
+
+		expect(response.toolCalls).toEqual([
+			{ name: 'list_files', arguments: { dir: '.' }, id: 'c2', thoughtSignature: undefined },
+		]);
+	});
+
+	test('keeps seed/empty args when streamed fragments are not valid JSON', () => {
+		const { response } = run([
+			{ event_type: 'step.start', index: 0, step: { type: 'function_call', id: 'c3', name: 'x' } },
+			{ event_type: 'step.delta', index: 0, delta: { type: 'arguments_delta', arguments: '{bad json' } },
+			{ event_type: 'step.stop', index: 0 },
+		]);
+		expect(response.toolCalls).toEqual([{ name: 'x', arguments: {}, id: 'c3', thoughtSignature: undefined }]);
+	});
+
+	test('interleaves text and a tool call, and flushes an unstopped step on finalize', () => {
+		const { response } = run([
+			{ event_type: 'step.start', index: 0, step: { type: 'model_output' } },
+			{ event_type: 'step.delta', index: 0, delta: { type: 'text', text: 'Let me look' } },
+			{ event_type: 'step.stop', index: 0 },
+			{
+				event_type: 'step.start',
+				index: 1,
+				step: { type: 'function_call', id: 'c9', name: 'search', arguments: { q: 'x' } },
+			},
+			// no step.stop for index 1 — finalize() must still flush it
+		]);
+
+		expect(response.markdown).toBe('Let me look');
+		expect(response.toolCalls).toEqual([
+			{ name: 'search', arguments: { q: 'x' }, id: 'c9', thoughtSignature: undefined },
+		]);
+	});
+
+	test('parallel tool calls keyed by distinct step indexes do not cross-contaminate args', () => {
+		const { response } = run([
+			{ event_type: 'step.start', index: 0, step: { type: 'function_call', id: 'a', name: 'read_file' } },
+			{ event_type: 'step.start', index: 1, step: { type: 'function_call', id: 'b', name: 'list_files' } },
+			{ event_type: 'step.delta', index: 1, delta: { type: 'arguments_delta', arguments: '{"dir":"."}' } },
+			{ event_type: 'step.delta', index: 0, delta: { type: 'arguments_delta', arguments: '{"path":"x"}' } },
+			{ event_type: 'step.stop', index: 0 },
+			{ event_type: 'step.stop', index: 1 },
+		]);
+
+		expect(response.toolCalls).toEqual([
+			{ name: 'read_file', arguments: { path: 'x' }, id: 'a', thoughtSignature: undefined },
+			{ name: 'list_files', arguments: { dir: '.' }, id: 'b', thoughtSignature: undefined },
+		]);
+	});
+});


### PR DESCRIPTION
## Summary

Phase 2 of the Interactions API migration (epic #1013). Replaces the Phase-1 single-chunk fallback with **real step-based streaming** when `useInteractionsApi` is on. The legacy `generateContentStream` path is untouched and still used when the flag is off.

Fixes #1015. Part of #1013.

## Changes

- **`InteractionStreamAccumulator`** (in `interactions-mapper.ts`) — a dependency-free state machine that folds the Interactions SSE event stream into a `ModelResponse`:
  - `step.start` carrying a `function_call` step → captures the tool's `id` / `name` / `signature` (these arrive here, not in the deltas)
  - `step.delta` → `text` (emit + accumulate markdown), `thought_summary` (emit as reasoning + accumulate), `arguments_delta` (buffer JSON fragments keyed by step `index`)
  - `step.stop` → JSON-parse the buffered args and finalize that `ToolCall`
  - `interaction.completed` → token `usage`
  - `finalize()` flushes any step that never received an explicit stop
- **`streamViaInteractions`** in `GeminiClient` replaces the single-chunk fallback: requests `stream: true`, routes through the same `requestUrl` CORS bypass (extracted into `ensureInteractionsFetch`), consumes the async iterable, emits chunks via `onChunk`, and preserves `cancel()` (stops processing, returns the partial).
- Shared `mapInteractionUsage` helper (DRY between the non-streaming extractor and the accumulator).

## Tests

- 7 accumulator unit tests: multi-fragment `arguments_delta`, parallel tool calls keyed by step index, seed-args fallback, malformed-JSON fallback, unstopped-step flush, interleaved text+tool.
- 2 client-level streaming tests: full text+tool+usage stream (asserts `stream: true`), and `cancel()` returning the partial.
- 3140 total, all green; `typecheck:test` clean.

## Manual verification (real vault)

- Plain streaming: response streamed token-by-token, usage metadata flowed, Interactions path confirmed (not legacy), no errors.
- Tool-call streaming: model streamed text → `list_files` assembled from `arguments_delta` and executed → follow-up turn also via Interactions, **with the thought signature preserved across the continuation** (the failure mode js-genai#1735 warns about did not occur).

## Notes for reviewers

- Function-call arguments stream as `arguments_delta` string fragments and are JSON-parsed at `step.stop`; the name/id come from `step.start`. The accumulator keys in-flight calls by step `index` so parallel calls don't cross-contaminate.
- Per-turn caveat tracked on the issue: `thinking_summaries: "auto"` (set in Phase 1) can emit unsigned thought steps (js-genai#1735); signatures are captured and replayed, and the manual tool-call test exercised this path cleanly.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop
- [ ] I have verified this change does not break Mobile — N/A: no platform-specific APIs; behind a default-off flag
- [x] Documentation has been updated (if applicable) — N/A: no user-facing surface change; the setting + behavior were documented in Phase 1 (streaming note already hedged)
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactions API responses now stream incrementally, including text, reasoning, and tool calls.
  * Streaming output is assembled progressively into the final response while emitting partial chunks as they arrive.

* **Bug Fixes**
  * Improved streamed tool-call reconstruction and final usage totals.
  * Streaming cancellation now reliably stops further updates (including when a stream is stalled).

* **Documentation**
  * Updated advanced “Use Interactions API” setting to reflect incremental streaming details and clarified the fallback behavior when disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->