### PR TITLE
feat(evals): model orchestration — preload, swap, and multi-model sweep (#716)

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -25,8 +25,11 @@ npm run eval -- --task=smoke
 # Override how many times each task runs
 npm run eval -- --repeat=5
 
-# Sweep models against a fixed task suite (see Model overrides below)
+# Run against a specific model (see Model overrides below)
 npm run eval -- --model=gemini-2.5-flash-lite
+
+# Sweep several models in one shot and write a comparison table
+npm run eval -- --models=gemma4:latest,gemma4:26b --provider=ollama
 
 # Keep scratch files and session history for debugging
 npm run eval -- --keep-artifacts
@@ -57,9 +60,9 @@ npm run eval -- --model=gemini-2.5-flash-lite
 npm run eval -- --model=gemini-2.5-pro --repeat=5
 ```
 
-The override is **transient**: it's applied to `plugin.settings.chatModelName` in memory at the start of the run and restored on exit (including on Ctrl-C / SIGTERM). The setting is **not** persisted to disk, so the user's configured model is unaffected.
+The override is **transient**: it's applied in memory at the start of the run and restored on exit (including on Ctrl-C / SIGTERM). The settings are **not** persisted to disk, so the user's configured models are unaffected. `--model=` sets **all three** model fields — `chatModelName`, `summaryModelName`, and `completionsModelName` — so summary- and completion-driven tasks exercise the requested model too, not just chat.
 
-The override stamps into the result file's `model` field, so a multi-model sweep produces one result file per invocation that compare and trend independently:
+The override stamps into the result file's `model` field, so a multi-model sweep produces one result file per model that compare and trend independently. Use the built-in sweep (below) or a shell loop:
 
 ```bash
 for m in gemini-2.5-flash gemini-2.5-flash-lite gemini-2.5-pro; do
@@ -69,9 +72,28 @@ done
 
 Caveat: while the harness is running, the live agent view is using the override too. That's the same disruption already implied by the harness driving the agent — just don't try to use the agent view in another window mid-run.
 
+### Multi-model sweep and comparison
+
+`--models=A,B,C` runs the whole task suite once per model and writes a side-by-side comparison table, for the "which model should I use?" decision:
+
+```bash
+npm run eval -- --models=gemma4:latest,gemma4:26b,gemma4:31b --provider=ollama
+```
+
+Each model still produces its own `results/<slug>.json` (and compares against its own baseline). At the end, a `results/comparison-<slug>.md` is written and printed: one column per model, a `solved/n` cell per task (flaky tasks flagged with ⚠), and summary rows for solve^k / pass^k rate, mean turns, and total cost. `--models=` and `--model=` are mutually exclusive.
+
+### Model orchestration (Ollama)
+
+When the active provider is **Ollama**, model runs are orchestrated so timings and swaps are clean — this drives the local `ollama` CLI:
+
+- **Warmup** — before the first _timed_ task, the harness fires a throwaway generation to load the model into memory, so the first task's turn time excludes cold-start load. The warmup duration is printed separately (`warmup: Xs`) and never counted toward scores.
+- **Auto-swap with unload** — before loading the target model, any _other_ resident model (per `ollama ps`) is unloaded with `ollama stop` and polled until clear, so a swap doesn't briefly double-load two large models. This applies to both `--model=` and each step of a `--models=` sweep.
+
+These paths are Ollama-only and degrade to a no-op (with a one-line warning) if the `ollama` CLI isn't installed or reachable, so Gemini runs are unaffected. Set `OLLAMA_BIN` to point at a non-default `ollama` binary.
+
 ### Cross-provider runs
 
-`--model=` only sets `chatModelName`. To run against a different provider (e.g. an Ollama model from a Gemini-default setup), also pass `--provider=`:
+`--model=` / `--models=` set the model fields but not the provider. To run against a different provider (e.g. an Ollama model from a Gemini-default setup), also pass `--provider=`:
 
 ```bash
 npm run eval -- --model=gemma4:latest --provider=ollama
@@ -283,7 +305,7 @@ ETA is shown only when the task declares `maxTurns` and at least one turn has co
 - Prints `=== Interrupted (SIGINT): N of M tasks completed ===`.
 - Cancels the in-flight agent loop in the plugin.
 - Cleans the in-progress task's scratch fixtures and session history (so `eval-scratch/` doesn't leak into the user's vault).
-- Restores any `--model=` override that was applied for the run.
+- Restores any `--model=` / `--models=` override (chat, summary, and completions models) and `--provider=` override that was applied for the run.
 - Exits with `130` (SIGINT) or `143` (SIGTERM) so CI / wrappers can distinguish "interrupted" from "all green."
 
 A second Ctrl-C while cleanup is in flight is ignored; let the first one finish.

--- a/evals/README.md
+++ b/evals/README.md
@@ -62,7 +62,7 @@ npm run eval -- --model=gemini-2.5-pro --repeat=5
 
 The override is **transient**: it's applied in memory at the start of the run and restored on exit (including on Ctrl-C / SIGTERM). The settings are **not** persisted to disk, so the user's configured models are unaffected. `--model=` sets **all three** model fields — `chatModelName`, `summaryModelName`, and `completionsModelName` — so summary- and completion-driven tasks exercise the requested model too, not just chat.
 
-The override stamps into the result file's `model` field, so a multi-model sweep produces one result file per model that compare and trend independently. Use the built-in sweep (below) or a shell loop:
+The override stamps into the result file's `model` field, so a multi-model sweep produces one result file per model that can be compared and trended independently. Use the built-in sweep (below) or a shell loop:
 
 ```bash
 for m in gemini-2.5-flash gemini-2.5-flash-lite gemini-2.5-pro; do
@@ -80,7 +80,7 @@ Caveat: while the harness is running, the live agent view is using the override 
 npm run eval -- --models=gemma4:latest,gemma4:26b,gemma4:31b --provider=ollama
 ```
 
-Each model still produces its own `results/<slug>.json` (and compares against its own baseline). At the end, a `results/comparison-<slug>.md` is written and printed: one column per model, a `solved/n` cell per task (flaky tasks flagged with ⚠), and summary rows for solve^k / pass^k rate, mean turns, and total cost. `--models=` and `--model=` are mutually exclusive.
+Each model still produces its own `results/<slug>.json` (which you can `eval:bless` as that model's baseline independently). At the end, a `results/comparison-<slug>.md` is written and printed: one column per model, a `solved/n` cell per task (flaky tasks flagged with ⚠), and summary rows for solve^k / pass^k rate, mean turns, and total cost. Note the automatic baseline regression check (see below) runs only for single-model `--model=` runs, not sweeps — a sweep's output is the comparison report, not per-model baseline diffs. `--models=` and `--model=` are mutually exclusive.
 
 ### Model orchestration (Ollama)
 

--- a/evals/lib/ollama.mjs
+++ b/evals/lib/ollama.mjs
@@ -11,8 +11,11 @@
  * — these paths are only exercised when the active provider is Ollama.
  */
 
-import { execFileSync } from 'node:child_process';
+import { execFile, execFileSync } from 'node:child_process';
+import { promisify } from 'node:util';
 import { setTimeout as sleep } from 'node:timers/promises';
+
+const execFileAsync = promisify(execFile);
 
 const OLLAMA_BIN = process.env.OLLAMA_BIN || 'ollama';
 
@@ -22,6 +25,15 @@ function runOllama(args, { timeoutMs = 30_000 } = {}) {
 		timeout: timeoutMs,
 		stdio: ['ignore', 'pipe', 'pipe'],
 	});
+}
+
+// Async variant for the one potentially slow call (warmup): a cold-start model
+// load can take many seconds, and a synchronous exec would block the event loop
+// the whole time — starving the SIGINT/SIGTERM handlers that restore the
+// operator's settings on Ctrl-C. `ollama ps`/`stop` stay synchronous (sub-second).
+async function runOllamaAsync(args, { timeoutMs = 30_000 } = {}) {
+	const { stdout } = await execFileAsync(OLLAMA_BIN, args, { encoding: 'utf8', timeout: timeoutMs });
+	return stdout;
 }
 
 const firstLine = (message) => String(message ?? '').split('\n')[0];
@@ -108,7 +120,8 @@ export async function warmupOllamaModel(model) {
 	try {
 		// A tiny prompt is enough to force the model resident; the response is
 		// discarded. Generous timeout — a large model's first load can be slow.
-		runOllama(['run', model, 'Reply with the single word: ready'], { timeoutMs: 300_000 });
+		// Async so the (potentially long) load doesn't block SIGINT cleanup.
+		await runOllamaAsync(['run', model, 'Reply with the single word: ready'], { timeoutMs: 300_000 });
 	} catch (err) {
 		console.warn(
 			`  [ollama] warmup for '${model}' failed: ${firstLine(err.message)} — first task may include load time.`

--- a/evals/lib/ollama.mjs
+++ b/evals/lib/ollama.mjs
@@ -1,0 +1,119 @@
+/**
+ * Minimal Ollama CLI helpers for the eval harness's model-orchestration mode
+ * (#716). These shell out to the local `ollama` binary to inspect and control
+ * which model is resident in memory, so a model-swap eval run doesn't
+ * double-load (bring the new model up while the old one is still resident) and
+ * so the first *timed* task excludes cold-start model-load latency.
+ *
+ * Every helper degrades gracefully when `ollama` isn't installed or reachable:
+ * it logs a one-line warning and behaves as a no-op rather than aborting the
+ * run. A Gemini run has no ollama server, and the harness must still work there
+ * — these paths are only exercised when the active provider is Ollama.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { setTimeout as sleep } from 'node:timers/promises';
+
+const OLLAMA_BIN = process.env.OLLAMA_BIN || 'ollama';
+
+function runOllama(args, { timeoutMs = 30_000 } = {}) {
+	return execFileSync(OLLAMA_BIN, args, {
+		encoding: 'utf8',
+		timeout: timeoutMs,
+		stdio: ['ignore', 'pipe', 'pipe'],
+	});
+}
+
+const firstLine = (message) => String(message ?? '').split('\n')[0];
+
+/**
+ * Return the model names currently resident in the Ollama server (the NAME
+ * column of `ollama ps`). Empty array if nothing is loaded or if the ollama
+ * CLI isn't available.
+ */
+export function ollamaResidentModels() {
+	let out;
+	try {
+		out = runOllama(['ps']);
+	} catch (err) {
+		console.warn(`  [ollama] 'ollama ps' unavailable (${firstLine(err.message)}) — skipping resident-model check.`);
+		return [];
+	}
+	// `ollama ps` prints a header row (NAME  ID  SIZE  PROCESSOR  UNTIL) then one
+	// row per resident model. Take the first whitespace-delimited column of each
+	// non-header, non-empty line.
+	const lines = out
+		.split('\n')
+		.map((l) => l.trim())
+		.filter(Boolean);
+	if (lines.length <= 1) return []; // header only (or empty) => nothing resident
+	return lines
+		.slice(1)
+		.map((line) => line.split(/\s+/)[0])
+		.filter(Boolean);
+}
+
+/**
+ * Ask Ollama to unload a resident model. Best-effort — a failure is logged and
+ * swallowed; `waitForOllamaUnload` is the real gate on whether it cleared.
+ */
+export function ollamaStop(model) {
+	try {
+		runOllama(['stop', model]);
+	} catch (err) {
+		console.warn(`  [ollama] 'ollama stop ${model}' failed: ${firstLine(err.message)}`);
+	}
+}
+
+/**
+ * Poll `ollama ps` until `model` is no longer resident (or the timeout hits).
+ * Returns true if the model unloaded, false on timeout.
+ */
+export async function waitForOllamaUnload(model, { timeoutMs = 120_000, pollMs = 2_000 } = {}) {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (!ollamaResidentModels().includes(model)) return true;
+		await sleep(pollMs);
+	}
+	return false;
+}
+
+/**
+ * Unload every resident model that isn't `target` and wait for each to clear,
+ * so the target loads into a clean slot instead of alongside the prior model.
+ * No-op when `target` is already the only resident model or nothing is
+ * resident. Returns the list of models it unloaded.
+ */
+export async function ensureResidentModel(target, { timeoutMs, pollMs } = {}) {
+	const resident = ollamaResidentModels();
+	const toUnload = resident.filter((m) => m !== target);
+	for (const m of toUnload) {
+		console.log(`  [ollama] unloading resident model '${m}' before loading '${target}'...`);
+		ollamaStop(m);
+		const cleared = await waitForOllamaUnload(m, { timeoutMs, pollMs });
+		if (!cleared) {
+			console.warn(`  [ollama] '${m}' still resident after wait — continuing anyway.`);
+		}
+	}
+	return toUnload;
+}
+
+/**
+ * Load `model` into memory with a throwaway generation so the first timed task
+ * doesn't pay the cold-start load. Returns the warmup duration in ms, or 0 if
+ * warmup was skipped because ollama is unavailable.
+ */
+export async function warmupOllamaModel(model) {
+	const start = Date.now();
+	try {
+		// A tiny prompt is enough to force the model resident; the response is
+		// discarded. Generous timeout — a large model's first load can be slow.
+		runOllama(['run', model, 'Reply with the single word: ready'], { timeoutMs: 300_000 });
+	} catch (err) {
+		console.warn(
+			`  [ollama] warmup for '${model}' failed: ${firstLine(err.message)} — first task may include load time.`
+		);
+		return 0;
+	}
+	return Date.now() - start;
+}

--- a/evals/lib/reporter.mjs
+++ b/evals/lib/reporter.mjs
@@ -209,6 +209,90 @@ export async function writeResults(result, evalsDir) {
 }
 
 /**
+ * Render a side-by-side markdown comparison of several per-model eval results
+ * (the `--models=A,B,C` sweep). One column per model; each task contributes a
+ * `solved/n` row, followed by bold summary rows (solve^k rate, mean solve
+ * rate, pass^k rate, mean turns, total cost). Pure — returns the markdown
+ * string so the runner can both print it and write it to disk.
+ *
+ * @param {Array<object>} results - buildResult() objects, one per model, in sweep order.
+ * @returns {string} Markdown document (trailing newline included).
+ */
+export function formatComparisonMarkdown(results) {
+	if (!Array.isArray(results) || results.length === 0) return '_No results to compare._\n';
+
+	const models = results.map((r) => r.model || 'unknown');
+	const k = results[0].aggregate?.n_runs ?? 1;
+
+	// Union of task ids across all results, preserving first-seen order so the
+	// table row order is stable even if a later model ran a different subset.
+	const taskIds = [];
+	const seen = new Set();
+	for (const r of results) {
+		for (const t of r.tasks) {
+			if (!seen.has(t.id)) {
+				seen.add(t.id);
+				taskIds.push(t.id);
+			}
+		}
+	}
+
+	const header = ['Task', ...models];
+	const lines = [];
+	lines.push('# Eval model comparison');
+	lines.push('');
+	lines.push(`Provider: ${results[0].provider || 'gemini'} · ${k} run${k === 1 ? '' : 's'} per task`);
+	lines.push('');
+	lines.push(`| ${header.join(' | ')} |`);
+	lines.push(`| ${header.map(() => '---').join(' | ')} |`);
+
+	// Per-task solve^k cell (solved_count/n_runs), flagged when flaky.
+	for (const id of taskIds) {
+		const row = [id];
+		for (const r of results) {
+			const t = r.tasks.find((x) => x.id === id);
+			if (!t) {
+				row.push('—');
+				continue;
+			}
+			row.push(`${t.solved_count}/${t.n_runs}${t.flaky ? ' ⚠' : ''}`);
+		}
+		lines.push(`| ${row.join(' | ')} |`);
+	}
+
+	const summaryRow = (label, fn) => `| **${label}** | ${results.map((r) => fn(r.aggregate || {})).join(' | ')} |`;
+	lines.push(summaryRow(`solve^${k} rate`, (a) => `${a.solve_k_rate ?? 0}%`));
+	lines.push(summaryRow('mean solve rate', (a) => `${a.mean_solve_rate ?? 0}%`));
+	lines.push(summaryRow(`pass^${k} rate`, (a) => `${a.pass_k_rate ?? 0}%`));
+	lines.push(summaryRow('mean turns', (a) => `${a.mean_turns ?? 0}`));
+	lines.push(summaryRow('total cost', (a) => (a.total_cost_usd ? `$${a.total_cost_usd.toFixed(4)}` : 'free')));
+
+	return lines.join('\n') + '\n';
+}
+
+/**
+ * Write the model-comparison markdown (from `formatComparisonMarkdown`) to
+ * evals/results/comparison-<runId>.md.
+ *
+ * @param {Array<object>} results - buildResult() objects, one per model.
+ * @param {string} evalsDir
+ * @param {string} runId - Shared sweep id, used in the filename.
+ * @returns {Promise<string>} Path to the written markdown file.
+ */
+export async function writeComparisonTable(results, evalsDir, runId) {
+	const resultsDir = join(evalsDir, 'results');
+	const stamp = (runId || new Date().toISOString()).replace(/[:.]/g, '-');
+	const outPath = join(resultsDir, `comparison-${stamp}.md`);
+	try {
+		await mkdir(resultsDir, { recursive: true });
+		await writeFile(outPath, formatComparisonMarkdown(results));
+		return outPath;
+	} catch (err) {
+		throw new Error(`Failed to write eval comparison table to ${outPath}: ${err.message}`, { cause: err });
+	}
+}
+
+/**
  * Print a human-readable summary to stdout.
  */
 export function printSummary(result) {

--- a/evals/run.mjs
+++ b/evals/run.mjs
@@ -40,8 +40,16 @@ import { installCollector, peekCollector, readAndClearCollector, removeCollector
 import { scoreTask } from './lib/scorer.mjs';
 import { vaultAssertionPaths } from './lib/vault-assertions.mjs';
 import { taskHasJudgeMatcher } from './lib/matchers.mjs';
-import { aggregateTaskRuns, buildResult, writeResults, printSummary } from './lib/reporter.mjs';
+import {
+	aggregateTaskRuns,
+	buildResult,
+	writeResults,
+	printSummary,
+	writeComparisonTable,
+	formatComparisonMarkdown,
+} from './lib/reporter.mjs';
 import { compareResults, loadBaseline, printRegressionSummary, getBaselinePath } from './lib/compare.mjs';
+import { ensureResidentModel, warmupOllamaModel } from './lib/ollama.mjs';
 import { createJudge } from './lib/judge.mjs';
 import { summarizeProgress, formatProgressLine, progressChanged } from './lib/progress.mjs';
 import { waitForTurnCompletion } from './lib/turn-waiter.mjs';
@@ -70,6 +78,23 @@ function parseArgs() {
 	if (model !== null && model.length === 0) {
 		throw new Error('--model requires a non-empty value');
 	}
+	// `--models=A,B,C` runs the whole suite once per model and writes a
+	// comparison table (#716). Mutually exclusive with `--model=` — one picks a
+	// single model, the other sweeps several.
+	const modelsArg = args.find((a) => a.startsWith('--models='));
+	const models = modelsArg
+		? modelsArg
+				.slice('--models='.length)
+				.split(',')
+				.map((s) => s.trim())
+				.filter(Boolean)
+		: null;
+	if (modelsArg && (!models || models.length === 0)) {
+		throw new Error('--models requires a comma-separated list of at least one model');
+	}
+	if (models && model !== null) {
+		throw new Error('--model and --models are mutually exclusive; pass one or the other');
+	}
 	// Optional `--provider=` override. Mirrors `--model=` and is required for
 	// hands-free cross-provider sweeps (e.g. an Ollama run from a Gemini-default
 	// setup); see #845. Validated against the two real providers — invalid
@@ -84,6 +109,7 @@ function parseArgs() {
 		keepArtifacts: args.includes('--keep-artifacts'),
 		repeat,
 		model,
+		models,
 		providerOverride,
 	};
 }
@@ -97,7 +123,10 @@ function parseArgs() {
 //     eval-scratch leaks into the user's vault).
 //   - Print a "N of M tasks completed" summary so the operator knows where
 //     the run stopped.
-let originalChatModel = null;
+// `--model=` / `--models=` override chat, summary, AND completions models for
+// the run (#716) — the originals of all three are captured on the first
+// override so restore is exact even across a multi-model sweep.
+let originalModels = null; // { chatModelName, summaryModelName, completionsModelName }
 let modelWasOverridden = false;
 let originalProvider = null;
 let providerWasOverridden = false;
@@ -108,12 +137,34 @@ let completedTaskCount = 0;
 let totalPlannedTasks = 0;
 let interruptInProgress = false;
 
-async function restoreChatModel() {
-	if (!modelWasOverridden) return;
-	try {
-		await setSetting('chatModelName', originalChatModel);
-	} catch (err) {
-		console.error(`Failed to restore chatModelName: ${err.message}`);
+const MODEL_SETTING_KEYS = ['chatModelName', 'summaryModelName', 'completionsModelName'];
+
+/**
+ * Point chat, summary, and completions at `model` for the run. Captures the
+ * originals on the first call only, so repeated applications during a sweep
+ * still restore the operator's real settings. Transient — never persisted.
+ */
+async function applyModelOverride(model) {
+	if (!modelWasOverridden) {
+		originalModels = {};
+		for (const key of MODEL_SETTING_KEYS) {
+			originalModels[key] = await getSetting(key);
+		}
+	}
+	for (const key of MODEL_SETTING_KEYS) {
+		await setSetting(key, model);
+	}
+	modelWasOverridden = true;
+}
+
+async function restoreModelOverride() {
+	if (!modelWasOverridden || !originalModels) return;
+	for (const key of MODEL_SETTING_KEYS) {
+		try {
+			await setSetting(key, originalModels[key]);
+		} catch (err) {
+			console.error(`Failed to restore ${key}: ${err.message}`);
+		}
 	}
 	modelWasOverridden = false;
 }
@@ -177,7 +228,7 @@ async function handleInterrupt(signal, exitCode) {
 		} catch (err) {
 			console.warn(`  collector cleanup warning: ${err.message}`);
 		}
-		await restoreChatModel();
+		await restoreModelOverride();
 		await restoreProvider();
 		await restoreChatHistory();
 		process.exit(exitCode);
@@ -537,11 +588,76 @@ async function maybeCompareToBaseline(result) {
 }
 
 /**
+ * Ollama-only pre-run orchestration (#716): unload any *other* resident model
+ * so the swap doesn't double-load, then fire a throwaway generation to warm the
+ * target so the first *timed* task excludes cold-start load. No-op for non-Ollama
+ * providers, and degrades to a no-op when the `ollama` CLI isn't reachable.
+ *
+ * @param {string} model - The model to make resident (an Ollama tag, e.g. `gemma4:latest`).
+ * @param {string} provider - Active provider id.
+ */
+async function prepareOllamaModel(model, provider) {
+	if (provider !== 'ollama' || !model) return;
+	await ensureResidentModel(model);
+	const warmupMs = await warmupOllamaModel(model);
+	if (warmupMs > 0) {
+		console.log(`  warmup: ${(warmupMs / 1000).toFixed(1)}s for '${model}' (excluded from scored timings)`);
+	}
+}
+
+/**
+ * Run the loaded task suite once against the active provider/model and return
+ * the built result (also writing the result file + transcripts and printing the
+ * per-run summary). Shared by the single-model and `--models=` sweep paths.
+ */
+async function runAllTasks({ tasks, repeat, keepArtifacts, provider, judgeFn }) {
+	// One run id per suite invocation, shared by the result file
+	// (`results/<slug>.json`) and the transcript directory (`results/<slug>/`)
+	// so they are trivially correlated on disk. A sweep gets one per model.
+	const runId = new Date().toISOString();
+	const runIdSlug = runId.replace(/[:.]/g, '-');
+	const transcriptDir = join(EVALS_DIR, 'results', runIdSlug);
+	await mkdir(transcriptDir, { recursive: true });
+
+	// Run tasks sequentially. Each task runs `repeat` times so we can report
+	// pass^k reliability on top of per-run pass/solve rates. Module-scoped
+	// task tracking lets the SIGINT handler print "N of M completed" and
+	// clean up the in-progress task's scratch files.
+	totalPlannedTasks = tasks.length * repeat;
+	completedTaskCount = 0;
+	const taskResults = [];
+	for (const task of tasks) {
+		const runs = [];
+		for (let i = 0; i < repeat; i++) {
+			const runLabel = repeat > 1 ? ` [run ${i + 1}/${repeat}]` : '';
+			console.log(`\n--- Running: ${task.id}${runLabel} ---`);
+			currentTaskInfo = { taskId: task.id, sessionInfo: null, runIndex: i, repeat };
+			try {
+				runs.push(await runTask(task, keepArtifacts, provider, judgeFn, { transcriptDir, runIdSlug, runIndex: i + 1 }));
+			} finally {
+				currentTaskInfo = null;
+				completedTaskCount += 1;
+			}
+		}
+		taskResults.push(aggregateTaskRuns(task, runs));
+	}
+
+	// Build result, write, print
+	const gitSha = getGitSha();
+	const modelName = await getModelName();
+	const result = buildResult(taskResults, gitSha, modelName, provider, runId);
+	const outPath = await writeResults(result, EVALS_DIR);
+	printSummary(result);
+	console.log(`Results written to: ${outPath}`);
+	return result;
+}
+
+/**
  * Execute a full eval harness run: validate prerequisites, run tasks, write
  * aggregate results, and restore any temporary model override.
  */
 async function main() {
-	const { taskFilter, keepArtifacts, repeat, model, providerOverride } = parseArgs();
+	const { taskFilter, keepArtifacts, repeat, model, models, providerOverride } = parseArgs();
 	console.log('=== Gemini Scribe Eval Harness ===');
 
 	// Verify prerequisites
@@ -554,14 +670,10 @@ async function main() {
 	}
 	console.log(`Plugin v${pluginStatus.version} ready.`);
 
-	// Apply the chat-model override BEFORE loading tasks so the result-file's
-	// `model` field (read via getModelName at the end) reflects the override.
-	if (model) {
-		originalChatModel = await getSetting('chatModelName');
-		await setSetting('chatModelName', model);
-		modelWasOverridden = true;
-		console.log(`Overriding chatModelName: ${originalChatModel ?? '(unset)'} → ${model}`);
-	}
+	// The single-model override is applied just before the run (below), not
+	// here, so the single and `--models=` sweep paths share one code path
+	// (`applyModelOverride`) — the result file's `model` field is read via
+	// getModelName at the end and reflects whichever override is active.
 
 	// Apply the provider override BEFORE getProvider() resolves below, so the
 	// resolved value (used for scoring + cost) reflects the override. Required
@@ -616,52 +728,44 @@ async function main() {
 			}
 		}
 
-		// One run id for the whole sweep, shared by the result file
-		// (`results/<slug>.json`) and the transcript directory
-		// (`results/<slug>/`) so they are trivially correlated on disk.
-		const runId = new Date().toISOString();
-		const runIdSlug = runId.replace(/[:.]/g, '-');
-		const transcriptDir = join(EVALS_DIR, 'results', runIdSlug);
-		await mkdir(transcriptDir, { recursive: true });
-
-		// Run tasks sequentially. Each task runs `repeat` times so we can report
-		// pass^k reliability on top of per-run pass/solve rates. Module-scoped
-		// task tracking lets the SIGINT handler print "N of M completed" and
-		// clean up the in-progress task's scratch files.
-		totalPlannedTasks = tasks.length * repeat;
-		completedTaskCount = 0;
-		const taskResults = [];
-		for (const task of tasks) {
-			const runs = [];
-			for (let i = 0; i < repeat; i++) {
-				const runLabel = repeat > 1 ? ` [run ${i + 1}/${repeat}]` : '';
-				console.log(`\n--- Running: ${task.id}${runLabel} ---`);
-				currentTaskInfo = { taskId: task.id, sessionInfo: null, runIndex: i, repeat };
-				try {
-					runs.push(
-						await runTask(task, keepArtifacts, provider, judgeFn, { transcriptDir, runIdSlug, runIndex: i + 1 })
-					);
-				} finally {
-					currentTaskInfo = null;
-					completedTaskCount += 1;
-				}
+		if (models) {
+			// Multi-model sweep: run the suite once per model, then emit a
+			// side-by-side comparison table. Each model gets its own result file
+			// (and baseline lineage) via runAllTasks; the comparison is the
+			// "which model should I use" view the operator wants at a glance.
+			console.log(`Sweeping ${models.length} model(s): ${models.join(', ')}`);
+			const sweepResults = [];
+			for (const m of models) {
+				console.log(`\n========== Model: ${m} ==========`);
+				await applyModelOverride(m);
+				await prepareOllamaModel(m, provider);
+				sweepResults.push(await runAllTasks({ tasks, repeat, keepArtifacts, provider, judgeFn }));
 			}
-			taskResults.push(aggregateTaskRuns(task, runs));
+			const sweepId = new Date().toISOString();
+			const comparisonPath = await writeComparisonTable(sweepResults, EVALS_DIR, sweepId);
+			console.log('\n=== Model comparison ===');
+			console.log(formatComparisonMarkdown(sweepResults));
+			console.log(`Comparison table written to: ${comparisonPath}`);
+		} else {
+			// Single-model run. Apply the `--model=` override (if any) up front so
+			// the result file's `model` field reflects it, then warm the model.
+			if (model !== null) {
+				await applyModelOverride(model);
+				console.log(`Overriding chat/summary/completions models → ${model}`);
+			}
+			// Warm whichever model the run will actually use — the override target,
+			// or the plugin's current chat model when no override was passed.
+			const effectiveModel = model ?? (await getSetting('chatModelName'));
+			await prepareOllamaModel(effectiveModel, provider);
+
+			const result = await runAllTasks({ tasks, repeat, keepArtifacts, provider, judgeFn });
+
+			// Auto-compare against the blessed baseline for this (provider, model)
+			// so the operator sees regressions without typing eval:compare.
+			await maybeCompareToBaseline(result);
 		}
-
-		// Build result, write, print
-		const gitSha = getGitSha();
-		const modelName = await getModelName();
-		const result = buildResult(taskResults, gitSha, modelName, provider, runId);
-		const outPath = await writeResults(result, EVALS_DIR);
-		printSummary(result);
-		console.log(`Results written to: ${outPath}`);
-
-		// Auto-compare against the blessed baseline for this (provider, model)
-		// so the operator sees regressions without typing eval:compare.
-		await maybeCompareToBaseline(result);
 	} finally {
-		await restoreChatModel();
+		await restoreModelOverride();
 		await restoreProvider();
 		await restoreChatHistory();
 	}

--- a/test/evals/reporter.test.ts
+++ b/test/evals/reporter.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { aggregateTaskRuns, buildResult, computeAggregates } from '../../evals/lib/reporter.mjs';
+import {
+	aggregateTaskRuns,
+	buildResult,
+	computeAggregates,
+	formatComparisonMarkdown,
+} from '../../evals/lib/reporter.mjs';
 
 function run(passed: boolean, solved: boolean) {
 	return {
@@ -76,5 +81,51 @@ describe('buildResult — run id', () => {
 		const result = buildResult([], 'abc123', 'gemini-2.5-flash', 'gemini');
 		expect(typeof result.run_id).toBe('string');
 		expect(Number.isNaN(Date.parse(result.run_id))).toBe(false);
+	});
+});
+
+describe('formatComparisonMarkdown — model sweep table', () => {
+	function resultFor(model: string, tasks: ReturnType<typeof aggregateTaskRuns>[]) {
+		return buildResult(tasks, 'abc123', model, 'ollama', '2026-07-02T00:00:00.000Z');
+	}
+
+	it('renders one column per model with per-task solve cells and summary rows', () => {
+		const tasksA = [
+			aggregateTaskRuns({ id: 'find-tagged' }, [run(true, true), run(true, true)]),
+			aggregateTaskRuns({ id: 'summarize' }, [run(true, true), run(true, false)]),
+		];
+		const md = formatComparisonMarkdown([resultFor('gemma4:latest', tasksA), resultFor('gemma4:26b', tasksA)]);
+
+		// Header carries both model names.
+		expect(md).toContain('| Task | gemma4:latest | gemma4:26b |');
+		// Per-task solve cells, with the flaky flag on the 1/2 task.
+		expect(md).toContain('| find-tagged | 2/2 | 2/2 |');
+		expect(md).toContain('| summarize | 1/2 ⚠ | 1/2 ⚠ |');
+		// Summary rows use the k from n_runs.
+		expect(md).toContain('**solve^2 rate**');
+		expect(md).toContain('**pass^2 rate**');
+	});
+
+	it('fills a dash for a task missing from one model and unions task ids in order', () => {
+		const a = resultFor('model-a', [aggregateTaskRuns({ id: 'shared' }, [run(true, true)])]);
+		const b = resultFor('model-b', [
+			aggregateTaskRuns({ id: 'shared' }, [run(true, true)]),
+			aggregateTaskRuns({ id: 'only-b' }, [run(true, true)]),
+		]);
+		const md = formatComparisonMarkdown([a, b]);
+		expect(md).toContain('| shared | 1/1 | 1/1 |');
+		// `only-b` ran only for model-b, so model-a's cell is an em dash.
+		expect(md).toContain('| only-b | — | 1/1 |');
+	});
+
+	it('reports "free" total cost when spend is zero (local providers)', () => {
+		const freeRun = { ...run(true, true), metrics: { ...run(true, true).metrics, cost_usd: 0 } };
+		const md = formatComparisonMarkdown([resultFor('gemma4:latest', [aggregateTaskRuns({ id: 't' }, [freeRun])])]);
+		expect(md).toContain('**total cost**');
+		expect(md).toContain('free');
+	});
+
+	it('returns a placeholder for an empty result set', () => {
+		expect(formatComparisonMarkdown([])).toContain('No results to compare');
 	});
 });


### PR DESCRIPTION
<!-- auto-dev -->

## Summary

Makes model-swap eval runs friction-free by teaching `npm run eval` three model-orchestration behaviors. PR #694's Ollama runs exposed how manual switching is today (read settings → kill run → poll `ollama ps` for unload → re-set model → re-run); this removes that dance and adds a comparison mode for the "which model should I use?" decision.

Fixes #716

## Changes

- **Warmup (Ollama):** before the first *timed* task, fire a throwaway generation to load the model so the first task's turn time excludes cold-start latency. Printed separately as `warmup: Xs`, never counted toward scores.
- **Auto-swap with unload (Ollama):** before loading the target model, unload any *other* resident model (`ollama ps` → `ollama stop`) and poll until clear, so a swap doesn't briefly double-load two large models. Applies to `--model=` and each step of a `--models=` sweep.
- **Multi-model sweep:** `--models=A,B,C` runs the whole suite once per model and writes/prints a side-by-side comparison table — one column per model, `solved/n` per task (flaky flagged ⚠), plus solve^k / pass^k / mean-turns / total-cost summary rows. Mutually exclusive with `--model=`. Each model still produces its own `results/<slug>.json` and baseline lineage.
- **`--model=` now sets all three model fields** (`chatModelName`, `summaryModelName`, `completionsModelName`) rather than chat only, so summary/completion-driven tasks exercise the requested model. All three are captured on first override and restored on exit — across a sweep and on SIGINT/SIGTERM.
- `evals/lib/ollama.mjs` **(new)** — resident-model inspection, unload+poll, and warmup helpers that shell out to the `ollama` CLI and **degrade to a no-op** (with a one-line warning) when it isn't installed/reachable, so Gemini runs are unaffected. Honors `OLLAMA_BIN`.
- `evals/lib/reporter.mjs` — `formatComparisonMarkdown()` (pure) + `writeComparisonTable()`.
- `evals/run.mjs` — `--models` parsing, extracted `runAllTasks()` suite core, and `applyModelOverride`/`restoreModelOverride`.
- `test/evals/reporter.test.ts` — coverage for `formatComparisonMarkdown` (columns/cells, flaky flag, missing-task dash + id union, "free" cost, empty set).
- `docs` — `evals/README.md` updated: model-orchestration, multi-model sweep, and override sections.

**Deviations from the plan:** (1) the real setting key is `completionsModelName` (plural), not the plan's `completionModelName`. (2) the ollama CLI helpers live in a small new `evals/lib/ollama.mjs` rather than inline in `run.mjs`, matching the repo's `evals/lib/` module pattern and keeping `run.mjs` reviewable. Scope, warmup, unload-before-load, all-three-model override, sweep + comparison table all follow the approved plan.

## Screenshots / Screencast

N/A — dev-only eval harness change; no plugin UI or runtime behavior touched.

> [!IMPORTANT]
> The Ollama runtime paths (`ollama ps`/`stop`, unload polling, warmup, and real model-swap timing) **cannot be exercised headlessly** — CI covers only the pure logic (arg parsing, comparison-table rendering) and no-op degradation. This needs a **manual test pass against a live Ollama** before merge, per the maintainer's note on #716: `npm run eval -- --model=…` and `--models=A,B,C` to confirm the swap/unload/warmup and comparison table work end-to-end.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer — Fixes #716 (plan approved via `auto:ready`)
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — 3184 tests pass; build, `typecheck:test`, and format-check clean locally
- [ ] I have tested this change on Desktop — **partially**: pure logic verified via unit tests; the Ollama runtime paths require a manual test pass against a live Ollama (see note above)
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A: dev-only Node eval harness, never bundled into the plugin
- [x] Documentation has been updated (if applicable) — `evals/README.md`
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude (auto-dev pipeline)
- [x] I have reviewed and understand all AI-generated code in this PR

---
_Produced by the auto-dev pipeline from the approved plan on #716._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--model=` and `--models=` for single-model runs and multi-model sweeps (with mutual exclusivity), including per-model outputs and an automatically generated side-by-side comparison markdown report.
  * Improved Ollama orchestration with model warmup, resident model unloading/switching, and best-effort handling when Ollama CLI isn’t available.
* **Bug Fixes**
  * Ensured temporary `--model=`/`--models=` and `--provider=` overrides are restored on completion or interruption (Ctrl-C/SIGTERM).
* **Documentation**
  * Expanded eval run and model-selection guidance, including provider behavior and overwrite/transience details.
* **Tests**
  * Added coverage for sweep comparison markdown formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->