### PR TITLE
refactor: drop unnecessary `as any` on DomElementInfo `title` fields

### DIFF
--- a/src/ui/background-tasks-modal.ts
+++ b/src/ui/background-tasks-modal.ts
@@ -279,7 +279,7 @@ export class BackgroundTasksModal extends Modal {
 
 		if (task.error && task.status === 'failed') {
 			const short = this.truncateError(task.error);
-			info.createSpan({ text: short, cls: 'gemini-bg-task-error', title: task.error } as any);
+			info.createSpan({ text: short, cls: 'gemini-bg-task-error', title: task.error });
 		}
 
 		if (canCancel) {

--- a/src/ui/scheduled-tasks-modal.ts
+++ b/src/ui/scheduled-tasks-modal.ts
@@ -95,7 +95,7 @@ export class ScheduledTasksModal extends Modal {
 					text: this.truncateError(taskState.lastError),
 					cls: 'gemini-scheduled-task-error',
 					title: taskState.lastError, // full message on hover
-				} as any);
+				});
 			}
 		}
 

--- a/src/ui/scheduler-management-modal.ts
+++ b/src/ui/scheduler-management-modal.ts
@@ -122,7 +122,7 @@ export class SchedulerManagementModal extends ManagementModalBase<ScheduledTask,
 				text: this.truncateError(taskState.lastError),
 				cls: 'gemini-scheduler-item-error',
 				title: taskState.lastError,
-			} as any);
+			});
 		}
 
 		// Action buttons


### PR DESCRIPTION
## Summary

Architecture-audit nightly sweep flagged: **improper typing** in three UI modals.

`title` is a documented field on Obsidian's `DomElementInfo` type (see `obsidian.d.ts`), so the surrounding `as any` casts on `createDiv({ ..., title })` / `createSpan({ ..., title })` calls weren't needed. Removing them tightens the typing without changing behavior. The pattern is identical in all three modals — the "error detail" row that shows a truncated error message with the full text on hover.

## Changes

- `src/ui/background-tasks-modal.ts` — drop `as any` on the failed-task error span
- `src/ui/scheduled-tasks-modal.ts` — drop `as any` on the last-error detail div
- `src/ui/scheduler-management-modal.ts` — drop `as any` on the last-error detail div

Verified with `tsc -noEmit -skipLibCheck`, `npm run build`, and `npm test` (3178 tests passing). No behavior change; the rendered DOM is identical.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A, mechanical typing cleanup filed by the nightly `architecture-audit` skill
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop — verified via `tsc -noEmit -skipLibCheck` + full test suite; the DOM output is unchanged
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — no platform-specific code touched
- [x] Documentation has been updated (if applicable) — N/A, purely internal typing cleanup
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (architecture-audit skill)
- [x] I have reviewed and understand all AI-generated code in this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01RvhFF63PKtsTaMxxJgTM4U)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability of several task-related dialogs by tightening internal type handling.
  * No visible changes to layout, behavior, or task information display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->