### PR TITLE
docs: add provider capability matrix reference page

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Gemini Scribe is an Obsidian plugin that integrates Google's Gemini AI models, p
 > **Note:** Pick one of two setup paths in plugin settings → **Provider**:
 >
 > - **Google Gemini (cloud)** — requires a Gemini API key (free tier available at [Google AI Studio](https://aistudio.google.com/apikey)).
-> - **Ollama (local)** — runs locally with no API key; install [Ollama](https://ollama.com), pull a model, and select it in settings. See [docs/guide/ollama-setup.md](docs/guide/ollama-setup.md) for the feature-parity table.
+> - **Ollama (local)** — runs locally with no API key; install [Ollama](https://ollama.com), pull a model, and select it in settings. See [docs/guide/ollama-setup.md](docs/guide/ollama-setup.md) and the [provider capability matrix](docs/reference/provider-capabilities.md) for what's supported.
 
 ## What's New in v4.10.2
 
@@ -228,6 +228,7 @@ For detailed guides on all features, visit the [Documentation Site](https://alle
 
 - [Settings Reference](docs/reference/settings.md) - Complete settings documentation
 - [Advanced Settings Guide](docs/reference/advanced-settings.md)
+- [Provider Capabilities](docs/reference/provider-capabilities.md) - Gemini vs. Ollama feature matrix
 - [Tool Development Guide](docs/contributing/tool-development.md) - Create custom agent tools
 
 ### Chat Interface

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -61,6 +61,7 @@ export default defineConfig({
 					items: [
 						{ text: 'Settings', link: '/reference/settings' },
 						{ text: 'Advanced Settings', link: '/reference/advanced-settings' },
+						{ text: 'Provider Capabilities', link: '/reference/provider-capabilities' },
 						{ text: 'Loop Detection', link: '/reference/loop-detection' },
 						{ text: 'Eval Suite', link: '/reference/evals' },
 					],

--- a/docs/guide/ollama-setup.md
+++ b/docs/guide/ollama-setup.md
@@ -25,16 +25,7 @@ If the daemon runs on a different host or port, edit the **Ollama base URL** fie
 
 ## What does not work in Phase 1
 
-These features depend on Gemini built-in services and are hidden when Ollama is the active provider:
-
-| Feature                         | Why it's gated                         | Workaround                                  |
-| ------------------------------- | -------------------------------------- | ------------------------------------------- |
-| Google Search tool              | Uses Gemini's `googleSearch` grounding | Switch to Gemini for search-heavy sessions  |
-| URL Context (web fetch)         | Uses Gemini's URL Context API          | Paste content into a note, then `read_file` |
-| Deep Research                   | Built on Gemini multi-step search      | Switch to Gemini                            |
-| Image generation                | Ollama has no image-generation API     | Switch to Gemini for image-gen              |
-| RAG / Vault Search              | Uses Gemini File Search Store          | Future phase: Ollama embeddings             |
-| PDF / audio / video attachments | Ollama only accepts images             | Convert to image or text first              |
+These features depend on Gemini built-in services and are hidden when Ollama is the active provider. See the [Provider Capabilities reference](/reference/provider-capabilities) for the full Gemini-vs-Ollama matrix and the reasons behind each gap.
 
 Switching back to Gemini at any time restores all features — settings persist across switches.
 

--- a/docs/reference/provider-capabilities.md
+++ b/docs/reference/provider-capabilities.md
@@ -1,0 +1,31 @@
+# Provider Capabilities
+
+Gemini Scribe can run on either the **Google Gemini (cloud)** or **Ollama (local)** provider, set globally in Settings → Gemini Scribe → Provider. Some features depend on Gemini-specific cloud APIs and are unavailable when Ollama is active. This page is the single source of truth for what works where; `docs/guide/ollama-setup.md` links here instead of duplicating the table.
+
+> Today the provider choice is a single global setting — there is no per-feature override (e.g. "chat on Ollama, search on Gemini" in the same session). Per-use-case provider selection is tracked in [#704](https://github.com/allenhutchison/obsidian-gemini/issues/704).
+
+## Capability matrix
+
+| Feature                         | Gemini | Ollama                                                                              |
+| ------------------------------- | :----: | ----------------------------------------------------------------------------------- |
+| Chat                            |   ✓    | ✓                                                                                   |
+| Tool calling (agent mode)       |   ✓    | ✓ (model-dependent)                                                                 |
+| Vision (image attachments)      |   ✓    | ✓ (model-dependent, auto-detected)                                                  |
+| Scheduled tasks                 |   ✓    | ✓ (inherits the model's tool/vision limits)                                         |
+| RAG / Vault Semantic Search     |   ✓    | ✗ — tracked in [#705](https://github.com/allenhutchison/obsidian-gemini/issues/705) |
+| Image generation                |   ✓    | ✗ — tracked in [#706](https://github.com/allenhutchison/obsidian-gemini/issues/706) |
+| Google Search grounding         |   ✓    | ✗                                                                                   |
+| URL Context (web fetch tool)    |   ✓    | ✗                                                                                   |
+| Deep Research                   |   ✓    | ✗                                                                                   |
+| PDF / audio / video attachments |   ✓    | ✗ (images only)                                                                     |
+
+## Notes
+
+- **Tool calling** — Whether an Ollama model can call tools depends on the model itself; most modern instruct models (Llama 3.2, Qwen 2.5, Mistral 0.3, …) support it, smaller or older models may not.
+- **Vision** — Ollama vision support is auto-detected per model from its `/api/show` capabilities (with a template/name-hint fallback for older Ollama versions) — no manual configuration is needed when you pull a new multimodal model.
+- **RAG, image generation, Google Search, URL Context, and Deep Research** all call Google's cloud APIs directly and require a Gemini API key regardless of the active provider setting; they are hidden from the UI when Ollama is selected rather than failing at call time.
+- **Scheduled tasks** run through the same chat/tool-calling path as interactive agent sessions, so a task that needs vision or tool calling on Ollama is still bound by that model's capabilities.
+
+Switching the **Provider** setting between Gemini and Ollama at any time restores or hides these features immediately — no data is lost, and settings persist across switches.
+
+See the [Ollama Setup Guide](/guide/ollama-setup) for installation steps and local-model tips.

--- a/src/services/generated-help-references.ts
+++ b/src/services/generated-help-references.ts
@@ -28,6 +28,7 @@ import refSummarization from '../../docs/guide/summarization.md';
 import refAdvancedSettings from '../../docs/reference/advanced-settings.md';
 import refEvals from '../../docs/reference/evals.md';
 import refLoopDetection from '../../docs/reference/loop-detection.md';
+import refProviderCapabilities from '../../docs/reference/provider-capabilities.md';
 import refSettings from '../../docs/reference/settings.md';
 
 export const helpResources = new Map<string, string>([
@@ -52,6 +53,7 @@ export const helpResources = new Map<string, string>([
 	['references/advanced-settings.md', refAdvancedSettings],
 	['references/evals.md', refEvals],
 	['references/loop-detection.md', refLoopDetection],
+	['references/provider-capabilities.md', refProviderCapabilities],
 	['references/settings.md', refSettings],
 ]);
 
@@ -78,4 +80,5 @@ export const helpReferencesTable = `| Reference | Topic |
 | \`references/advanced-settings.md\` | Advanced Settings Guide |
 | \`references/evals.md\` | Eval Suite |
 | \`references/loop-detection.md\` | Tool loop detection |
+| \`references/provider-capabilities.md\` | Provider Capabilities |
 | \`references/settings.md\` | Settings Reference |`;


### PR DESCRIPTION
## Summary

Adds a single source-of-truth capability matrix comparing the Gemini and Ollama providers, replacing the table that was duplicated inline in the Ollama setup guide. The plan was approved on the issue.

Fixes #711

## Changes

- `docs/reference/provider-capabilities.md` (new) — Gemini vs. Ollama matrix for Chat, Tool calling, Vision, Scheduled tasks, RAG, Image generation, Google Search, URL Context, Deep Research, and binary attachments. Verified against the provider factory (`src/api/factory.ts`), the Ollama client (`src/api/providers/ollama/client.ts`), and the Gemini-only services (`src/services/rag-indexing.ts`, `src/services/image-generation.ts`, `src/tools/google-search-tool.ts`, `src/tools/web-fetch-tool.ts`, `src/services/deep-research.ts`).
- `docs/guide/ollama-setup.md` — replaced the inline "What does not work in Phase 1" table with a link to the new reference page.
- `README.md` — linked the new page from the provider setup note and the Configuration & Development docs list.
- `docs/.vitepress/config.mts` — added the new page to the Reference sidebar.
- `src/services/generated-help-references.ts` — regenerated by `npm run generate-refs` to pick up the new doc (auto-generated, not hand-edited).

**Out of scope** (per the approved plan): the "Adding a Provider" contributor guide is deferred until the provider-abstraction epic (#703) lands and the `Provider` interface is stable enough to document; the maintainer noted it's being tracked as a sub-task of #703.

## Screenshots / Screencast

N/A — documentation-only change.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [ ] I have tested this change on Desktop — N/A, documentation-only
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A, documentation-only
- [x] Documentation has been updated (if applicable)
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

---

<!-- auto-dev -->
This PR was produced by the auto-dev pipeline from the plan approved on #711.

---
_Generated by [Claude Code](https://claude.ai/code/session_01R4VuY6vCpdckhyPpwAuiSK)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new **Provider Capabilities** reference page covering feature availability across Gemini cloud and Ollama local setups.
  * Updated the Ollama setup guide to point readers to the full capability matrix.
  * Added the new reference to the docs navigation and help links, making it easier to find.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->