### PR TITLE
feat(agent): prefer background execution for long-running tools by default (#658)

### DIFF
--- a/prompts/agentRulesPrompt.hbs
+++ b/prompts/agentRulesPrompt.hbs
@@ -20,16 +20,15 @@ For complex tasks involving multiple tool calls, plan before executing.
 - Read files BEFORE modifying or deleting them
 
 **BACKGROUND TASKS** (`deep_research` and `generate_image`):
-Both tools accept an optional `background: true` parameter. Use it when:
-- The operation is one step in a larger plan and you want to continue other work without waiting
-- The user explicitly asks to "run in the background" or "don't wait for it"
-- You have other tool calls to make that don't depend on the result
+Both tools accept an optional `background: true` parameter. These are long-running operations, so **prefer background by default** — reach for foreground only when the very next step depends on the output.
+- **deep_research** → default `background: true`. Use foreground only when the report IS the direct inline answer to the user's current question (i.e. you have nothing to do with the result except hand it back immediately).
+- **generate_image** → default `background: true`, especially for illustrations produced alongside writing and for multi-image batches. Use foreground only when the image must appear embedded in the same turn.
+- **Foreground exception:** use foreground only when the very next step depends on the output, or the user explicitly says "show me now" / "I need it inline".
 
 When using `background: true`:
 - The tool returns `{ taskId, output_file }` or `{ taskId, output_path }` immediately — the path is always populated, you don't have to provide one
 - You may optionally pass `output_file` / `output_path` to override the default location (research defaults to `Background Research/<date> <topic>.md`; images default to the vault's configured attachment folder)
 - Retrieve the result later using `read_file` on the returned path — no new tool call to the original tool is needed
-- Do NOT use `background: true` if subsequent steps immediately depend on the output — use foreground mode instead so the result is available inline
 
 **RESEARCH AND INVESTIGATION**:
 When the user asks questions about their notes, be THOROUGH in your research:


### PR DESCRIPTION
<!-- auto-dev -->

## Summary

Long-running agent tools (`deep_research` and `generate_image`) previously only ran in the background when the model *opted in*. This flips the guidance in `prompts/agentRulesPrompt.hbs` from **opt-in** to **opt-out**: both tools now default to `background: true`, and foreground is reserved for the case where the very next step depends on the output (or the user explicitly asks to see it inline). This keeps the editing session responsive for illustrations-alongside-writing, multi-image batches, and long research runs — matching the behavior the user-facing docs already describe.

Prompt/guidance only — no tool-API, TypeScript, or settings changes; the `background: true` parameter already exists (from #651).

Produced by the auto-dev pipeline from the approved plan on #658.

Fixes #658

## Changes

- `prompts/agentRulesPrompt.hbs` — rewrote the `**BACKGROUND TASKS**` section:
  - "Prefer background by default" replaces the old "Use it when:" opt-in list.
  - **deep_research** → default `background: true`; foreground only when the report is the direct inline answer to the user's current question.
  - **generate_image** → default `background: true`, especially for illustrations alongside writing and multi-image batches; foreground only when the image must appear embedded in the same turn.
  - Added an explicit foreground exception (next step depends on output, or the user says "show me now" / "I need it inline").
  - The `output_file`/`output_path` override docs and the "retrieve result later via `read_file`" pattern are unchanged.

## Screenshots / Screencast

<!-- Deleted: change is a model-facing prompt/guidance edit with no UI surface. -->

N/A — model-facing prompt guidance; no UI or user-configurable surface changed.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer — Fixes #658 (plan approved by the maintainer)
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — 3194 tests pass; build, `typecheck:test`, and `format-check` all clean
- [ ] I have tested this change on Desktop — N/A: prompt-guidance change with no code path to exercise; verified by full pre-flight suite
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — no platform-specific code touched
- [x] Documentation has been updated (if applicable) — N/A: `docs/guide/background-tasks.md` already documents background as the default behavior; no drift introduced
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude (auto-dev pipeline)
- [x] I have reviewed and understand all AI-generated code in this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01ErKvHZqEhaRGa4TdExyjYR)_