### PR TITLE
feat(agent-loop): streaming hook for follow-up requests

### DIFF
--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -2,7 +2,7 @@ import type { Content } from '@google/genai';
 import type ObsidianGemini from '../main';
 import type { ChatSession, PerTurnContext } from '../types/agent';
 import type { FeatureToolPolicy } from '../types/tool-policy';
-import type { ToolCall, ModelResponse, ModelApi } from '../api/interfaces/model-api';
+import type { ToolCall, ModelResponse, ModelApi, StreamChunk } from '../api/interfaces/model-api';
 import type { CustomPrompt } from '../prompts/types';
 import type { IConfirmationProvider, IToolHostView, ToolExecutionContext, ToolResult } from '../tools/types';
 import { generateToolDescription } from '../utils/text-generation';
@@ -71,6 +71,14 @@ export interface AgentLoopHooks {
 	 * remaining-turns counter as the budget runs low.
 	 */
 	onBudgetUpdate?(state: { remaining: number; limit: number | undefined; extended: boolean }): void | Promise<void>;
+	/**
+	 * Fired per text chunk when the follow-up model call uses the streaming API.
+	 * Only present on the UI path — headless callers leave it unset and follow-ups
+	 * use the non-streaming path unchanged. Thought/reasoning chunks are not
+	 * forwarded here; they are returned on `AgentLoopResult.thoughts` at the end
+	 * of the turn.
+	 */
+	onFollowUpChunk?(chunk: StreamChunk): void | Promise<void>;
 }
 
 export interface AgentLoopOptions {
@@ -403,7 +411,34 @@ export class AgentLoop {
 			});
 
 			const modelApi = createModel();
-			const followUpResponse = await modelApi.generateModelResponse(followUpRequest);
+			let followUpResponse: ModelResponse;
+
+			if (hooks?.onFollowUpChunk && modelApi.generateStreamingResponse) {
+				// Streaming follow-up: fire hook per text chunk so the UI can render
+				// tokens as they arrive instead of showing a progress bar then a dump.
+				// Only create the live container when there is actual text to show —
+				// an intermediate tool-continuation turn may produce no text at all.
+				let accText = '';
+				let accThoughts = '';
+				const stream = modelApi.generateStreamingResponse(followUpRequest, (chunk: StreamChunk) => {
+					if (chunk.thought) accThoughts += chunk.thought;
+					if (chunk.text) {
+						accText += chunk.text;
+						void this.safeHook('onFollowUpChunk', plugin, () => hooks?.onFollowUpChunk?.({ text: chunk.text }));
+					}
+				});
+				followUpResponse = await stream.complete;
+				// Prefer the completed response's text; fall back to the accumulated
+				// streaming text when the response object arrives empty.
+				if (!followUpResponse.markdown?.trim() && accText.trim()) {
+					followUpResponse = { ...followUpResponse, markdown: accText };
+				}
+				if (!followUpResponse.thoughts?.trim() && accThoughts.trim()) {
+					followUpResponse = { ...followUpResponse, thoughts: accThoughts };
+				}
+			} else {
+				followUpResponse = await modelApi.generateModelResponse(followUpRequest);
+			}
 
 			if (followUpResponse.usageMetadata) {
 				await this.safeEmit(plugin, 'apiResponseReceived', {

--- a/src/ui/agent-view/agent-view-tools.ts
+++ b/src/ui/agent-view/agent-view-tools.ts
@@ -6,7 +6,7 @@ import { IConfirmationProvider, IToolHostView, ToolResult } from '../../tools/ty
 import { CustomPrompt } from '../../prompts/types';
 import { AgentLoop, DEFAULT_INTERACTIVE_MAX_ITERATIONS } from '../../agent/agent-loop';
 import { DEFAULT_TURN_BUDGET_REMIND_AT } from '../../agent/turn-budget';
-import type { ToolCall } from '../../api/interfaces/model-api';
+import type { ToolCall, StreamChunk } from '../../api/interfaces/model-api';
 import { AgentViewToolDisplay } from './agent-view-tool-display';
 import type { PerTurnContext } from './agent-view-tool-followup';
 import { t } from '../../i18n';
@@ -27,6 +27,18 @@ export interface AgentViewContext {
 	confirmationProvider: IConfirmationProvider;
 	/** View side effects tools can trigger (shelf updates, header refresh). */
 	viewActions: IToolHostView;
+	/**
+	 * Create an empty live streaming container for follow-up response text.
+	 * Returns undefined when the view can't create one (e.g. in tests that don't
+	 * implement this method).
+	 */
+	createFollowUpStream?(): HTMLElement;
+	/**
+	 * Finalize the live streaming container with full markdown rendering and
+	 * scroll the view to the bottom. Called in place of `displayMessage` when
+	 * a follow-up was streamed.
+	 */
+	finalizeFollowUpStream?(container: HTMLElement, entry: GeminiConversationEntry): Promise<void>;
 }
 
 /**
@@ -44,6 +56,8 @@ export class AgentViewTools {
 	private currentExecutingTool: string | null = null;
 	private lastCompletedTool: string | null = null;
 	private currentGroupContainer: HTMLElement | null = null;
+	/** Live streaming container for the follow-up text response, set on first text chunk. */
+	private streamingFollowUpContainer: HTMLElement | null = null;
 	private display: AgentViewToolDisplay;
 	/** Reasoning produced before the first tool batch, rendered into the group once it exists. */
 	private pendingReasoning: string | null = null;
@@ -154,6 +168,24 @@ export class AgentViewTools {
 						onFollowUpRequestStart: () => {
 							this.context.updateProgress(this.thinkingLabel(), 'thinking');
 						},
+						onFollowUpChunk: (chunk: StreamChunk) => {
+							if (!chunk.text) return;
+							if (!this.streamingFollowUpContainer) {
+								// Only create a container once there's actual (non-whitespace) text
+								// to show — intermediate tool-continuation turns that produce no
+								// text must not spawn an empty streaming bubble.
+								if (!chunk.text.trim()) return;
+								this.streamingFollowUpContainer = this.context.createFollowUpStream?.() ?? null;
+								this.context.updateProgress(t('agent.progress.generating'), 'streaming');
+							}
+							if (!this.streamingFollowUpContainer) return;
+							const contentDiv = this.streamingFollowUpContainer.querySelector(
+								'.gemini-agent-message-content'
+							) as HTMLElement | null;
+							if (contentDiv) {
+								contentDiv.appendChild(document.createTextNode(chunk.text));
+							}
+						},
 						onModelReasoning: async (thoughts) => {
 							// Reasoning the model produced before deciding to call the
 							// next tool batch — render it as a row inside the current tool
@@ -196,7 +228,21 @@ export class AgentViewTools {
 				...(result.thoughts ? { thoughts: result.thoughts } : {}),
 			};
 
-			await this.context.displayMessage(aiEntry);
+			const streamingContainer = this.streamingFollowUpContainer;
+			this.streamingFollowUpContainer = null;
+
+			if (streamingContainer && this.context.finalizeFollowUpStream) {
+				// Follow-up was streamed into a live container — finalize it with
+				// proper markdown rendering rather than creating a duplicate message.
+				await this.context.finalizeFollowUpStream(streamingContainer, aiEntry);
+			} else {
+				if (streamingContainer) {
+					// View doesn't support finalization — remove the partial container
+					// so displayMessage can render the full markdown cleanly.
+					streamingContainer.remove();
+				}
+				await this.context.displayMessage(aiEntry);
+			}
 
 			// `fellBack` (empty-response courtesy) and `loopAborted` (loop-detector
 			// escalation) both produce UI-only notices — don't pollute session
@@ -209,6 +255,7 @@ export class AgentViewTools {
 		} catch (error) {
 			this.plugin.logger.error('[AgentViewTools] Failed to process tool results:', error);
 			this.currentGroupContainer = null;
+			this.streamingFollowUpContainer = null;
 			this.context.hideProgress();
 		}
 	}

--- a/src/ui/agent-view/agent-view-tools.ts
+++ b/src/ui/agent-view/agent-view-tools.ts
@@ -208,6 +208,8 @@ export class AgentViewTools {
 			this.currentGroupContainer = null;
 
 			if (result.cancelled) {
+				this.streamingFollowUpContainer?.remove();
+				this.streamingFollowUpContainer = null;
 				this.context.hideProgress();
 				return;
 			}
@@ -215,6 +217,8 @@ export class AgentViewTools {
 			if (!result.markdown) {
 				// Loop ran but produced nothing actionable (cancelled mid-stream or
 				// exhausted iterations without a text response). Just hide progress.
+				this.streamingFollowUpContainer?.remove();
+				this.streamingFollowUpContainer = null;
 				this.context.hideProgress();
 				return;
 			}
@@ -255,6 +259,7 @@ export class AgentViewTools {
 		} catch (error) {
 			this.plugin.logger.error('[AgentViewTools] Failed to process tool results:', error);
 			this.currentGroupContainer = null;
+			this.streamingFollowUpContainer?.remove();
 			this.streamingFollowUpContainer = null;
 			this.context.hideProgress();
 		}

--- a/src/ui/agent-view/agent-view.ts
+++ b/src/ui/agent-view/agent-view.ts
@@ -757,6 +757,11 @@ export class AgentView extends ItemView {
 				updateSessionHeader: () => this.updateSessionHeader(),
 				updateSessionMetadata: () => this.updateSessionMetadata(),
 			},
+			createFollowUpStream: () => this.messages.createStreamingMessageContainer('model'),
+			finalizeFollowUpStream: async (container: HTMLElement, entry: GeminiConversationEntry) => {
+				await this.messages.finalizeStreamingMessage(container, entry.message, entry, this.currentSession);
+				this.messages.scrollToBottom();
+			},
 		};
 	}
 

--- a/test/agent/agent-loop.test.ts
+++ b/test/agent/agent-loop.test.ts
@@ -1,6 +1,12 @@
 import type { Mock } from 'vitest';
 import { AgentLoop } from '../../src/agent/agent-loop';
-import type { ToolCall, ModelResponse, ModelApi } from '../../src/api/interfaces/model-api';
+import type {
+	ToolCall,
+	ModelResponse,
+	ModelApi,
+	StreamChunk,
+	StreamCallback,
+} from '../../src/api/interfaces/model-api';
 import type { IConfirmationProvider } from '../../src/tools/types';
 
 // None of these tests exercise the confirmation UI branch (enabledTools/requireConfirmation
@@ -1005,6 +1011,177 @@ describe('AgentLoop', () => {
 			expect(result.iterations).toBe(0);
 			expect(result.markdown).toBe('');
 			expect(plugin.toolExecutionEngine.executeTool).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('streaming follow-up (onFollowUpChunk)', () => {
+		// Build a streaming-capable mock model API. `chunks` are fired via the
+		// StreamCallback when the complete promise resolves; `finalResponse` is
+		// what the complete promise resolves to.
+		function makeStreamingApi(chunks: StreamChunk[], finalResponse: ModelResponse) {
+			let streamCalls = 0;
+			let nonStreamCalls = 0;
+			const api = {
+				get streamCalls() {
+					return streamCalls;
+				},
+				get nonStreamCalls() {
+					return nonStreamCalls;
+				},
+				generateModelResponse: vi.fn().mockImplementation(() => {
+					nonStreamCalls++;
+					return Promise.resolve(finalResponse);
+				}),
+				generateStreamingResponse: vi.fn().mockImplementation((_req: any, onChunk: StreamCallback) => {
+					streamCalls++;
+					const complete = Promise.resolve().then(() => {
+						for (const chunk of chunks) {
+							onChunk(chunk);
+						}
+						return finalResponse;
+					});
+					return { complete, cancel: vi.fn() };
+				}),
+			} as any;
+			return api;
+		}
+
+		test('uses generateStreamingResponse and fires onFollowUpChunk per text chunk', async () => {
+			const plugin = buildPlugin();
+			const session = buildSession();
+			const received: StreamChunk[] = [];
+			const api = makeStreamingApi([{ text: 'Hello' }, { text: ', world' }], textResponse('Hello, world'));
+
+			const loop = new AgentLoop();
+			const result = await loop.run({
+				initialResponse: toolResponse([tc('read_file', { path: 'a.md' })]),
+				initialUserMessage: 'q',
+				initialHistory: [],
+				options: {
+					plugin,
+					session,
+					confirmationProvider,
+					isCancelled: () => false,
+					createModelApi: () => api,
+					hooks: {
+						onFollowUpChunk: (chunk) => {
+							received.push(chunk);
+						},
+					},
+				},
+			});
+
+			expect(result.markdown).toBe('Hello, world');
+			expect(api.streamCalls).toBe(1);
+			expect(api.nonStreamCalls).toBe(0);
+			// Hook receives only the text field, not thought
+			expect(received).toEqual([{ text: 'Hello' }, { text: ', world' }]);
+		});
+
+		test('falls back to generateModelResponse when onFollowUpChunk is absent', async () => {
+			const plugin = buildPlugin();
+			const session = buildSession();
+			const api = makeStreamingApi([], textResponse('done'));
+
+			const loop = new AgentLoop();
+			await loop.run({
+				initialResponse: toolResponse([tc('read_file', { path: 'a.md' })]),
+				initialUserMessage: 'q',
+				initialHistory: [],
+				options: {
+					plugin,
+					session,
+					confirmationProvider,
+					isCancelled: () => false,
+					createModelApi: () => api,
+					// No onFollowUpChunk — non-streaming path must be used
+				},
+			});
+
+			expect(api.nonStreamCalls).toBe(1);
+			expect(api.streamCalls).toBe(0);
+		});
+
+		test('does not forward thought-only chunks to onFollowUpChunk', async () => {
+			const plugin = buildPlugin();
+			const session = buildSession();
+			const received: StreamChunk[] = [];
+			// First chunk is thought-only (empty text), second carries text
+			const api = makeStreamingApi([{ text: '', thought: 'reasoning...' }, { text: 'answer' }], textResponse('answer'));
+
+			const loop = new AgentLoop();
+			const result = await loop.run({
+				initialResponse: toolResponse([tc('read_file', { path: 'a.md' })]),
+				initialUserMessage: 'q',
+				initialHistory: [],
+				options: {
+					plugin,
+					session,
+					confirmationProvider,
+					isCancelled: () => false,
+					createModelApi: () => api,
+					hooks: {
+						onFollowUpChunk: (chunk) => {
+							received.push(chunk);
+						},
+					},
+				},
+			});
+
+			expect(result.markdown).toBe('answer');
+			// Thought-only chunks (empty text) must not reach the hook
+			expect(received).toEqual([{ text: 'answer' }]);
+		});
+
+		test('multi-iteration: streaming fires per follow-up, result text accumulates correctly', async () => {
+			const plugin = buildPlugin();
+			const session = buildSession();
+			const chunksPerCall: StreamChunk[][] = [];
+
+			// First follow-up returns more tool calls; second returns text
+			let call = 0;
+			const responses: Array<{ chunks: StreamChunk[]; response: ModelResponse }> = [
+				{ chunks: [], response: { markdown: '', rendered: '', toolCalls: [tc('write_file', { path: 'b.md' })] } },
+				{ chunks: [{ text: 'final' }], response: textResponse('final') },
+			];
+
+			const api = {
+				streamCalls: 0,
+				generateModelResponse: vi.fn(),
+				generateStreamingResponse: vi.fn().mockImplementation((_req: any, onChunk: StreamCallback) => {
+					const entry = responses[call++];
+					(api as any).streamCalls++;
+					const chunks: StreamChunk[] = [];
+					const complete = Promise.resolve().then(() => {
+						for (const chunk of entry.chunks) {
+							onChunk(chunk);
+							chunks.push(chunk);
+						}
+						chunksPerCall.push(chunks);
+						return entry.response;
+					});
+					return { complete, cancel: vi.fn() };
+				}),
+			} as any;
+
+			const loop = new AgentLoop();
+			const result = await loop.run({
+				initialResponse: toolResponse([tc('read_file', { path: 'a.md' })]),
+				initialUserMessage: 'q',
+				initialHistory: [],
+				options: {
+					plugin,
+					session,
+					confirmationProvider,
+					isCancelled: () => false,
+					createModelApi: () => api,
+					hooks: { onFollowUpChunk: vi.fn() },
+				},
+			});
+
+			expect(result.markdown).toBe('final');
+			expect(result.iterations).toBe(2);
+			expect(api.streamCalls).toBe(2);
 		});
 	});
 


### PR DESCRIPTION
<!-- auto-dev -->

> This PR was produced by the auto-dev pipeline from the approved implementation plan on issue #663.

## Summary

Adds an `onFollowUpChunk` hook to `AgentLoopHooks` so follow-up requests after tool batches can stream token-by-token to the UI, eliminating the progress-bar-then-bulk-dump pattern users see today. When the hook is set **and** the model API implements `generateStreamingResponse`, the loop switches to streaming for that follow-up call; headless callers (scheduled tasks, hooks) that don't set the hook continue using the non-streaming path unchanged.

## What changed

**`src/agent/agent-loop.ts`**
- Added `onFollowUpChunk?(chunk: StreamChunk): void | Promise<void>` to `AgentLoopHooks` (JSDoc explains it's UI-only; headless callers omit it)
- Inside the follow-up request block: when `hooks.onFollowUpChunk` is set and `modelApi.generateStreamingResponse` exists, calls the streaming variant; accumulates `accText`/`accThoughts` from chunks and patches the completed response when its fields arrive empty; falls back to `generateModelResponse` otherwise

**`src/ui/agent-view/agent-view-tools.ts`**
- Added two optional methods to `AgentViewContext`: `createFollowUpStream?()` and `finalizeFollowUpStream?(container, entry)`
- Added `streamingFollowUpContainer` private field
- Implemented `onFollowUpChunk` hook: creates the live container on first non-whitespace text chunk, appends text nodes per chunk, updates progress label to "Generating…"
- Post-loop: finalizes the container via `finalizeFollowUpStream` (proper markdown re-render + scroll) instead of calling `displayMessage` again, preventing a duplicate bubble; falls back to `displayMessage` if the view doesn't support finalization
- Clears `streamingFollowUpContainer` in the catch block

**`src/ui/agent-view/agent-view.ts`**
- Wires `createFollowUpStream` → `this.messages.createStreamingMessageContainer('model')`
- Wires `finalizeFollowUpStream` → `this.messages.finalizeStreamingMessage(…)` + `scrollToBottom()`

**`test/agent/agent-loop.test.ts`**
- New `describe('streaming follow-up (onFollowUpChunk)')` block with four tests:
  1. Uses `generateStreamingResponse` and fires hook per text chunk when hook is set
  2. Falls back to `generateModelResponse` when hook is absent
  3. Does not forward thought-only (empty-text) chunks to the hook
  4. Multi-iteration: streaming fires per follow-up, result text accumulates correctly

## Testing

- `npm run format-check` ✓
- `npm run build` ✓
- `npm test` ✓ — 3164 tests pass (139 test files)
- `npm run typecheck:test` ✓

Fixes #663

---
_Generated by [Claude Code](https://claude.ai/code/session_012mNTiKXANQESz8bySpHFxb)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Follow-up responses can now stream live text updates while they’re generated.
  * Chat follow-ups appear progressively in the conversation view, updating as new chunks arrive.
* **Bug Fixes**
  * Ensures only the intended text chunks are streamed (ignores empty/whitespace and thought-only chunks).
  * Keeps the streamed preview consistent with the final rendered follow-up, including proper cleanup on cancellation/errors.
* **Tests**
  * Added coverage for streaming follow-ups, including streaming vs non-streaming fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->