### PR TITLE
test: cover provider routing and image-gen provider-switch transitions (#710)

### DIFF
--- a/test/api/factory.test.ts
+++ b/test/api/factory.test.ts
@@ -1,4 +1,5 @@
 import { ModelClientFactory, ModelUseCase } from '../../src/api/factory';
+import { getDefaultModelForRole } from '../../src/models';
 
 // --- Mocks ---
 
@@ -205,6 +206,43 @@ describe('ModelClientFactory', () => {
 			const config = MockGeminiClient.mock.calls[0][0];
 			// Should get a non-empty default from getDefaultModelForRole
 			expect(config.model).toBeTruthy();
+		});
+
+		describe('Ollama provider', () => {
+			// Mirrors the Gemini rows above but routes through the Ollama branch of
+			// createFromPlugin, asserting the resolved model lands on the
+			// OllamaClient config. resolveModelName reads the same settings keys
+			// regardless of provider (chatModelName / summaryModelName /
+			// completionsModelName); only the default fallback is provider-aware.
+			const cases: Array<{ useCase: ModelUseCase; settingKey: string; expected: string }> = [
+				{ useCase: ModelUseCase.CHAT, settingKey: 'chatModelName', expected: 'ollama-chat' },
+				{ useCase: ModelUseCase.SUMMARY, settingKey: 'summaryModelName', expected: 'ollama-summary' },
+				{ useCase: ModelUseCase.COMPLETIONS, settingKey: 'completionsModelName', expected: 'ollama-completions' },
+				{ useCase: ModelUseCase.REWRITE, settingKey: 'chatModelName', expected: 'ollama-chat' },
+				{ useCase: ModelUseCase.SEARCH, settingKey: 'chatModelName', expected: 'ollama-chat' },
+			];
+
+			it.each(cases)('resolves $useCase to the configured Ollama model', ({ useCase, settingKey, expected }) => {
+				const plugin = createMockPlugin({ provider: 'ollama', [settingKey]: expected });
+				ModelClientFactory.createFromPlugin(plugin, useCase);
+
+				expect(MockOllamaClient).toHaveBeenCalledTimes(1);
+				expect(MockGeminiClient).not.toHaveBeenCalled();
+				const config = MockOllamaClient.mock.calls[0][0];
+				expect(config.model).toBe(expected);
+			});
+
+			it('falls back to the Ollama default when the model name is empty', () => {
+				const plugin = createMockPlugin({ provider: 'ollama', chatModelName: '' });
+				ModelClientFactory.createFromPlugin(plugin, ModelUseCase.CHAT);
+
+				const config = MockOllamaClient.mock.calls[0][0];
+				// The default is resolved by the real getDefaultModelForRole (not mocked),
+				// so assert against it directly rather than a hard-coded string. In a unit
+				// context with no Ollama models loaded this is the empty-string sentinel,
+				// which is exactly the unconfigured-Ollama state the resolver is meant to pass through.
+				expect(config.model).toBe(getDefaultModelForRole('chat', 'ollama'));
+			});
 		});
 	});
 

--- a/test/services/lifecycle-service.test.ts
+++ b/test/services/lifecycle-service.test.ts
@@ -1257,4 +1257,35 @@ describe('LifecycleService', () => {
 			expect(plugin.imageGeneration).toBeUndefined();
 		});
 	});
+
+	describe('setup – image generation provider switch transitions', () => {
+		// Exercises the Gemini → Ollama → Gemini runtime provider switch: teardown
+		// nulls the Gemini-only ImageGeneration service (lifecycle-service.ts ~L134)
+		// and setup re-instantiates it only when the active provider isn't Ollama
+		// (~L513). A single-provider setup can't cover the drop + re-create cycle.
+		it('drops and re-instantiates ImageGeneration across gemini → ollama → gemini switches', async () => {
+			const { ImageGeneration } = await import('../../src/services/image-generation');
+			(ImageGeneration as unknown as Mock).mockClear();
+
+			// (a) First setup on Gemini creates the image-gen service.
+			mockPlugin.settings.provider = 'gemini';
+			await lifecycle.setup();
+			expect(ImageGeneration).toHaveBeenCalledTimes(1);
+			expect(mockPlugin.imageGeneration).toBeDefined();
+
+			// (b) Switch to Ollama and re-setup: teardown nulls the Gemini-only
+			// service and setup skips re-creating it — no second construction.
+			mockPlugin.isGeminiInitialized = true;
+			mockPlugin.settings.provider = 'ollama';
+			await lifecycle.setup();
+			expect(ImageGeneration).toHaveBeenCalledTimes(1);
+			expect(mockPlugin.imageGeneration).toBeNull();
+
+			// (c) Switch back to Gemini and re-setup: the service is re-instantiated.
+			mockPlugin.settings.provider = 'gemini';
+			await lifecycle.setup();
+			expect(ImageGeneration).toHaveBeenCalledTimes(2);
+			expect(mockPlugin.imageGeneration).toBeDefined();
+		});
+	});
 });


### PR DESCRIPTION
<!-- auto-dev -->

## Summary

Adds the two untested paths flagged in the review of PR #694 (Ollama integration): `resolveModelName` provider routing and `LifecycleService` provider-switch transitions. Test-only — no production code changes.

Produced by the auto-dev pipeline from the approved plan on #710.

Fixes #710

## Changes

- `test/api/factory.test.ts` — extend the existing `describe('resolveModelName (via createFromPlugin)')` block with an **Ollama provider** sub-describe. A table-driven `it.each` covers all five real `ModelUseCase` values (`CHAT`, `SUMMARY`, `COMPLETIONS`, `REWRITE`, `SEARCH`) routed through the Ollama branch of `createFromPlugin`, asserting the resolved name lands on `MockOllamaClient`'s config (and that the Gemini client is not constructed). An empty-model case asserts the fallback resolves to the **real** `getDefaultModelForRole('chat', 'ollama')` rather than a hard-coded string — which in a unit context with no Ollama models loaded is the empty-string sentinel, exactly the unconfigured-Ollama state the resolver passes through.
- `test/services/lifecycle-service.test.ts` — add a `setup – image generation provider switch transitions` block: a single test walks **gemini → ollama → gemini** re-setups, asserting `ImageGeneration` is constructed on the first Gemini setup, dropped (nulled by teardown, not re-created) on the Ollama pass, and re-instantiated on the switch back. The existing single-provider gating tests cover a fixed provider; this covers the drop + re-create cycle across a runtime switch.

**Plan anchors:** matches the maintainer-corrected plan — no new `simple-factory.ts`, real enum values (`COMPLETIONS`, `SEARCH`, no `EMBEDDING`), tested through `createFromPlugin`, and both existing test files extended rather than replaced.

## Screenshots / Screencast

N/A — test-only change; no UI or runtime behavior touched.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer — Fixes #710 (revised plan approved via `auto:ready`)
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — 3201 tests pass; build, `typecheck:test`, and format-check clean locally
- [x] I have tested this change on Desktop — N/A: pure unit-test addition, run via `npm test`
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A: no runtime/platform code touched
- [x] Documentation has been updated (if applicable) — N/A: no user-facing behavior change
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude (auto-dev pipeline)
- [x] I have reviewed and understand all AI-generated code in this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01MhLTS9g6FcQBRn3D8RJvh2)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded provider-routing coverage to ensure model selection works correctly for Ollama across multiple use cases.
  * Added verification that the app falls back to the expected default chat model when no model name is set.
  * Added lifecycle coverage for switching image generation providers at runtime, including transitions between Gemini and Ollama.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->