### PR TITLE
refactor: extract openPluginSettingsTab helper for @ts-expect-error sites

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -43,6 +43,7 @@ import { BackgroundStatusBar } from './services/background-status-bar';
 import { ScheduledTaskManager } from './services/scheduled-task-manager';
 import { HookManager } from './services/hook-manager';
 import { getErrorMessage, getRawErrorMessage } from './utils/error-utils';
+import { openPluginSettingsTab } from './utils/obsidian-settings';
 import { t } from './i18n';
 
 export interface RagIndexingSettings {
@@ -773,10 +774,7 @@ export default class ObsidianGemini extends Plugin {
 					this.ragIndexing.getDetailedStatus(),
 					() => {
 						// Open settings to RAG section
-						// @ts-expect-error - Obsidian's setting API
-						this.app.setting.open();
-						// @ts-expect-error - Obsidian's setting API
-						this.app.setting.openTabById('gemini-scribe');
+						openPluginSettingsTab(this.app, this.manifest.id);
 					},
 					async () => {
 						// Reindex

--- a/src/services/rag-status-bar.ts
+++ b/src/services/rag-status-bar.ts
@@ -2,6 +2,7 @@ import { Notice, setIcon, setTooltip } from 'obsidian';
 import type ObsidianGemini from '../main';
 import type { RagIndexStatus, RagProgressInfo, IndexResult, ProgressListener } from './rag-types';
 import { getErrorMessage } from '../utils/error-utils';
+import { openPluginSettingsTab } from '../utils/obsidian-settings';
 import { t } from '../i18n';
 
 /**
@@ -67,10 +68,7 @@ export class RagStatusBar {
 						this.provider.getDetailedStatus(),
 						() => {
 							// Open settings to RAG section
-							// @ts-expect-error - Obsidian's setting API
-							this.plugin.app.setting.open();
-							// @ts-expect-error - Obsidian's setting API
-							this.plugin.app.setting.openTabById('gemini-scribe');
+							openPluginSettingsTab(this.plugin.app, this.plugin.manifest.id);
 						},
 						async () => {
 							// Open progress modal and start reindexing

--- a/src/ui/background-tasks-modal.ts
+++ b/src/ui/background-tasks-modal.ts
@@ -6,6 +6,7 @@ import type { ProgressListener } from '../services/rag-types';
 import type { RagIndexingService } from '../services/rag-indexing';
 import { getErrorMessage } from '../utils/error-utils';
 import { formatRelativeTime } from '../utils/format-relative-time';
+import { openPluginSettingsTab } from '../utils/obsidian-settings';
 import { t } from '../i18n';
 
 type ModalTab = 'tasks' | 'rag';
@@ -488,10 +489,7 @@ export class BackgroundTasksModal extends Modal {
 					.setCta()
 					.onClick(() => {
 						this.close();
-						// @ts-expect-error — Obsidian internal API
-						this.plugin.app.setting.open();
-						// @ts-expect-error — Obsidian internal API
-						this.plugin.app.setting.openTabById('gemini-scribe');
+						openPluginSettingsTab(this.plugin.app, this.plugin.manifest.id);
 					})
 			);
 	}

--- a/src/utils/obsidian-settings.ts
+++ b/src/utils/obsidian-settings.ts
@@ -1,0 +1,15 @@
+import type { App } from 'obsidian';
+
+/**
+ * Open Obsidian's Settings modal and switch to the plugin's tab.
+ *
+ * Obsidian's typings don't expose `App.setting`, so each call site has to
+ * suppress the type-check twice. Centralising that here keeps the workaround
+ * (and the plugin ID literal) in one place.
+ */
+export function openPluginSettingsTab(app: App, pluginId: string): void {
+	// @ts-expect-error - Obsidian's setting API is internal and not in typings
+	app.setting.open();
+	// @ts-expect-error - Obsidian's setting API is internal and not in typings
+	app.setting.openTabById(pluginId);
+}

--- a/test/utils/obsidian-settings.test.ts
+++ b/test/utils/obsidian-settings.test.ts
@@ -1,0 +1,37 @@
+import { describe, test, expect, vi } from 'vitest';
+import type { App } from 'obsidian';
+import { openPluginSettingsTab } from '../../src/utils/obsidian-settings';
+
+describe('openPluginSettingsTab', () => {
+	test('opens the settings modal and switches to the plugin tab', () => {
+		const open = vi.fn();
+		const openTabById = vi.fn();
+		const app = { setting: { open, openTabById } } as unknown as App;
+
+		openPluginSettingsTab(app, 'gemini-scribe');
+
+		expect(open).toHaveBeenCalledTimes(1);
+		expect(openTabById).toHaveBeenCalledWith('gemini-scribe');
+	});
+
+	test('opens the requested tab id, not a hardcoded one', () => {
+		const open = vi.fn();
+		const openTabById = vi.fn();
+		const app = { setting: { open, openTabById } } as unknown as App;
+
+		openPluginSettingsTab(app, 'some-other-plugin');
+
+		expect(openTabById).toHaveBeenCalledWith('some-other-plugin');
+	});
+
+	test('calls open() before openTabById() so the modal exists when the tab is selected', () => {
+		const calls: string[] = [];
+		const open = vi.fn(() => calls.push('open'));
+		const openTabById = vi.fn(() => calls.push('openTabById'));
+		const app = { setting: { open, openTabById } } as unknown as App;
+
+		openPluginSettingsTab(app, 'gemini-scribe');
+
+		expect(calls).toEqual(['open', 'openTabById']);
+	});
+});


### PR DESCRIPTION
## Summary

Architecture-audit nightly sweep flagged a small DRY violation: three call sites duplicate the same two-line incantation to open Obsidian's Settings modal on this plugin's tab — `app.setting.open()` + `app.setting.openTabById('gemini-scribe')`, each preceded by `@ts-expect-error` because `App.setting` isn't in Obsidian's typings. Move the workaround into one helper (`src/utils/obsidian-settings.ts`) and have callers pass `this.manifest.id` instead of repeating the hardcoded plugin-id literal. Net effect: fewer suppressions (3 sites collapse to 1), the plugin id stops being string-duplicated across three files, and any future tweak to the workaround happens in one place.

## Changes

- Add `src/utils/obsidian-settings.ts` exporting `openPluginSettingsTab(app, pluginId)`; the two `@ts-expect-error` comments live here only.
- Replace the inline incantation in `src/main.ts` (RAG-status command callback), `src/services/rag-status-bar.ts` (status-bar click handler), and `src/ui/background-tasks-modal.ts` (settings button) with calls to the helper, passing `this.manifest.id` instead of the `'gemini-scribe'` literal.
- Add `test/utils/obsidian-settings.test.ts` covering call ordering, tab-id forwarding, and that it doesn't hardcode an id.

## Screenshots / Screencast

N/A — internal refactor, no user-visible behavior change.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: filed by the `architecture-audit` skill, which routes mechanical cleanups directly to PRs.
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [ ] I have tested this change on Desktop — N/A: pure code-motion refactor, no UI surface changed; the three call sites are exercised by existing user flows (the RAG-status command, the status-bar click, the background-tasks modal's "Open Settings" button) and the helper has unit tests.
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — same Obsidian `App.setting` surface used previously.
- [x] Documentation has been updated (if applicable) — N/A: internal refactor.
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude (architecture-audit skill)
- [x] I have reviewed and understand all AI-generated code in this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_015siDQ3prvEAYgfGEwY1FZ7)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The RAG status, background tasks, and related settings actions now open the correct plugin settings screen reliably.
  * Replaced inconsistent settings navigation with a single, more dependable flow from the app’s UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->