### PR TITLE
docs(skills): track upstream drift for kepano-adapted bundled skills (#966)

### DIFF
--- a/.agents/skills/daily-update/SKILL.md
+++ b/.agents/skills/daily-update/SKILL.md
@@ -26,7 +26,32 @@ Run these in order. Each one's full workflow lives in its own SKILL.md — read 
    - This sub-skill has GitHub side-effects — labels are applied directly. The working tree is unaffected.
    - Capture the count of issues labeled and the labels applied; surface it in the PR body even when the working tree is clean.
 
+4. **Bundled skill drift check** (inline — no separate `SKILL.md`; see "Bundled skill drift check" below)
+   - Compares the three kepano-adapted bundled skills against their upstream sources, using the SHAs pinned in `SKILL_SOURCES.md`.
+   - **Report-only, like `triage-issues`**: it writes nothing to the working tree and never bumps the pinned SHA. Surface any flagged drift in the run report (and the PR body if one is opened).
+
 When adding a new daily sub-skill in the future, append it here with the same shape (name → path → one-line outcome). Order matters only when sub-skills overlap on output paths (today they don't).
+
+## Bundled skill drift check
+
+Three bundled skills — `obsidian-markdown`, `json-canvas`, and `obsidian-bases` — are **adaptations** of upstream skills from [kepano/obsidian-skills](https://github.com/kepano/obsidian-skills), re-framed for this plugin's function tools. `SKILL_SOURCES.md` (repo root) pins the upstream path and last-reconciled SHA for each. This check flags when upstream has moved ahead of a pinned SHA so a human can reconcile; it does **not** edit any `SKILL.md` or bump the pin (see [docs/contributing/bundled-skills.md](../../../docs/contributing/bundled-skills.md) for the reconcile workflow).
+
+For each row in `SKILL_SOURCES.md`, read the pinned SHA and upstream path, then find the newest upstream commit that touched that path:
+
+```bash
+# newest upstream commit SHA affecting the path (main branch)
+gh api "repos/kepano/obsidian-skills/commits?path=<upstream-path>&per_page=1&sha=main" \
+  --jq '.[0].sha'
+```
+
+If the newest SHA differs from the pinned SHA, upstream has changed. Fetch the diff between the pin and `main` for that path and report it inline:
+
+```bash
+gh api "repos/kepano/obsidian-skills/compare/<pinned-sha>...main" \
+  --jq '.files[] | select(.filename=="<upstream-path>") | {filename, status, additions, deletions, patch}'
+```
+
+Report, per adapted skill: `up to date` (newest == pinned) or `drift: upstream moved to <short-sha>` with the diff and a note that the adapted `SKILL.md` needs a manual reconcile. If `gh`/the network is unavailable, record the check as errored (like any other sub-skill error) and move on — never guess.
 
 ## Workflow
 
@@ -60,17 +85,17 @@ git status --short
 
 Decide what to do based on three cases:
 
-**Case A — the working tree is clean and `triage-issues` did nothing.** Quiet day:
+**Case A — the working tree is clean, `triage-issues` did nothing, and the drift check found no drift.** Quiet day:
 
 - Don't commit. Don't push. Don't open a PR. Empty PRs are noise.
 - Delete the branch you just created (`git checkout master && git branch -D "$BRANCH_NAME"`) so the local branch list stays clean.
 - Report "no daily changes" and stop. The cron's job is done; absence of a PR is the signal.
 
-**Case B — the working tree is clean but `triage-issues` applied labels.** Report-only day:
+**Case B — the working tree is clean but `triage-issues` applied labels or the drift check flagged upstream drift.** Report-only day:
 
-- Don't open a PR. Labels on GitHub are already applied — opening an empty-diff PR just to write a summary is more friction than it's worth.
+- Don't open a PR. Labels on GitHub are already applied, and the drift check writes nothing — opening an empty-diff PR just to write a summary is more friction than it's worth.
 - Delete the branch (same as Case A: `git checkout master && git branch -D "$BRANCH_NAME"`).
-- Reply with the triage summary so a human can audit the labels if they want.
+- Reply with the triage summary and/or the flagged bundled-skill drift so a human can act on it if they want.
 
 **Case C — the working tree has changes.** Commit them all in one commit:
 

--- a/.agents/skills/daily-update/SKILL.md
+++ b/.agents/skills/daily-update/SKILL.md
@@ -44,14 +44,14 @@ gh api "repos/kepano/obsidian-skills/commits?path=<upstream-path>&per_page=1&sha
   --jq '.[0].sha'
 ```
 
-If the newest SHA differs from the pinned SHA, upstream has changed. Fetch the diff between the pin and `main` for that path and report it inline:
+If the newest SHA differs from the pinned SHA, upstream has changed — the differing SHA is the authoritative drift signal, and a **rename or delete counts as drift too**. Fetch the diff between the pin and `main`, matching the path as either the current filename **or** a `previous_filename` (renamed-from), so moves and deletions aren't missed:
 
 ```bash
 gh api "repos/kepano/obsidian-skills/compare/<pinned-sha>...main" \
-  --jq '.files[] | select(.filename=="<upstream-path>") | {filename, status, additions, deletions, patch}'
+  --jq '.files[] | select(.filename=="<upstream-path>" or .previous_filename=="<upstream-path>") | {filename, previous_filename, status, additions, deletions, patch}'
 ```
 
-Report, per adapted skill: `up to date` (newest == pinned) or `drift: upstream moved to <short-sha>` with the diff and a note that the adapted `SKILL.md` needs a manual reconcile. If `gh`/the network is unavailable, record the check as errored (like any other sub-skill error) and move on — never guess.
+Report, per adapted skill: `up to date` (newest == pinned) or `drift: upstream moved to <short-sha>` with the diff and a note that the adapted `SKILL.md` needs a manual reconcile. A `renamed` or `removed` status means the upstream file moved or was deleted — still drift; flag it for reconcile even when the patch is empty. If the SHA differs but the filter yields nothing (e.g. an unusual rename chain), treat it as drift needing investigation, never as "up to date." If `gh`/the network is unavailable, record the check as errored (like any other sub-skill error) and move on — never guess.
 
 ## Workflow
 

--- a/.agents/skills/daily-update/SKILL.md
+++ b/.agents/skills/daily-update/SKILL.md
@@ -85,17 +85,17 @@ git status --short
 
 Decide what to do based on three cases:
 
-**Case A — the working tree is clean, `triage-issues` did nothing, and the drift check found no drift.** Quiet day:
+**Case A — the working tree is clean, `triage-issues` did nothing, the drift check found no drift, and no sub-skill errored.** Quiet day:
 
 - Don't commit. Don't push. Don't open a PR. Empty PRs are noise.
 - Delete the branch you just created (`git checkout master && git branch -D "$BRANCH_NAME"`) so the local branch list stays clean.
 - Report "no daily changes" and stop. The cron's job is done; absence of a PR is the signal.
 
-**Case B — the working tree is clean but `triage-issues` applied labels or the drift check flagged upstream drift.** Report-only day:
+**Case B — the working tree is clean but `triage-issues` applied labels, the drift check flagged upstream drift, or a sub-skill errored.** Report-only day:
 
 - Don't open a PR. Labels on GitHub are already applied, and the drift check writes nothing — opening an empty-diff PR just to write a summary is more friction than it's worth.
 - Delete the branch (same as Case A: `git checkout master && git branch -D "$BRANCH_NAME"`).
-- Reply with the triage summary and/or the flagged bundled-skill drift so a human can act on it if they want.
+- Reply with the triage summary, any flagged bundled-skill drift, and any sub-skill errors captured during the run, so a human can act on them. A run that produced no changes but hit a sub-skill error still reports here — it is never silently swallowed as a quiet day.
 
 **Case C — the working tree has changes.** Commit them all in one commit:
 

--- a/SKILL_SOURCES.md
+++ b/SKILL_SOURCES.md
@@ -1,0 +1,35 @@
+# Bundled skill sources
+
+Three of this repo's bundled agent skills are **adaptations** of upstream skills from
+[kepano/obsidian-skills](https://github.com/kepano/obsidian-skills). They are re-framed for
+this plugin's in-Obsidian function tools (`write_file`, `update_frontmatter`, `read_file`)
+rather than the CLI workflow the upstream skills assume, so they are **adaptations, not
+verbatim copies** — upstream changes are hand-merged into our framing, never blindly
+re-pulled.
+
+This file pins the upstream commit each adapted skill was last reconciled against, so the
+`daily-update` skill's [bundled skill drift check](.agents/skills/daily-update/SKILL.md)
+can flag upstream changes to those files since that point. See
+[docs/contributing/bundled-skills.md](docs/contributing/bundled-skills.md) for the full
+reconcile workflow.
+
+| Adapted skill       | Local path                                          | Upstream repo            | Upstream path                       | Last-reconciled SHA                        | Date       |
+| ------------------- | --------------------------------------------------- | ------------------------ | ----------------------------------- | ------------------------------------------ | ---------- |
+| `obsidian-markdown` | `prompts/bundled-skills/obsidian-markdown/SKILL.md` | `kepano/obsidian-skills` | `skills/obsidian-markdown/SKILL.md` | `a1dc48e68138490d522c04cbf5822214c6eb1202` | 2026-06-08 |
+| `json-canvas`       | `prompts/bundled-skills/json-canvas/SKILL.md`       | `kepano/obsidian-skills` | `skills/json-canvas/SKILL.md`       | `a1dc48e68138490d522c04cbf5822214c6eb1202` | 2026-06-08 |
+| `obsidian-bases`    | `prompts/bundled-skills/obsidian-bases/SKILL.md`    | `kepano/obsidian-skills` | `skills/obsidian-bases/SKILL.md`    | `a1dc48e68138490d522c04cbf5822214c6eb1202` | 2026-06-08 |
+
+## Not tracked here
+
+- The `obsidian-cli` skill (`.agents/skills/obsidian-cli/`) tracks the official Obsidian CLI
+  directly (`obsidian --help` / help.obsidian.md), **not** kepano — out of scope.
+- Every other bundled skill under `prompts/bundled-skills/` is original to this repo and has
+  no upstream to reconcile against.
+
+## Reconciling
+
+When the drift check flags upstream commits, follow
+[docs/contributing/bundled-skills.md](docs/contributing/bundled-skills.md): read the upstream
+diff, **adapt** (don't copy) the change into our function-tool framing, then bump the SHA and
+date in the row above. Bumping the SHA without adapting hides real drift, so the two always
+move together.

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -75,6 +75,7 @@ export default defineConfig({
 						{ text: 'AI Policy', link: '/contributing/ai-policy' },
 						{ text: 'Testing', link: '/contributing/testing' },
 						{ text: 'Tool Development', link: '/contributing/tool-development' },
+						{ text: 'Bundled Skills', link: '/contributing/bundled-skills' },
 					],
 				},
 			],

--- a/docs/contributing/bundled-skills.md
+++ b/docs/contributing/bundled-skills.md
@@ -1,0 +1,52 @@
+# Reconciling Bundled Skills with Upstream
+
+Three of the plugin's bundled agent skills are **adaptations** of upstream skills from
+[kepano/obsidian-skills](https://github.com/kepano/obsidian-skills):
+
+- `prompts/bundled-skills/obsidian-markdown/SKILL.md`
+- `prompts/bundled-skills/json-canvas/SKILL.md`
+- `prompts/bundled-skills/obsidian-bases/SKILL.md`
+
+They are re-framed for this plugin's in-Obsidian **function tools** (`write_file`,
+`update_frontmatter`, `read_file`) instead of the CLI workflow the upstream skills assume.
+Because they are adaptations rather than verbatim copies, we can't blindly re-pull upstream
+when kepano changes the underlying format guidance (Bases syntax, the JSON Canvas spec,
+Obsidian Flavored Markdown). Instead we **track drift and hand-merge**.
+
+## The pinned baseline
+
+[`SKILL_SOURCES.md`](../../SKILL_SOURCES.md) (repo root) records, per adapted skill, the
+upstream path and the commit SHA it was last reconciled against. That SHA is the baseline the
+drift check compares against — it is the single source of truth for "how current are our
+adaptations."
+
+## How drift is surfaced
+
+The [`daily-update`](../../.agents/skills/daily-update/SKILL.md) skill runs a **report-only**
+bundled skill drift check on each scheduled run. For each adapted skill it lists the upstream
+commits that touched that file since the pinned SHA and, if any exist, surfaces the diff in
+the run report so a human can decide whether it's worth reconciling. The check never edits a
+`SKILL.md` and never bumps the pinned SHA — flagging drift is automated, adapting it is not.
+
+## Reconcile workflow
+
+When the drift check flags an upstream change:
+
+1. **daily-update reports the drift** — the run report names which adapted skill has upstream
+   commits ahead of its pinned SHA and links the upstream diff.
+2. **Read the upstream diff** — understand what changed in the format guidance. Not every
+   upstream commit is relevant; a wording tweak on a section we don't mirror may need no
+   action beyond bumping the SHA.
+3. **Adapt, don't copy** — re-frame the meaningful change for our function-tool framing
+   (`write_file` / `update_frontmatter` / `read_file`), matching the voice and structure of
+   the existing adapted skill. Never paste the upstream CLI-oriented text verbatim.
+4. **Bump the SHA and date** — update the skill's row in `SKILL_SOURCES.md` to the upstream
+   commit you reconciled against and today's date. Do this in the **same** PR as the
+   adaptation so the pin never claims currency the content doesn't have.
+
+## Out of scope
+
+- **Automated merging** of upstream changes — reconciliation is always a human adaptation.
+- **Non-`SKILL.md` upstream files** — only the three `SKILL.md` files above are tracked.
+- **The `obsidian-cli` skill** — it tracks the official Obsidian CLI, not kepano, and is
+  reconciled through its own mechanism.

--- a/docs/contributing/bundled-skills.md
+++ b/docs/contributing/bundled-skills.md
@@ -15,14 +15,14 @@ Obsidian Flavored Markdown). Instead we **track drift and hand-merge**.
 
 ## The pinned baseline
 
-[`SKILL_SOURCES.md`](../../SKILL_SOURCES.md) (repo root) records, per adapted skill, the
+[`SKILL_SOURCES.md`](https://github.com/allenhutchison/obsidian-gemini/blob/master/SKILL_SOURCES.md) (repo root) records, per adapted skill, the
 upstream path and the commit SHA it was last reconciled against. That SHA is the baseline the
 drift check compares against — it is the single source of truth for "how current are our
 adaptations."
 
 ## How drift is surfaced
 
-The [`daily-update`](../../.agents/skills/daily-update/SKILL.md) skill runs a **report-only**
+The [`daily-update`](https://github.com/allenhutchison/obsidian-gemini/blob/master/.agents/skills/daily-update/SKILL.md) skill runs a **report-only**
 bundled skill drift check on each scheduled run. For each adapted skill it lists the upstream
 commits that touched that file since the pinned SHA and, if any exist, surfaces the diff in
 the run report so a human can decide whether it's worth reconciling. The check never edits a


### PR DESCRIPTION
<!-- auto-dev -->

## Summary

Three bundled agent skills (`obsidian-markdown`, `json-canvas`, `obsidian-bases`) are **adaptations** of upstream skills from [kepano/obsidian-skills](https://github.com/kepano/obsidian-skills), re-framed for this plugin's in-Obsidian function tools (`write_file`, `update_frontmatter`, `read_file`). Because they're adaptations rather than copies, we can't blindly re-pull upstream — but until now there was also no signal when kepano fixed or extended the underlying format guidance (Bases syntax, JSON Canvas spec, OFM), so that drift was invisible. This adds a durable pinned baseline, an automated report-only drift check, and a documented reconcile workflow.

Produced by the auto-dev pipeline from the approved plan on #966.

Fixes #966

## Changes

- **`SKILL_SOURCES.md` (new, repo root)** — a table mapping each adapted skill → upstream repo (`kepano/obsidian-skills`), upstream path, last-reconciled SHA (`a1dc48e68138490d522c04cbf5822214c6eb1202`), and date (2026-06-08). Notes that `obsidian-cli` and all other bundled skills are out of scope.
- **`.agents/skills/daily-update/SKILL.md`** — add a **report-only** "Bundled skill drift check": for each pinned skill it uses the GitHub API to find the newest upstream commit touching that path, and if it differs from the pinned SHA, fetches and reports the diff. It writes nothing and never bumps the pin. Wired into the sub-skill list and the report-only Case A/B logic alongside `triage-issues`.
- **`docs/contributing/bundled-skills.md` (new)** — documents the reconcile workflow: daily-update flags drift → maintainer reads the upstream diff → adapts (not copies) into our function-tool framing → bumps the SHA + date in `SKILL_SOURCES.md`.
- **`docs/.vitepress/config.mts`** — add the new contributing doc to the sidebar nav.

**Deviation from the plan:** the plan proposed `docs/contributing/bundled-skills.md` "(new, or extend `docs/contributing/`)"; a new dedicated doc was the better fit, and its sidebar entry was added for navigation parity with the other contributing docs. Scope (pinned baseline, drift check, reconcile doc) otherwise follows the approved plan; the reconcile step stays a documented manual action — auto-dev flags drift, the maintainer adapts.

## Screenshots / Screencast

N/A — documentation/tooling only; no plugin UI or runtime behavior touched.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer — Fixes #966 (plan approved via `auto:ready`)
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — 3180 tests pass; build, `typecheck:test`, and format-check clean locally
- [x] I have tested this change on Desktop — N/A: no runtime code; docs + a scheduled-skill instruction change, verified via the build/test/format preflight
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A: no plugin runtime/platform code touched
- [x] Documentation has been updated (if applicable) — this PR is the documentation (`SKILL_SOURCES.md`, `docs/contributing/bundled-skills.md`, sidebar nav)
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude (auto-dev pipeline)
- [x] I have reviewed and understand all AI-generated code in this PR

---
_Produced by the auto-dev pipeline from the approved plan on #966._

---
_Generated by [Claude Code](https://claude.ai/code/session_01MD4AkUeLzbbKujXQY5sFhp)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a report-only upstream drift check for bundled skills, highlighting when upstream changes affect the pinned versions without auto-updating bundled content.
  * Updated the daily automation logic to incorporate drift-check outcomes when deciding whether to create a report/PR or remain silent.

* **Documentation**
  * Added `SKILL_SOURCES.md` to record the pinned upstream commit SHA and date for each bundled skill.
  * Introduced a new “Bundled Skills” contributing page and expanded the manual reconciliation workflow and scope notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->