### PR TITLE
feat(attachments): rasterize SVG/SVGZ to PNG before inlining (#641)

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Let the AI actively work with your vault through tool calling capabilities.
 
 - **Search Files by Name:** Find any file by filename patterns (wildcards supported)
 - **Search File Contents:** Grep-style text search within note contents (supports regex and case-sensitive search)
-- **Read Files:** Access text files or analyze binary files (images, audio, video, PDF) directly through Gemini
+- **Read Files:** Access text files or analyze binary files (images, audio, video, PDF, SVG) directly through Gemini — SVGs are rasterized to PNG on-device so vector artwork and handwritten ink can be viewed and OCR'd
 - **Create Notes:** Generate new notes with specified content
 - **Edit Notes:** Modify existing notes with precision
 - **Move/Rename Files:** Reorganize and rename notes in your vault

--- a/docs/guide/agent-mode.md
+++ b/docs/guide/agent-mode.md
@@ -72,7 +72,7 @@ Each tool call in the chat is collapsible — click a tool row to expand its det
 
 ### File Attachments & Drag-and-Drop
 
-You can include images, audio, video, PDFs, and text files in your chat. Files are automatically classified and routed:
+You can include images, audio, video, PDFs, SVGs, and text files in your chat. Files are automatically classified and routed:
 
 **Adding Files:**
 
@@ -90,14 +90,20 @@ When you drop a file, the plugin classifies it based on its extension:
 | ----------------------------- | ----------------------------------------------------------------------------- | ------------------------------------------------------------------ |
 | **Text**                      | `.md`, `.txt`, `.ts`, `.js`, `.json`, `.html`, `.css`, `.py`, etc.            | Added as context chips (the AI reads the file content)             |
 | **Binary (Gemini-supported)** | `.png`, `.jpg`, `.gif`, `.webp`, `.pdf`, `.mp3`, `.wav`, `.mp4`, `.mov`, etc. | Sent as inline data (the AI processes the binary content directly) |
+| **SVG**                       | `.svg`, `.svgz`                                                               | Rasterized to PNG on-device, then sent as inline data              |
 | **Unsupported**               | `.zip`, `.exe`, `.dmg`, etc.                                                  | Skipped with a notification                                        |
 
 **Supported Binary Formats:**
 
 - **Images**: PNG, JPEG, GIF, WebP, HEIC, HEIF
+- **Vector images**: SVG, SVGZ (rasterized to PNG before sending — see below)
 - **Audio**: WAV, MP3, AAC, FLAC
 - **Video**: MP4, MPEG, MOV, FLV, MPG, WebM, WMV, 3GP
 - **Documents**: PDF
+
+**SVG Handling:**
+
+Gemini's API can't process `image/svg+xml` directly, so SVG (and gzip-compressed `.svgz`) files are **rasterized to PNG on your device** before being sent — whether you drag, paste, `@`-mention, or have the agent read them with the Read File tool. Rasterization renders the SVG onto a white background (so transparent artwork like handwritten ink strokes stays legible for OCR) and caps the longest edge at 2048px to keep the payload within the inline-data limit. If an SVG can't be rendered (malformed markup or unresolvable external references), it's skipped with the same "unsupported file type" notice rather than sending unusable data.
 
 **How It Works:**
 
@@ -155,7 +161,7 @@ Context files are displayed in a **unified file shelf** — a horizontal strip a
 
 **Adding files:**
 
-1. Type `@` in the chat input to open the file picker (supports text files **and** Gemini-compatible binary files like images, PDFs, audio, and video)
+1. Type `@` in the chat input to open the file picker (supports text files **and** Gemini-compatible binary files like images, SVGs, PDFs, audio, and video)
 2. Type `/` in an empty chat input to open the skill picker — select a skill to insert an activation prompt you can edit before sending (see [Agent Skills](agent-skills.md) for details)
 3. Click the file icon in the session header to open the multi-select modal:
    - Already-added files appear pre-checked
@@ -255,7 +261,7 @@ Supports:
 
 #### read_file
 
-Read the contents of any file in your vault. Supports text files (markdown, code, `.base`, `.canvas`) and binary files that Gemini can process (images, audio, video, PDF):
+Read the contents of any file in your vault. Supports text files (markdown, code, `.base`, `.canvas`) and binary files that Gemini can process (images, audio, video, PDF, and SVG — SVGs are rasterized to PNG on-device first):
 
 ```
 Read the contents of my daily note
@@ -263,9 +269,10 @@ Show me what's in Projects/Todo.md
 Describe the image at images/diagram.png
 Transcribe the recording at audio/meeting.mp3
 Read the PDF at docs/report.pdf
+Transcribe the handwriting in Ink/Writing/note.svg
 ```
 
-When you ask the agent to read a binary file, it sends the file data directly to Gemini for analysis — enabling image description, audio transcription, PDF reading, and video analysis without manual drag-and-drop.
+When you ask the agent to read a binary file, it sends the file data directly to Gemini for analysis — enabling image description, audio transcription, PDF reading, and video analysis without manual drag-and-drop. SVG files are rasterized to PNG on-device before sending, so the agent can view and OCR vector artwork (e.g. handwritten ink strokes) that Gemini would otherwise reject.
 
 If a file doesn't exist, the agent receives a non-error response with `exists: false` and helpful suggestions for similar file names. This allows automation skills to probe for files without triggering error states.
 

--- a/src/tools/vault/read-file-tool.ts
+++ b/src/tools/vault/read-file-tool.ts
@@ -10,6 +10,7 @@ import {
 	arrayBufferToBase64,
 	detectWebmMimeType,
 } from '../../utils/file-classification';
+import { rasterizeSvg } from '../../utils/svg-rasterizer';
 import { resolvePathToFileOrFolder } from './utils';
 
 /**
@@ -126,6 +127,29 @@ export class ReadFileTool implements Tool {
 					data: { path: file.path, type: 'binary_file', mimeType, size: buffer.byteLength },
 					inlineData: [{ base64, mimeType }],
 				};
+			}
+
+			if (classification.category === FileCategory.SVG) {
+				// SVG can't be inlined directly (Gemini rejects image/svg+xml). Rasterize
+				// to PNG so the agent can actually view/OCR it. On failure, return an error
+				// string rather than sending anything unusable to the API.
+				const buffer = await plugin.app.vault.readBinary(file);
+				if (buffer.byteLength > GEMINI_INLINE_DATA_LIMIT) {
+					return { success: false, error: `File too large for inline processing (max 20 MB): ${file.name}` };
+				}
+				try {
+					const base64 = await rasterizeSvg(buffer, file.extension.toLowerCase() === 'svgz');
+					return {
+						success: true,
+						data: { path: file.path, type: 'binary_file', mimeType: 'image/png', size: buffer.byteLength },
+						inlineData: [{ base64, mimeType: 'image/png' }],
+					};
+				} catch (rasterErr) {
+					return {
+						success: false,
+						error: `Failed to rasterize SVG for viewing: ${file.name} (${rasterErr instanceof Error ? rasterErr.message : 'Unknown error'})`,
+					};
+				}
 			}
 
 			if (classification.category === FileCategory.UNSUPPORTED) {

--- a/src/ui/agent-view/agent-view-attachments.ts
+++ b/src/ui/agent-view/agent-view-attachments.ts
@@ -6,6 +6,7 @@ import { AgentViewShelf, getTextFilesFromFolder } from './agent-view-shelf';
 import { FileMentionModal } from './file-mention-modal';
 import { getContextSelection, createContextRange } from '../../utils/dom-context';
 import { shouldExcludePathForPlugin } from '../../utils/file-utils';
+import { rasterizeSvg } from '../../utils/svg-rasterizer';
 import type ObsidianGemini from '../../main';
 import { t } from '../../i18n';
 
@@ -88,7 +89,6 @@ export class AgentViewAttachments {
 						let base64: string;
 						let mimeType: string;
 						if (classification.category === FileCategory.SVG) {
-							const { rasterizeSvg } = await import('../../utils/svg-rasterizer');
 							try {
 								base64 = await rasterizeSvg(buffer, fileOrFolder.extension.toLowerCase() === 'svgz');
 								mimeType = 'image/png';

--- a/src/ui/agent-view/agent-view-attachments.ts
+++ b/src/ui/agent-view/agent-view-attachments.ts
@@ -68,8 +68,12 @@ export class AgentViewAttachments {
 					this.ctx.context.addFileToContext(fileOrFolder, this.ctx.getCurrentSession());
 					this.ctx.updateSessionHeader();
 					this.ctx.updateSessionMetadata();
-				} else if (classification.category === FileCategory.GEMINI_BINARY) {
-					// Handle binary file — create inline attachment (same as drag-drop)
+				} else if (
+					classification.category === FileCategory.GEMINI_BINARY ||
+					classification.category === FileCategory.SVG
+				) {
+					// Handle binary/SVG file — create inline attachment (same as drag-drop).
+					// SVG is rasterized to PNG; other binaries are inlined as-is.
 					try {
 						const buffer = await this.ctx.app.vault.readBinary(fileOrFolder);
 						const existing = this.ctx.getShelf().getPendingAttachments();
@@ -81,9 +85,23 @@ export class AgentViewAttachments {
 							return;
 						}
 
-						const base64 = arrayBufferToBase64(buffer);
-						const mimeType =
-							fileOrFolder.extension.toLowerCase() === 'webm' ? detectWebmMimeType(buffer) : classification.mimeType;
+						let base64: string;
+						let mimeType: string;
+						if (classification.category === FileCategory.SVG) {
+							const { rasterizeSvg } = await import('../../utils/svg-rasterizer');
+							try {
+								base64 = await rasterizeSvg(buffer, fileOrFolder.extension.toLowerCase() === 'svgz');
+								mimeType = 'image/png';
+							} catch (rasterErr) {
+								this.ctx.plugin.logger.error(`Failed to rasterize SVG ${fileOrFolder.path}:`, rasterErr);
+								new Notice(t('agent.attachments.attachFailed', { name: fileOrFolder.name }));
+								return;
+							}
+						} else {
+							base64 = arrayBufferToBase64(buffer);
+							mimeType =
+								fileOrFolder.extension.toLowerCase() === 'webm' ? detectWebmMimeType(buffer) : classification.mimeType;
+						}
 						const { generateAttachmentId } = await import('./inline-attachment');
 						const attachment: InlineAttachment = {
 							base64,

--- a/src/ui/agent-view/agent-view-ui.ts
+++ b/src/ui/agent-view/agent-view-ui.ts
@@ -18,6 +18,7 @@ import {
 	detectWebmMimeType,
 	GEMINI_INLINE_DATA_LIMIT,
 } from '../../utils/file-classification';
+import { rasterizeSvg } from '../../utils/svg-rasterizer';
 import { t } from '../../i18n';
 
 /**
@@ -607,6 +608,7 @@ export class AgentViewUI {
 
 				// Classify each file
 				const textFiles: TFile[] = [];
+				// Binary + SVG both inline as base64; SVG is rasterized to PNG first.
 				const binaryFiles: TFile[] = [];
 				const unsupportedExts: string[] = [];
 
@@ -617,6 +619,7 @@ export class AgentViewUI {
 							textFiles.push(file);
 							break;
 						case FileCategory.GEMINI_BINARY:
+						case FileCategory.SVG:
 							binaryFiles.push(file);
 							break;
 						case FileCategory.UNSUPPORTED:
@@ -646,11 +649,27 @@ export class AgentViewUI {
 							continue;
 						}
 
-						const base64 = arrayBufferToBase64(buffer);
 						const classification = classifyFile(file.extension);
-						// For .webm files, detect audio vs video from container header
-						const mimeType =
-							file.extension.toLowerCase() === 'webm' ? detectWebmMimeType(buffer) : classification.mimeType;
+						let base64: string;
+						let mimeType: string;
+						if (classification.category === FileCategory.SVG) {
+							// SVG can't be inlined directly — rasterize to PNG. On failure
+							// (malformed SVG, unresolvable refs), fall back to the
+							// unsupported-file notice rather than sending raw XML.
+							try {
+								base64 = await rasterizeSvg(buffer, file.extension.toLowerCase() === 'svgz');
+								mimeType = 'image/png';
+							} catch (rasterErr) {
+								this.plugin.logger.error(`Failed to rasterize SVG ${file.path}:`, rasterErr);
+								unsupportedExts.push(`.${file.extension}`);
+								cumulativeSize -= buffer.byteLength;
+								continue;
+							}
+						} else {
+							base64 = arrayBufferToBase64(buffer);
+							// For .webm files, detect audio vs video from container header
+							mimeType = file.extension.toLowerCase() === 'webm' ? detectWebmMimeType(buffer) : classification.mimeType;
+						}
 						const attachment: InlineAttachment = {
 							base64,
 							mimeType,
@@ -715,7 +734,7 @@ export class AgentViewUI {
 			// Non-vault drops: handle images from external sources (browser, desktop)
 			const files = e.dataTransfer?.files;
 			const fileArray = files?.length ? Array.from(files) : [];
-			const hasImages = fileArray.some((file) => isSupportedImageType(file.type));
+			const hasImages = fileArray.some((file) => isSupportedImageType(file.type) || this.isSvgFile(file));
 
 			// Only prevent default behavior if we have images to handle
 			if (!hasImages) {
@@ -754,6 +773,18 @@ export class AgentViewUI {
 					} catch (err) {
 						this.plugin.logger.error('Failed to process dropped image:', err);
 						new Notice(t('agent.attachments.imageAttachFailed'));
+					}
+				} else if (this.isSvgFile(file)) {
+					// External SVG/SVGZ — rasterize to PNG before inlining.
+					if (cumulativeSize + file.size > GEMINI_INLINE_DATA_LIMIT) {
+						new Notice(t('agent.attachments.sizeLimitReached'));
+						break;
+					}
+					if (await this.attachExternalSvgFile(file, callbacks)) {
+						cumulativeSize += file.size;
+						imagesProcessed++;
+					} else {
+						unsupportedCount++;
 					}
 				} else if (file.type.startsWith('image/')) {
 					unsupportedCount++;
@@ -802,6 +833,21 @@ export class AgentViewUI {
 						} catch (err) {
 							this.plugin.logger.error('Failed to process pasted image:', err);
 							new Notice(t('agent.attachments.imageAttachFailed'));
+						}
+					} else if (this.isSvgFile(file)) {
+						// External SVG/SVGZ paste — rasterize to PNG before inlining.
+						if (cumulativeSize + file.size > GEMINI_INLINE_DATA_LIMIT) {
+							new Notice(t('agent.attachments.sizeLimitReached'));
+							break;
+						}
+						if (imagesProcessed === 0) {
+							e.preventDefault();
+						}
+						if (await this.attachExternalSvgFile(file, callbacks)) {
+							cumulativeSize += file.size;
+							imagesProcessed++;
+						} else {
+							unsupportedCount++;
 						}
 					} else if (file.type.startsWith('image/')) {
 						unsupportedCount++;
@@ -907,6 +953,39 @@ export class AgentViewUI {
 	 */
 	private getCurrentAttachmentSize(callbacks: UICallbacks): number {
 		return callbacks.getAttachments().reduce((sum, a) => sum + Math.ceil((a.base64.length * 3) / 4), 0);
+	}
+
+	/**
+	 * Whether an external (non-vault) File is an SVG/SVGZ that needs rasterization.
+	 * Checks MIME type and, for `.svgz` (which may arrive with a gzip or empty
+	 * type), the filename extension.
+	 */
+	private isSvgFile(file: File): boolean {
+		return file.type === 'image/svg+xml' || /\.svgz?$/i.test(file.name);
+	}
+
+	/**
+	 * Rasterize an external SVG/SVGZ File to a PNG inline attachment and add it.
+	 * Returns true if an attachment was added. On rasterization failure, logs and
+	 * returns false so the caller can count it as unsupported.
+	 */
+	private async attachExternalSvgFile(file: File, callbacks: UICallbacks): Promise<boolean> {
+		try {
+			const buffer = await file.arrayBuffer();
+			const isSvgz = /\.svgz$/i.test(file.name) || file.type === 'application/gzip';
+			const base64 = await rasterizeSvg(buffer, isSvgz);
+			const attachment: InlineAttachment = {
+				base64,
+				mimeType: 'image/png',
+				id: generateAttachmentId(),
+				fileName: file.name || undefined,
+			};
+			callbacks.addAttachment(attachment);
+			return true;
+		} catch (err) {
+			this.plugin.logger.error('Failed to rasterize external SVG:', err);
+			return false;
+		}
 	}
 
 	/**

--- a/src/ui/agent-view/file-mention-modal.ts
+++ b/src/ui/agent-view/file-mention-modal.ts
@@ -44,7 +44,7 @@ export class FileMentionModal extends FuzzySuggestModal<TAbstractFile> {
 		}
 		if (item instanceof TFile) {
 			const result = classifyFile(item.extension);
-			if (result.category === FileCategory.GEMINI_BINARY) {
+			if (result.category === FileCategory.GEMINI_BINARY || result.category === FileCategory.SVG) {
 				const icon = this.getIconForMime(result.mimeType);
 				return `${icon} ${item.path}`;
 			}

--- a/src/utils/file-classification.ts
+++ b/src/utils/file-classification.ts
@@ -56,6 +56,13 @@ export const OBSIDIAN_TEXT_EXTENSIONS: Record<string, string> = {
 export enum FileCategory {
 	TEXT = 'text',
 	GEMINI_BINARY = 'gemini_binary',
+	/**
+	 * SVG/SVGZ vector image. Gemini rejects `image/svg+xml` on the inline-data
+	 * endpoint, so these must be rasterized to PNG (see `svg-rasterizer.ts`)
+	 * before inlining. The reported `mimeType` is the source `image/svg+xml`;
+	 * the rasterized attachment carries `image/png`.
+	 */
+	SVG = 'svg',
 	UNSUPPORTED = 'unsupported',
 }
 
@@ -73,6 +80,15 @@ export interface FileClassification {
 export function classifyFile(extension: string): FileClassification {
 	// Normalize: strip leading dot, lowercase
 	const ext = extension.replace(/^\./, '').toLowerCase();
+
+	// SVG/SVGZ: recognized as an image, but requires client-side rasterization
+	// to PNG before inlining (Gemini rejects image/svg+xml as inline data).
+	if (ext === 'svg' || ext === 'svgz') {
+		return {
+			category: FileCategory.SVG,
+			mimeType: 'image/svg+xml',
+		};
+	}
 
 	// Check binary types first (more specific match)
 	if (Object.prototype.hasOwnProperty.call(GEMINI_INLINE_BINARY_MIMES, ext)) {

--- a/src/utils/svg-rasterizer.ts
+++ b/src/utils/svg-rasterizer.ts
@@ -1,0 +1,168 @@
+/**
+ * Client-side SVG rasterization.
+ *
+ * Gemini's inline-data endpoint rejects `image/svg+xml` outright, so an SVG can
+ * never be inlined directly. Instead we rasterize it to a PNG in the renderer
+ * (Obsidian runs in Chromium/Electron, so a `<canvas>` is available) and inline
+ * that PNG. Rasterizing — rather than sending the raw XML as text — is also the
+ * only path that lets the model OCR ink/handwriting stored as `<path>` strokes.
+ *
+ * The rasterizer runs at the shared classify/inline boundary, so every entry
+ * point (drag, paste, @-mention, ReadFileTool) shares this one implementation.
+ */
+
+/** Longest-edge cap for the rasterized PNG (px). Bounds the base64 payload and keeps OCR legible. */
+export const SVG_RASTER_MAX_EDGE = 2048;
+
+/** Fallback dimension (px) used when an SVG declares no intrinsic size and no viewBox. */
+const SVG_FALLBACK_SIZE = 512;
+
+/**
+ * Whether an extension is an SVG variant that must be rasterized before inlining.
+ *
+ * @param extension - File extension, with or without a leading dot.
+ */
+export function isSvgExtension(extension: string): boolean {
+	const ext = extension.replace(/^\./, '').toLowerCase();
+	return ext === 'svg' || ext === 'svgz';
+}
+
+/**
+ * Scale a (width, height) pair so its longest edge is at most `maxEdge`,
+ * preserving aspect ratio. Dimensions already within the cap are returned
+ * unchanged (never upscaled). Result dimensions are rounded to whole pixels
+ * and clamped to a minimum of 1.
+ */
+export function computeScaledDimensions(
+	width: number,
+	height: number,
+	maxEdge: number = SVG_RASTER_MAX_EDGE
+): { width: number; height: number } {
+	const w = width > 0 ? width : SVG_FALLBACK_SIZE;
+	const h = height > 0 ? height : SVG_FALLBACK_SIZE;
+	const longest = Math.max(w, h);
+	if (longest <= maxEdge) {
+		return { width: Math.max(1, Math.round(w)), height: Math.max(1, Math.round(h)) };
+	}
+	const scale = maxEdge / longest;
+	return {
+		width: Math.max(1, Math.round(w * scale)),
+		height: Math.max(1, Math.round(h * scale)),
+	};
+}
+
+/**
+ * Gzip-decompress an `.svgz` buffer using the Web Streams `DecompressionStream`
+ * (available in Chromium/Electron and Node 18+).
+ */
+async function gunzip(buffer: ArrayBuffer): Promise<ArrayBuffer> {
+	const ds = new DecompressionStream('gzip');
+	const writer = ds.writable.getWriter();
+	// Fire-and-forget the write; the reader below drains the inflated output.
+	void writer.write(new Uint8Array(buffer));
+	void writer.close();
+	return await new Response(ds.readable).arrayBuffer();
+}
+
+/**
+ * Parse intrinsic dimensions from an SVG document's markup as a fallback when
+ * the loaded `<img>` reports no natural size (SVGs with only a `viewBox` and no
+ * width/height often report 0 in some engines).
+ */
+function parseSvgDimensions(svgText: string): { width: number; height: number } {
+	const rootMatch = svgText.match(/<svg\b[^>]*>/i);
+	const root = rootMatch ? rootMatch[0] : '';
+
+	const readLength = (attr: string): number => {
+		const m = root.match(new RegExp(`\\b${attr}\\s*=\\s*["']?\\s*([0-9]*\\.?[0-9]+)`, 'i'));
+		return m ? parseFloat(m[1]) : 0;
+	};
+
+	let width = readLength('width');
+	let height = readLength('height');
+
+	if (width <= 0 || height <= 0) {
+		const vb = root.match(/\bviewBox\s*=\s*["']?\s*([-\d.]+)[\s,]+([-\d.]+)[\s,]+([-\d.]+)[\s,]+([-\d.]+)/i);
+		if (vb) {
+			const vbW = parseFloat(vb[3]);
+			const vbH = parseFloat(vb[4]);
+			if (width <= 0) width = vbW;
+			if (height <= 0) height = vbH;
+		}
+	}
+
+	return { width, height };
+}
+
+/**
+ * Load an SVG blob URL into an `<img>` element, resolving once decoded.
+ * Rejects on load failure (malformed SVG, unresolvable external references).
+ */
+function loadSvgImage(url: string): Promise<HTMLImageElement> {
+	return new Promise((resolve, reject) => {
+		const img = new Image();
+		img.onload = () => resolve(img);
+		img.onerror = () => reject(new Error('Failed to load SVG image'));
+		img.src = url;
+	});
+}
+
+/**
+ * Rasterize an SVG (or gzip-compressed `.svgz`) to a base64-encoded PNG.
+ *
+ * The SVG is drawn onto an off-screen `<canvas>` scaled so its longest edge is
+ * at most {@link SVG_RASTER_MAX_EDGE}px (aspect ratio preserved) over a white
+ * background — ink strokes are frequently on a transparent canvas, and a
+ * transparent→black flatten would ruin OCR.
+ *
+ * @param buffer - Raw file bytes (`.svg` XML or gzip-compressed `.svgz`).
+ * @param isSvgz - Whether `buffer` is gzip-compressed and must be inflated first.
+ * @returns Base64 PNG payload (no `data:` URI prefix).
+ * @throws If the SVG cannot be decompressed, parsed, loaded, or rasterized —
+ *   callers fall back to the existing "unsupported file type" notice.
+ */
+export async function rasterizeSvg(buffer: ArrayBuffer, isSvgz: boolean): Promise<string> {
+	const svgBuffer = isSvgz ? await gunzip(buffer) : buffer;
+	const svgText = new TextDecoder('utf-8').decode(new Uint8Array(svgBuffer));
+
+	const blob = new Blob([svgBuffer], { type: 'image/svg+xml' });
+	const url = URL.createObjectURL(blob);
+
+	try {
+		const img = await loadSvgImage(url);
+
+		// Prefer the browser's intrinsic size; fall back to parsing the markup.
+		let width = img.naturalWidth || img.width;
+		let height = img.naturalHeight || img.height;
+		if (width <= 0 || height <= 0) {
+			const parsed = parseSvgDimensions(svgText);
+			width = width > 0 ? width : parsed.width;
+			height = height > 0 ? height : parsed.height;
+		}
+
+		const dims = computeScaledDimensions(width, height);
+
+		const canvas = document.createElement('canvas');
+		canvas.width = dims.width;
+		canvas.height = dims.height;
+
+		const ctx = canvas.getContext('2d');
+		if (!ctx) {
+			throw new Error('Failed to acquire 2D canvas context for SVG rasterization');
+		}
+
+		// White background so transparent SVGs (ink strokes) do not flatten to black.
+		ctx.fillStyle = '#ffffff';
+		ctx.fillRect(0, 0, dims.width, dims.height);
+		ctx.drawImage(img, 0, 0, dims.width, dims.height);
+
+		const dataUrl = canvas.toDataURL('image/png');
+		const base64 = dataUrl.split(',')[1];
+		if (!base64) {
+			throw new Error('SVG rasterization produced no PNG data');
+		}
+		return base64;
+	} finally {
+		URL.revokeObjectURL(url);
+	}
+}

--- a/src/utils/svg-rasterizer.ts
+++ b/src/utils/svg-rasterizer.ts
@@ -64,34 +64,45 @@ async function gunzip(buffer: ArrayBuffer): Promise<ArrayBuffer> {
 	return await new Response(ds.readable).arrayBuffer();
 }
 
+/** Intrinsic sizing declared by an SVG's root element. Absent/unusable values are 0. */
+interface SvgIntrinsicSize {
+	/** Explicit `width` attribute in user units (0 if absent or a percentage). */
+	width: number;
+	/** Explicit `height` attribute in user units (0 if absent or a percentage). */
+	height: number;
+	/** `viewBox` width (0 if no viewBox). */
+	viewBoxWidth: number;
+	/** `viewBox` height (0 if no viewBox). */
+	viewBoxHeight: number;
+}
+
 /**
- * Parse intrinsic dimensions from an SVG document's markup as a fallback when
- * the loaded `<img>` reports no natural size (SVGs with only a `viewBox` and no
- * width/height often report 0 in some engines).
+ * Parse the sizing declared on an SVG's root element: explicit `width`/`height`
+ * and the `viewBox` extent. Percentage widths/heights (relative to the
+ * viewport, meaningless for off-screen rasterization) are reported as 0 so
+ * callers fall back to the viewBox.
  */
-function parseSvgDimensions(svgText: string): { width: number; height: number } {
+function parseSvgIntrinsicSize(svgText: string): SvgIntrinsicSize {
 	const rootMatch = svgText.match(/<svg\b[^>]*>/i);
 	const root = rootMatch ? rootMatch[0] : '';
 
 	const readLength = (attr: string): number => {
-		const m = root.match(new RegExp(`\\b${attr}\\s*=\\s*["']?\\s*([0-9]*\\.?[0-9]+)`, 'i'));
-		return m ? parseFloat(m[1]) : 0;
+		const m = root.match(new RegExp(`\\b${attr}\\s*=\\s*["']?\\s*([0-9]*\\.?[0-9]+)\\s*(%?)`, 'i'));
+		if (!m) return 0;
+		// Percentages are relative to the viewport and unusable as a render size.
+		if (m[2] === '%') return 0;
+		return parseFloat(m[1]);
 	};
 
-	let width = readLength('width');
-	let height = readLength('height');
-
-	if (width <= 0 || height <= 0) {
-		const vb = root.match(/\bviewBox\s*=\s*["']?\s*([-\d.]+)[\s,]+([-\d.]+)[\s,]+([-\d.]+)[\s,]+([-\d.]+)/i);
-		if (vb) {
-			const vbW = parseFloat(vb[3]);
-			const vbH = parseFloat(vb[4]);
-			if (width <= 0) width = vbW;
-			if (height <= 0) height = vbH;
-		}
+	let viewBoxWidth = 0;
+	let viewBoxHeight = 0;
+	const vb = root.match(/\bviewBox\s*=\s*["']?\s*([-\d.]+)[\s,]+([-\d.]+)[\s,]+([-\d.]+)[\s,]+([-\d.]+)/i);
+	if (vb) {
+		viewBoxWidth = parseFloat(vb[3]);
+		viewBoxHeight = parseFloat(vb[4]);
 	}
 
-	return { width, height };
+	return { width: readLength('width'), height: readLength('height'), viewBoxWidth, viewBoxHeight };
 }
 
 /**
@@ -131,14 +142,15 @@ export async function rasterizeSvg(buffer: ArrayBuffer, isSvgz: boolean): Promis
 	try {
 		const img = await loadSvgImage(url);
 
-		// Prefer the browser's intrinsic size; fall back to parsing the markup.
-		let width = img.naturalWidth || img.width;
-		let height = img.naturalHeight || img.height;
-		if (width <= 0 || height <= 0) {
-			const parsed = parseSvgDimensions(svgText);
-			width = width > 0 ? width : parsed.width;
-			height = height > 0 ? height : parsed.height;
-		}
+		// Determine the render size. Explicit width/height win; for viewBox-only
+		// SVGs prefer the viewBox extent, because Chromium reports a *reduced*
+		// default intrinsic size for them (e.g. a viewBox="0 0 400 300" SVG loads
+		// as 200×150), which would rasterize at half resolution. Fall back to the
+		// browser's reported intrinsic size, then to the default in
+		// computeScaledDimensions when nothing is declared.
+		const intrinsic = parseSvgIntrinsicSize(svgText);
+		const width = intrinsic.width || intrinsic.viewBoxWidth || img.naturalWidth || img.width;
+		const height = intrinsic.height || intrinsic.viewBoxHeight || img.naturalHeight || img.height;
 
 		const dims = computeScaledDimensions(width, height);
 

--- a/test/utils/file-classification.test.ts
+++ b/test/utils/file-classification.test.ts
@@ -89,6 +89,23 @@ describe('file-classification', () => {
 			expect(result.mimeType).toBe('video/webm');
 		});
 
+		it('should classify .svg as SVG (requires rasterization)', () => {
+			const result = classifyFile('svg');
+			expect(result.category).toBe(FileCategory.SVG);
+			expect(result.mimeType).toBe('image/svg+xml');
+		});
+
+		it('should classify .svgz as SVG (requires rasterization)', () => {
+			const result = classifyFile('svgz');
+			expect(result.category).toBe(FileCategory.SVG);
+			expect(result.mimeType).toBe('image/svg+xml');
+		});
+
+		it('should classify SVG case-insensitively', () => {
+			expect(classifyFile('.SVG').category).toBe(FileCategory.SVG);
+			expect(classifyFile('SvgZ').category).toBe(FileCategory.SVG);
+		});
+
 		it('should classify .zip as UNSUPPORTED', () => {
 			const result = classifyFile('zip');
 			expect(result.category).toBe(FileCategory.UNSUPPORTED);

--- a/test/utils/svg-rasterizer.test.ts
+++ b/test/utils/svg-rasterizer.test.ts
@@ -9,6 +9,13 @@ import {
 
 const SIMPLE_SVG =
 	'<svg xmlns="http://www.w3.org/2000/svg" width="100" height="50"><rect width="100" height="50" fill="black"/></svg>';
+const LARGE_SVG =
+	'<svg xmlns="http://www.w3.org/2000/svg" width="8192" height="4096"><rect width="8192" height="4096" fill="black"/></svg>';
+// viewBox but no explicit width/height — Chromium reports a reduced default
+// intrinsic size (here mocked as 200×150), so the rasterizer must fall back to
+// the viewBox extent (400×300) rather than the img's default.
+const VIEWBOX_ONLY_SVG =
+	'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 300"><rect width="400" height="300" fill="black"/></svg>';
 
 // --- Mock harness for the DOM rasterization path -------------------------------
 
@@ -157,14 +164,21 @@ describe('rasterizeSvg', () => {
 	});
 
 	it('scales an oversized SVG so neither canvas dimension exceeds the cap', async () => {
-		imageNatural = { width: 8192, height: 4096 };
-		const buffer = new TextEncoder().encode(SIMPLE_SVG).buffer;
+		const buffer = new TextEncoder().encode(LARGE_SVG).buffer;
 		await rasterizeSvg(buffer, false);
 		expect(lastCanvasDims).not.toBeNull();
 		expect(lastCanvasDims!.width).toBeLessThanOrEqual(SVG_RASTER_MAX_EDGE);
 		expect(lastCanvasDims!.height).toBeLessThanOrEqual(SVG_RASTER_MAX_EDGE);
 		expect(lastCanvasDims!.width).toBe(2048);
 		expect(lastCanvasDims!.height).toBe(1024);
+	});
+
+	it('rasterizes a viewBox-only SVG at the viewBox size, not the reduced img intrinsic size', async () => {
+		// Mock the browser's reduced default intrinsic size for a viewBox-only SVG.
+		imageNatural = { width: 200, height: 150 };
+		const buffer = new TextEncoder().encode(VIEWBOX_ONLY_SVG).buffer;
+		await rasterizeSvg(buffer, false);
+		expect(lastCanvasDims).toEqual({ width: 400, height: 300 });
 	});
 
 	it('rejects when the SVG fails to load (malformed / unresolvable refs)', async () => {

--- a/test/utils/svg-rasterizer.test.ts
+++ b/test/utils/svg-rasterizer.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { gzipSync } from 'zlib';
+import {
+	rasterizeSvg,
+	computeScaledDimensions,
+	isSvgExtension,
+	SVG_RASTER_MAX_EDGE,
+} from '../../src/utils/svg-rasterizer';
+
+const SIMPLE_SVG =
+	'<svg xmlns="http://www.w3.org/2000/svg" width="100" height="50"><rect width="100" height="50" fill="black"/></svg>';
+
+// --- Mock harness for the DOM rasterization path -------------------------------
+
+let capturedBlobs: Blob[] = [];
+let lastCanvasDims: { width: number; height: number } | null = null;
+let lastContext: { fillStyle: string; fillRect: ReturnType<typeof vi.fn>; drawImage: ReturnType<typeof vi.fn> } | null =
+	null;
+let imageBehavior: 'load' | 'error' = 'load';
+let imageNatural = { width: 100, height: 50 };
+
+class MockImage {
+	onload: (() => void) | null = null;
+	onerror: (() => void) | null = null;
+	naturalWidth = 0;
+	naturalHeight = 0;
+	width = 0;
+	height = 0;
+	private _src = '';
+	set src(value: string) {
+		this._src = value;
+		// Fire asynchronously to mirror real image decoding.
+		queueMicrotask(() => {
+			if (imageBehavior === 'load') {
+				this.naturalWidth = imageNatural.width;
+				this.naturalHeight = imageNatural.height;
+				this.onload?.();
+			} else {
+				this.onerror?.();
+			}
+		});
+	}
+	get src(): string {
+		return this._src;
+	}
+}
+
+let origCreate: typeof URL.createObjectURL;
+let origRevoke: typeof URL.revokeObjectURL;
+
+beforeEach(() => {
+	capturedBlobs = [];
+	lastCanvasDims = null;
+	lastContext = null;
+	imageBehavior = 'load';
+	imageNatural = { width: 100, height: 50 };
+
+	vi.stubGlobal('Image', MockImage);
+
+	origCreate = URL.createObjectURL;
+	origRevoke = URL.revokeObjectURL;
+	URL.createObjectURL = ((blob: Blob) => {
+		capturedBlobs.push(blob);
+		return 'blob:mock-url';
+	}) as typeof URL.createObjectURL;
+	URL.revokeObjectURL = (() => {}) as typeof URL.revokeObjectURL;
+
+	vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockImplementation(() => {
+		lastContext = { fillStyle: '', fillRect: vi.fn(), drawImage: vi.fn() };
+		return lastContext as unknown as CanvasRenderingContext2D;
+	});
+	vi.spyOn(HTMLCanvasElement.prototype, 'toDataURL').mockImplementation(function (this: HTMLCanvasElement) {
+		lastCanvasDims = { width: this.width, height: this.height };
+		return 'data:image/png;base64,UE5HREFUQQ==';
+	});
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+	vi.unstubAllGlobals();
+	URL.createObjectURL = origCreate;
+	URL.revokeObjectURL = origRevoke;
+});
+
+// --- isSvgExtension ------------------------------------------------------------
+
+describe('isSvgExtension', () => {
+	it('recognizes svg and svgz with and without a dot, case-insensitively', () => {
+		expect(isSvgExtension('svg')).toBe(true);
+		expect(isSvgExtension('.svg')).toBe(true);
+		expect(isSvgExtension('SVG')).toBe(true);
+		expect(isSvgExtension('svgz')).toBe(true);
+		expect(isSvgExtension('.SVGZ')).toBe(true);
+	});
+
+	it('rejects non-svg extensions', () => {
+		expect(isSvgExtension('png')).toBe(false);
+		expect(isSvgExtension('svgx')).toBe(false);
+		expect(isSvgExtension('')).toBe(false);
+	});
+});
+
+// --- computeScaledDimensions ---------------------------------------------------
+
+describe('computeScaledDimensions', () => {
+	it('leaves dimensions within the cap unchanged', () => {
+		expect(computeScaledDimensions(100, 50)).toEqual({ width: 100, height: 50 });
+		expect(computeScaledDimensions(2048, 1024)).toEqual({ width: 2048, height: 1024 });
+	});
+
+	it('scales oversized dimensions so the longest edge equals the cap, preserving aspect ratio', () => {
+		expect(computeScaledDimensions(4096, 2048)).toEqual({ width: 2048, height: 1024 });
+		expect(computeScaledDimensions(1000, 5000)).toEqual({ width: 410, height: 2048 });
+	});
+
+	it('never upscales and always caps the longest edge', () => {
+		const { width, height } = computeScaledDimensions(8000, 100);
+		expect(Math.max(width, height)).toBeLessThanOrEqual(SVG_RASTER_MAX_EDGE);
+		expect(width).toBe(2048);
+		expect(height).toBe(26); // round(100 * 2048/8000) = round(25.6) = 26
+	});
+
+	it('falls back to a default size when a dimension is zero or negative', () => {
+		expect(computeScaledDimensions(0, 0)).toEqual({ width: 512, height: 512 });
+		expect(computeScaledDimensions(-10, 200)).toEqual({ width: 512, height: 200 });
+	});
+});
+
+// --- rasterizeSvg --------------------------------------------------------------
+
+describe('rasterizeSvg', () => {
+	it('returns a non-empty base64 PNG string for a valid SVG', async () => {
+		const buffer = new TextEncoder().encode(SIMPLE_SVG).buffer;
+		const base64 = await rasterizeSvg(buffer, false);
+		expect(base64).toBe('UE5HREFUQQ==');
+		expect(base64.length).toBeGreaterThan(0);
+	});
+
+	it('paints a white background before drawing the SVG', async () => {
+		const buffer = new TextEncoder().encode(SIMPLE_SVG).buffer;
+		await rasterizeSvg(buffer, false);
+		expect(lastContext).not.toBeNull();
+		expect(lastContext!.fillStyle).toBe('#ffffff');
+		expect(lastContext!.fillRect).toHaveBeenCalled();
+		expect(lastContext!.drawImage).toHaveBeenCalled();
+	});
+
+	it('decompresses .svgz before rasterizing', async () => {
+		const gz = gzipSync(Buffer.from(SIMPLE_SVG, 'utf-8'));
+		const buffer = gz.buffer.slice(gz.byteOffset, gz.byteOffset + gz.byteLength);
+		const base64 = await rasterizeSvg(buffer, true);
+		expect(base64).toBe('UE5HREFUQQ==');
+		// The blob handed to the image loader must be the decompressed SVG markup.
+		expect(capturedBlobs.length).toBeGreaterThan(0);
+		const decoded = await capturedBlobs[0].text();
+		expect(decoded).toBe(SIMPLE_SVG);
+	});
+
+	it('scales an oversized SVG so neither canvas dimension exceeds the cap', async () => {
+		imageNatural = { width: 8192, height: 4096 };
+		const buffer = new TextEncoder().encode(SIMPLE_SVG).buffer;
+		await rasterizeSvg(buffer, false);
+		expect(lastCanvasDims).not.toBeNull();
+		expect(lastCanvasDims!.width).toBeLessThanOrEqual(SVG_RASTER_MAX_EDGE);
+		expect(lastCanvasDims!.height).toBeLessThanOrEqual(SVG_RASTER_MAX_EDGE);
+		expect(lastCanvasDims!.width).toBe(2048);
+		expect(lastCanvasDims!.height).toBe(1024);
+	});
+
+	it('rejects when the SVG fails to load (malformed / unresolvable refs)', async () => {
+		imageBehavior = 'error';
+		const buffer = new TextEncoder().encode('<not-svg>').buffer;
+		await expect(rasterizeSvg(buffer, false)).rejects.toThrow(/Failed to load SVG/);
+	});
+});


### PR DESCRIPTION
<!-- auto-dev -->

## Summary

Gemini's inline-data endpoint rejects `image/svg+xml` outright, so SVG files could never be sent to the model — the reported symptom was the agent locating a vault `.svg` (Obsidian Ink handwriting export) but being unable to read it. This adds **client-side SVG → PNG rasterization** at the shared classify/inline boundary, so `.svg` and `.svgz` files are rendered to PNG (via an off-screen Electron `<canvas>`) before hitting the inline-base64 path. Rasterizing — rather than sending raw XML as text — is the only path that lets the model view and OCR ink `<path>` strokes.

Produced by the auto-dev pipeline from the approved plan on #641.

Fixes #641

## Changes

- **`src/utils/svg-rasterizer.ts` (new)** — `rasterizeSvg(buffer, isSvgz)`: decompresses `.svgz` via `DecompressionStream('gzip')`, loads the SVG into an `<img>`, and draws it onto an off-screen `<canvas>` scaled to at most **2048px on the longest edge** (aspect-ratio preserved) over a **white background** (transparent ink would otherwise flatten to black and hurt OCR). Returns a base64 PNG; throws on malformed/unloadable SVG so callers can fall back. Exports `computeScaledDimensions`/`isSvgExtension` helpers.
- **`src/utils/file-classification.ts`** — new `FileCategory.SVG` returned for `svg`/`svgz` (mimeType `image/svg+xml`).
- **Wired SVG handling into every inline entry point** (one rasterization path, not four): vault drag-drop and external drop/paste (`agent-view-ui.ts`), the `@`-mention picker (`agent-view-attachments.ts`), and the **Read File tool** (`read-file-tool.ts`, the actual reported scenario). On rasterization failure each path falls back to the existing "unsupported file type" notice / an error string rather than sending anything unusable.
- **`file-mention-modal.ts`** — SVG files show the image icon and remain selectable in the picker.
- **Tests** — `test/utils/svg-rasterizer.test.ts` (scaling/cap, white-background fill, `.svgz` decompression, malformed-SVG rejection) and new SVG cases in `file-classification.test.ts`.
- **Docs** — `docs/guide/agent-mode.md` (routing table, supported-formats list, new "SVG Handling" section, Read File examples) and `README.md`.

**Deviation from the plan:** the plan listed the `@`-mention edit under `agent-view.ts`; that flow actually lives in `agent-view-attachments.ts`, and external drop/paste of raw SVG `File` objects is handled in `agent-view-ui.ts`. Scope, sizing, white background, `.svgz`, and fallback behavior all follow the spec.

## Screenshots / Screencast

N/A — no visual UI change; SVG attachments render as standard PNG image thumbnails through the existing attachment preview.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer (#641)
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop
- [ ] I have verified this change does not break Mobile — rasterization relies only on `<canvas>`, `Image`, and `DecompressionStream`, all available in Obsidian's mobile WebView, but this was **not** manually verified on a mobile device
- [x] Documentation has been updated (if applicable)
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude (auto-dev pipeline)
- [x] I have reviewed and understand all AI-generated code in this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01WtTRvGn5fUV73Ez7BXYytV)_