### PR TITLE
chore(daily): 2026-06-26 daily update

### DIFF
--- a/docs/guide/agent-mode.md
+++ b/docs/guide/agent-mode.md
@@ -278,7 +278,7 @@ Update my todo list with these items
 
 #### delete_file
 
-Remove files (requires confirmation):
+Move files or folders to Obsidian's trash (requires confirmation). The exact destination depends on your Obsidian **"Deleted files"** setting — system trash, the vault's `.trash` folder, or permanent deletion if you've configured it that way. Folder deletions are recursive.
 
 ```
 Delete the old draft file

--- a/package-lock.json
+++ b/package-lock.json
@@ -1900,9 +1900,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1920,9 +1917,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1940,9 +1934,6 @@
 				"ppc64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1960,9 +1951,6 @@
 				"riscv64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1980,9 +1968,6 @@
 				"riscv64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2000,9 +1985,6 @@
 				"s390x"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2020,9 +2002,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2040,9 +2019,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2289,9 +2265,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2306,9 +2279,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2323,9 +2293,6 @@
 				"ppc64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2340,9 +2307,6 @@
 				"riscv64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2357,9 +2321,6 @@
 				"riscv64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2374,9 +2335,6 @@
 				"s390x"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2391,9 +2349,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2408,9 +2363,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [

--- a/planning/changelog/2026-06-26.md
+++ b/planning/changelog/2026-06-26.md
@@ -1,0 +1,58 @@
+# Daily changelog — June 26, 2026
+
+**Date:** 2026-06-26
+**PRs merged:** 8
+
+---
+
+## Summary
+
+Heavy Interactions API day: Phases 2 and 3 of the transport migration landed (real step-based streaming and grounding/attachment coverage), followed by a dependency refresh and a critical CORS hotfix that prevented the new transport from working at all in the Obsidian renderer. Sandwiched in were a developer-tooling fix for the test-vault installer and a correctness pass that routes all vault deletions through Obsidian's trash instead of permanent deletion.
+
+## What shipped
+
+### [#1024 chore(daily): 2026-06-25 daily update](https://github.com/allenhutchison/obsidian-gemini/pull/1024)
+
+Automated daily housekeeping for 2026-06-25. Added `planning/changelog/2026-06-25.md` covering the Phase 1 Interactions API PR and a README drift fix for the new toggle.
+
+---
+
+### [#1026 fix(scripts): safer test-vault resolution for install:test-vault](https://github.com/allenhutchison/obsidian-gemini/pull/1026)
+
+Hardens `npm run install:test-vault` so it cannot silently deploy into a plugin folder that Obsidian is not actually loading. Adds a `TEST_VAULT_DIR` (vault-root) override that uses the robust id-based scan, validates the existing `TEST_VAULT_PLUGIN_DIR` override against the target manifest, and establishes a clear precedence order: exact-dir override → vault-root override → default `~/Obsidian/Test Vault`. This bit the maintainer during Phase 2 testing when rebuilds appeared to "not take" because stale code was running.
+
+---
+
+### [#1025 feat: step-based streaming for the Interactions transport (Phase 2)](https://github.com/allenhutchison/obsidian-gemini/pull/1025)
+
+Phase 2 of the Interactions API migration (epic #1013, fixes #1015). Replaces the single-chunk Phase 1 fallback with real incremental streaming when `useInteractionsApi` is on. A new `InteractionStreamAccumulator` state machine folds the Interactions SSE event stream into a `ModelResponse`, handling `step.start` (captures tool `id`/`name`/`signature`), `step.delta` (text, reasoning, argument fragments), `step.stop` (JSON-parses buffered args per step `index` to prevent parallel-call cross-contamination), and `interaction.completed` (usage). Cancellation stops processing and returns the partial. Seven accumulator unit tests and two client-level streaming tests; 3140 total, all green.
+
+---
+
+### [#1027 feat: grounding, image-gen decision, attachment coverage (Phase 3)](https://github.com/allenhutchison/obsidian-gemini/pull/1027)
+
+Phase 3 of the Interactions API migration (fixes #1016). Covers the remaining Gemini surfaces under the Interactions transport: grounding citations now arrive as inline `url_citation` annotations on the Interactions path and are collected, deduped by URL, and rendered into `ModelResponse.rendered` using the same `<div class="search-grounding">` markup as the `generateContent` path. The `generate_image` call intentionally stays on `generateContent` regardless of the flag — it is a distinct one-shot capability on a dedicated model and migrating adds risk for no user-visible benefit. Inline attachments (image/audio/video/PDF) are confirmed to flow through the Interactions `{type, mime_type, data}` input shape, with the unsupported-file case degrading to a text note. Seven new mapper tests; 3148 total.
+
+---
+
+### [#1028 chore(deps): update dependencies ahead of release](https://github.com/allenhutchison/obsidian-gemini/pull/1028)
+
+Dependency refresh ahead of the 4.10.0 release. Key bumps: `@allenhutchison/gemini-utils` 1.0.0 → 1.1.0 (newly published), `@google/genai` 2.9.0 → 2.10.0 (the SDK powering the Interactions transport). Also bumps `@types/node`, `typescript-eslint`, `knip`, and `prettier`. Re-ran live Interactions smoke tests on the new SDK; plain streaming and grounded `google_search` (tool call → follow-up → answer with source link) clean.
+
+---
+
+### [#1030 fix(vault): delete via FileManager.trashFile + small obsidianmd correctness fixes](https://github.com/allenhutchison/obsidian-gemini/pull/1030)
+
+Routes all vault deletions through `FileManager.trashFile()` (was `Vault.delete()`) across six sites: session history, hooks, RAG scanner, scheduled tasks, the `delete_file` tool, and the session-list modal. This honors the user's "Deleted files" setting — system trash, `.trash` folder, or permanent — making deletions recoverable rather than permanently destructive. Also annotates the one intentional `require()` in `agent-loop.ts` with an `eslint-disable` comment, and replaces two deprecated `substr()` calls with `substring()`. Re-enables `obsidianmd/prefer-file-manager-trash-file` (0 violations). Note: the updated delete-confirmation i18n string needs `npm run translate` (needs `GOOGLE_API_KEY`) to regenerate locale files — English is correct; other locales fall back until then.
+
+---
+
+### [#1045 fix(api): route Interactions transport through requestUrl on @google/genai 2.10.0](https://github.com/allenhutchison/obsidian-gemini/pull/1045)
+
+Fixes #1044. The `@google/genai` 2.9.0 → 2.10.0 bump restructured the next-gen client, making the CORS workaround that was patching `.fetch` a no-op. Requests fell through to the renderer's global `fetch` and hit CORS, breaking all Interactions calls with `TypeError: Failed to fetch` (retried 4× then failed). Root cause: `ai.interactions.getClient(api_version)` rebuilds a sub-client on each call whose `_httpClient` defaults to the renderer global `fetch`, not the patched object. Fix: wraps `ai.interactions.getClient` so every sub-client it builds gets a `requestUrl`-backed fetcher installed on its `_httpClient`. Idempotent; silent no-op if SDK internals shift again. Also adds a live transport smoke gate to the release-process skill — any `@google/genai` bump now makes a renderer smoke test mandatory before release, codifying how this regression shipped. This PR ships in 4.10.1.
+
+---
+
+### [#1047 chore(auto-dev): retarget pipeline at a web scheduled task; drop local runner](https://github.com/allenhutchison/obsidian-gemini/pull/1047)
+
+The auto-dev pipeline now runs as a recurring scheduled task in the cloud that invokes `/auto-dev` directly in a fresh full-toolchain sandbox, rather than a local cron script driving headless Claude Code. Removes `scripts/auto-dev.sh` and `scripts/auto-dev-settings.json` (the permissions allowlist); the allowlist's deny-list intent moves into the skill as self-enforced hard prohibitions. The skill's Step 0 now owns environment prep in a mode-aware way (disposable sandboxes may reset/clean; interactive checkouts never are). Updates `AGENTS.md` to describe the new execution model. Skills/docs only; no source or test changes.


### PR DESCRIPTION
## Summary

Automated daily housekeeping run for 2026-06-26. All pre-flight checks pass (format, build, 3150 tests).

## Changes

- **daily-changelog**: Added `planning/changelog/2026-06-26.md` — 8 PRs merged on 2026-06-26: Interactions API Phase 2 (step-based streaming), Phase 3 (grounding/attachments), a CORS hotfix that shipped as 4.10.1, a dependency refresh, a test-vault installer hardening, trash-based deletions via `FileManager.trashFile`, and the auto-dev pipeline migration to a cloud scheduled task.
- **audit-docs**: `docs/guide/agent-mode.md` — updated the `delete_file` tool description to reflect that files now move to Obsidian's trash (via `FileManager.trashFile`, honoring the user's "Deleted files" setting) rather than being permanently deleted. All other settings defaults, command IDs, schedule formats, tool names, folder paths, model defaults, loop-detection thresholds, and task frontmatter fields verified correct against code. No new docs warranted.

## Sub-skill outcomes

- **daily-changelog**: wrote `planning/changelog/2026-06-26.md`, 8 PRs merged on 2026-06-26
  - [#1024](https://github.com/allenhutchison/obsidian-gemini/pull/1024) — chore(daily): 2026-06-25 daily update (automated housekeeping)
  - [#1026](https://github.com/allenhutchison/obsidian-gemini/pull/1026) — fix(scripts): safer test-vault resolution for install:test-vault
  - [#1025](https://github.com/allenhutchison/obsidian-gemini/pull/1025) — feat: step-based streaming for the Interactions transport (Phase 2)
  - [#1027](https://github.com/allenhutchison/obsidian-gemini/pull/1027) — feat: grounding, image-gen decision, attachment coverage (Phase 3)
  - [#1028](https://github.com/allenhutchison/obsidian-gemini/pull/1028) — chore(deps): update dependencies ahead of release
  - [#1030](https://github.com/allenhutchison/obsidian-gemini/pull/1030) — fix(vault): delete via FileManager.trashFile + small obsidianmd correctness fixes
  - [#1045](https://github.com/allenhutchison/obsidian-gemini/pull/1045) — fix(api): route Interactions transport through requestUrl on @google/genai 2.10.0 (ships as 4.10.1)
  - [#1047](https://github.com/allenhutchison/obsidian-gemini/pull/1047) — chore(auto-dev): retarget pipeline at a web scheduled task; drop local runner
- **audit-docs**: one drift fix — `docs/guide/agent-mode.md` `delete_file` description did not mention that deletion is now trash-based (via `FileManager.trashFile`, PR #1030). All other documented surfaces verified correct against code.
- **triage-issues**: no unlabeled open issues (0 processed, 0 labeled)

## Screenshots / Screencast

N/A — changelog file and one-line doc fix only.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: automated daily housekeeping
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [ ] I have tested this change on Desktop — N/A: changelog file and one-line doc fix only
- [ ] I have verified this change does not break Mobile — N/A: no code changes
- [x] Documentation has been updated (if applicable) — the audit-docs fix IS the documentation update
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01NhhYxTK66W2rFwvsR3oLmE)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the file deletion guide to explain that deleted items go to Obsidian’s trash, confirmation is required, and folder deletions apply recursively.
  * Added a new changelog entry summarizing recent updates and fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->