### PR TITLE
fix(api): route Interactions transport through requestUrl on @google/genai 2.10.0

### DIFF
--- a/.agents/skills/release-process/SKILL.md
+++ b/.agents/skills/release-process/SKILL.md
@@ -59,12 +59,31 @@ This is a required, easy-to-forget step:
 - Demote the previous version's block to a `**Previous Updates (vX.Y.Z):**` entry
 - Keep the README's feature/configuration/localization sections in sync if the release changed them
 
-### 4. Run Tests and Build
+### 4. Run Tests, Build, and the Live Transport Smoke Gate
 
 ```bash
 npm test        # Ensure all tests pass
 npm run build   # Verify production build succeeds
 ```
+
+**🚨 Live transport smoke gate — run this LAST, after EVERY code and dependency change is final.**
+
+`npm test` / `npm run build` run in Node and **cannot catch renderer-only failures** — CORS, the Obsidian `requestUrl` fetch shim, and anything that depends on the Electron renderer environment. A green build is **not** proof the plugin works in Obsidian.
+
+Before bumping the version, install the exact bytes you're about to ship into the test vault and exercise the real API paths:
+
+```bash
+npm run install:test-vault
+# In Obsidian (or via `obsidian dev:debug on` + eval): with the CURRENT settings,
+#   1. Summarize a note  (generateContent path)
+#   2. Send an agent chat message that streams
+#   3. Toggle "Use Interactions API" ON and repeat 1–2, plus a grounded google_search
+# Confirm no console errors and real model output for each.
+```
+
+**If `@google/genai` changed at all — even a semver-minor or -patch bump — the Interactions smoke test (flag ON) is MANDATORY and non-negotiable.** The CORS workaround (`installObsidianFetch` / `obsidian-fetch.ts`) reaches into the SDK's next-gen client internals, which minor releases have restructured before (2.9.0→2.10.0 silently broke it and shipped in 4.10.1 — see #1044). Instrument `window.fetch` to confirm Interactions requests route through `requestUrl`, not the renderer global `fetch`.
+
+**Ordering rule: the smoke gate is the FINAL pre-bump step.** If you update any dependency (or any code) _after_ smoke-testing, you have invalidated the smoke test — re-run it. Never bump deps after the gate. (This is exactly how 4.10.1 broke: the smoke test passed on 2.9.0, deps were then bumped to 2.10.0, and the release was cut without re-testing because the updates "looked minor.")
 
 ### 5. Commit Release Notes
 
@@ -113,6 +132,7 @@ A GitHub Actions runner automatically creates a draft release when a tag is push
 - Build the notes from ALL changes since the previous tag (Step 1), not just the current session's work.
 - Update the README "What's New" section as part of every release (Step 3).
 - The GitHub release **name must include the full `X.Y.Z` version** from `manifest.json`, or Obsidian's developer dashboard warns (Step 7).
+- **Run the live transport smoke gate LAST, in the test vault, after all code AND dependency changes (Step 4).** `npm test`/`build` can't see renderer CORS failures. Any `@google/genai` change — even minor/patch — makes the Interactions smoke test (flag ON) mandatory. Never bump a dependency after smoke-testing without re-running it.
 - Ensure you're on the master branch and it's up to date before releasing.
 
 ## Build system context

--- a/src/api/providers/gemini/obsidian-fetch.ts
+++ b/src/api/providers/gemini/obsidian-fetch.ts
@@ -1,8 +1,8 @@
 /**
- * A WHATWG-`fetch`-compatible adapter backed by Obsidian's `requestUrl`.
+ * Route the `@google/genai` Interactions (Next-Gen) client through Obsidian's
+ * `requestUrl` so its requests bypass renderer CORS.
  *
- * Why this exists: the `@google/genai` Interactions client (the "Next-Gen" API
- * client behind `client.interactions.*`) issues requests with the renderer's
+ * Why this exists: the Next-Gen client issues requests with the renderer's
  * global `fetch`. In Obsidian's Electron renderer that is subject to CORS, and
  * the Interactions endpoint's preflight fails ("Failed to fetch"). Obsidian's
  * `requestUrl` runs in the main process and is not CORS-constrained, so routing
@@ -14,64 +14,69 @@
  * `Access-Control-Allow-Headers`, so the browser preflight returns 403 with no
  * `Access-Control-Allow-Origin`. (`models.generateContent` works in the browser
  * because it never sets that header.) Tracked upstream at
- * https://github.com/googleapis/js-genai/issues/1723, where a Google maintainer
- * proposed removing the header from the SDK. There is also no public hook to
- * supply a custom `fetch` to the Next-Gen client (feature requests
- * https://github.com/googleapis/js-genai/issues/999 and /1215), which is why
- * `installObsidianFetch` patches `fetch` onto the lazily constructed client
- * instance (see `GeminiClient.generateViaInteractions`).
+ * https://github.com/googleapis/js-genai/issues/1723. There is also no public
+ * hook to supply a custom `fetch`/`fetcher` to the Next-Gen client (feature
+ * requests https://github.com/googleapis/js-genai/issues/999 and /1215), which
+ * is why this module reaches into SDK internals.
  *
- * Revisit when the upstream fix ships — tracked in #1023 (includes a recipe for
- * checking whether Google has fixed it). Even once fixed, routing through
- * `requestUrl` remains harmless and consistent with the plugin's other network
- * calls.
+ * How it works (as of `@google/genai` 2.10.0): the plugin calls
+ * `ai.interactions.create()`. `ai.interactions` lazily builds a
+ * `GeminiNextGenInteractions` (bound to the top-level `apiClient`) and caches it.
+ * Each `create()` dispatches via `interactions.getClient(api_version)`, which
+ * builds a Next-Gen sub-client (`GoogleGenAI` extends `ClientSDK`) whose
+ * `ClientSDK._httpClient.request(req)` calls `this.fetcher(req)` — a
+ * `(req: Request) => Promise<Response>` defaulting to the global `fetch`. We wrap
+ * `getClient` so every sub-client it returns gets its `_httpClient.fetcher`
+ * swapped for {@link obsidianFetcher}.
+ *
+ * ⚠️ History: a previous version patched `ai.getNextGenClient().fetch`. That was
+ * wrong on two counts after the 2.9.0→2.10.0 restructure — it targeted a
+ * different service object than `ai.interactions`, and a `.fetch` property the
+ * transport no longer consults — so it silently no-op'd and every Interactions
+ * request fell through to the global `fetch` and CORS. See issue #1044.
+ *
+ * ⚠️ Streaming caveat: `requestUrl` buffers the whole response, so a streamed
+ * interaction resolves all at once on completion rather than incrementally.
+ * Functional, but not token-by-token. Revisit alongside the upstream CORS fix
+ * (#1023) — once the Next-Gen client works with the global `fetch`, this shim
+ * (and the buffering it imposes) can be removed.
  */
 import { requestUrl, type RequestUrlParam } from 'obsidian';
 
-/** Normalize `HeadersInit` (Headers | [k,v][] | record) into a plain record. */
-function normalizeHeaders(headers: HeadersInit | undefined): Record<string, string> {
+/** Marker so wrapping a given interactions service is idempotent. */
+const WRAP_FLAG = '__obsidianFetcherWrapped';
+
+/** Convert a `Headers` object into the plain record `requestUrl` expects. */
+function headersToRecord(headers: Headers): Record<string, string> {
 	const out: Record<string, string> = {};
-	if (!headers) return out;
-	if (headers instanceof Headers) {
-		headers.forEach((value, key) => {
-			out[key] = value;
-		});
-	} else if (Array.isArray(headers)) {
-		for (const [key, value] of headers) out[key] = value;
-	} else {
-		Object.assign(out, headers);
-	}
+	headers.forEach((value, key) => {
+		out[key] = value;
+	});
 	return out;
 }
 
-/** Coerce a `fetch` body (string | ArrayBuffer | undefined) into what `requestUrl` accepts. */
-function normalizeBody(body: BodyInit | null | undefined): string | ArrayBuffer | undefined {
-	if (body == null) return undefined;
-	if (typeof body === 'string') return body;
-	if (body instanceof ArrayBuffer) return body;
-	// The Interactions client only sends JSON string bodies in the non-streaming
-	// path; anything else is unexpected, so stringify defensively.
-	return String(body);
-}
-
 /**
- * `fetch`-shaped function that proxies through Obsidian's `requestUrl` and
- * returns a real `Response`, so the SDK's response handling (`.json()`,
- * `.status`, `.headers`) works unchanged.
+ * A `fetcher`-shaped adapter — `(req: Request) => Promise<Response>` — backed by
+ * Obsidian's `requestUrl`. The Next-Gen `HTTPClient` invokes its fetcher with a
+ * single WHATWG `Request`, so we read the URL, method, headers, and body off it
+ * (the Interactions client only sends JSON-string bodies) and return a real
+ * `Response` so the SDK's response handling (`.json()`, `.status`, `.headers`,
+ * SSE body reads) works unchanged.
  */
-export async function obsidianFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
-	const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
-
+export async function obsidianFetcher(req: Request): Promise<Response> {
 	const param: RequestUrlParam = {
-		url,
-		method: (init?.method ?? 'GET').toUpperCase(),
-		headers: normalizeHeaders(init?.headers),
+		url: req.url,
+		method: req.method,
+		headers: headersToRecord(req.headers),
 		// Return the response regardless of status so the SDK maps HTTP errors
 		// itself instead of requestUrl throwing on non-2xx.
 		throw: false,
 	};
-	const body = normalizeBody(init?.body);
-	if (body !== undefined) param.body = body;
+
+	if (req.method !== 'GET' && req.method !== 'HEAD') {
+		const buffer = await req.arrayBuffer();
+		if (buffer.byteLength > 0) param.body = buffer;
+	}
 
 	const response = await requestUrl(param);
 	return new Response(response.arrayBuffer, {
@@ -80,26 +85,45 @@ export async function obsidianFetch(input: RequestInfo | URL, init?: RequestInit
 	});
 }
 
+/** Swap a Next-Gen sub-client's transport fetcher for {@link obsidianFetcher}. */
+function applyFetcher(subClient: unknown): void {
+	try {
+		const httpClient = (subClient as { _httpClient?: { fetcher?: unknown } } | null)?._httpClient;
+		if (httpClient && httpClient.fetcher !== obsidianFetcher) {
+			httpClient.fetcher = obsidianFetcher;
+		}
+	} catch {
+		/* Defensive: if SDK internals shift, leave the default fetcher in place. */
+	}
+}
+
 /**
- * Patch `obsidianFetch` onto a `GoogleGenAI` instance's Next-Gen (Interactions)
- * client so its requests bypass renderer CORS. Idempotent and defensive: if the
- * SDK internals change shape, it silently no-ops and the caller falls back to the
- * SDK's global-`fetch` behaviour. Returns true if the patch was applied (or was
- * already in place).
+ * Route a `GoogleGenAI` instance's Interactions requests through Obsidian's
+ * `requestUrl`. Wraps `ai.interactions.getClient` so each sub-client it builds
+ * gets {@link obsidianFetcher} installed on its transport. Idempotent and
+ * defensive: if the SDK internals change shape it silently no-ops and the caller
+ * falls back to the SDK's global-`fetch` behaviour. Returns true if the wrap was
+ * applied (or was already in place).
  */
 export function installObsidianFetch(ai: unknown): boolean {
-	const getNextGenClient = (ai as { getNextGenClient?: () => { fetch?: unknown; __obsidianFetch?: boolean } })
-		?.getNextGenClient;
-	if (typeof getNextGenClient !== 'function') return false;
-
+	let service: { getClient?: unknown; [WRAP_FLAG]?: boolean } | undefined;
 	try {
-		const client = getNextGenClient.call(ai);
-		if (!client) return false;
-		if (client.__obsidianFetch) return true;
-		client.fetch = obsidianFetch;
-		client.__obsidianFetch = true;
-		return true;
+		// Accessing `.interactions` triggers the lazy getter that builds and
+		// caches the service the plugin's `ai.interactions.create()` calls use.
+		service = (ai as { interactions?: { getClient?: unknown } } | null)?.interactions;
 	} catch {
 		return false;
 	}
+
+	if (!service || typeof service.getClient !== 'function') return false;
+	if (service[WRAP_FLAG]) return true;
+
+	const originalGetClient = (service.getClient as (...args: unknown[]) => unknown).bind(service);
+	service.getClient = (...args: unknown[]) => {
+		const subClient = originalGetClient(...args);
+		applyFetcher(subClient);
+		return subClient;
+	};
+	service[WRAP_FLAG] = true;
+	return true;
 }

--- a/test/api/providers/gemini/client.test.ts
+++ b/test/api/providers/gemini/client.test.ts
@@ -11,16 +11,17 @@ import { ModelUseCase } from '../../../../src/api/model-use-case';
 // the params (system instruction, contents, etc.) the SDK sees. vi.hoisted lets
 // us share the spy with the factory while keeping vitest's mock-hoisting safe.
 const { generateContentMock, interactionsCreateMock, interactionsService } = vi.hoisted(() => {
-	// Stands in for the Next-Gen sub-client `interactions.getClient()` returns,
-	// whose `_httpClient.fetcher` installObsidianFetch swaps for the requestUrl
-	// adapter. Starts with a sentinel default so the test can assert the swap.
-	const interactionsSubClient = { _httpClient: { fetcher: 'default-fetcher' as unknown } };
 	return {
 		generateContentMock: vi.fn(),
 		interactionsCreateMock: vi.fn(),
-		interactionsSubClient,
 		// Shared so the test can observe the getClient wrap installObsidianFetch applies.
-		interactionsService: { create: vi.fn(), getClient: () => interactionsSubClient },
+		// getClient returns a FRESH sub-client per call (each with its own `_httpClient`),
+		// mirroring the real 2.10.0 SDK — so the assertion only passes if installObsidianFetch
+		// wraps the getter, not if it mutates a single prebuilt client one time.
+		interactionsService: {
+			create: vi.fn(),
+			getClient: vi.fn(() => ({ _httpClient: { fetcher: 'default-fetcher' as unknown } })),
+		},
 	};
 });
 // Keep the create spy name the existing tests use.

--- a/test/api/providers/gemini/client.test.ts
+++ b/test/api/providers/gemini/client.test.ts
@@ -1,6 +1,7 @@
 import type { Mock } from 'vitest';
 import { GoogleGenAI } from '@google/genai';
 import { GeminiClient } from '../../../../src/api/providers/gemini/client';
+import { obsidianFetcher } from '../../../../src/api/providers/gemini/obsidian-fetch';
 import type { GeminiClientConfig } from '../../../../src/api/providers/gemini/config';
 import { GeminiPrompts } from '../../../../src/prompts';
 import type { ExtendedModelRequest } from '../../../../src/api/interfaces/model-api';
@@ -9,26 +10,31 @@ import { ModelUseCase } from '../../../../src/api/model-use-case';
 // Capture every call to `client.models.generateContent` so tests can assert on
 // the params (system instruction, contents, etc.) the SDK sees. vi.hoisted lets
 // us share the spy with the factory while keeping vitest's mock-hoisting safe.
-const { generateContentMock, interactionsCreateMock, nextGenClient } = vi.hoisted(() => ({
-	generateContentMock: vi.fn(),
-	interactionsCreateMock: vi.fn(),
-	// Stands in for the SDK's internal Next-Gen client so installObsidianFetch
-	// has a `getNextGenClient()` + patchable `.fetch` to bind to.
-	nextGenClient: { fetch: undefined as unknown },
-}));
+const { generateContentMock, interactionsCreateMock, interactionsService } = vi.hoisted(() => {
+	// Stands in for the Next-Gen sub-client `interactions.getClient()` returns,
+	// whose `_httpClient.fetcher` installObsidianFetch swaps for the requestUrl
+	// adapter. Starts with a sentinel default so the test can assert the swap.
+	const interactionsSubClient = { _httpClient: { fetcher: 'default-fetcher' as unknown } };
+	return {
+		generateContentMock: vi.fn(),
+		interactionsCreateMock: vi.fn(),
+		interactionsSubClient,
+		// Shared so the test can observe the getClient wrap installObsidianFetch applies.
+		interactionsService: { create: vi.fn(), getClient: () => interactionsSubClient },
+	};
+});
+// Keep the create spy name the existing tests use.
+interactionsService.create = interactionsCreateMock;
 
 vi.mock('@google/genai', () => ({
 	GoogleGenAI: vi.fn().mockImplementation(function () {
 		return {
 			getModel: vi.fn(),
-			getNextGenClient: () => nextGenClient,
 			models: {
 				generateContent: generateContentMock,
 				generateContentStream: vi.fn(),
 			},
-			interactions: {
-				create: interactionsCreateMock,
-			},
+			interactions: interactionsService,
 		};
 	}),
 }));
@@ -1014,9 +1020,11 @@ describe('GeminiClient', () => {
 			expect(interactionsCreateMock).toHaveBeenCalledTimes(1);
 			expect(generateContentMock).not.toHaveBeenCalled();
 			expect(response.markdown).toBe('Hello from interactions');
-			// Next-Gen client routed through Obsidian's requestUrl (CORS bypass).
-			expect(typeof nextGenClient.fetch).toBe('function');
-			expect((nextGenClient as any).__obsidianFetch).toBe(true);
+			// Next-Gen requests routed through Obsidian's requestUrl (CORS bypass):
+			// installObsidianFetch wrapped interactions.getClient, so the sub-client
+			// it builds carries the requestUrl-backed fetcher.
+			const subClient = interactionsService.getClient() as { _httpClient: { fetcher: unknown } };
+			expect(subClient._httpClient.fetcher).toBe(obsidianFetcher);
 		});
 
 		test('sends stateless params: store=false and snake_case generation_config', async () => {

--- a/test/api/providers/gemini/obsidian-fetch.test.ts
+++ b/test/api/providers/gemini/obsidian-fetch.test.ts
@@ -4,9 +4,25 @@ import { describe, test, expect, vi, beforeEach } from 'vitest';
 const { requestUrlMock } = vi.hoisted(() => ({ requestUrlMock: vi.fn() }));
 vi.mock('obsidian', () => ({ requestUrl: requestUrlMock }));
 
-import { obsidianFetch, installObsidianFetch } from '../../../../src/api/providers/gemini/obsidian-fetch';
+import { obsidianFetcher, installObsidianFetch } from '../../../../src/api/providers/gemini/obsidian-fetch';
 
-describe('obsidianFetch', () => {
+/**
+ * Build a minimal `fetcher`-shaped request. The Next-Gen `HTTPClient` calls its
+ * fetcher with a WHATWG `Request`; we only touch `url`, `method`, `headers`, and
+ * `arrayBuffer()`, so a duck-typed object keeps the test independent of the
+ * jsdom `Request` body implementation.
+ */
+function fakeRequest(url: string, method: string, headers: Record<string, string>, body?: string): Request {
+	const buffer = body !== undefined ? new TextEncoder().encode(body).buffer : new ArrayBuffer(0);
+	return {
+		url,
+		method,
+		headers: new Headers(headers),
+		arrayBuffer: async () => buffer,
+	} as unknown as Request;
+}
+
+describe('obsidianFetcher', () => {
 	beforeEach(() => {
 		requestUrlMock.mockReset();
 		requestUrlMock.mockResolvedValue({
@@ -16,19 +32,18 @@ describe('obsidianFetch', () => {
 		});
 	});
 
-	test('proxies a POST through requestUrl and returns a real Response', async () => {
-		const res = await obsidianFetch('https://example.com/v1beta/interactions', {
-			method: 'post',
-			headers: { 'x-goog-api-key': 'k', 'content-type': 'application/json' },
-			body: JSON.stringify({ model: 'gemini-3.5-flash' }),
-		});
+	test('proxies a POST Request through requestUrl and returns a real Response', async () => {
+		const body = JSON.stringify({ model: 'gemini-3.5-flash' });
+		const res = await obsidianFetcher(
+			fakeRequest('https://example.com/v1beta/interactions', 'POST', { 'x-goog-api-key': 'k' }, body)
+		);
 
 		expect(requestUrlMock).toHaveBeenCalledTimes(1);
 		const param = requestUrlMock.mock.calls[0][0];
 		expect(param.url).toBe('https://example.com/v1beta/interactions');
-		expect(param.method).toBe('POST'); // upper-cased
+		expect(param.method).toBe('POST');
 		expect(param.headers['x-goog-api-key']).toBe('k');
-		expect(param.body).toBe(JSON.stringify({ model: 'gemini-3.5-flash' }));
+		expect(new TextDecoder().decode(param.body)).toBe(body);
 		expect(param.throw).toBe(false); // let the SDK map HTTP errors itself
 
 		expect(res).toBeInstanceOf(Response);
@@ -36,14 +51,21 @@ describe('obsidianFetch', () => {
 		await expect(res.json()).resolves.toEqual({ ok: true });
 	});
 
-	test('normalizes a Headers instance into a plain record', async () => {
-		const headers = new Headers();
-		headers.set('authorization', 'Bearer t');
-		await obsidianFetch(new URL('https://example.com/x'), { headers });
+	test('omits the body for GET requests (does not read arrayBuffer)', async () => {
+		const arrayBuffer = vi.fn();
+		const req = {
+			url: 'https://example.com/x',
+			method: 'GET',
+			headers: new Headers({ authorization: 'Bearer t' }),
+			arrayBuffer,
+		} as unknown as Request;
+
+		await obsidianFetcher(req);
 
 		const param = requestUrlMock.mock.calls[0][0];
 		expect(param.headers.authorization).toBe('Bearer t');
-		expect(param.url).toBe('https://example.com/x');
+		expect(param.body).toBeUndefined();
+		expect(arrayBuffer).not.toHaveBeenCalled();
 	});
 
 	test('non-2xx responses are returned (not thrown) for the SDK to handle', async () => {
@@ -52,38 +74,65 @@ describe('obsidianFetch', () => {
 			headers: {},
 			arrayBuffer: new TextEncoder().encode('rate limited').buffer,
 		});
-		const res = await obsidianFetch('https://example.com/x', { method: 'GET' });
+		const res = await obsidianFetcher(fakeRequest('https://example.com/x', 'GET', {}));
 		expect(res.status).toBe(429);
 		expect(res.ok).toBe(false);
 	});
 });
 
 describe('installObsidianFetch', () => {
-	test('patches the Next-Gen client fetch and is idempotent', () => {
-		const client: { fetch?: unknown; __obsidianFetch?: boolean } = { fetch: window.fetch };
-		const ai = { getNextGenClient: () => client };
+	function makeAi(initialFetcher: unknown) {
+		// Each getClient call rebuilds a sub-client, mirroring the real SDK where
+		// `interactions.getClient(api_version)` returns a fresh client per call.
+		const built: Array<{ _httpClient: { fetcher: unknown } }> = [];
+		const getClient = vi.fn(() => {
+			const subClient = { _httpClient: { fetcher: initialFetcher } };
+			built.push(subClient);
+			return subClient;
+		});
+		return { ai: { interactions: { getClient } }, getClient, built };
+	}
+
+	test('wraps getClient so each sub-client uses obsidianFetcher; idempotent', () => {
+		const original = () => Promise.resolve(new Response());
+		const { ai, built } = makeAi(original);
 
 		expect(installObsidianFetch(ai)).toBe(true);
-		expect(client.fetch).toBe(obsidianFetch);
-		expect(client.__obsidianFetch).toBe(true);
 
-		// Second call is a no-op that still reports success.
-		const prev = client.fetch;
+		// The fetcher is swapped when getClient runs (per-call rebuild).
+		const sub1 = ai.interactions.getClient();
+		expect(sub1._httpClient.fetcher).toBe(obsidianFetcher);
+
+		const sub2 = ai.interactions.getClient();
+		expect(sub2._httpClient.fetcher).toBe(obsidianFetcher);
+		expect(built).toHaveLength(2); // genuinely rebuilt each call
+
+		// Second install is a no-op that still reports success and keeps wrapping.
 		expect(installObsidianFetch(ai)).toBe(true);
-		expect(client.fetch).toBe(prev);
+		const sub3 = ai.interactions.getClient();
+		expect(sub3._httpClient.fetcher).toBe(obsidianFetcher);
 	});
 
-	test('returns false when the SDK lacks getNextGenClient', () => {
+	test('returns false when the SDK lacks an interactions.getClient', () => {
 		expect(installObsidianFetch({})).toBe(false);
 		expect(installObsidianFetch(null)).toBe(false);
+		expect(installObsidianFetch({ interactions: {} })).toBe(false);
 	});
 
-	test('returns false (no throw) when getNextGenClient throws', () => {
+	test('returns false (no throw) when the interactions getter throws', () => {
 		const ai = {
-			getNextGenClient: () => {
+			get interactions(): unknown {
 				throw new Error('internal');
 			},
 		};
 		expect(installObsidianFetch(ai)).toBe(false);
+	});
+
+	test('leaves the default fetcher in place if a sub-client lacks _httpClient', () => {
+		const getClient = vi.fn(() => ({}) as Record<string, unknown>);
+		const ai = { interactions: { getClient } };
+		expect(installObsidianFetch(ai)).toBe(true);
+		// Should not throw when the expected internal shape is missing.
+		expect(() => ai.interactions.getClient()).not.toThrow();
 	});
 });


### PR DESCRIPTION
## Summary

Fixes #1044. With **Use Interactions API** enabled, every Interactions request fails in the Obsidian renderer with `TypeError: Failed to fetch` (CORS), retries 4×, and gives up — breaking summarize, chat, and any model call. Shipped in 4.10.1. (Interactions is opt-in/default-off, so only users who enabled it are affected; immediate workaround is toggling it off.)

**Root cause:** the CORS workaround patched `ai.getNextGenClient().fetch`. The `@google/genai` 2.9.0 → 2.10.0 bump (#1028) restructured the next-gen client, making that patch a no-op on **two** counts:
1. The plugin calls `ai.interactions.create()`, and `ai.interactions` builds a `GeminiNextGenInteractions` from the **top-level** `apiClient` — a *different* object than `getNextGenClient().interactions`.
2. The transport no longer reads a `.fetch` property. `interactions.getClient(api_version)` **rebuilds a sub-client per call** whose `ClientSDK._httpClient.request(req)` invokes `this.fetcher(req: Request)`, defaulting to the renderer global `fetch`.

So requests fell through to global `fetch` and hit CORS. `npm test`/`build` can't catch this — it's a renderer-only failure.

**Fix:** wrap `ai.interactions.getClient` so every sub-client it builds gets a `requestUrl`-backed **fetcher** installed on its `_httpClient`. The fetcher adapts the WHATWG `Request` the HTTPClient passes (reads url/method/headers/body off it) and returns a real `Response`, so the SDK's response handling works unchanged.

## Changes

- `src/api/providers/gemini/obsidian-fetch.ts`: replace the dead `.fetch` patch with `obsidianFetcher` (`(req: Request) => Promise<Response>` via `requestUrl`) + a `getClient`-wrapping `installObsidianFetch`. Idempotent, defensive (silent no-op if SDK internals shift again), and documents the 2.10.0 object graph + the prior bug.
- `test/api/providers/gemini/obsidian-fetch.test.ts`: rewritten for the Request→Response fetcher and the getClient-wrap (per-call rebuild, idempotency, missing-shape tolerance).
- `test/api/providers/gemini/client.test.ts`: mock now exposes `interactions.getClient`; asserts the requestUrl-backed fetcher is installed on the sub-client.
- `.agents/skills/release-process/SKILL.md`: add a **live transport smoke gate** as the final pre-bump step (run after all code AND dependency changes; any `@google/genai` change makes the flag-on Interactions smoke test mandatory). Codifies how this regression shipped — bundled here per maintainer request.

## Verification

Built, installed to the test vault, reloaded, and exercised live in the renderer with **Interactions ON**:
- **Summarize (non-streaming):** ✅ succeeds, `window.fetch` called **0** times (routed through `requestUrl`).
- **Agent chat (streaming):** ✅ processed (tokens flowed, session created), **0** global-fetch calls.

Streaming is buffered through `requestUrl` (resolves on completion, not incrementally) — same as prior behaviour; to be revisited with the upstream CORS fix (#1023).

**Gating:** blocks Phase 4 default-on (#1017) until merged; commented there.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer (#1044)
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop (live renderer smoke test, Interactions on)
- [ ] I have verified this change does not break Mobile — N/A: desktop-only path; `requestUrl` is cross-platform and the change is transport-internal
- [x] Documentation has been updated (if applicable) — release-process skill; code is heavily commented
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded the release-process “live transport smoke gate” with a concrete in-app Obsidian test sequence, clarified why build/test success may miss renderer-only issues, and added rules to run it last and rerun after any dependency/code changes (with Interactions smoke testing required for `@google/genai` updates).
* **Bug Fixes**
  * Improved reliability of Gemini interaction requests through the app’s transport layer, including better handling of non-2xx responses.
* **Tests**
  * Updated and expanded transport tests to validate the new request/response wiring and idempotent installation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->