### PR TITLE
refactor(tools): extract shared grounding-tool runner (#974)

### DIFF
--- a/src/tools/google-maps-tool.ts
+++ b/src/tools/google-maps-tool.ts
@@ -1,15 +1,15 @@
 import { Tool, ToolResult, ToolExecutionContext } from './types';
 import { ToolCategory } from '../types/agent';
 import { ToolClassification } from '../types/tool-policy';
-import { getDefaultModelForRole } from '../models';
-import { createGoogleGenAI } from '../api/providers/gemini/google-genai-factory';
-import { executeWithRetry } from '../utils/retry';
+import { runGroundingTool } from './grounding-tool-runner';
 
 /**
  * Google Maps grounding tool that uses a separate model instance with the
  * `googleMaps` grounding tool enabled. Mirrors {@link GoogleSearchTool} but
  * grounds answers in Google Maps place data (locations, hours, reviews,
- * directions) instead of web search results.
+ * directions) instead of web search results. The shared execute pipeline lives
+ * in {@link runGroundingTool}; this class only holds the Maps-specific metadata
+ * and grounding configuration.
  */
 export class GoogleMapsTool implements Tool {
 	name = 'google_maps';
@@ -39,120 +39,20 @@ export class GoogleMapsTool implements Tool {
 	}
 
 	async execute(params: { query: string }, context: ToolExecutionContext): Promise<ToolResult> {
-		const plugin = context.plugin;
-
-		try {
-			// Check if API key is available
-			if (!plugin.apiKey) {
-				return {
-					success: false,
-					error: 'Google API key not configured',
-				};
-			}
-
-			// Create a separate model instance with Google Maps grounding enabled
-			const genAI = createGoogleGenAI(plugin);
-			const modelToUse = plugin.settings.chatModelName || getDefaultModelForRole('chat');
-			const config = {
-				temperature: plugin.settings.temperature,
-				maxOutputTokens: 8192,
-				tools: [{ googleMaps: {} }],
-			};
-
-			const prompt = `Please answer the following using current Google Maps information about real-world places: ${params.query}`;
-
-			const result = await executeWithRetry(
-				() =>
-					genAI.models.generateContent({
-						model: modelToUse,
-						config: config,
-						contents: prompt,
-					}),
-				undefined,
-				{ operationName: 'GoogleMapsTool.generateContent', logger: plugin.logger }
-			);
-
-			// Extract text from response
-			let text = '';
-			if (result.candidates?.[0]?.content?.parts) {
-				for (const part of result.candidates[0].content.parts) {
-					if (part.text) {
-						text += part.text;
-					}
-				}
-			} else if (result.text) {
-				try {
-					text = result.text;
-				} catch (e) {
-					plugin.logger.warn('Failed to get text from result:', e);
-				}
-			}
-
-			// Extract grounding metadata and place citations if available
-			const groundingMetadata = result.candidates?.[0]?.groundingMetadata;
-			let citations: Array<{ title?: string; url: string; snippet?: string }> = [];
-			let textWithCitations = text;
-
-			// Maps grounding returns place evidence on `chunk.maps` rather than `chunk.web`.
-			if (groundingMetadata?.groundingChunks) {
-				const chunks = groundingMetadata.groundingChunks;
-				citations = chunks
-					.filter((chunk: any) => chunk.maps?.uri)
-					.map((chunk: any) => ({
-						url: chunk.maps.uri,
-						title: chunk.maps.title || chunk.maps.uri,
-						snippet: chunk.maps.text || '',
-					}));
-
-				// Add inline citations to text if supports are available
-				if (groundingMetadata.groundingSupports) {
-					const supports = groundingMetadata.groundingSupports;
-					// Sort supports by end_index in descending order so insertions don't shift later offsets
-					const sortedSupports = [...supports].sort(
-						(a: any, b: any) => (b.segment?.endIndex ?? 0) - (a.segment?.endIndex ?? 0)
-					);
-
-					for (const support of sortedSupports) {
-						const endIndex = support.segment?.endIndex;
-						if (endIndex === undefined || !support.groundingChunkIndices?.length) {
-							continue;
-						}
-
-						const citationLinks = support.groundingChunkIndices
-							.map((i: number) => {
-								const uri = chunks[i]?.maps?.uri;
-								if (uri) {
-									return `[${i + 1}](${uri})`;
-								}
-								return null;
-							})
-							.filter(Boolean);
-
-						if (citationLinks.length > 0) {
-							const citationString = ` ${citationLinks.join(', ')}`;
-							textWithCitations =
-								textWithCitations.slice(0, endIndex) + citationString + textWithCitations.slice(endIndex);
-						}
-					}
-				}
-			}
-
-			return {
-				success: true,
-				data: {
-					query: params.query,
-					answer: textWithCitations, // Text with inline citations
-					originalAnswer: text, // Original text without citations
-					citations: citations,
-					searchGrounding: groundingMetadata || undefined,
-				},
-			};
-		} catch (error) {
-			return {
-				success: false,
-				error: `Google Maps lookup failed: ${error instanceof Error ? error.message : 'Unknown error'}`,
-			};
-		}
+		return runGroundingTool(context.plugin, {
+			query: params.query,
+			groundingTool: { googleMaps: {} },
+			// Maps grounding returns place evidence on `chunk.maps` rather than `chunk.web`,
+			// with the snippet stored on `text`.
+			getChunkCitation: (chunk) => ({
+				uri: chunk.maps?.uri,
+				title: chunk.maps?.title,
+				snippet: chunk.maps?.text,
+			}),
+			promptPrefix: 'Please answer the following using current Google Maps information about real-world places: ',
+			errorPrefix: 'Google Maps lookup failed: ',
+			operationName: 'GoogleMapsTool.generateContent',
+		});
 	}
 }
 

--- a/src/tools/google-search-tool.ts
+++ b/src/tools/google-search-tool.ts
@@ -1,12 +1,12 @@
 import { Tool, ToolResult, ToolExecutionContext } from './types';
 import { ToolCategory } from '../types/agent';
 import { ToolClassification } from '../types/tool-policy';
-import { getDefaultModelForRole } from '../models';
-import { createGoogleGenAI } from '../api/providers/gemini/google-genai-factory';
-import { executeWithRetry } from '../utils/retry';
+import { runGroundingTool } from './grounding-tool-runner';
 
 /**
- * Google Search tool that uses a separate model instance with search grounding
+ * Google Search tool that uses a separate model instance with search grounding.
+ * The shared execute pipeline lives in {@link runGroundingTool}; this class only
+ * holds the Search-specific metadata and grounding configuration.
  */
 export class GoogleSearchTool implements Tool {
 	name = 'google_search';
@@ -37,126 +37,20 @@ export class GoogleSearchTool implements Tool {
 	}
 
 	async execute(params: { query: string }, context: ToolExecutionContext): Promise<ToolResult> {
-		const plugin = context.plugin;
-
-		try {
-			// Check if API key is available
-			if (!plugin.apiKey) {
-				return {
-					success: false,
-					error: 'Google API key not configured',
-				};
-			}
-
-			// Create a separate model instance with Google Search enabled
-			const genAI = createGoogleGenAI(plugin);
-			// Use the models API similar to gemini-api-new.ts
-			const modelToUse = plugin.settings.chatModelName || getDefaultModelForRole('chat');
-			const config = {
-				temperature: plugin.settings.temperature,
-				maxOutputTokens: 8192, // Default max tokens
-				tools: [{ googleSearch: {} }],
-			};
-
-			// Create a simple prompt that encourages the model to search
-			const prompt = `Please search for the following and provide a comprehensive answer based on current web results: ${params.query}`;
-
-			// Generate response with search grounding using the same API as gemini-api-new.ts
-			const result = await executeWithRetry(
-				() =>
-					genAI.models.generateContent({
-						model: modelToUse,
-						config: config,
-						contents: prompt,
-					}),
-				undefined,
-				{ operationName: 'GoogleSearchTool.generateContent', logger: plugin.logger }
-			);
-
-			// Extract text from response
-			let text = '';
-			if (result.candidates?.[0]?.content?.parts) {
-				// Extract text from parts
-				for (const part of result.candidates[0].content.parts) {
-					if (part.text) {
-						text += part.text;
-					}
-				}
-			} else if (result.text) {
-				// The text property might be a getter, not a function
-				try {
-					text = result.text;
-				} catch (e) {
-					// If it fails, it might be a legacy format
-					plugin.logger.warn('Failed to get text from result:', e);
-				}
-			}
-
-			// Extract search results metadata and citations if available
-			const searchMetadata = result.candidates?.[0]?.groundingMetadata;
-			let citations: Array<{ title?: string; url: string; snippet?: string }> = [];
-			let textWithCitations = text;
-
-			// Extract citations from groundingChunks
-			if (searchMetadata?.groundingChunks) {
-				const chunks = searchMetadata.groundingChunks;
-				citations = chunks
-					.filter((chunk: any) => chunk.web?.uri)
-					.map((chunk: any, _index: number) => ({
-						url: chunk.web.uri,
-						title: chunk.web.title || chunk.web.uri,
-						snippet: chunk.web.snippet || '',
-					}));
-
-				// Add inline citations to text if supports are available
-				if (searchMetadata.groundingSupports) {
-					const supports = searchMetadata.groundingSupports;
-					// Sort supports by end_index in descending order
-					const sortedSupports = [...supports].sort(
-						(a: any, b: any) => (b.segment?.endIndex ?? 0) - (a.segment?.endIndex ?? 0)
-					);
-
-					for (const support of sortedSupports) {
-						const endIndex = support.segment?.endIndex;
-						if (endIndex === undefined || !support.groundingChunkIndices?.length) {
-							continue;
-						}
-
-						const citationLinks = support.groundingChunkIndices
-							.map((i: number) => {
-								const uri = chunks[i]?.web?.uri;
-								if (uri) {
-									return `[${i + 1}](${uri})`;
-								}
-								return null;
-							})
-							.filter(Boolean);
-
-						if (citationLinks.length > 0) {
-							const citationString = ` ${citationLinks.join(', ')}`;
-							textWithCitations =
-								textWithCitations.slice(0, endIndex) + citationString + textWithCitations.slice(endIndex);
-						}
-					}
-				}
-			}
-
-			return {
-				success: true,
-				data: {
-					query: params.query,
-					answer: textWithCitations, // Text with inline citations
-					originalAnswer: text, // Original text without citations
-					citations: citations,
-					searchGrounding: searchMetadata || undefined,
-				},
-			};
-		} catch (error) {
-			return {
-				success: false,
-				error: `Google search failed: ${error instanceof Error ? error.message : 'Unknown error'}`,
-			};
-		}
+		return runGroundingTool(context.plugin, {
+			query: params.query,
+			groundingTool: { googleSearch: {} },
+			// Web-search evidence lives on `chunk.web`. `snippet` isn't in the SDK's
+			// GroundingChunkWeb type but the API returns it, so read it via a narrow cast.
+			getChunkCitation: (chunk) => ({
+				uri: chunk.web?.uri,
+				title: chunk.web?.title,
+				snippet: (chunk.web as { snippet?: string } | undefined)?.snippet,
+			}),
+			promptPrefix: 'Please search for the following and provide a comprehensive answer based on current web results: ',
+			errorPrefix: 'Google search failed: ',
+			operationName: 'GoogleSearchTool.generateContent',
+		});
 	}
 }
 

--- a/src/tools/grounding-tool-runner.ts
+++ b/src/tools/grounding-tool-runner.ts
@@ -1,0 +1,169 @@
+import { ToolResult } from './types';
+import type ObsidianGemini from '../main';
+import { getDefaultModelForRole } from '../models';
+import { createGoogleGenAI } from '../api/providers/gemini/google-genai-factory';
+import { executeWithRetry } from '../utils/retry';
+import { getRawErrorMessage } from '../utils/error-utils';
+import type { GroundingChunk } from '@google/genai';
+
+/**
+ * Citation fields pulled from a single grounding chunk. Each Gemini grounding
+ * source stores its evidence under a different subkey (`chunk.web` for Google
+ * Search, `chunk.maps` for Google Maps), so the caller supplies a
+ * {@link GroundingToolRequest.getChunkCitation} accessor that normalizes the
+ * provider-specific shape into these common fields.
+ */
+export interface GroundingCitationFields {
+	uri?: string;
+	title?: string;
+	snippet?: string;
+}
+
+/**
+ * Everything a specific grounding tool (Google Search, Google Maps, …) needs to
+ * feed into the shared {@link runGroundingTool} pipeline. Only the provider-specific
+ * pieces live here; the API-key guard, client construction, retry, text
+ * extraction, and reverse-sorted citation splicing are shared.
+ */
+export interface GroundingToolRequest {
+	/** The user's raw query. */
+	query: string;
+	/** The grounding tool config object passed to `generateContent`, e.g. `{ googleSearch: {} }`. */
+	groundingTool: object;
+	/** Pull the citation fields out of a grounding chunk (reads `chunk.web` vs `chunk.maps`). */
+	getChunkCitation(chunk: GroundingChunk): GroundingCitationFields;
+	/** Prefix prepended to the query to form the model prompt (include any trailing separator). */
+	promptPrefix: string;
+	/** Prefix for the error message on failure (include any trailing separator), e.g. `'Google search failed: '`. */
+	errorPrefix: string;
+	/** Operation name used for retry/logging telemetry. */
+	operationName: string;
+}
+
+/**
+ * Shared execution pipeline for Gemini "grounding" tools that answer a query by
+ * grounding the response in an external source (web search, Maps, …).
+ *
+ * Runs a single `generateContent` call with the given grounding tool enabled,
+ * extracts the answer text, collects citations from `groundingMetadata`, and
+ * splices inline `[n](url)` links into the answer by walking `groundingSupports`
+ * in descending `endIndex` order so earlier insertions don't shift later offsets.
+ *
+ * `GoogleSearchTool` and `GoogleMapsTool` are thin wrappers over this helper; the
+ * only differences between them are captured in {@link GroundingToolRequest}.
+ */
+export async function runGroundingTool(plugin: ObsidianGemini, req: GroundingToolRequest): Promise<ToolResult> {
+	try {
+		// Check if API key is available
+		if (!plugin.apiKey) {
+			return {
+				success: false,
+				error: 'Google API key not configured',
+			};
+		}
+
+		// Create a separate model instance with the requested grounding tool enabled
+		const genAI = createGoogleGenAI(plugin);
+		const modelToUse = plugin.settings.chatModelName || getDefaultModelForRole('chat');
+		const config = {
+			temperature: plugin.settings.temperature,
+			maxOutputTokens: 8192, // Default max tokens
+			tools: [req.groundingTool],
+		};
+
+		const prompt = `${req.promptPrefix}${req.query}`;
+
+		const result = await executeWithRetry(
+			() =>
+				genAI.models.generateContent({
+					model: modelToUse,
+					config: config,
+					contents: prompt,
+				}),
+			undefined,
+			{ operationName: req.operationName, logger: plugin.logger }
+		);
+
+		// Extract text from response
+		let text = '';
+		if (result.candidates?.[0]?.content?.parts) {
+			for (const part of result.candidates[0].content.parts) {
+				if (part.text) {
+					text += part.text;
+				}
+			}
+		} else if (result.text) {
+			// The text property might be a getter, not a function
+			try {
+				text = result.text;
+			} catch (e) {
+				// If it fails, it might be a legacy format
+				plugin.logger.warn('Failed to get text from result:', e);
+			}
+		}
+
+		// Extract grounding metadata and citations if available
+		const groundingMetadata = result.candidates?.[0]?.groundingMetadata;
+		let citations: Array<{ title?: string; url: string; snippet?: string }> = [];
+		let textWithCitations = text;
+
+		if (groundingMetadata?.groundingChunks) {
+			const chunks = groundingMetadata.groundingChunks;
+			citations = chunks
+				.map((chunk) => req.getChunkCitation(chunk))
+				.filter((citation): citation is GroundingCitationFields & { uri: string } => Boolean(citation.uri))
+				.map((citation) => ({
+					url: citation.uri,
+					title: citation.title || citation.uri,
+					snippet: citation.snippet || '',
+				}));
+
+			// Add inline citations to text if supports are available
+			if (groundingMetadata.groundingSupports) {
+				const supports = groundingMetadata.groundingSupports;
+				// Sort supports by end_index in descending order so insertions don't shift later offsets
+				const sortedSupports = [...supports].sort((a, b) => (b.segment?.endIndex ?? 0) - (a.segment?.endIndex ?? 0));
+
+				for (const support of sortedSupports) {
+					const endIndex = support.segment?.endIndex;
+					if (endIndex === undefined || !support.groundingChunkIndices?.length) {
+						continue;
+					}
+
+					const citationLinks = support.groundingChunkIndices
+						.map((i) => {
+							const chunk = chunks[i];
+							const uri = chunk ? req.getChunkCitation(chunk).uri : undefined;
+							if (uri) {
+								return `[${i + 1}](${uri})`;
+							}
+							return null;
+						})
+						.filter(Boolean);
+
+					if (citationLinks.length > 0) {
+						const citationString = ` ${citationLinks.join(', ')}`;
+						textWithCitations =
+							textWithCitations.slice(0, endIndex) + citationString + textWithCitations.slice(endIndex);
+					}
+				}
+			}
+		}
+
+		return {
+			success: true,
+			data: {
+				query: req.query,
+				answer: textWithCitations, // Text with inline citations
+				originalAnswer: text, // Original text without citations
+				citations: citations,
+				searchGrounding: groundingMetadata || undefined,
+			},
+		};
+	} catch (error) {
+		return {
+			success: false,
+			error: `${req.errorPrefix}${getRawErrorMessage(error)}`,
+		};
+	}
+}

--- a/test/tools/google-maps-tool.test.ts
+++ b/test/tools/google-maps-tool.test.ts
@@ -497,13 +497,13 @@ describe('GoogleMapsTool', () => {
 	});
 
 	describe('non-Error thrown by API', () => {
-		it('should include Unknown error for non-Error thrown', async () => {
+		it('should stringify a non-Error thrown value via getRawErrorMessage', async () => {
 			mockGenAI.models.generateContent.mockRejectedValue('string error');
 
 			const result = await tool.execute({ query: 'test' }, mockContext);
 
 			expect(result.success).toBe(false);
-			expect(result.error).toBe('Google Maps lookup failed: Unknown error');
+			expect(result.error).toBe('Google Maps lookup failed: string error');
 		});
 	});
 });

--- a/test/tools/google-search-tool.test.ts
+++ b/test/tools/google-search-tool.test.ts
@@ -554,22 +554,22 @@ describe('GoogleSearchTool', () => {
 	});
 
 	describe('non-Error thrown by API', () => {
-		it('should include Unknown error for non-Error thrown', async () => {
+		it('should stringify a non-Error string thrown via getRawErrorMessage', async () => {
 			mockGenAI.models.generateContent.mockRejectedValue('string error');
 
 			const result = await tool.execute({ query: 'test' }, mockContext);
 
 			expect(result.success).toBe(false);
-			expect(result.error).toBe('Google search failed: Unknown error');
+			expect(result.error).toBe('Google search failed: string error');
 		});
 
-		it('should include Unknown error for number thrown', async () => {
+		it('should stringify a non-Error number thrown via getRawErrorMessage', async () => {
 			mockGenAI.models.generateContent.mockRejectedValue(42);
 
 			const result = await tool.execute({ query: 'test' }, mockContext);
 
 			expect(result.success).toBe(false);
-			expect(result.error).toBe('Google search failed: Unknown error');
+			expect(result.error).toBe('Google search failed: 42');
 		});
 	});
 });

--- a/test/tools/grounding-tool-runner.test.ts
+++ b/test/tools/grounding-tool-runner.test.ts
@@ -1,0 +1,312 @@
+import type { Mock } from 'vitest';
+import { runGroundingTool, GroundingToolRequest } from '../../src/tools/grounding-tool-runner';
+import { createGoogleGenAI } from '../../src/api/providers/gemini/google-genai-factory';
+import { getDefaultModelForRole } from '../../src/models';
+import type { GroundingChunk } from '@google/genai';
+
+// Mock the genAI factory so we control the generateContent implementation.
+vi.mock('../../src/api/providers/gemini/google-genai-factory', () => ({
+	createGoogleGenAI: vi.fn(),
+}));
+
+// Run the wrapped operation with zero retries so tests stay fast and deterministic.
+vi.mock('../../src/utils/retry', async () => {
+	const actual = await vi.importActual<any>('../../src/utils/retry');
+	return {
+		...actual,
+		executeWithRetry: vi.fn().mockImplementation((operation, _config, options) => {
+			const zeroConfig = { maxRetries: 0, initialDelayMs: 1, maxDelayMs: 1, jitter: false };
+			return actual.executeWithRetry(operation, zeroConfig, options);
+		}),
+	};
+});
+
+/** A `chunk.web`-style accessor, matching how GoogleSearchTool reads its chunks. */
+const webCitation = (chunk: GroundingChunk) => ({
+	uri: chunk.web?.uri,
+	title: chunk.web?.title,
+	snippet: (chunk.web as { snippet?: string } | undefined)?.snippet,
+});
+
+function makeRequest(overrides: Partial<GroundingToolRequest> = {}): GroundingToolRequest {
+	return {
+		query: 'test query',
+		groundingTool: { googleSearch: {} },
+		getChunkCitation: webCitation,
+		promptPrefix: 'Please search for: ',
+		errorPrefix: 'Grounding failed: ',
+		operationName: 'GroundingToolRunner.test',
+		...overrides,
+	};
+}
+
+describe('runGroundingTool', () => {
+	let mockPlugin: any;
+	let mockGenAI: any;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+
+		mockGenAI = {
+			models: {
+				generateContent: vi.fn(),
+			},
+		};
+		(createGoogleGenAI as Mock).mockReturnValue(mockGenAI);
+
+		mockPlugin = {
+			apiKey: 'test-api-key',
+			settings: {
+				chatModelName: 'gemini-1.5-flash-002',
+				temperature: 0.7,
+			},
+			logger: {
+				warn: vi.fn(),
+				log: vi.fn(),
+				error: vi.fn(),
+				debug: vi.fn(),
+			},
+		};
+	});
+
+	describe('API-key guard', () => {
+		it('returns an error and does not call the API when no key is configured', async () => {
+			mockPlugin.apiKey = '';
+
+			const result = await runGroundingTool(mockPlugin, makeRequest());
+
+			expect(result.success).toBe(false);
+			expect(result.error).toBe('Google API key not configured');
+			expect(mockGenAI.models.generateContent).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('request construction', () => {
+		it('passes the grounding tool, model, and prefixed prompt through to generateContent', async () => {
+			mockGenAI.models.generateContent.mockResolvedValue({
+				candidates: [{ content: { parts: [{ text: 'answer' }] } }],
+			});
+
+			await runGroundingTool(mockPlugin, makeRequest({ query: 'coffee', promptPrefix: 'Find: ' }));
+
+			expect(mockGenAI.models.generateContent).toHaveBeenCalledWith({
+				model: 'gemini-1.5-flash-002',
+				config: {
+					temperature: 0.7,
+					maxOutputTokens: 8192,
+					tools: [{ googleSearch: {} }],
+				},
+				contents: 'Find: coffee',
+			});
+		});
+
+		it('falls back to the default chat model when none is configured', async () => {
+			mockPlugin.settings.chatModelName = undefined;
+			mockGenAI.models.generateContent.mockResolvedValue({
+				candidates: [{ content: { parts: [{ text: 'answer' }] } }],
+			});
+
+			await runGroundingTool(mockPlugin, makeRequest());
+
+			expect(mockGenAI.models.generateContent).toHaveBeenCalledWith(
+				expect.objectContaining({ model: getDefaultModelForRole('chat') })
+			);
+		});
+	});
+
+	describe('text extraction', () => {
+		it('concatenates text from candidate parts', async () => {
+			mockGenAI.models.generateContent.mockResolvedValue({
+				candidates: [{ content: { parts: [{ text: 'Hello ' }, { text: 'world' }] } }],
+			});
+
+			const result = await runGroundingTool(mockPlugin, makeRequest());
+
+			expect(result.success).toBe(true);
+			expect(result.data.originalAnswer).toBe('Hello world');
+			expect(result.data.answer).toBe('Hello world');
+			expect(result.data.citations).toEqual([]);
+			expect(result.data.searchGrounding).toBeUndefined();
+		});
+
+		it('falls back to result.text when candidates are missing', async () => {
+			mockGenAI.models.generateContent.mockResolvedValue({ text: 'Fallback text' });
+
+			const result = await runGroundingTool(mockPlugin, makeRequest());
+
+			expect(result.success).toBe(true);
+			expect(result.data.originalAnswer).toBe('Fallback text');
+			expect(result.data.answer).toBe('Fallback text');
+		});
+
+		it('routes a throwing result.text getter into the outer catch', async () => {
+			mockGenAI.models.generateContent.mockResolvedValue({
+				get text() {
+					throw new Error('Cannot access text');
+				},
+			});
+
+			const result = await runGroundingTool(mockPlugin, makeRequest({ errorPrefix: 'Grounding failed: ' }));
+
+			expect(result.success).toBe(false);
+			expect(result.error).toBe('Grounding failed: Cannot access text');
+		});
+	});
+
+	describe('citation extraction', () => {
+		it('maps chunks to citations with title/snippet fallbacks and filters chunks without a URI', async () => {
+			mockGenAI.models.generateContent.mockResolvedValue({
+				candidates: [
+					{
+						content: { parts: [{ text: 'answer' }] },
+						groundingMetadata: {
+							groundingChunks: [
+								{ web: { uri: 'https://a.com', title: 'A', snippet: 'Snippet A' } },
+								{ web: { uri: 'https://b.com' } }, // no title/snippet → fallbacks
+								{ web: {} }, // no URI → filtered
+								{ notWeb: 'x' }, // no web property → filtered
+							],
+						},
+					},
+				],
+			});
+
+			const result = await runGroundingTool(mockPlugin, makeRequest());
+
+			expect(result.success).toBe(true);
+			expect(result.data.citations).toEqual([
+				{ url: 'https://a.com', title: 'A', snippet: 'Snippet A' },
+				{ url: 'https://b.com', title: 'https://b.com', snippet: '' },
+			]);
+		});
+
+		it('reads citations through a maps-style accessor', async () => {
+			mockGenAI.models.generateContent.mockResolvedValue({
+				candidates: [
+					{
+						content: { parts: [{ text: 'answer' }] },
+						groundingMetadata: {
+							groundingChunks: [{ maps: { uri: 'https://maps/1', title: 'Place', text: 'Review text' } }],
+						},
+					},
+				],
+			});
+
+			const mapsCitation = (chunk: GroundingChunk) => ({
+				uri: chunk.maps?.uri,
+				title: chunk.maps?.title,
+				snippet: chunk.maps?.text,
+			});
+
+			const result = await runGroundingTool(mockPlugin, makeRequest({ getChunkCitation: mapsCitation }));
+
+			expect(result.data.citations).toEqual([{ url: 'https://maps/1', title: 'Place', snippet: 'Review text' }]);
+		});
+	});
+
+	describe('inline citation splicing', () => {
+		it('inserts links at endIndex positions in descending order without shifting offsets', async () => {
+			// "Hello world" (11 chars). Support at endIndex 5 → chunk 0, at 11 → chunk 1.
+			mockGenAI.models.generateContent.mockResolvedValue({
+				candidates: [
+					{
+						content: { parts: [{ text: 'Hello world' }] },
+						groundingMetadata: {
+							groundingChunks: [
+								{ web: { uri: 'https://a.com', title: 'A' } },
+								{ web: { uri: 'https://b.com', title: 'B' } },
+							],
+							groundingSupports: [
+								{ segment: { endIndex: 5 }, groundingChunkIndices: [0] },
+								{ segment: { endIndex: 11 }, groundingChunkIndices: [1] },
+							],
+						},
+					},
+				],
+			});
+
+			const result = await runGroundingTool(mockPlugin, makeRequest());
+
+			expect(result.data.answer).toBe('Hello [1](https://a.com) world [2](https://b.com)');
+			expect(result.data.originalAnswer).toBe('Hello world');
+		});
+
+		it('skips supports with a missing endIndex or empty groundingChunkIndices', async () => {
+			mockGenAI.models.generateContent.mockResolvedValue({
+				candidates: [
+					{
+						content: { parts: [{ text: 'Some text' }] },
+						groundingMetadata: {
+							groundingChunks: [{ web: { uri: 'https://a.com' } }],
+							groundingSupports: [
+								{ segment: {}, groundingChunkIndices: [0] }, // no endIndex
+								{ segment: { endIndex: 9 } }, // no indices
+								{ segment: { endIndex: 9 }, groundingChunkIndices: [] }, // empty indices
+							],
+						},
+					},
+				],
+			});
+
+			const result = await runGroundingTool(mockPlugin, makeRequest());
+
+			expect(result.data.answer).toBe('Some text');
+		});
+
+		it('filters out citation links for chunk indices without a URI', async () => {
+			mockGenAI.models.generateContent.mockResolvedValue({
+				candidates: [
+					{
+						content: { parts: [{ text: 'Hello world' }] },
+						groundingMetadata: {
+							groundingChunks: [{ web: { uri: 'https://a.com' } }, { web: {} }],
+							groundingSupports: [{ segment: { endIndex: 11 }, groundingChunkIndices: [0, 1] }],
+						},
+					},
+				],
+			});
+
+			const result = await runGroundingTool(mockPlugin, makeRequest());
+
+			expect(result.data.answer).toBe('Hello world [1](https://a.com)');
+		});
+
+		it('leaves text untouched when there are chunks but no supports', async () => {
+			mockGenAI.models.generateContent.mockResolvedValue({
+				candidates: [
+					{
+						content: { parts: [{ text: 'Just text' }] },
+						groundingMetadata: {
+							groundingChunks: [{ web: { uri: 'https://a.com', title: 'A' } }],
+						},
+					},
+				],
+			});
+
+			const result = await runGroundingTool(mockPlugin, makeRequest());
+
+			expect(result.data.answer).toBe('Just text');
+			expect(result.data.citations).toEqual([{ url: 'https://a.com', title: 'A', snippet: '' }]);
+		});
+	});
+
+	describe('error handling', () => {
+		it('prefixes an Error message with errorPrefix via getRawErrorMessage', async () => {
+			mockGenAI.models.generateContent.mockRejectedValue(new Error('API rate limit exceeded'));
+
+			const result = await runGroundingTool(mockPlugin, makeRequest({ errorPrefix: 'Google search failed: ' }));
+
+			expect(result.success).toBe(false);
+			expect(result.error).toBe('Google search failed: API rate limit exceeded');
+		});
+
+		it('stringifies a non-Error thrown value via getRawErrorMessage', async () => {
+			mockGenAI.models.generateContent.mockRejectedValue('boom');
+
+			const result = await runGroundingTool(mockPlugin, makeRequest({ errorPrefix: 'Google Maps lookup failed: ' }));
+
+			expect(result.success).toBe(false);
+			expect(result.error).toBe('Google Maps lookup failed: boom');
+		});
+	});
+});


### PR DESCRIPTION
<!-- auto-dev -->

## Summary

`src/tools/google-search-tool.ts` and `src/tools/google-maps-tool.ts` were near-mirror copies (~85% shared), including the most subtle code in either file — the reverse-`endIndex`-sorted citation-splicing math. This PR extracts that shared execute pipeline into a single `runGroundingTool()` helper and rebuilds both tools as thin wrappers, so a future bug fix or a new grounding tool (arxiv, URL-context, …) has one place to live instead of drifting copies.

Produced by the auto-dev pipeline from the approved plan on the issue.

Fixes #974

## Changes

- **New `src/tools/grounding-tool-runner.ts`** — exports `GroundingToolRequest` (`query`, `groundingTool`, `getChunkCitation`, `promptPrefix`, `errorPrefix`, `operationName`) and `runGroundingTool(plugin, req): Promise<ToolResult>`. Owns the full shared pipeline: API-key guard → `createGoogleGenAI` → `executeWithRetry` → text extraction → citation collection → inline `[n](url)` splicing (descending `endIndex` order).
- **`src/tools/google-search-tool.ts`** — reduced to metadata + a one-line delegation with `groundingTool: { googleSearch: {} }` and a `chunk.web` citation accessor.
- **`src/tools/google-maps-tool.ts`** — same, with `groundingTool: { googleMaps: {} }` and a `chunk.maps` accessor (snippet on `chunk.maps.text`).
- Swapped the duplicated `error instanceof Error ? error.message : 'Unknown error'` for `getRawErrorMessage(error)` from `src/utils/error-utils.ts`, aligning with the codebase-wide migration in closed #912.
- Tightened the previously `any`-cast `chunk`/`support` handling against the `@google/genai` `GroundingChunk` / `GroundingSupport` types (one narrow local cast remains to read `chunk.web.snippet`, which the API returns but the SDK type omits).

**Behavioral note / deviation from the plan:** the plan asked for both the `getRawErrorMessage` swap *and* for the existing tool tests to pass unchanged. Those two conflict for the non-`Error` throw path: the old code returned the literal `'Unknown error'`, while `getRawErrorMessage` returns `String(error)` (more informative, and the established #912 convention). I kept the `getRawErrorMessage` swap and updated the three non-`Error` assertions in `google-search-tool.test.ts` / `google-maps-tool.test.ts` accordingly (e.g. `'... failed: string error'` instead of `'... failed: Unknown error'`). The happy-path answer/citation output is byte-identical; only the rare non-`Error` throw message changes.

## Testing

- **New `test/tools/grounding-tool-runner.test.ts`** — covers the citation-splicing math once (descending `endIndex` order, `groundingChunkIndices` mapping, slice arithmetic), title/snippet fallbacks, URI filtering, both `chunk.web` and `chunk.maps` accessors, the `result.text` fallback and throwing-getter path, the API-key guard, and `getRawErrorMessage` error handling.
- Existing `test/tools/google-search-tool.test.ts` and `test/tools/google-maps-tool.test.ts` pass (behavior-identical refactor apart from the documented non-`Error` message change).
- Full pre-flight green: `npm run format-check`, `npm run build`, `npm test` (3220 passed), `npm run typecheck:test`.

## Documentation

No user-facing docs changed: this is a pure internal code-motion refactor. Tool names, parameters, descriptions, and happy-path behavior of `google_search` / `google_maps` are unchanged, so `docs/guide/agent-mode.md` and the reference pages that mention these tools remain accurate.

## Out of scope

Per the issue: `WebFetchTool` and `RagSearchTool` are left alone (different pipelines), no public tool-name/parameter/description changes, and no broader `getRawErrorMessage` sweep beyond the two sites in this refactor.

## Checklist

### Required

- [x] I have read and agree to the Contributing Guidelines
- [x] I have read and agree to the AI Policy
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer (#974, plan approved via `auto:ready`)
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop (unit tests; pure internal refactor)
- [x] I have verified this change does not break Mobile (no platform-specific code touched)
- [x] Documentation has been updated (if applicable) — N/A, no user-facing change
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (auto-dev pipeline)
- [x] I have reviewed and understand all AI-generated code in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DfyCDGQ7iEAso62eVwpCWz

---
_Generated by [Claude Code](https://claude.ai/code/session_01DfyCDGQ7iEAso62eVwpCWz)_