### PR TITLE
feat(ollama): auto-detect vision capability via /api/show probe

### DIFF
--- a/docs/guide/ollama-setup.md
+++ b/docs/guide/ollama-setup.md
@@ -40,6 +40,7 @@ Switching back to Gemini at any time restores all features — settings persist 
 
 ## Tips
 
+- **Vision model detection** — Vision capability is auto-detected from each model's `/api/show` response. Any model that Ollama reports as vision-capable is enabled for image attachments automatically; you do not need to add new keywords or update settings when pulling a new multimodal model.
 - **Tool calling** — Most modern instruct models support function calling; older or very small models may not. If the agent loop stalls, try a different model (Llama 3.2, Qwen 2.5, Mistral 0.3 are good starting points).
 - **Context window** — Local models often have smaller context than Gemini. Compaction triggers at the percentage set by `Context Compaction Threshold` (default `20`%) of an estimated 32k-token window; long sessions will summarize older turns earlier than they do on Gemini.
 - **Token counts** — Ollama does not expose a `countTokens` endpoint, so the plugin estimates tokens from character length (chars ÷ 4). The token-usage indicator is approximate.

--- a/docs/guide/ollama-setup.md
+++ b/docs/guide/ollama-setup.md
@@ -19,7 +19,7 @@ If the daemon runs on a different host or port, edit the **Ollama base URL** fie
 ## What works
 
 - Agent chat with streaming, tool calling, and conversation memory
-- Drag-and-drop / paste of **image** attachments to vision models (e.g. `llava`, `moondream`, `qwen2.5-vl`)
+- Drag-and-drop / paste of **image** attachments to vision models (e.g. `llava`, `moondream`, `qwen2.5-vl`); vision support is auto-detected from the model's reported capabilities via `/api/show`
 - File summarization, IDE-style completions, selection rewriting
 - Custom prompts, projects, agent skills, scheduled tasks, MCP servers
 

--- a/src/services/ollama-models-service.ts
+++ b/src/services/ollama-models-service.ts
@@ -178,9 +178,9 @@ export class OllamaModelsService {
 	 */
 	private detectVision(name: string, show: OllamaShowResponse | null): boolean {
 		if (show !== null) {
+			// A present-but-empty capabilities array is authoritative: the daemon
+			// explicitly reports no capabilities, so we do not fall through to name hints.
 			if (Array.isArray(show.capabilities)) {
-				// A present-but-empty array is authoritative — the daemon knows this model
-				// and it has no vision capability; do not fall through to name hints.
 				return show.capabilities.includes('vision');
 			}
 			if (typeof show.template === 'string') {

--- a/src/services/ollama-models-service.ts
+++ b/src/services/ollama-models-service.ts
@@ -148,7 +148,7 @@ export class OllamaModelsService {
 		}
 		try {
 			const url = `${baseUrl.replace(/\/$/, '')}/api/show`;
-			const response = await requestUrl({ url, method: 'POST', body: JSON.stringify({ name }), throw: false });
+			const response = await requestUrl({ url, method: 'POST', body: JSON.stringify({ model: name }), throw: false });
 			if (response.status !== 200) {
 				return null;
 			}

--- a/src/services/ollama-models-service.ts
+++ b/src/services/ollama-models-service.ts
@@ -19,8 +19,10 @@ const COMPLETION_NAME_HINT_PATTERNS = [
 ];
 
 /**
- * Models known to support vision (image input). Used as a hint only — Ollama
- * does not expose this in /api/tags, so we pattern-match on the family.
+ * Last-resort vision hint list used only when the /api/show probe is unavailable
+ * (network failure, older Ollama that lacks the endpoint, etc.). Primary detection
+ * now uses the structured `capabilities` array returned by /api/show, with a
+ * template-regex fallback for Ollama versions that predate the capabilities field.
  */
 const VISION_NAME_HINTS = ['llava', 'bakllava', 'vision', 'moondream', 'qwen2-vl', 'qwen2.5-vl', 'minicpm-v'];
 
@@ -42,6 +44,14 @@ interface OllamaTagsResponse {
 	models: OllamaTagsModel[];
 }
 
+/** Subset of the /api/show response used for capability detection. */
+interface OllamaShowResponse {
+	/** Structured capability strings present in Ollama ≥ 0.x (e.g. "vision", "tools"). */
+	capabilities?: string[];
+	/** Modelfile template text, present in all Ollama versions. */
+	template?: string;
+}
+
 /**
  * Fetches the list of locally available models from an Ollama server's
  * `/api/tags` endpoint and returns them as `GeminiModel` entries that can
@@ -54,6 +64,12 @@ export class OllamaModelsService {
 	private plugin: ObsidianGemini;
 	private cachedModels: GeminiModel[] | null = null;
 	private lastBaseUrl: string | null = null;
+	/**
+	 * Caches /api/show responses by model name so each model is probed at most
+	 * once per listing cycle. A sibling probe (e.g. for tool-use detection,
+	 * issue #709) can reuse these cached responses without extra network calls.
+	 */
+	private showCache = new Map<string, OllamaShowResponse>();
 
 	constructor(plugin: ObsidianGemini) {
 		this.plugin = plugin;
@@ -70,6 +86,11 @@ export class OllamaModelsService {
 		const cacheMatchesBaseUrl = this.lastBaseUrl === baseUrl;
 		if (!forceRefresh && this.cachedModels && cacheMatchesBaseUrl) {
 			return this.cachedModels;
+		}
+
+		// Clear capability probes so they run against the current daemon state.
+		if (forceRefresh || !cacheMatchesBaseUrl) {
+			this.showCache.clear();
 		}
 
 		try {
@@ -91,7 +112,7 @@ export class OllamaModelsService {
 				throw new Error('Invalid /api/tags response shape');
 			}
 
-			this.cachedModels = data.models.map((m) => this.toGeminiModel(m));
+			this.cachedModels = await Promise.all(data.models.map((m) => this.toGeminiModel(m, baseUrl)));
 			this.lastBaseUrl = baseUrl;
 			this.plugin.logger.log(`[OllamaModelsService] Loaded ${this.cachedModels.length} models from ${baseUrl}`);
 			return this.cachedModels;
@@ -114,13 +135,59 @@ export class OllamaModelsService {
 	invalidate(): void {
 		this.cachedModels = null;
 		this.lastBaseUrl = null;
+		this.showCache.clear();
 	}
 
-	private toGeminiModel(m: OllamaTagsModel): GeminiModel {
+	/**
+	 * Fetches /api/show for a model and caches the result. Returns null on any
+	 * failure so callers can fall back to name-hint detection gracefully.
+	 */
+	private async probeModel(name: string, baseUrl: string): Promise<OllamaShowResponse | null> {
+		if (this.showCache.has(name)) {
+			return this.showCache.get(name)!;
+		}
+		try {
+			const url = `${baseUrl.replace(/\/$/, '')}/api/show`;
+			const response = await requestUrl({ url, method: 'POST', body: JSON.stringify({ name }), throw: false });
+			if (response.status !== 200) {
+				return null;
+			}
+			const result = response.json as OllamaShowResponse;
+			this.showCache.set(name, result);
+			return result;
+		} catch {
+			return null;
+		}
+	}
+
+	/**
+	 * Three-tier vision detection (most- to least-authoritative):
+	 *   1. `capabilities` array from /api/show — structured, authoritative on
+	 *      current Ollama (e.g. `["completion", "vision"]`).
+	 *   2. Template regex — covers older Ollama versions that predate the
+	 *      capabilities field but document image support in the modelfile template.
+	 *   3. VISION_NAME_HINTS name-match — last resort when /api/show is
+	 *      unavailable (daemon unreachable, network error, etc.).
+	 */
+	private detectVision(name: string, show: OllamaShowResponse | null): boolean {
+		if (show !== null) {
+			if (Array.isArray(show.capabilities)) {
+				return show.capabilities.includes('vision');
+			}
+			if (typeof show.template === 'string') {
+				return /image|vision|multimodal/i.test(show.template);
+			}
+		}
+		const lower = name.toLowerCase();
+		return VISION_NAME_HINTS.some((h) => lower.includes(h));
+	}
+
+	private async toGeminiModel(m: OllamaTagsModel, baseUrl: string): Promise<GeminiModel> {
 		const name = m.name;
 		const lower = name.toLowerCase();
 		const isCompletion = COMPLETION_NAME_HINT_PATTERNS.some((re) => re.test(lower));
-		const isVision = VISION_NAME_HINTS.some((h) => lower.includes(h));
+		const show = await this.probeModel(name, baseUrl);
+		const isVision = this.detectVision(name, show);
 
 		const defaultForRoles = isCompletion ? (['completions'] as const) : undefined;
 

--- a/src/services/ollama-models-service.ts
+++ b/src/services/ollama-models-service.ts
@@ -148,14 +148,21 @@ export class OllamaModelsService {
 		}
 		try {
 			const url = `${baseUrl.replace(/\/$/, '')}/api/show`;
-			const response = await requestUrl({ url, method: 'POST', body: JSON.stringify({ model: name }), throw: false });
+			const response = await requestUrl({
+				url,
+				method: 'POST',
+				contentType: 'application/json',
+				body: JSON.stringify({ model: name }),
+				throw: false,
+			});
 			if (response.status !== 200) {
 				return null;
 			}
 			const result = response.json as OllamaShowResponse;
 			this.showCache.set(name, result);
 			return result;
-		} catch {
+		} catch (err) {
+			this.plugin.logger.debug(`[OllamaModelsService] /api/show probe failed for ${name}:`, err);
 			return null;
 		}
 	}
@@ -172,6 +179,8 @@ export class OllamaModelsService {
 	private detectVision(name: string, show: OllamaShowResponse | null): boolean {
 		if (show !== null) {
 			if (Array.isArray(show.capabilities)) {
+				// A present-but-empty array is authoritative — the daemon knows this model
+				// and it has no vision capability; do not fall through to name hints.
 				return show.capabilities.includes('vision');
 			}
 			if (typeof show.template === 'string') {

--- a/test/services/ollama-models-service.test.ts
+++ b/test/services/ollama-models-service.test.ts
@@ -187,6 +187,33 @@ describe('OllamaModelsService', () => {
 			expect(showCallCount).toBe(1);
 		});
 
+		it('falls back to VISION_NAME_HINTS when /api/show returns 200 but neither capabilities nor template', async () => {
+			mockEndpoints([{ name: 'llava:13b' }, { name: 'llama3.2:latest' }], () => ({}));
+			const svc = new OllamaModelsService(buildPlugin());
+			const models = await svc.getModels();
+			expect(models[0].supportsVision).toBe(true); // llava → name hint wins
+			expect(models[1].supportsVision).toBe(false); // llama3.2 → not in hints
+		});
+
+		it('capabilities array wins over a conflicting template keyword', async () => {
+			mockEndpoints([{ name: 'mymodel:latest' }], () => ({
+				capabilities: ['completion'],
+				template: 'This model accepts image input for visual understanding',
+			}));
+			const svc = new OllamaModelsService(buildPlugin());
+			const models = await svc.getModels();
+			// capabilities (no vision entry) wins; template keyword is not consulted
+			expect(models[0].supportsVision).toBe(false);
+		});
+
+		it('empty capabilities array is authoritative — does not fall through to name hints', async () => {
+			mockEndpoints([{ name: 'llava:13b' }], () => ({ capabilities: [] }));
+			const svc = new OllamaModelsService(buildPlugin());
+			const models = await svc.getModels();
+			// empty array short-circuits the name-hint tier
+			expect(models[0].supportsVision).toBe(false);
+		});
+
 		it('clears the /api/show cache on invalidate so probes re-run after refresh', async () => {
 			let showCallCount = 0;
 			mockedRequestUrl.mockImplementation((opts: { url: string; body?: string }) => {

--- a/test/services/ollama-models-service.test.ts
+++ b/test/services/ollama-models-service.test.ts
@@ -10,22 +10,32 @@ const buildPlugin = () =>
 		settings: { ollamaBaseUrl: 'http://localhost:11434' },
 	}) as any;
 
+/** Mock requestUrl so /api/tags and /api/show can return different payloads. */
+function mockEndpoints(tagsModels: any[], showResponse: (name: string) => any) {
+	mockedRequestUrl.mockImplementation((opts: { url: string; body?: string }) => {
+		if (opts.url.endsWith('/api/show')) {
+			const body = JSON.parse(opts.body ?? '{}');
+			return Promise.resolve({ status: 200, json: showResponse(body.name) });
+		}
+		return Promise.resolve({ status: 200, json: { models: tagsModels } });
+	});
+}
+
 describe('OllamaModelsService', () => {
 	beforeEach(() => {
 		mockedRequestUrl.mockReset();
 	});
 
 	it('parses /api/tags response into GeminiModel entries', async () => {
-		mockedRequestUrl.mockResolvedValue({
-			status: 200,
-			json: {
-				models: [
-					{ name: 'llama3.2:3b', details: { parameter_size: '3.2B' } },
-					{ name: 'qwen2.5:7b', details: { parameter_size: '7B' } },
-					{ name: 'llava:13b', details: { parameter_size: '13B' } },
-				],
-			},
-		});
+		mockEndpoints(
+			[
+				{ name: 'llama3.2:3b', details: { parameter_size: '3.2B' } },
+				{ name: 'qwen2.5:7b', details: { parameter_size: '7B' } },
+				{ name: 'llava:13b', details: { parameter_size: '13B' } },
+			],
+			// llava reports vision via capabilities; others do not
+			(name) => (name === 'llava:13b' ? { capabilities: ['completion', 'vision'] } : { capabilities: ['completion'] })
+		);
 
 		const svc = new OllamaModelsService(buildPlugin());
 		const models = await svc.getModels();
@@ -52,19 +62,18 @@ describe('OllamaModelsService', () => {
 	});
 
 	it('caches results and only re-fetches after invalidate()', async () => {
-		mockedRequestUrl.mockResolvedValue({
-			status: 200,
-			json: { models: [{ name: 'llama3.2' }] },
-		});
+		mockEndpoints([{ name: 'llama3.2' }], () => ({ capabilities: ['completion'] }));
 
 		const svc = new OllamaModelsService(buildPlugin());
 		await svc.getModels();
 		await svc.getModels();
-		expect(mockedRequestUrl).toHaveBeenCalledTimes(1);
+		// 1 /api/tags + 1 /api/show for llama3.2 = 2 calls; second getModels() hits cache
+		expect(mockedRequestUrl).toHaveBeenCalledTimes(2);
 
 		svc.invalidate();
 		await svc.getModels();
-		expect(mockedRequestUrl).toHaveBeenCalledTimes(2);
+		// another 1 /api/tags + 1 /api/show = 4 total
+		expect(mockedRequestUrl).toHaveBeenCalledTimes(4);
 	});
 
 	it('invalidates the cache when the base URL changes', async () => {
@@ -84,10 +93,7 @@ describe('OllamaModelsService', () => {
 		const plugin = buildPlugin();
 
 		// First daemon: warm the cache with two models
-		mockedRequestUrl.mockResolvedValueOnce({
-			status: 200,
-			json: { models: [{ name: 'old-only-model' }, { name: 'shared-model' }] },
-		});
+		mockEndpoints([{ name: 'old-only-model' }, { name: 'shared-model' }], () => ({ capabilities: [] }));
 		const svc = new OllamaModelsService(plugin);
 		const initial = await svc.getModels();
 		expect(initial).toHaveLength(2);
@@ -99,5 +105,103 @@ describe('OllamaModelsService', () => {
 
 		// Must not surface the previous daemon's models as choices for the new one
 		expect(afterFailure).toEqual([]);
+	});
+
+	describe('vision capability detection', () => {
+		it('uses capabilities array as primary signal — vision present', async () => {
+			mockEndpoints([{ name: 'mymodel:latest' }], () => ({ capabilities: ['completion', 'vision'] }));
+			const svc = new OllamaModelsService(buildPlugin());
+			const models = await svc.getModels();
+			expect(models[0].supportsVision).toBe(true);
+		});
+
+		it('uses capabilities array as primary signal — no vision entry', async () => {
+			mockEndpoints([{ name: 'mymodel:latest' }], () => ({ capabilities: ['completion', 'tools'] }));
+			const svc = new OllamaModelsService(buildPlugin());
+			const models = await svc.getModels();
+			expect(models[0].supportsVision).toBe(false);
+		});
+
+		it('falls back to template regex when capabilities field is absent — keyword present', async () => {
+			mockEndpoints([{ name: 'mymodel:latest' }], () => ({
+				template: 'This model accepts image input for visual understanding',
+			}));
+			const svc = new OllamaModelsService(buildPlugin());
+			const models = await svc.getModels();
+			expect(models[0].supportsVision).toBe(true);
+		});
+
+		it('falls back to template regex when capabilities field is absent — no keyword', async () => {
+			mockEndpoints([{ name: 'mymodel:latest' }], () => ({
+				template: 'A language model for text generation only',
+			}));
+			const svc = new OllamaModelsService(buildPlugin());
+			const models = await svc.getModels();
+			expect(models[0].supportsVision).toBe(false);
+		});
+
+		it('falls back to VISION_NAME_HINTS when /api/show probe fails', async () => {
+			mockedRequestUrl.mockImplementation((opts: { url: string }) => {
+				if (opts.url.endsWith('/api/show')) {
+					return Promise.reject(new Error('ECONNREFUSED'));
+				}
+				return Promise.resolve({
+					status: 200,
+					json: { models: [{ name: 'llava:13b' }, { name: 'llama3.2:latest' }] },
+				});
+			});
+			const svc = new OllamaModelsService(buildPlugin());
+			const models = await svc.getModels();
+			expect(models[0].supportsVision).toBe(true); // llava → VISION_NAME_HINTS
+			expect(models[1].supportsVision).toBe(false); // llama3.2 → not in hints
+		});
+
+		it('falls back to VISION_NAME_HINTS when /api/show returns non-200', async () => {
+			mockedRequestUrl.mockImplementation((opts: { url: string }) => {
+				if (opts.url.endsWith('/api/show')) {
+					return Promise.resolve({ status: 404, json: {} });
+				}
+				return Promise.resolve({
+					status: 200,
+					json: { models: [{ name: 'moondream:latest' }, { name: 'llama3.2:latest' }] },
+				});
+			});
+			const svc = new OllamaModelsService(buildPlugin());
+			const models = await svc.getModels();
+			expect(models[0].supportsVision).toBe(true); // moondream → VISION_NAME_HINTS
+			expect(models[1].supportsVision).toBe(false);
+		});
+
+		it('caches /api/show responses — each model probed only once per listing cycle', async () => {
+			let showCallCount = 0;
+			mockedRequestUrl.mockImplementation((opts: { url: string; body?: string }) => {
+				if (opts.url.endsWith('/api/show')) {
+					showCallCount++;
+					return Promise.resolve({ status: 200, json: { capabilities: ['completion'] } });
+				}
+				return Promise.resolve({ status: 200, json: { models: [{ name: 'mymodel:latest' }] } });
+			});
+			const svc = new OllamaModelsService(buildPlugin());
+			await svc.getModels();
+			await svc.getModels(); // cache hit — model list and show cache both warm
+			expect(showCallCount).toBe(1);
+		});
+
+		it('clears the /api/show cache on invalidate so probes re-run after refresh', async () => {
+			let showCallCount = 0;
+			mockedRequestUrl.mockImplementation((opts: { url: string; body?: string }) => {
+				if (opts.url.endsWith('/api/show')) {
+					showCallCount++;
+					return Promise.resolve({ status: 200, json: { capabilities: ['completion'] } });
+				}
+				return Promise.resolve({ status: 200, json: { models: [{ name: 'mymodel:latest' }] } });
+			});
+			const svc = new OllamaModelsService(buildPlugin());
+			await svc.getModels();
+			expect(showCallCount).toBe(1);
+			svc.invalidate();
+			await svc.getModels();
+			expect(showCallCount).toBe(2); // fresh probe after invalidate
+		});
 	});
 });

--- a/test/services/ollama-models-service.test.ts
+++ b/test/services/ollama-models-service.test.ts
@@ -15,7 +15,7 @@ function mockEndpoints(tagsModels: any[], showResponse: (name: string) => any) {
 	mockedRequestUrl.mockImplementation((opts: { url: string; body?: string }) => {
 		if (opts.url.endsWith('/api/show')) {
 			const body = JSON.parse(opts.body ?? '{}');
-			return Promise.resolve({ status: 200, json: showResponse(body.name) });
+			return Promise.resolve({ status: 200, json: showResponse(body.model) });
 		}
 		return Promise.resolve({ status: 200, json: { models: tagsModels } });
 	});


### PR DESCRIPTION
<!-- auto-dev -->

## Summary

Fixes #708

Replaces the brittle `VISION_NAME_HINTS` name-pattern list with a structured `/api/show` probe so new vision models are detected automatically without requiring code changes. The probe uses three tiers in order of authority:

1. **`capabilities` array** (current Ollama, e.g. `["vision", "completion"]`) — authoritative when present
2. **Template regex** `/image|vision|multimodal/i` — covers older Ollama versions that predate the capabilities field
3. **`VISION_NAME_HINTS` name-match** — last resort when the daemon is unreachable or the probe fails

The cached `/api/show` response is stored by model name so a future `probeToolSupport()` (issue #709) can reuse the same response without an extra network call.

> This PR was produced by the auto-dev pipeline from the approved plan on #708 (with maintainer amendments from the approval comment).

## Changes

- `src/services/ollama-models-service.ts` — adds `OllamaShowResponse` interface; adds `showCache: Map<string, OllamaShowResponse>` property; adds private `probeModel(name, baseUrl)` method that calls `/api/show`, caches the result, and returns `null` on failure; adds private `detectVision(name, show)` implementing the three-tier logic; makes `toGeminiModel` async (now accepts `baseUrl`); updates `getModels()` to `await Promise.all(...)` the async model builds and clear `showCache` on force-refresh or URL change; updates `invalidate()` to also clear `showCache`. Updates the `VISION_NAME_HINTS` comment to clarify it is now a fallback, not the primary detection path.
- `test/services/ollama-models-service.test.ts` — adds `mockEndpoints()` helper for endpoint-aware URL mocking; updates existing tests that checked call counts (now 2 calls per listing cycle: `/api/tags` + `/api/show` per model); adds a `describe('vision capability detection')` block with 8 new tests covering all three tiers (capabilities hit, template-regex positive and negative, name-hint fallback on probe failure and non-200, show-cache hit, show-cache cleared on invalidate)

## Screenshots / Screencast

No UI changes — internal capability-detection logic only.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer (#708)
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [ ] I have tested this change on Desktop — N/A: internal service logic; no UI surface changed
- [ ] I have verified this change does not break Mobile — uses `requestUrl` throughout (cross-platform)
- [x] Documentation has been updated (if applicable) — inline comments updated; no user-facing docs affected
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude (auto-dev pipeline)
- [x] I have reviewed and understand all AI-generated code in this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01116yYVTCrXpMQkL97UhWQL)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved vision model capability detection by probing Ollama models for image support, using reliable fallbacks when full details can’t be retrieved.
* **Bug Fixes**
  * Prevented stale or incorrect vision capability results by clearing the per-model detection cache when switching Ollama servers or refreshing models.
* **Tests**
  * Expanded automated coverage for vision detection precedence, probe failure fallbacks, and per-cycle probing/caching plus invalidation.
* **Documentation**
  * Updated the Ollama setup guide to state that vision support is auto-detected when pulling models, enabling image drag-and-drop/paste without extra configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->