### PR TITLE
feat: grounding, image-gen decision, attachment coverage (Phase 3)

### DIFF
--- a/src/api/providers/gemini/client.ts
+++ b/src/api/providers/gemini/client.ts
@@ -757,7 +757,15 @@ export class GeminiClient implements ModelApi {
 	}
 
 	/**
-	 * Generate an image from a text prompt
+	 * Generate an image from a text prompt.
+	 *
+	 * Intentionally stays on `generateContent` even when `useInteractionsApi` is
+	 * on (see #1016): image generation is a distinct one-shot capability on a
+	 * dedicated image model — not the conversational transport the flag governs —
+	 * and the existing path is proven across image-tools and scheduled tasks.
+	 * Migrating it to the Interactions image-output surface is deferred until
+	 * there's a concrete reason to (no user-facing benefit today).
+	 *
 	 * @param prompt - Text description of the image to generate
 	 * @param model - Image generation model (defaults to gemini-2.5-flash-image-preview)
 	 * @returns Base64 encoded image data

--- a/src/api/providers/gemini/interactions-mapper.ts
+++ b/src/api/providers/gemini/interactions-mapper.ts
@@ -182,14 +182,46 @@ function collectCitationsFromContent(content: unknown, into: Map<string, Groundi
 	}
 }
 
+/** Escape a string for safe interpolation into HTML text/attribute context. */
+function escapeHtml(value: string): string {
+	return value
+		.replace(/&/g, '&amp;')
+		.replace(/</g, '&lt;')
+		.replace(/>/g, '&gt;')
+		.replace(/"/g, '&quot;')
+		.replace(/'/g, '&#39;');
+}
+
+/** Return `value` only if it's an http(s) URL, else '#' — blocks javascript:/data: hrefs. */
+function safeExternalUrl(value: string): string {
+	try {
+		const parsed = new URL(value);
+		// Return the original (not parsed.toString(), which normalizes/adds a
+		// trailing slash) so the link stays faithful to the cited URL.
+		return parsed.protocol === 'http:' || parsed.protocol === 'https:' ? value : '#';
+	} catch {
+		return '#';
+	}
+}
+
 /**
  * Render grounding sources as the same `<div class="search-grounding">` block the
  * generateContent path emits, so the agent view renders Interactions grounding
  * identically. Returns '' when there are no sources.
+ *
+ * Citation `url`/`title` come from model/provider annotations (untrusted), so the
+ * href is restricted to http(s) and both the href and label are HTML-escaped to
+ * keep `ModelResponse.rendered` injection-safe. Links get `rel="noopener noreferrer"`.
  */
-export function renderGroundingSources(sources: GroundingSource[]): string {
+function renderGroundingSources(sources: GroundingSource[]): string {
 	if (sources.length === 0) return '';
-	const items = sources.map((s) => `<li><a href="${s.url}" target="_blank">${s.title || s.url}</a></li>`).join('');
+	const items = sources
+		.map((s) => {
+			const href = escapeHtml(safeExternalUrl(s.url));
+			const label = escapeHtml(s.title || s.url);
+			return `<li><a href="${href}" target="_blank" rel="noopener noreferrer">${label}</a></li>`;
+		})
+		.join('');
 	return `<div class="search-grounding"><h4>Sources:</h4><ul>${items}</ul></div>`;
 }
 

--- a/src/api/providers/gemini/interactions-mapper.ts
+++ b/src/api/providers/gemini/interactions-mapper.ts
@@ -156,17 +156,58 @@ function textFromContentArray(content: unknown): string {
  * to scanning trailing `model_output` steps. Thought summaries, tool calls, and
  * token usage are read directly off the `steps`/`usage` surface.
  */
+/** A grounding source surfaced as an inline `url_citation` annotation. */
+interface GroundingSource {
+	url: string;
+	title?: string;
+}
+
+/** Collect deduped `url_citation` annotations into `into` (keyed by URL, first title wins). */
+function collectUrlCitations(annotations: unknown, into: Map<string, GroundingSource>): void {
+	if (!Array.isArray(annotations)) return;
+	for (const annotation of annotations) {
+		const a = annotation as { type?: string; url?: string; title?: string };
+		if (a.type === 'url_citation' && typeof a.url === 'string' && a.url && !into.has(a.url)) {
+			into.set(a.url, { url: a.url, title: a.title });
+		}
+	}
+}
+
+/** Collect `url_citation` annotations from the text items of a step's `content` array. */
+function collectCitationsFromContent(content: unknown, into: Map<string, GroundingSource>): void {
+	if (!Array.isArray(content)) return;
+	for (const item of content) {
+		const i = item as { type?: string; annotations?: unknown };
+		if (i.type === 'text') collectUrlCitations(i.annotations, into);
+	}
+}
+
+/**
+ * Render grounding sources as the same `<div class="search-grounding">` block the
+ * generateContent path emits, so the agent view renders Interactions grounding
+ * identically. Returns '' when there are no sources.
+ */
+export function renderGroundingSources(sources: GroundingSource[]): string {
+	if (sources.length === 0) return '';
+	const items = sources.map((s) => `<li><a href="${s.url}" target="_blank">${s.title || s.url}</a></li>`).join('');
+	return `<div class="search-grounding"><h4>Sources:</h4><ul>${items}</ul></div>`;
+}
+
 export function extractModelResponseFromInteraction(interaction: Record<string, unknown>): ModelResponse {
 	const steps = Array.isArray(interaction.steps) ? (interaction.steps as InteractionStep[]) : [];
 
 	let markdown = typeof interaction.output_text === 'string' ? interaction.output_text : '';
 	let thoughts = '';
 	const toolCalls: ToolCall[] = [];
+	const sources = new Map<string, GroundingSource>();
 
 	for (const step of steps) {
 		const type = step.type as string;
-		if (type === 'model_output' && !markdown) {
-			markdown += textFromContentArray(step.content);
+		if (type === 'model_output') {
+			if (!markdown) markdown += textFromContentArray(step.content);
+			// Grounding sources arrive as inline url_citation annotations on the
+			// model output text, not as a separate chunks list (see #1016).
+			collectCitationsFromContent(step.content, sources);
 		} else if (type === 'thought') {
 			thoughts += textFromContentArray(step.summary);
 		} else if (type === 'function_call') {
@@ -183,7 +224,7 @@ export function extractModelResponseFromInteraction(interaction: Record<string, 
 
 	const response: ModelResponse = {
 		markdown,
-		rendered: '', // search grounding is Phase 3 (#1016)
+		rendered: renderGroundingSources([...sources.values()]),
 	};
 	if (thoughts) response.thoughts = thoughts;
 	if (toolCalls.length > 0) response.toolCalls = toolCalls;
@@ -244,6 +285,7 @@ export class InteractionStreamAccumulator {
 	private usage: ModelResponse['usageMetadata'] | undefined;
 	private readonly pending = new Map<number, PendingToolCall>();
 	private readonly toolCalls: ToolCall[] = [];
+	private readonly sources = new Map<string, GroundingSource>();
 
 	/** Process one streamed event; returns a chunk to emit, or null if nothing to surface. */
 	handleEvent(event: InteractionStreamEvent): InteractionStreamChunk | null {
@@ -311,6 +353,11 @@ export class InteractionStreamAccumulator {
 				}
 				return null;
 			}
+			case 'text_annotation_delta': {
+				// Grounding sources stream as url_citation annotations (#1016).
+				collectUrlCitations(delta.annotations, this.sources);
+				return null;
+			}
 			default:
 				return null;
 		}
@@ -347,7 +394,7 @@ export class InteractionStreamAccumulator {
 
 		const response: ModelResponse = {
 			markdown: this.text,
-			rendered: '', // search grounding is Phase 3 (#1016)
+			rendered: renderGroundingSources([...this.sources.values()]),
 		};
 		if (this.thoughts) response.thoughts = this.thoughts;
 		if (this.toolCalls.length > 0) response.toolCalls = this.toolCalls;

--- a/test/api/providers/gemini/interactions-mapper.test.ts
+++ b/test/api/providers/gemini/interactions-mapper.test.ts
@@ -1,5 +1,11 @@
 import { describe, test, expect } from 'vitest';
-import { InteractionStreamAccumulator } from '../../../../src/api/providers/gemini/interactions-mapper';
+import {
+	InteractionStreamAccumulator,
+	extractModelResponseFromInteraction,
+	contentToSteps,
+	buildUserInputStep,
+} from '../../../../src/api/providers/gemini/interactions-mapper';
+import type { Content } from '@google/genai';
 
 /** Feed a list of events through the accumulator, collecting emitted chunks. */
 function run(events: Array<Record<string, unknown>>) {
@@ -134,6 +140,114 @@ describe('InteractionStreamAccumulator', () => {
 		expect(response.toolCalls).toEqual([
 			{ name: 'read_file', arguments: { path: 'x' }, id: 'a', thoughtSignature: undefined },
 			{ name: 'list_files', arguments: { dir: '.' }, id: 'b', thoughtSignature: undefined },
+		]);
+	});
+});
+
+describe('grounding sources (rendered)', () => {
+	test('non-streaming: url_citation annotations on model_output → deduped sources block', () => {
+		const response = extractModelResponseFromInteraction({
+			output_text: 'Paris is the capital of France.',
+			steps: [
+				{
+					type: 'model_output',
+					content: [
+						{
+							type: 'text',
+							text: 'Paris is the capital of France.',
+							annotations: [
+								{ type: 'url_citation', url: 'https://a.example/paris', title: 'Paris' },
+								{ type: 'url_citation', url: 'https://b.example/france', title: 'France' },
+								{ type: 'url_citation', url: 'https://a.example/paris', title: 'dup (ignored)' },
+							],
+						},
+					],
+				},
+			],
+		});
+
+		expect(response.rendered).toContain('<div class="search-grounding">');
+		expect(response.rendered).toContain('<a href="https://a.example/paris" target="_blank">Paris</a>');
+		expect(response.rendered).toContain('<a href="https://b.example/france" target="_blank">France</a>');
+		// Deduped by URL — only two <li> entries.
+		expect(response.rendered.match(/<li>/g)).toHaveLength(2);
+	});
+
+	test('non-streaming: no annotations → empty rendered', () => {
+		const response = extractModelResponseFromInteraction({
+			output_text: 'hi',
+			steps: [{ type: 'model_output', content: [{ type: 'text', text: 'hi' }] }],
+		});
+		expect(response.rendered).toBe('');
+	});
+
+	test('streaming: text_annotation_delta events accumulate into the sources block', () => {
+		const { response } = run([
+			{ event_type: 'step.start', index: 0, step: { type: 'model_output' } },
+			{ event_type: 'step.delta', index: 0, delta: { type: 'text', text: 'Answer' } },
+			{
+				event_type: 'step.delta',
+				index: 0,
+				delta: {
+					type: 'text_annotation_delta',
+					annotations: [{ type: 'url_citation', url: 'https://src.example', title: 'Source' }],
+				},
+			},
+			{ event_type: 'step.stop', index: 0 },
+		]);
+
+		expect(response.markdown).toBe('Answer');
+		expect(response.rendered).toContain('<a href="https://src.example" target="_blank">Source</a>');
+	});
+
+	test('falls back to the URL when a citation has no title', () => {
+		const response = extractModelResponseFromInteraction({
+			steps: [
+				{
+					type: 'model_output',
+					content: [
+						{ type: 'text', text: 'x', annotations: [{ type: 'url_citation', url: 'https://no-title.example' }] },
+					],
+				},
+			],
+		});
+		expect(response.rendered).toContain(
+			'<a href="https://no-title.example" target="_blank">https://no-title.example</a>'
+		);
+	});
+});
+
+describe('inline attachments (all media classes)', () => {
+	const att = (mimeType: string) => ({ base64: 'AAAA', mimeType });
+
+	test('buildUserInputStep classifies image/audio/video/pdf as first-class media', () => {
+		const step = buildUserInputStep('look', undefined, [
+			att('image/png'),
+			att('audio/mp3'),
+			att('video/mp4'),
+			att('application/pdf'),
+		]);
+		expect(step?.content).toEqual([
+			{ type: 'text', text: 'look' },
+			{ type: 'image', data: 'AAAA', mime_type: 'image/png' },
+			{ type: 'audio', data: 'AAAA', mime_type: 'audio/mp3' },
+			{ type: 'video', data: 'AAAA', mime_type: 'video/mp4' },
+			{ type: 'document', data: 'AAAA', mime_type: 'application/pdf' },
+		]);
+	});
+
+	test('unsupported mime degrades to a text note rather than dropping silently', () => {
+		const step = buildUserInputStep(undefined, undefined, [att('application/zip')]);
+		expect(step?.content).toEqual([{ type: 'text', text: '[attachment: application/zip]' }]);
+	});
+
+	test('contentToSteps maps a history inlineData PDF part to a document content item', () => {
+		const content: Content = {
+			role: 'user',
+			parts: [{ inlineData: { mimeType: 'application/pdf', data: 'BBBB' } }],
+		};
+		expect(contentToSteps(content)).toEqual([
+			{ type: 'user_input', content: [{ type: 'document', data: 'BBBB', mime_type: 'application/pdf' }] },
 		]);
 	});
 });

--- a/test/api/providers/gemini/interactions-mapper.test.ts
+++ b/test/api/providers/gemini/interactions-mapper.test.ts
@@ -167,8 +167,12 @@ describe('grounding sources (rendered)', () => {
 		});
 
 		expect(response.rendered).toContain('<div class="search-grounding">');
-		expect(response.rendered).toContain('<a href="https://a.example/paris" target="_blank">Paris</a>');
-		expect(response.rendered).toContain('<a href="https://b.example/france" target="_blank">France</a>');
+		expect(response.rendered).toContain(
+			'<a href="https://a.example/paris" target="_blank" rel="noopener noreferrer">Paris</a>'
+		);
+		expect(response.rendered).toContain(
+			'<a href="https://b.example/france" target="_blank" rel="noopener noreferrer">France</a>'
+		);
 		// Deduped by URL — only two <li> entries.
 		expect(response.rendered.match(/<li>/g)).toHaveLength(2);
 	});
@@ -197,7 +201,9 @@ describe('grounding sources (rendered)', () => {
 		]);
 
 		expect(response.markdown).toBe('Answer');
-		expect(response.rendered).toContain('<a href="https://src.example" target="_blank">Source</a>');
+		expect(response.rendered).toContain(
+			'<a href="https://src.example" target="_blank" rel="noopener noreferrer">Source</a>'
+		);
 	});
 
 	test('falls back to the URL when a citation has no title', () => {
@@ -212,8 +218,35 @@ describe('grounding sources (rendered)', () => {
 			],
 		});
 		expect(response.rendered).toContain(
-			'<a href="https://no-title.example" target="_blank">https://no-title.example</a>'
+			'<a href="https://no-title.example" target="_blank" rel="noopener noreferrer">https://no-title.example</a>'
 		);
+	});
+
+	test('sanitizes malicious citation url/title (no HTML injection, no javascript: href)', () => {
+		const response = extractModelResponseFromInteraction({
+			steps: [
+				{
+					type: 'model_output',
+					content: [
+						{
+							type: 'text',
+							text: 'x',
+							annotations: [
+								{ type: 'url_citation', url: 'javascript:alert(1)', title: '<img src=x onerror=alert(1)>' },
+							],
+						},
+					],
+				},
+			],
+		});
+
+		// Disallowed scheme is neutralized to '#'.
+		expect(response.rendered).toContain('href="#"');
+		expect(response.rendered).not.toContain('javascript:');
+		// Title is HTML-escaped, so no raw tag survives.
+		expect(response.rendered).not.toContain('<img');
+		expect(response.rendered).toContain('&lt;img src=x onerror=alert(1)&gt;');
+		expect(response.rendered).toContain('rel="noopener noreferrer"');
 	});
 });
 


### PR DESCRIPTION
## Summary

Phase 3 of the Interactions API migration (epic #1013) — covers the remaining Gemini surfaces under the Interactions transport. Fixes #1016.

## Changes

- **Grounding → `rendered`**: On the Interactions transport, grounding sources arrive as inline `url_citation` annotations on `model_output` text (non-streaming) and `text_annotation_delta` events (streaming), **not** as a separate `groundingChunks` list. The mapper now collects and dedupes them (by URL) into `ModelResponse.rendered` using the same `<div class="search-grounding">` markup the `generateContent` path emits, so the agent view renders both identically. Wired into both `extractModelResponseFromInteraction` and `InteractionStreamAccumulator`.
- **Image generation**: documented decision — `generateImage` **stays on `generateContent`** even when `useInteractionsApi` is on. It's a distinct one-shot image capability on a dedicated model, not the conversational transport the flag governs; migrating adds risk for no user-facing benefit today.
- **Inline attachments**: added coverage confirming image/audio/video/PDF flow through the Interactions `{type, mime_type, data}` input shape (Phase 1's `contentToSteps`/`buildUserInputStep`), plus the unsupported→text-note degrade.

## Tests

- 7 new mapper tests: grounding (non-streaming dedupe, streaming `text_annotation_delta`, no-title→URL fallback, empty case) + inline-attachment classification across all four media classes and the unsupported fallback.
- 3148 total, all green; `typecheck:test` clean.

## Manual verification (real vault, flag on)

Ran an agent google-search query end-to-end through the Interactions transport: the model streamed a `function_call` to `google_search` (assembled correctly from `step.start` + `arguments_delta` + `step.stop`), the tool executed, the follow-up turn ran, and the final answer rendered **with a source link** ("The capital of Australia is Canberra" → `https://en.wikipedia.org/wiki/Canberra`). (An initial "empty response" was just the headless test harness declining the external-tool confirmation; granting the tool resolved it.)

## Notes for reviewers

- The agent's `google_search` is a **function tool** the plugin executes itself (its own `generateContent` call returns the cited answer), so the grounded answer surfaces via the tool result and is transport-independent. The new `rendered` extraction is the parity path for when the **main** request itself produces built-in grounding citations — it matches the `generateContent` extractor and is unit-tested.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop
- [ ] I have verified this change does not break Mobile — N/A: no platform-specific APIs; behind a default-off flag
- [x] Documentation has been updated (if applicable) — N/A user-facing: grounding already worked via the search tool; this is transport parity + an internal decision comment
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Gemini responses can now show “Sources” with citation links when available, including while streaming.
  * Inline attachments (images, audio, video, PDFs) are better recognized in user inputs and rendered as appropriate content.

* **Bug Fixes**
  * Unsupported attachment types are preserved as a note rather than dropped.
  * Citation link rendering is improved, including cases with missing titles.

* **Security / Safety**
  * Citation URLs and titles are sanitized to prevent unsafe schemes and HTML/script injection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->