### PR TITLE
refactor(providers): generalize init-error surfacing across providers

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -25,7 +25,7 @@ import { VaultAnalyzer } from './services/vault-analyzer';
 import { DeepResearchService } from './services/deep-research';
 import { Logger } from './utils/logger';
 import { FileLogWriter } from './utils/file-log-writer';
-import { getApiKeyErrorMessage } from './utils/init-error-message';
+import { getApiKeyErrorMessage as buildApiKeyErrorMessage } from './utils/init-error-message';
 import { RagIndexingService } from './services/rag-indexing';
 import { SelectionActionService } from './services/selection-action-service';
 import { MCPManager } from './mcp/mcp-manager';
@@ -305,7 +305,7 @@ export default class ObsidianGemini extends Plugin {
 	 * Distinguishes between "never configured" and "storage retrieval failure".
 	 */
 	private getApiKeyErrorMessage(): string {
-		return getApiKeyErrorMessage({
+		return buildApiKeyErrorMessage({
 			provider: this.settings.provider,
 			lastInitError: this.lastInitError,
 			apiKeySecretName: this.settings.apiKeySecretName,

--- a/src/main.ts
+++ b/src/main.ts
@@ -25,6 +25,7 @@ import { VaultAnalyzer } from './services/vault-analyzer';
 import { DeepResearchService } from './services/deep-research';
 import { Logger } from './utils/logger';
 import { FileLogWriter } from './utils/file-log-writer';
+import { getApiKeyErrorMessage } from './utils/init-error-message';
 import { RagIndexingService } from './services/rag-indexing';
 import { SelectionActionService } from './services/selection-action-service';
 import { MCPManager } from './mcp/mcp-manager';
@@ -304,22 +305,12 @@ export default class ObsidianGemini extends Plugin {
 	 * Distinguishes between "never configured" and "storage retrieval failure".
 	 */
 	private getApiKeyErrorMessage(): string {
-		if (this.settings.provider === 'ollama') {
-			// Surface the captured init error when we have one \u2014 connectivity is the
-			// most common Ollama failure but far from the only one (no model
-			// selected, model not pulled, base URL points at a non-Ollama HTTP
-			// server). The init-time Notice may have already disappeared by the
-			// time the user invokes a guarded command, so reuse the error here
-			// instead of always defaulting to "make sure the daemon is running".
-			if (this.lastInitError) {
-				return t('notice.main.initFailedFix', { error: this.lastInitError });
-			}
-			return t('notice.main.ollamaUnreachable', { url: this.settings.ollamaBaseUrl });
-		}
-		if (!this.settings.apiKeySecretName) {
-			return t('notice.main.noApiKey');
-		}
-		return t('notice.main.apiKeyRetrieveFailed');
+		return getApiKeyErrorMessage({
+			provider: this.settings.provider,
+			lastInitError: this.lastInitError,
+			apiKeySecretName: this.settings.apiKeySecretName,
+			ollamaBaseUrl: this.settings.ollamaBaseUrl,
+		});
 	}
 
 	/**

--- a/src/services/ollama-models-service.ts
+++ b/src/services/ollama-models-service.ts
@@ -94,12 +94,9 @@ export class OllamaModelsService {
 		}
 
 		try {
-			// Deliberately no retry/backoff here. The Ollama daemon is local; the
-			// dominant failure mode is `ECONNREFUSED` against `localhost:11434`,
-			// which is permanent until the user runs `ollama serve` — retrying
-			// would just delay the actionable error by 6–14s. Settings → Refresh
-			// model list provides the recovery path. Mirrors ModelListProvider's
-			// best-effort + manual-refresh pattern for the bundled Gemini list.
+			// Deliberately no retry/backoff: ECONNREFUSED against the local daemon is
+			// permanent until `ollama serve` runs, so retrying only delays the
+			// actionable error — see #709 for the full rationale.
 			const url = `${baseUrl.replace(/\/$/, '')}/api/tags`;
 			const response = await requestUrl({ url, method: 'GET', throw: false });
 

--- a/src/utils/init-error-message.ts
+++ b/src/utils/init-error-message.ts
@@ -1,0 +1,31 @@
+/**
+ * Builds the user-facing message for "plugin isn't usable right now" cases
+ * (guarded commands, ribbon icon) shared by every provider.
+ */
+
+import { t } from '../i18n';
+import type { ModelProvider } from '../models';
+
+export interface ApiKeyErrorMessageParams {
+	provider: ModelProvider;
+	lastInitError: string | null;
+	apiKeySecretName: string;
+	ollamaBaseUrl: string;
+}
+
+/**
+ * A captured init-time error is provider-agnostic and more specific than any
+ * generic fallback, so it wins regardless of which provider is active.
+ */
+export function getApiKeyErrorMessage(params: ApiKeyErrorMessageParams): string {
+	if (params.lastInitError) {
+		return t('notice.main.initFailedFix', { error: params.lastInitError });
+	}
+	if (params.provider === 'ollama') {
+		return t('notice.main.ollamaUnreachable', { url: params.ollamaBaseUrl });
+	}
+	if (!params.apiKeySecretName) {
+		return t('notice.main.noApiKey');
+	}
+	return t('notice.main.apiKeyRetrieveFailed');
+}

--- a/test/utils/init-error-message.test.ts
+++ b/test/utils/init-error-message.test.ts
@@ -1,0 +1,55 @@
+import { getApiKeyErrorMessage } from '../../src/utils/init-error-message';
+
+describe('getApiKeyErrorMessage', () => {
+	test('a captured init error wins for the Gemini provider', () => {
+		const message = getApiKeyErrorMessage({
+			provider: 'gemini',
+			lastInitError: 'model not found',
+			apiKeySecretName: 'my-key',
+			ollamaBaseUrl: 'http://localhost:11434',
+		});
+		expect(message).toContain('model not found');
+		expect(message).toContain('Open Settings');
+	});
+
+	test('a captured init error wins for the Ollama provider', () => {
+		const message = getApiKeyErrorMessage({
+			provider: 'ollama',
+			lastInitError: 'model not pulled',
+			apiKeySecretName: '',
+			ollamaBaseUrl: 'http://localhost:11434',
+		});
+		expect(message).toContain('model not pulled');
+	});
+
+	test('falls back to the Ollama-unreachable message when no init error was captured', () => {
+		const message = getApiKeyErrorMessage({
+			provider: 'ollama',
+			lastInitError: null,
+			apiKeySecretName: '',
+			ollamaBaseUrl: 'http://localhost:11434',
+		});
+		expect(message).toContain('http://localhost:11434');
+		expect(message).toContain('Ollama');
+	});
+
+	test('falls back to the no-API-key message for Gemini when nothing is configured', () => {
+		const message = getApiKeyErrorMessage({
+			provider: 'gemini',
+			lastInitError: null,
+			apiKeySecretName: '',
+			ollamaBaseUrl: 'http://localhost:11434',
+		});
+		expect(message).toContain('No Gemini API key configured');
+	});
+
+	test('falls back to the key-retrieval-failed message for Gemini when a key is configured but unreadable', () => {
+		const message = getApiKeyErrorMessage({
+			provider: 'gemini',
+			lastInitError: null,
+			apiKeySecretName: 'my-key',
+			ollamaBaseUrl: 'http://localhost:11434',
+		});
+		expect(message).toContain('Could not retrieve your API key');
+	});
+});


### PR DESCRIPTION
## Summary

Bundle of small follow-ups from PR #694 review, per the scope the maintainer confirmed on #709.

Fixes #709

This PR was produced by the auto-dev pipeline from the maintainer's direction on the issue: keep `REWRITE → chatModelName` unchanged (no migration), generalize `lastInitError`/`getApiKeyErrorMessage` to be provider-agnostic, shorten the "no retry" comment in `OllamaModelsService.getModels` to one line + link, defer the `provider || 'gemini'` eval-fallback removal (out of scope, gated on re-running historical evals), and don't file the command-palette unregister request externally (kept as the existing code comment).

While confirming the Ollama-model-collapse question the maintainer raised inline ("all use-cases should resolve to the one configured model... if use-case resolution doesn't already collapse to a single model on Ollama, file a small follow-up"), I found it does **not** collapse today — `chatModelName`/`summaryModelName`/`completionsModelName` are independent settings for both providers. Filed #1077 to track that as its own decision (needs a settings-UI change and a migration call, out of scope for this PR).

## Changes

- `src/utils/init-error-message.ts` (new) — extracts `getApiKeyErrorMessage` into a pure, provider-agnostic function: a captured `lastInitError` now wins for *any* provider (previously only surfaced for Ollama), with the existing per-provider fallbacks (Ollama-unreachable / no-API-key / key-retrieval-failed) unchanged when no init error was captured.
- `src/main.ts` — `getApiKeyErrorMessage()` becomes a thin wrapper delegating to the new helper with the plugin's current state.
- `src/services/ollama-models-service.ts` — shortens the 6-line "deliberately no retry" rationale comment to one line, linking to #709 where the full rationale is preserved.
- `test/utils/init-error-message.test.ts` (new) — covers all four message paths (captured error for each provider, Ollama-unreachable fallback, no-API-key fallback, key-retrieval-failed fallback).

**Out of scope** (per the approved plan): the `REWRITE → chatModelName` mapping (no change), the eval-reporter `provider || 'gemini'` fallback removal (deferred), filing the Obsidian command-palette unregister API request externally, and collapsing Ollama's per-use-case model resolution (tracked separately as #1077).

## Screenshots / Screencast

N/A — backend/internal change to error-message construction; no UI surface changed.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [ ] I have tested this change on Desktop (not run interactively in this environment; unit tests cover the new behavior)
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — no platform-specific code paths touched
- [x] Documentation has been updated (if applicable) — N/A, internal error-message refactor with no new user-facing behavior or settings surface
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (auto-dev pipeline)
- [x] I have reviewed and understand all AI-generated code in this PR

<!-- auto-dev -->


---
_Generated by [Claude Code](https://claude.ai/code/session_01DPhCXTtwyQC6svxkWoLwLr)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved startup error messaging with clearer, provider-aware guidance when the app can’t initialize (including actionable steps for opening settings and handling missing/unreadable API keys).

* **Bug Fixes**
  * Refined handling and messaging for unavailable local model services, clarifying when connection issues won’t resolve until the local server is running.

* **Tests**
  * Added Jest coverage to verify error-message prioritization and fallback behavior across providers (including Ollama and Gemini).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->