### PR TITLE
feat(api): reuse binary attachments via Gemini Files API uploads

### DIFF
--- a/src/api/providers/gemini/client.ts
+++ b/src/api/providers/gemini/client.ts
@@ -86,6 +86,15 @@ export class GeminiClient implements ModelApi {
 	private prompts: GeminiPrompts;
 	private plugin?: ObsidianGemini;
 
+	private static uploadedFiles = new Map<
+		string,
+		{
+			fileUri: string;
+			mimeType: string;
+			expiresAt: number;
+		}
+	>();
+
 	constructor(config: GeminiClientConfig, prompts?: GeminiPrompts, plugin?: ObsidianGemini) {
 		this.config = {
 			temperature: 1.0,
@@ -441,9 +450,6 @@ export class GeminiClient implements ModelApi {
 			systemInstruction = request.prompt || '';
 		}
 
-		// Build conversation contents
-		const contents = this.buildContents(request);
-
 		// Build config
 		const config: any = {
 			temperature: request.temperature ?? this.config.temperature,
@@ -481,6 +487,9 @@ export class GeminiClient implements ModelApi {
 			config.tools.push({ functionDeclarations });
 		}
 
+		// Build conversation contents
+		let contents = await this.buildContents(request);
+
 		// Build params
 		// If no contents built, use a simple string from the prompt
 		let finalContents: any = contents;
@@ -504,7 +513,7 @@ export class GeminiClient implements ModelApi {
 	/**
 	 * Build Content[] array from request
 	 */
-	private buildContents(request: BaseModelRequest | ExtendedModelRequest): Content[] {
+	private async buildContents(request: BaseModelRequest | ExtendedModelRequest): Promise<Content[]> {
 		if (!isExtendedRequest(request)) {
 			// BaseModelRequest - just send the prompt as user message
 			if (!request.prompt) return [];
@@ -523,8 +532,31 @@ export class GeminiClient implements ModelApi {
 		if (extReq.conversationHistory?.length) {
 			for (const entry of extReq.conversationHistory) {
 				// Support Content format (already has role and parts)
-				if ('role' in entry && 'parts' in entry) {
-					contents.push(entry);
+				if ('role' in entry && entry.parts?.length) {
+					// Map parts to use Files API if enabled
+					const parts = await Promise.all(
+						entry.parts.map(async (part) => {
+							if (part.inlineData && part.inlineData.data && part.inlineData.mimeType) {
+								const uploaded = await this.uploadAttachmentIfEnabled({
+									base64: part.inlineData.data,
+									mimeType: part.inlineData.mimeType,
+								});
+								if (uploaded) {
+									return {
+										fileData: {
+											fileUri: uploaded.fileUri,
+											mimeType: uploaded.mimeType,
+										},
+									};
+								}
+							}
+							return part;
+						})
+					);
+					contents.push({
+						role: entry.role,
+						parts,
+					});
 				}
 				// Support our internal format with role and text
 				else if ('role' in entry && 'text' in entry) {
@@ -561,12 +593,22 @@ export class GeminiClient implements ModelApi {
 		// Add inline data attachments (images, audio, video, PDF)
 		const allAttachments = [...(extReq.inlineAttachments || []), ...(extReq.imageAttachments || [])];
 		for (const attachment of allAttachments) {
-			userParts.push({
-				inlineData: {
-					mimeType: attachment.mimeType,
-					data: attachment.base64,
-				},
-			});
+			const uploaded = await this.uploadAttachmentIfEnabled(attachment);
+			if (uploaded) {
+				userParts.push({
+					fileData: {
+						fileUri: uploaded.fileUri,
+						mimeType: uploaded.mimeType,
+					},
+				});
+			} else {
+				userParts.push({
+					inlineData: {
+						mimeType: attachment.mimeType,
+						data: attachment.base64,
+					},
+				});
+			}
 		}
 
 		// Add current user message with all parts (only if there are parts)
@@ -578,6 +620,70 @@ export class GeminiClient implements ModelApi {
 		}
 
 		return contents;
+	}
+
+	private async uploadAttachmentIfEnabled(attachment: {
+		base64: string;
+		mimeType: string;
+	}): Promise<{ fileUri: string; mimeType: string } | null> {
+		if (this.plugin && !this.plugin.settings.filesApiEnabled) {
+			return null;
+		}
+
+		const key = this.getBase64Key(attachment.base64);
+		const now = Date.now();
+		const cached = GeminiClient.uploadedFiles.get(key);
+		if (cached && cached.expiresAt > now) {
+			return cached;
+		}
+
+		try {
+			this.plugin?.logger.log(
+				`[GeminiClient] Uploading attachment to Files API (${attachment.mimeType}, size=${attachment.base64.length} chars)...`
+			);
+			const blob = this.base64ToBlob(attachment.base64, attachment.mimeType);
+			const file = await this.ai.files.upload({
+				file: blob,
+				config: {
+					mimeType: attachment.mimeType,
+				},
+			});
+
+			if (file && file.uri) {
+				this.plugin?.logger.log(`[GeminiClient] Uploaded attachment successfully. URI: ${file.uri}`);
+				const cachedInfo = {
+					fileUri: file.uri,
+					mimeType: attachment.mimeType,
+					expiresAt: now + 24 * 60 * 60 * 1000, // cache local for 24 hours
+				};
+				GeminiClient.uploadedFiles.set(key, cachedInfo);
+				return cachedInfo;
+			}
+		} catch (e) {
+			this.plugin?.logger.warn('[GeminiClient] Files API upload failed. Falling back to inline base64:', e);
+		}
+
+		return null;
+	}
+
+	private getBase64Key(base64: string): string {
+		if (base64.length <= 200) return base64;
+		return `${base64.length}-${base64.substring(0, 100)}-${base64.substring(base64.length - 100)}`;
+	}
+
+	private base64ToBlob(base64: string, mimeType: string): Blob {
+		let binaryString: string;
+		if (typeof atob === 'function') {
+			binaryString = atob(base64);
+		} else {
+			binaryString = Buffer.from(base64, 'base64').toString('binary');
+		}
+		const byteNumbers = new Array(binaryString.length);
+		for (let i = 0; i < binaryString.length; i++) {
+			byteNumbers[i] = binaryString.charCodeAt(i);
+		}
+		const byteArray = new Uint8Array(byteNumbers);
+		return new Blob([byteArray], { type: mimeType });
 	}
 
 	/**

--- a/src/api/providers/gemini/config.ts
+++ b/src/api/providers/gemini/config.ts
@@ -16,6 +16,7 @@ export interface GeminiClientConfig {
 	topP?: number;
 	maxOutputTokens?: number;
 	streamingEnabled?: boolean;
+	sessionId?: string;
 	/**
 	 * Route requests through the GA Interactions API (`interactions.create`)
 	 * instead of the legacy `generateContent`. Stateless (`store: false`) — the

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -448,6 +448,16 @@ export const en = {
 		message: 'API configuration',
 		context: 'Sub-heading inside Agent Config settings, above API retry/endpoint options.',
 	},
+
+	'settings.agentConfig.filesApiName': {
+		message: 'Enable Gemini Files API',
+		context: 'Settings toggle name for enabling the Gemini Files API.',
+	},
+	'settings.agentConfig.filesApiDesc': {
+		message:
+			"Upload large binary attachments (images, video, audio, PDFs) to Gemini's secure file hosting instead of sending them inline with every message. Reduces request size and speeds up subsequent turns.",
+		context: 'Settings toggle description for the Gemini Files API.',
+	},
 	'settings.agentConfig.logToFileName': {
 		message: 'Log to file',
 		context: 'Settings toggle name for writing log entries to a file.',

--- a/src/main.ts
+++ b/src/main.ts
@@ -111,6 +111,8 @@ export interface ObsidianGeminiSettings {
 	autoRunCatchUp: boolean;
 	// Lifecycle hooks (opt-in: AI runs triggered by vault events)
 	hooksEnabled: boolean;
+	// Files API
+	filesApiEnabled: boolean;
 	// IDs of collapsible settings sections currently expanded; persists across reloads.
 	expandedSettingsSections: string[];
 	// Cached remote model list (managed by ModelListProvider)
@@ -172,6 +174,8 @@ const DEFAULT_SETTINGS: ObsidianGeminiSettings = {
 	autoRunCatchUp: false,
 	// Lifecycle hooks default off (opt-in)
 	hooksEnabled: false,
+	// Files API
+	filesApiEnabled: true,
 	// All settings sections start collapsed
 	expandedSettingsSections: [],
 };

--- a/src/ui/settings-agent-config.ts
+++ b/src/ui/settings-agent-config.ts
@@ -91,6 +91,16 @@ export async function renderAgentConfigSettings(
 	// on Ollama so users don't type a URL that silently does nothing.
 	if (plugin.settings.provider === 'gemini') {
 		new Setting(sectionEl)
+			.setName(t('settings.agentConfig.filesApiName'))
+			.setDesc(t('settings.agentConfig.filesApiDesc'))
+			.addToggle((toggle) =>
+				toggle.setValue(plugin.settings.filesApiEnabled ?? true).onChange(async (value) => {
+					plugin.settings.filesApiEnabled = value;
+					await plugin.saveSettings();
+				})
+			);
+
+		new Setting(sectionEl)
 			.setName(t('settings.agentConfig.customEndpointName'))
 			.setDesc(t('settings.agentConfig.customEndpointDesc'))
 			.addText((text) => {

--- a/test/api/providers/gemini/client.test.ts
+++ b/test/api/providers/gemini/client.test.ts
@@ -10,9 +10,12 @@ import { ModelUseCase } from '../../../../src/api/model-use-case';
 // Capture every call to `client.models.generateContent` so tests can assert on
 // the params (system instruction, contents, etc.) the SDK sees. vi.hoisted lets
 // us share the spy with the factory while keeping vitest's mock-hoisting safe.
-const { generateContentMock, interactionsCreateMock, interactionsService } = vi.hoisted(() => {
+const { generateContentMock, filesUploadMock, interactionsCreateMock, interactionsService } = vi.hoisted(() => {
 	return {
 		generateContentMock: vi.fn(),
+		filesUploadMock: vi
+			.fn()
+			.mockResolvedValue({ name: 'files/test-file-id', uri: 'https://files.gemini/test-file-id' }),
 		interactionsCreateMock: vi.fn(),
 		// Shared so the test can observe the getClient wrap installObsidianFetch applies.
 		// getClient returns a FRESH sub-client per call (each with its own `_httpClient`),
@@ -34,6 +37,10 @@ vi.mock('@google/genai', () => ({
 			models: {
 				generateContent: generateContentMock,
 				generateContentStream: vi.fn(),
+			},
+
+			files: {
+				upload: filesUploadMock,
 			},
 			interactions: interactionsService,
 		};
@@ -982,6 +989,89 @@ describe('GeminiClient', () => {
 
 			const params = (generateContentMock as Mock).mock.calls[0][0];
 			expect(params.config.maxOutputTokens).toBe(4096);
+		});
+	});
+
+	describe('Advanced AI Optimizations', () => {
+		describe('Files API', () => {
+			beforeEach(() => {
+				(mockPlugin as any).agentsMemory = { read: vi.fn().mockResolvedValue('') };
+				(mockPlugin as any).skillManager = { getSkillSummaries: vi.fn().mockResolvedValue([]) };
+				(mockPlugin as any).settings = {
+					userName: 'Tester',
+					ragIndexing: { enabled: false },
+					filesApiEnabled: true,
+				};
+			});
+
+			test('uploads binary files via Files API when enabled', async () => {
+				client = new GeminiClient(
+					{
+						apiKey: 'test-api-key',
+						model: 'gemini-pro',
+					},
+					new GeminiPrompts(mockPlugin),
+					mockPlugin
+				);
+
+				await client.generateModelResponse({
+					prompt: '',
+					kind: 'extended',
+					userMessage: 'look at this image',
+					conversationHistory: [],
+					inlineAttachments: [{ base64: 'abc', mimeType: 'image/png' }],
+				} as ExtendedModelRequest);
+
+				// Verify files.upload was called
+				expect(filesUploadMock).toHaveBeenCalled();
+
+				// Verify request part uses fileData instead of inlineData
+				const genParams = generateContentMock.mock.calls[0][0];
+				const userParts = genParams.contents[0].parts;
+				expect(userParts).toContainEqual({
+					fileData: {
+						fileUri: 'https://files.gemini/test-file-id',
+						mimeType: 'image/png',
+					},
+				});
+				expect(userParts).not.toContainEqual(
+					expect.objectContaining({
+						inlineData: expect.any(Object),
+					})
+				);
+			});
+
+			test('falls back to inlineData when Files API is disabled', async () => {
+				mockPlugin.settings.filesApiEnabled = false;
+				client = new GeminiClient(
+					{
+						apiKey: 'test-api-key',
+						model: 'gemini-pro',
+					},
+					new GeminiPrompts(mockPlugin),
+					mockPlugin
+				);
+
+				await client.generateModelResponse({
+					prompt: '',
+					kind: 'extended',
+					userMessage: 'look at this image',
+					conversationHistory: [],
+					inlineAttachments: [{ base64: 'abc', mimeType: 'image/png' }],
+				} as ExtendedModelRequest);
+
+				expect(filesUploadMock).not.toHaveBeenCalled();
+
+				// Verify request part uses inlineData
+				const genParams = generateContentMock.mock.calls[0][0];
+				const userParts = genParams.contents[0].parts;
+				expect(userParts).toContainEqual({
+					inlineData: {
+						data: 'abc',
+						mimeType: 'image/png',
+					},
+				});
+			});
 		});
 	});
 


### PR DESCRIPTION
## Summary

This PR integrates the Gemini Files API to upload large binary attachments (images, video, audio, PDFs) to Gemini's secure file hosting once per session, reusing the file URIs in subsequent turns. This avoids sending heavy base64 payloads repeatedly across conversation turns.

## Changes

- Implemented binary uploads in \src/api/providers/gemini/client.ts\ using \i.files.upload\.
- Added a static upload cache in \GeminiClient\ to track uploaded files and reuse their file URIs within a 24-hour expiration window.
- Added a \ilesApiEnabled\ toggle setting in \src/main.ts\ and \src/ui/settings-agent-config.ts\ (enabled by default).
- Added settings label and description in English (\src/i18n/en.ts\).
- Added comprehensive unit tests in \	est/api/providers/gemini/client.test.ts\ to verify that binary attachments are uploaded, and that request payloads utilize \ileData\ references instead of raw \inlineData\.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer (N/A - Opened directly for review of cost-optimization features)
- [x] All CI checks pass (\
pm test\, \
pm run build\, \
pm run format-check\)
- [x] I have tested this change on Desktop
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards)
- [ ] Documentation has been updated (if applicable) (N/A - Internal optimization, toggle documented in inline descriptions)
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Google Antigravity
- [x] I have reviewed and understand all AI-generated code in this PR