### PR TITLE
refactor: localize empty-response Notice via t()

### DIFF
--- a/src/ui/agent-view/agent-view-send.ts
+++ b/src/ui/agent-view/agent-view-send.ts
@@ -740,9 +740,7 @@ To reference an attachment in your response, use the path shown above.`;
 						} else {
 							// Empty response - might be thinking tokens
 							this.ctx.plugin.logger.warn('Model returned empty response');
-							new Notice(
-								'Model returned an empty response. This might happen with thinking models. Try rephrasing your question.'
-							);
+							new Notice(t('agent.send.emptyResponse'));
 
 							// User message already saved early in sendMessage()
 


### PR DESCRIPTION
## Summary

Architecture-audit nightly sweep flagged: **improper typing / missed i18n migration** in `src/ui/agent-view/agent-view-send.ts`.

The non-streaming fallback path in `AgentViewSend.sendMessage` printed a hardcoded English `Notice` for empty model responses, bypassing the i18n system. The exact same message already exists as `agent.send.emptyResponse` in `src/i18n/en.ts`, and two other call sites in the same file (the plan-approval empty case at line 133 and the streaming empty case at line 659) already localize it via `t()`. This wraps the remaining site so all three empty-response paths behave the same way in every locale.

## Changes

- `src/ui/agent-view/agent-view-send.ts` — replace the hardcoded English `new Notice('Model returned an empty response…')` on the non-streaming path with `new Notice(t('agent.send.emptyResponse'))`, matching the two existing localized call sites in the same file.

## Screenshots / Screencast

N/A — no visual change; the English message users on the default locale see is byte-identical (both strings resolve to the same `en.ts` value). Non-English locales now see the localized message instead of English.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A, filed by the `architecture-audit` skill as a nightly automated finding
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`, `npm run typecheck:test`)
- [ ] I have tested this change on Desktop — not run interactively; the change is a one-line localization wrap with identical resolved text on the default locale, covered by the existing streaming/plan-approval call sites
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — no platform-specific code paths touched
- [x] Documentation has been updated (if applicable) — N/A, internal i18n consistency fix with no user-facing behavior change on the default locale
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (`architecture-audit` skill)
- [x] I have reviewed and understand all AI-generated code in this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01HgdKZuU8r1GjmppdX82unh)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the message shown when sending results in an empty response, using a localized notice instead of a fixed English message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->