### PR TITLE
fix(scripts): safer test-vault resolution for install:test-vault

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@ npm run format-check # Check formatting without changes
 npm run lint         # Lint with ESLint (eslint-plugin-obsidianmd recommended preset)
 npm run lint:fix     # Auto-fix ESLint violations where possible
 npm run knip         # Detect unused files, exports, types, and dependencies (configured in knip.json)
-npm run install:test-vault # Copy built artifacts into test vault (default ~/Obsidian/Test Vault; point elsewhere with TEST_VAULT_DIR=<vault root>, or an exact plugin folder with TEST_VAULT_PLUGIN_DIR)
+npm run install:test-vault # Copy built artifacts into test vault. Target precedence: TEST_VAULT_PLUGIN_DIR (exact plugin folder, validated by id) > TEST_VAULT_DIR (vault root, scanned by id) > default ~/Obsidian/Test Vault
 npm run translate    # Regenerate AI translations in src/i18n/ (manual maintenance; needs GOOGLE_API_KEY — never runs in build/CI)
 ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@ npm run format-check # Check formatting without changes
 npm run lint         # Lint with ESLint (eslint-plugin-obsidianmd recommended preset)
 npm run lint:fix     # Auto-fix ESLint violations where possible
 npm run knip         # Detect unused files, exports, types, and dependencies (configured in knip.json)
-npm run install:test-vault # Copy built artifacts into test vault (override path with TEST_VAULT_PLUGIN_DIR)
+npm run install:test-vault # Copy built artifacts into test vault (default ~/Obsidian/Test Vault; point elsewhere with TEST_VAULT_DIR=<vault root>, or an exact plugin folder with TEST_VAULT_PLUGIN_DIR)
 npm run translate    # Regenerate AI translations in src/i18n/ (manual maintenance; needs GOOGLE_API_KEY — never runs in build/CI)
 ```
 

--- a/scripts/install-test-vault.mjs
+++ b/scripts/install-test-vault.mjs
@@ -9,18 +9,23 @@
 // `hot-reload` community plugin (an empty `.hotreload` file in the plugin
 // directory) for live reloads on rebuild.
 //
-// Target resolution (no TEST_VAULT_PLUGIN_DIR override):
-//   The plugin folder is found by scanning <vault>/.obsidian/plugins/* for a
-//   manifest.json whose `id` matches this plugin — NOT by assuming a folder
-//   name. Obsidian keys plugins by manifest id, and a vault folder may be named
-//   anything (e.g. `obsidian-gemini`). Installing into a hardcoded `gemini-scribe`
-//   folder silently misses a differently-named folder Obsidian actually loads.
-//   If several folders declare the id, all are updated (Obsidian loads only one
-//   and which is not knowable from outside it) and the duplicates are reported.
-//   If none exist yet (fresh vault), the canonical `<id>` folder is created.
+// Target resolution (highest precedence first):
+//   1. TEST_VAULT_PLUGIN_DIR — an exact plugin folder. Escape hatch; bypasses
+//      scanning. Validated against the plugin id (see below) so a typo or a
+//      stale path can't silently install into a folder Obsidian never loads.
+//   2. TEST_VAULT_DIR — a vault ROOT (the folder that contains `.obsidian/`).
+//      Preferred when your test vault lives somewhere other than the default:
+//      it scans `<root>/.obsidian/plugins` the same robust way as the default,
+//      so duplicate/renamed folders are still handled and reported.
+//   3. Default — `~/Obsidian/Test Vault`.
 //
-// Override the destination with TEST_VAULT_PLUGIN_DIR (an exact plugin dir) if
-// your test vault is elsewhere — that bypasses the scan.
+// Vault scanning (options 2 and 3): the plugin folder is found by reading every
+// `<vault>/.obsidian/plugins/*/manifest.json` and matching on `id`, NOT on
+// folder name — Obsidian keys plugins by manifest id and a vault folder may be
+// named anything (e.g. `obsidian-gemini`). If several folders declare the id,
+// ALL are updated (Obsidian loads only one and which is not knowable from
+// outside it) and the duplicates are reported. If none exist yet (fresh vault),
+// the canonical `<id>` folder is created.
 
 import { copyFileSync, existsSync, mkdirSync, readFileSync, readdirSync } from 'node:fs';
 import { homedir } from 'node:os';
@@ -61,28 +66,29 @@ for (const dest of destinations) {
 
 console.log('\nReload the plugin in Obsidian (or use the hot-reload plugin) to pick up changes.');
 
-/**
- * Resolve which plugin folder(s) to install into.
- * - TEST_VAULT_PLUGIN_DIR, if set, is used verbatim (no scanning).
- * - Otherwise scan the test vault's plugins directory for folders whose
- *   manifest.json declares `id`, falling back to the canonical `<id>` folder
- *   on a fresh vault.
- */
-function resolveDestinations(id) {
-	const override = process.env.TEST_VAULT_PLUGIN_DIR;
-	if (override) {
-		if (!existsSync(dirname(override))) {
-			console.error(`Parent directory not found: ${dirname(override)}. Check TEST_VAULT_PLUGIN_DIR.`);
-			process.exit(1);
-		}
-		return [override];
+/** Read a plugin folder's manifest id, or null if absent/unreadable. */
+function manifestId(pluginDir) {
+	const manifestPath = join(pluginDir, 'manifest.json');
+	if (!existsSync(manifestPath)) return null;
+	try {
+		return JSON.parse(readFileSync(manifestPath, 'utf8')).id ?? null;
+	} catch {
+		return null;
 	}
+}
 
-	const pluginsDir = join(homedir(), 'Obsidian', 'Test Vault', '.obsidian', 'plugins');
+/**
+ * Scan a vault root's plugins directory for folders whose manifest declares
+ * `id`. Returns matching plugin-dir paths (possibly several), or the canonical
+ * `<id>` folder on a fresh vault. Exits if the vault/plugins dir is missing.
+ */
+function scanVault(vaultRoot, id, { sourceLabel }) {
+	const pluginsDir = join(vaultRoot, '.obsidian', 'plugins');
 	if (!existsSync(pluginsDir)) {
 		console.error(
-			`Test vault plugins directory not found: ${pluginsDir}.\n` +
-				`Set TEST_VAULT_PLUGIN_DIR, or open the test vault in Obsidian at least once.`
+			`Test vault plugins directory not found: ${pluginsDir}\n` +
+				`(resolved from ${sourceLabel}). Open the vault in Obsidian at least once, ` +
+				`or set TEST_VAULT_DIR / TEST_VAULT_PLUGIN_DIR.`
 		);
 		process.exit(1);
 	}
@@ -90,20 +96,13 @@ function resolveDestinations(id) {
 	const matches = [];
 	for (const entry of readdirSync(pluginsDir, { withFileTypes: true })) {
 		if (!entry.isDirectory()) continue;
-		const manifestPath = join(pluginsDir, entry.name, 'manifest.json');
-		if (!existsSync(manifestPath)) continue;
-		try {
-			if (JSON.parse(readFileSync(manifestPath, 'utf8')).id === id) {
-				matches.push(join(pluginsDir, entry.name));
-			}
-		} catch {
-			// A folder with an unreadable manifest isn't ours — skip it.
-		}
+		const dir = join(pluginsDir, entry.name);
+		if (manifestId(dir) === id) matches.push(dir);
 	}
 
 	if (matches.length === 0) {
-		// Fresh vault — the plugin has never been installed. Create the
-		// canonical `<id>` folder.
+		// Fresh vault — the plugin has never been installed. Create the canonical
+		// `<id>` folder.
 		return [join(pluginsDir, id)];
 	}
 
@@ -117,4 +116,45 @@ function resolveDestinations(id) {
 	}
 
 	return matches;
+}
+
+/**
+ * Resolve which plugin folder(s) to install into. See the precedence list in the
+ * header comment.
+ */
+function resolveDestinations(id) {
+	const pluginDirOverride = process.env.TEST_VAULT_PLUGIN_DIR;
+	if (pluginDirOverride) {
+		if (!existsSync(dirname(pluginDirOverride))) {
+			console.error(`Parent directory not found: ${dirname(pluginDirOverride)}. Check TEST_VAULT_PLUGIN_DIR.`);
+			process.exit(1);
+		}
+		// Guard against pointing at the wrong place: if the target already holds a
+		// different plugin, that's a typo/stale path, not our install dir. A target
+		// with no manifest yet (fresh folder) is allowed but called out, since the
+		// most common mistake is aiming at a vault Obsidian doesn't actually load.
+		const existingId = manifestId(pluginDirOverride);
+		if (existingId && existingId !== id) {
+			console.error(
+				`TEST_VAULT_PLUGIN_DIR points at a folder for a different plugin ` +
+					`(found id "${existingId}", expected "${id}"): ${pluginDirOverride}`
+			);
+			process.exit(1);
+		}
+		if (existingId === null) {
+			console.warn(
+				`Warning: TEST_VAULT_PLUGIN_DIR has no existing ${id} manifest: ${pluginDirOverride}\n` +
+					`Installing anyway. If Obsidian isn't picking up changes, confirm this is the ` +
+					`folder the OPEN vault loads (prefer TEST_VAULT_DIR to scan a vault root by id).\n`
+			);
+		}
+		return [pluginDirOverride];
+	}
+
+	const vaultDirOverride = process.env.TEST_VAULT_DIR;
+	if (vaultDirOverride) {
+		return scanVault(vaultDirOverride, id, { sourceLabel: 'TEST_VAULT_DIR' });
+	}
+
+	return scanVault(join(homedir(), 'Obsidian', 'Test Vault'), id, { sourceLabel: 'the default ~/Obsidian/Test Vault' });
 }

--- a/scripts/install-test-vault.mjs
+++ b/scripts/install-test-vault.mjs
@@ -33,6 +33,13 @@ import { dirname, join } from 'node:path';
 
 const files = ['main.js', 'manifest.json', 'styles.css'];
 
+// Sentinels distinguishing "no manifest.json at all" from "manifest present but
+// unreadable/malformed". The exact-dir override must fail closed on the latter
+// (a corrupt manifest must not be mistaken for a fresh folder and overwritten),
+// while the vault scan stays tolerant of unrelated plugins' broken manifests.
+const MANIFEST_ABSENT = Symbol('manifest-absent');
+const MANIFEST_INVALID = Symbol('manifest-invalid');
+
 // Verify build artifacts exist in the current worktree.
 const missing = files.filter((f) => !existsSync(f));
 if (missing.length > 0) {
@@ -66,14 +73,19 @@ for (const dest of destinations) {
 
 console.log('\nReload the plugin in Obsidian (or use the hot-reload plugin) to pick up changes.');
 
-/** Read a plugin folder's manifest id, or null if absent/unreadable. */
-function manifestId(pluginDir) {
+/**
+ * Read a plugin folder's manifest id. Returns the id string, or a sentinel:
+ * MANIFEST_ABSENT (no manifest.json) / MANIFEST_INVALID (present but unparseable
+ * or missing a non-empty `id`).
+ */
+function readManifestId(pluginDir) {
 	const manifestPath = join(pluginDir, 'manifest.json');
-	if (!existsSync(manifestPath)) return null;
+	if (!existsSync(manifestPath)) return MANIFEST_ABSENT;
 	try {
-		return JSON.parse(readFileSync(manifestPath, 'utf8')).id ?? null;
+		const id = JSON.parse(readFileSync(manifestPath, 'utf8')).id;
+		return typeof id === 'string' && id ? id : MANIFEST_INVALID;
 	} catch {
-		return null;
+		return MANIFEST_INVALID;
 	}
 }
 
@@ -97,7 +109,9 @@ function scanVault(vaultRoot, id, { sourceLabel }) {
 	for (const entry of readdirSync(pluginsDir, { withFileTypes: true })) {
 		if (!entry.isDirectory()) continue;
 		const dir = join(pluginsDir, entry.name);
-		if (manifestId(dir) === id) matches.push(dir);
+		// Sentinels never equal the id string, so absent/invalid manifests are
+		// simply skipped here — a broken unrelated plugin won't abort the scan.
+		if (readManifestId(dir) === id) matches.push(dir);
 	}
 
 	if (matches.length === 0) {
@@ -129,19 +143,28 @@ function resolveDestinations(id) {
 			console.error(`Parent directory not found: ${dirname(pluginDirOverride)}. Check TEST_VAULT_PLUGIN_DIR.`);
 			process.exit(1);
 		}
-		// Guard against pointing at the wrong place: if the target already holds a
-		// different plugin, that's a typo/stale path, not our install dir. A target
-		// with no manifest yet (fresh folder) is allowed but called out, since the
+		// Guard against pointing at the wrong place. Fail closed when the target
+		// holds a different plugin (typo/stale path) OR an unreadable manifest (we
+		// can't verify it's ours, so we won't overwrite it). A target with no
+		// manifest yet (genuinely fresh folder) is allowed but called out, since the
 		// most common mistake is aiming at a vault Obsidian doesn't actually load.
-		const existingId = manifestId(pluginDirOverride);
-		if (existingId && existingId !== id) {
+		const existing = readManifestId(pluginDirOverride);
+		if (existing === MANIFEST_INVALID) {
 			console.error(
-				`TEST_VAULT_PLUGIN_DIR points at a folder for a different plugin ` +
-					`(found id "${existingId}", expected "${id}"): ${pluginDirOverride}`
+				`TEST_VAULT_PLUGIN_DIR has an unreadable/invalid manifest.json: ${pluginDirOverride}\n` +
+					`Refusing to overwrite — can't confirm it's the ${id} plugin. Fix or remove the ` +
+					`manifest, or point at the correct folder.`
 			);
 			process.exit(1);
 		}
-		if (existingId === null) {
+		if (typeof existing === 'string' && existing !== id) {
+			console.error(
+				`TEST_VAULT_PLUGIN_DIR points at a folder for a different plugin ` +
+					`(found id "${existing}", expected "${id}"): ${pluginDirOverride}`
+			);
+			process.exit(1);
+		}
+		if (existing === MANIFEST_ABSENT) {
 			console.warn(
 				`Warning: TEST_VAULT_PLUGIN_DIR has no existing ${id} manifest: ${pluginDirOverride}\n` +
 					`Installing anyway. If Obsidian isn't picking up changes, confirm this is the ` +


### PR DESCRIPTION
## Summary

Hardens `npm run install:test-vault` so it can't silently deploy into a folder Obsidian isn't actually loading. This bit us during Phase 2 testing: an exact-dir `TEST_VAULT_PLUGIN_DIR` override pointed at a valid-looking `gemini-scribe` plugin folder in a *different* vault than the one open, so every rebuild appeared to "not take" while Obsidian kept running stale code.

Maintainer-requested dev-tooling fix; **no plugin behavior change.**

## Changes

- **New `TEST_VAULT_DIR` (vault root) override** — the preferred way to point at a vault elsewhere. It reuses the robust id-based scan of `<root>/.obsidian/plugins`, so renamed folders (e.g. `obsidian-gemini` declaring id `gemini-scribe`) and duplicate folders are still found, updated, and reported — unlike the exact-dir override, which bypasses all of that.
- **`TEST_VAULT_PLUGIN_DIR` now validates the plugin id**: errors (exit 1) if the target already holds a *different* plugin's manifest; warns if it has no manifest yet (the common "wrong/closed vault" mistake), then installs.
- Precedence: `TEST_VAULT_PLUGIN_DIR` (exact, validated) → `TEST_VAULT_DIR` (vault root, scanned) → default `~/Obsidian/Test Vault` (scanned).
- Updated the script header and the `AGENTS.md` command note.

## Testing

Exercised all paths manually:
- Default scan and `TEST_VAULT_DIR` scan both resolve the vault and update all id-matching folders (with the duplicate-folder warning).
- `TEST_VAULT_PLUGIN_DIR` at a different-plugin folder → error, exit 1.
- `TEST_VAULT_PLUGIN_DIR` at a fresh folder → warn + install.
- `TEST_VAULT_PLUGIN_DIR` at a same-id folder → installs, exit 0.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue — N/A: direct maintainer request; dev-tooling only, no plugin behavior change
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop — exercised all resolution paths via the CLI
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A: build-time Node script, never runs in the plugin
- [ ] Documentation has been updated — updated the script header + AGENTS.md note (no user-facing docs)
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced test vault installation to support targeting a vault root (not only a direct plugin folder), selecting the correct destination by the plugin’s manifest ID.
  * Added clear precedence for destination overrides: exact plugin folder override first, then vault root override, otherwise the default test vault location.

* **Bug Fixes**
  * Added validation and safer handling for missing/unreadable manifests and absent vault/plugin directories, with clearer error/warning behavior.

* **Documentation**
  * Updated guidance for `install:test-vault` to reflect the default location and override precedence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->