### PR TITLE
fix(rag): rename "Reindex All" → "Rescan Vault" to match actual behaviour

### DIFF
--- a/docs/guide/semantic-search.md
+++ b/docs/guide/semantic-search.md
@@ -42,8 +42,10 @@ Initial indexing time depends on vault size. A vault with 1,000 notes typically 
 
 In the settings panel you'll find two action buttons:
 
-- **Reindex vault** — Performs a full re-index. Smart sync skips files that haven't changed, so this is safe to run anytime.
+- **Rescan vault** — Scans your vault for changed files and uploads any that are new or modified. Smart sync skips unchanged files, so the button is safe to run anytime. Files that haven't changed are reported as "unchanged" — this is expected behaviour, not a no-op.
 - **Delete index** — Permanently removes your data from Google Cloud. Use this if you want a fresh start or are done with the feature.
+
+> **Forcing a full re-embed** (e.g. after switching to a new model or recovering from a suspected corrupt index): use **Delete index** followed by **Rescan vault**. Deleting the index clears all stored embeddings, so the next rescan uploads every file from scratch.
 
 ## Commands
 
@@ -74,7 +76,7 @@ Click the status bar icon anytime to open the full status modal.
 
 The status modal has three tabs:
 
-- **Overview** — Current status, file counts, pending changes, last sync time, and action buttons (Sync now, Reindex all)
+- **Overview** — Current status, file counts, pending changes, last sync time, and action buttons (Sync now, Rescan vault)
 - **Files** — Searchable list of all indexed files with timestamps
 - **Failures** — Any files that failed to index with error details
 
@@ -163,7 +165,7 @@ You can also use **Delete index** in settings at any time.
 
 ## Known Limitations
 
-- **No individual file deletion from the index** — When you delete a vault file, it may remain as an orphan in Google Cloud. Use **Reindex vault** or **Delete index** for a clean state.
+- **No individual file deletion from the index** — When you delete a vault file, it may remain as an orphan in Google Cloud. Use **Delete index** followed by **Rescan vault** for a clean state.
 - **Search results don't include file paths** — The Google API returns text excerpts but not source file paths. The agent may not always be able to link results back to specific files.
 - **Rate limits during indexing** — Large vaults may hit API rate limits. The plugin handles this automatically with exponential backoff (30s base, up to 5 minutes). The status bar shows a countdown.
 - **Concurrent upload limit** — Files are uploaded 5 at a time to balance speed with rate limit avoidance.
@@ -184,7 +186,7 @@ This was fixed in v4.2+. Update to the latest version. The fix includes deferred
 
 - Verify the file is actually indexed — open the status modal (Files tab) and search for it
 - Check that the file's folder isn't in the exclude list
-- If you recently enabled **Include attachments**, run **Reindex vault** to pick up non-markdown files
+- If you recently enabled **Include attachments**, run **Rescan vault** to pick up non-markdown files
 - Try increasing `maxResults` by asking the agent: "Search for X with more results"
 
 ### Status shows errors
@@ -195,7 +197,7 @@ Click the status bar icon to see the Failures tab. Common causes:
 - **Invalid API key** — Verify your key in [Google AI Studio](https://aistudio.google.com)
 - **Network issues** — Check your internet connection
 
-For persistent issues, try **Delete index** followed by **Reindex vault** for a clean start.
+For persistent issues, try **Delete index** followed by **Rescan vault** for a clean start.
 
 ## Further Reading
 

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -684,8 +684,8 @@ export const en = {
 		context: 'Settings field name for the row showing index state with reindex/delete buttons.',
 	},
 	'settings.rag.reindexButton': {
-		message: 'Reindex vault',
-		context: 'Button label that rebuilds the vault search index.',
+		message: 'Rescan vault',
+		context: 'Button label that rescans the vault for changed files and updates the search index.',
 	},
 	'settings.rag.indexingButton': {
 		message: 'Indexing...',
@@ -713,9 +713,9 @@ export const en = {
 		context: 'Temporary button label while the search index is being deleted.',
 	},
 	'settings.rag.indexDeletedNotice': {
-		message: 'Index deleted. Use "Reindex vault" to rebuild.',
+		message: 'Index deleted. Use "Rescan vault" to rebuild.',
 		context:
-			'Notice after the search index was deleted. "Reindex Vault" refers to the button labeled by settings.rag.reindexButton; translate consistently.',
+			'Notice after the search index was deleted. "Rescan vault" refers to the button labeled by settings.rag.reindexButton; translate consistently.',
 	},
 	'settings.rag.deleteIndexFailed': {
 		message: 'Failed to delete index: {error}',
@@ -1425,8 +1425,8 @@ export const en = {
 		context: 'Notice when the manual sync fails. {message} is the raw error message.',
 	},
 	'ragStatus.reindexButton': {
-		message: 'Reindex all',
-		context: 'Button in the RAG status modal that rebuilds the entire index.',
+		message: 'Rescan vault',
+		context: 'Button in the RAG status modal that rescans the vault for changed files.',
 	},
 	'ragStatus.settingsButton': {
 		message: 'Settings',
@@ -2002,8 +2002,8 @@ export const en = {
 		context: 'Accessibility label of a file row that opens the note. {path} is a vault file path.',
 	},
 	'backgroundTasks.indexingComplete': {
-		message: 'RAG indexing complete: {indexed} indexed, {skipped} unchanged',
-		context: 'Notice when a full reindex finishes. {indexed} and {skipped} are counts.',
+		message: 'Rescan complete: {indexed} re-indexed, {skipped} unchanged',
+		context: 'Notice when a vault rescan finishes. {indexed} and {skipped} are counts.',
 	},
 	'backgroundTasks.indexingFailed': {
 		message: 'RAG indexing failed: {message}',
@@ -2896,9 +2896,9 @@ export const en = {
 		context: 'Confirmation notice after RAG synchronization was resumed.',
 	},
 	'notice.main.ragIndexComplete': {
-		message: 'RAG indexing complete: {indexed} indexed, {skipped} unchanged',
+		message: 'Rescan complete: {indexed} re-indexed, {skipped} unchanged',
 		context:
-			'Notice after a full RAG index run; {indexed} is the number of files indexed and {skipped} the number left unchanged.',
+			'Notice after a vault rescan; {indexed} is the number of files uploaded and {skipped} the number left unchanged because they had not changed.',
 	},
 	'notice.main.ragIndexFailed': {
 		message: 'RAG indexing failed: {error}',
@@ -3021,8 +3021,8 @@ export const en = {
 		context: 'Toast notification when the user chooses to discard the interrupted index and rebuild from scratch.',
 	},
 	'notice.rag.indexingComplete': {
-		message: 'RAG indexing complete: {indexed} indexed, {skipped} unchanged',
-		context: 'Toast notification when vault search indexing finishes. {indexed} and {skipped} are file counts.',
+		message: 'Rescan complete: {indexed} re-indexed, {skipped} unchanged',
+		context: 'Toast notification when vault rescan finishes. {indexed} and {skipped} are file counts.',
 	},
 	'notice.rag.indexingFailed': {
 		message: 'RAG indexing failed: {error}',

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -697,8 +697,8 @@ export const en = {
 			'Notice when an indexing action is attempted before the indexing service is ready. RAG stands for retrieval-augmented generation.',
 	},
 	'settings.rag.indexResult': {
-		message: 'Indexed {indexed} files ({skipped} skipped, {failed} failed)',
-		context: 'Notice summarizing an indexing run. {indexed}, {skipped}, and {failed} are file counts.',
+		message: 'Rescan complete: {indexed} re-indexed, {skipped} skipped, {failed} failed',
+		context: 'Notice summarizing a rescan run. {indexed}, {skipped}, and {failed} are file counts.',
 	},
 	'settings.rag.indexingFailed': {
 		message: 'Indexing failed: {error}',
@@ -763,12 +763,12 @@ export const en = {
 		context: 'Settings toggle name for indexing non-markdown files such as PDFs.',
 	},
 	'settings.rag.includeAttachmentsDesc': {
-		message: 'Index PDFs and other supported file types in addition to markdown notes. Requires reindexing.',
+		message: 'Index PDFs and other supported file types in addition to markdown notes. Requires rescanning.',
 		context: 'Settings toggle description for including attachments in the search index.',
 	},
 	'settings.rag.attachmentSettingChangedNotice': {
-		message: 'Attachment setting changed. Reindex vault to apply changes.',
-		context: 'Notice after toggling attachment indexing, reminding the user to reindex.',
+		message: 'Attachment setting changed. Rescan vault to apply changes.',
+		context: 'Notice after toggling attachment indexing, reminding the user to rescan.',
 	},
 	'settings.rag.excludeFoldersName': {
 		message: 'Exclude folders',


### PR DESCRIPTION
<!-- auto-dev -->

## Summary

Fixes #681

The **Reindex All** / **Reindex vault** buttons call `indexVault()` with `smartSync: true`, which skips unchanged files — they scan the vault for changes rather than doing a full reindex. This was mislabelled since `abd6619` and flagged by CodeRabbit on #674. Option A (relabel, no scanner changes) was approved on 2026-06-27.

This PR renames the button and aligns the completion notice wording so users are no longer misled about what happened. It also adds a docs note pointing users at Delete index + Rescan vault as the supported path for a true full re-embed.

> This PR was produced by the auto-dev pipeline from the approved plan on #681.

## Changes

- `src/i18n/en.ts` — rename i18n keys: `settings.rag.reindexButton` `'Reindex vault'` → `'Rescan vault'`; `ragStatus.reindexButton` `'Reindex all'` → `'Rescan vault'`; update cross-reference in `settings.rag.indexDeletedNotice`; update all three completion notice strings from `'RAG indexing complete: {indexed} indexed, {skipped} unchanged'` → `'Rescan complete: {indexed} re-indexed, {skipped} unchanged'`
- `docs/guide/semantic-search.md` — replace all "Reindex All" / "Reindex vault" button references with "Rescan vault"; rewrite the button description to accurately say it scans for *changed* files; add a callout explaining that Delete index + Rescan vault is the path for forcing a full re-embed (e.g. after switching models)

No changes to scanner/uploader behaviour — `smartSync: true` is unchanged.

## Screenshots / Screencast

UI-only label change (no logic change). Before → After:
- Settings panel button: **Reindex vault** → **Rescan vault**
- Status modal button: **Reindex all** → **Rescan vault**
- Completion notice: `RAG indexing complete: 42 indexed, 18 unchanged` → `Rescan complete: 42 re-indexed, 18 unchanged`

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [ ] I have tested this change on Desktop
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards)
- [x] Documentation has been updated (if applicable)
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude (auto-dev pipeline)
- [x] I have reviewed and understand all AI-generated code in this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_013Lrs7qg8KaPSc8V21SuWMf)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated semantic search operational guidance to recommend **Rescan vault** over **Reindex** for scan-and-upload of changed files and for recovery after index changes.
  * Clarified the full refresh flow as **Delete index** followed by **Rescan vault**.

* **Bug Fixes**
  * Updated user-facing RAG indexing/rescanning labels and notifications to consistently use **Rescan** terminology.
  * Refined completion messaging and toasts to clearly indicate what was **rescanned/re-indexed** versus **unchanged**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->