### PR TITLE
chore(daily): 2026-07-02 daily update

### DIFF
--- a/docs/contributing/contributing.md
+++ b/docs/contributing/contributing.md
@@ -28,7 +28,7 @@ npm run dev    # Development build with watch mode
 | `npm install`          | Install dependencies                     |
 | `npm run dev`          | Development build with watch mode        |
 | `npm run build`        | Production build (runs TypeScript check) |
-| `npm test`             | Run Jest tests                           |
+| `npm test`             | Run Vitest tests                         |
 | `npm run format`       | Format code with Prettier                |
 | `npm run format-check` | Check formatting without changes         |
 

--- a/docs/contributing/contributing.md
+++ b/docs/contributing/contributing.md
@@ -45,7 +45,7 @@ Before requesting a review, ensure **all CI checks are green**. Run these locall
 ```bash
 npm run format-check   # Prettier formatting
 npm run build          # TypeScript type checking + production build
-npm test               # Jest test suite
+npm test               # Vitest test suite
 ```
 
 PRs with failing CI will not be reviewed. Fix the failures first.

--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -234,15 +234,15 @@ Use the appropriate checklist based on what your change affects. All changes sho
 
 The project enforces quality gates through git hooks and CI:
 
-| Check          | Command                  | When it runs    |
-| -------------- | ------------------------ | --------------- |
-| Formatting     | `npm run format-check`   | Pre-commit hook |
-| Build          | `npm run build`          | Pre-push hook   |
-| Tests          | `npm test`               | Pre-push hook   |
-| Lint           | `npm run lint`           | CI only         |
-| Test typecheck | `npm run typecheck:test` | CI only         |
+| Check          | Command                  | When it runs                                          |
+| -------------- | ------------------------ | ----------------------------------------------------- |
+| Formatting     | `npm run format-check`   | CI only (pre-commit auto-fixes staged files instead)  |
+| Build          | `npm run build`          | Pre-push hook                                         |
+| Tests          | `npm test`               | Pre-push hook                                         |
+| Lint           | `npm run lint`           | CI only (pre-commit auto-fixes staged `*.ts` instead) |
+| Test typecheck | `npm run typecheck:test` | CI only                                               |
 
-The last two run only in CI — no local hook covers them. Run all five locally before pushing to avoid a CI-only failure:
+The pre-commit hook runs `lint-staged`, which auto-fixes formatting (`prettier --write`) and lint issues (`eslint --fix`) on staged files only — a different (and narrower) check than the full-repo, fix-nothing commands CI runs. Run all five full-repo commands locally before pushing to avoid a CI-only failure:
 
 ```bash
 npm run format-check && npm run build && npm test && npm run lint && npm run typecheck:test

--- a/docs/guide/agent-mode.md
+++ b/docs/guide/agent-mode.md
@@ -796,6 +796,15 @@ Prevents infinite execution loops:
 - Stops after threshold (default: 3)
 - Configurable time window
 
+### Turn Budget
+
+Long agent turns (many tool-call batches in a row) are bounded by a soft budget instead of a hard cutoff:
+
+- As a turn nears its limit, the agent is reminded how many tool-call batches it has left so it can wrap up cleanly
+- If it runs out mid-task, it gets a one-time extension (half the original budget, rounded up) with a nudge to finish
+- Interactive agent chat sessions default to 50 tool-call batches per turn — high enough to stay out of the way of normal multi-step work
+- See [Scheduled Tasks → Tool Iteration Limit](/guide/scheduled-tasks#tool-iteration-limit) for the same mechanism as it applies to headless runs (default 20, configurable via `maxIterations`)
+
 ### Error Handling
 
 - Operations stop on errors (configurable)

--- a/docs/guide/ai-writing.md
+++ b/docs/guide/ai-writing.md
@@ -231,13 +231,17 @@ You can assign a keyboard shortcut to "Explain selection with AI" in Obsidian's 
 
 ## Default Prompts
 
-When you first use Explain Selection, three default prompts are created in your Prompts folder:
+The plugin ships with five bundled prompts, available immediately — they aren't written as files to your Prompts folder, but appear in the selection menu alongside any custom prompts you create there:
 
-| Prompt                  | Description                     | Best For           |
-| ----------------------- | ------------------------------- | ------------------ |
-| **Explain Selection**   | General explanation of the text | Most content types |
-| **Explain Code**        | Detailed code walkthrough       | Programming code   |
-| **Summarize Selection** | Concise summary                 | Long passages      |
+| Prompt                       | Description                      | Best For           |
+| ---------------------------- | -------------------------------- | ------------------ |
+| **Explain Selection**        | General explanation of the text  | Most content types |
+| **Explain Code**             | Detailed code walkthrough        | Programming code   |
+| **Summarize Selection**      | Concise summary                  | Long passages      |
+| **Fix Grammar**              | Fixes grammar and improves style | Any text           |
+| **Convert to Bullet Points** | Converts text to a list          | Dense paragraphs   |
+
+If you create a custom prompt in your Prompts folder with the same name as a bundled one, your version takes precedence.
 
 ## Creating Custom Explain Prompts {#creating-custom-explain-prompts}
 

--- a/docs/reference/loop-detection.md
+++ b/docs/reference/loop-detection.md
@@ -34,7 +34,7 @@ The AI will receive an error message:
 
 ## Per-Turn Abort
 
-In addition to the per-tool detection above, the agent loop counts how many times loop detection fires within a single turn. If it fires three or more times in one turn (the model keeps trying near-identical calls after being blocked), the entire turn aborts cleanly with a "loop detected — turn aborted" notice. This prevents a model that is genuinely stuck from spinning through every tool variation. The abort is per-turn — the next user message starts fresh.
+In addition to the per-tool detection above, the agent loop counts how many times loop detection fires within a single turn. If it fires three or more times in one turn (the model keeps trying near-identical calls after being blocked), the entire turn aborts cleanly with a notice: "The agent kept retrying the same tool call (loop detector fired N times). Stopping this turn to prevent a runaway loop. Try rephrasing your request or starting a new session." This prevents a model that is genuinely stuck from spinning through every tool variation. The abort is per-turn — the next user message starts fresh.
 
 ## Implementation Details
 

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -300,6 +300,7 @@ Advanced settings for developers and power users. Access by clicking "Show advan
 - **Description**: Routes Gemini requests through Google's GA [Interactions API](https://ai.google.dev/gemini-api/docs/interactions) (`interactions.create`) instead of the legacy `generateContent` API.
 - **Privacy**: Runs statelessly (`store: false`) — conversation history is replayed with each request, and the plugin does not persist Interactions state on Google's side between turns. (Requests are still sent to Google to generate each response, subject to Google's standard API data-handling terms.)
 - **Status**: Experimental. Responses stream incrementally (text, reasoning, and tool calls); turn it off to fall back to `generateContent` if you hit issues.
+- **Scope**: Governs the conversational chat transport only. Image generation (the `generate_image` tool and **Generate image** command) always uses `generateContent` regardless of this setting.
 
 #### Custom API Endpoint
 
@@ -424,7 +425,7 @@ Controls which agent tools execute automatically, which require user confirmatio
 - **Setting**: `toolPolicy.toolPermissions`
 - **Type**: Object (tool name → permission)
 - **Default**: `{}` (empty — preset governs all tools)
-- **Description**: Each registered tool can be individually set to `deny` (blocked), `ask` (confirmation required), or `allow` (runs automatically). Overrides take precedence over the active preset. Setting an override causes the preset to switch to `custom`. Legacy aliases `ask_user` and `approve` still parse correctly but `ask` and `allow` are the canonical forms.
+- **Description**: Each registered tool can be individually set to `deny` (blocked), `ask_user` (confirmation required), or `approve` (runs automatically) — these are the values persisted in `data.json` for this setting. Overrides take precedence over the active preset. Setting an override causes the preset to switch to `custom`. (This is distinct from the `toolPolicy` YAML block used by Projects, Scheduled Tasks, and Hooks, which uses the shorter `deny`/`ask`/`allow` aliases in frontmatter — see those guides.)
 
 ### MCP servers
 

--- a/planning/changelog/2026-07-01.md
+++ b/planning/changelog/2026-07-01.md
@@ -1,0 +1,24 @@
+# Daily changelog — July 01, 2026
+
+**Date:** 2026-07-01
+**PRs merged:** 3
+
+---
+
+## Summary
+
+A backend-focused day: mid-loop context compaction landed for the agent loop, a small typing cleanup from the nightly architecture-audit sweep merged, and Ollama's token estimation got a real calibration step instead of a fixed chars/4 guess.
+
+## What shipped
+
+### [#1074 feat(agent-loop): call contextManager.prepareHistory inside the loop](https://github.com/allenhutchison/obsidian-gemini/pull/1074)
+
+Long tool chains within a single agent turn could grow `AgentLoop`'s in-memory history unbounded, since `ContextManager.prepareHistory` only ran once, before the initial request. `AgentLoop` now calls `prepareHistory` after every tool batch (via a new `protectFromIndex` option that clamps summarization so it never crosses into the current turn's in-flight tool chain), so long tool loops can be compacted mid-flight. A new `onMidLoopCompaction` hook wires the same "Context Compacted" notice into the UI. Fixes #662.
+
+### [#1075 refactor: drop unnecessary `as any` on DomElementInfo `title` fields](https://github.com/allenhutchison/obsidian-gemini/pull/1075)
+
+Mechanical typing cleanup flagged by the nightly architecture-audit sweep: `title` is a documented field on Obsidian's `DomElementInfo` type, so the `as any` casts around `createDiv`/`createSpan` calls in three modals (`background-tasks-modal.ts`, `scheduled-tasks-modal.ts`, `scheduler-management-modal.ts`) weren't needed. No behavior change.
+
+### [#1076 feat(ollama): calibrate real token counts from prompt_eval_count](https://github.com/allenhutchison/obsidian-gemini/pull/1076)
+
+`ContextManager.countTokens` falls back to a fixed chars/4 estimate for Ollama, since Ollama has no `countTokens` endpoint — inaccurate enough that compaction could trigger at the wrong threshold and the token UI could underreport usage. This PR seeds the estimate with the same chars/4 default but calibrates a per-model chars-per-token ratio from each real response's `prompt_eval_count`, piggybacking on responses already being made rather than adding an extra API call. Fixes #707.


### PR DESCRIPTION
## Summary

Automated daily housekeeping run bundling the `daily-changelog`, `audit-docs`, and `triage-issues` sub-skills for 2026-07-02.

## Changes

- **daily-changelog**: wrote `planning/changelog/2026-07-01.md` — 3 PRs merged that day (#1074 mid-loop context compaction in `AgentLoop`, #1075 `DomElementInfo` typing cleanup, #1076 Ollama token-count calibration from `prompt_eval_count`).
- **audit-docs**: validated `docs/guide/`, `docs/reference/`, `docs/contributing/`, `README.md`, and `AGENTS.md` against the code; patched 6 files:
  - `docs/reference/settings.md` — **conceptual drift**: the per-tool permission override description had the canonical/legacy enum values backwards (global settings persist `deny`/`ask_user`/`approve`; the short `ask`/`allow` aliases only apply to frontmatter `toolPolicy` blocks). Also added a scope note that the Interactions API toggle never affects image generation (`generateContent` always handles it).
  - `docs/reference/loop-detection.md` — **conceptual drift**: replaced a fabricated turn-abort notice string with the real one from `agent-loop.ts`.
  - `docs/guide/ai-writing.md` — **conceptual drift**: corrected the bundled Explain-Selection prompt count (3 → 5) and mechanism (they're served virtually via `BundledPromptRegistry`, never written to the Prompts folder).
  - `docs/guide/agent-mode.md` — gap-fill: added a "Turn Budget" section documenting the soft per-turn tool-batch budget for interactive agent chat (previously only documented for headless runs).
  - `docs/contributing/testing.md` — corrected the CI-checks table: the pre-commit hook runs `lint-staged` (auto-fixing, staged files only), not the full-repo `format-check`/`lint` commands.
  - `docs/contributing/contributing.md` — stale reference: `npm test` runs Vitest, not Jest.
- **triage-issues**: no unlabeled open issues found — no-op.

## Screenshots / Screencast

N/A — documentation and internal changelog changes only.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A, scheduled daily-housekeeping run
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop — N/A, docs/changelog-only change; verified via build + full test suite
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — no code changes
- [x] Documentation has been updated (if applicable) — this PR *is* the documentation update
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (daily-update pipeline)
- [x] I have reviewed and understand all AI-generated code in this PR


---
_Generated by [Claude Code](https://claude.ai/code/session_01DLr2RwhXcLVq8sbdkXFLS7)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated contributing/testing guides to reflect current test commands (Vitest) and revised CI vs pre-commit/pre-push behavior.
  * Expanded agent-mode guidance with the new **Turn Budget** safety feature, including reminders, one-time extension behavior, and updated tool-iteration defaults.
  * Refined loop-detection “per-turn abort” messaging and improved settings references for chat/image generation scope and per-tool override values.
  * Updated AI writing defaults to reflect the current bundled Explain Selection prompts.
  * Added a new daily changelog entry covering history handling, UI notifications, and token estimation improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->