### PR TITLE
refactor(ui): move agent progress + shelf inline styles to CSS classes (#1034)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -39,7 +39,10 @@ const PERVASIVE_OBSIDIANMD_RULES_TODO = {
 	// 82 violations: pervasive `document` usage. Migrating to `activeDocument` is
 	// a separate refactor with cross-window implications.
 	'obsidianmd/prefer-active-doc': 'off',
-	// 81 violations: direct `style.X = ...` assignments. Needs CSS class migration.
+	// ~69 violations remaining: direct `style.X = ...` assignments. Needs CSS class
+	// migration. Cleaned so far and enforced per-file below (see the scoped override
+	// block): src/ui/agent-view/agent-view-progress.ts, agent-view-shelf.ts. Flip to
+	// 'error' globally once the remaining sites are migrated.
 	'obsidianmd/no-static-styles-assignment': 'off',
 	// 48 violations: `x as TFile` / `x as TFolder` casts scattered across vault
 	// helpers. Replacing each with `instanceof` checks is a careful refactor.
@@ -109,6 +112,13 @@ export default defineConfig([
 			globals: NODE_GLOBALS,
 		},
 		rules: { ...SOFTENED_TS_RULES, ...PERVASIVE_OBSIDIANMD_RULES_TODO },
+	},
+	{
+		// Files fully migrated off direct `style.X = ...` assignments to CSS classes.
+		// Enforce `no-static-styles-assignment` here so they cannot regress while the
+		// rule stays globally disabled for the remaining unmigrated files (#1034).
+		files: ['src/ui/agent-view/agent-view-progress.ts', 'src/ui/agent-view/agent-view-shelf.ts'],
+		rules: { 'obsidianmd/no-static-styles-assignment': 'error' },
 	},
 	{
 		files: ['test/**/*.ts'],

--- a/src/ui/agent-view/agent-view-progress.ts
+++ b/src/ui/agent-view/agent-view-progress.ts
@@ -41,7 +41,7 @@ export class AgentViewProgress {
 	 */
 	createProgressBar(container: HTMLElement): void {
 		this.progressBarContainer = container;
-		this.progressBarContainer.style.display = 'none'; // Hidden by default
+		this.progressBarContainer.addClass('gemini-agent-progress-container--hidden'); // Hidden by default
 
 		// Progress bar wrapper
 		const barWrapper = this.progressBarContainer.createDiv({
@@ -68,7 +68,7 @@ export class AgentViewProgress {
 		// eslint-disable-next-line @microsoft/sdl/no-inner-html -- static SVG literal, no user input
 		this.thinkingChevron.innerHTML =
 			'<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"></polyline></svg>';
-		this.thinkingChevron.style.display = 'none'; // Hidden until thinking content arrives
+		this.thinkingChevron.addClass('gemini-agent-thinking-chevron--hidden'); // Hidden until thinking content arrives
 
 		this.progressStatus = this.progressStatusContainer.createSpan({
 			cls: 'gemini-agent-progress-status-text',
@@ -101,7 +101,7 @@ export class AgentViewProgress {
 		this.thinkingSection = this.progressBarContainer.createDiv({
 			cls: 'gemini-agent-thinking-section',
 		});
-		this.thinkingSection.style.display = 'none';
+		this.thinkingSection.addClass('gemini-agent-thinking-section--collapsed');
 
 		this.thinkingContent = this.thinkingSection.createDiv({
 			cls: 'gemini-agent-thinking-content',
@@ -114,7 +114,7 @@ export class AgentViewProgress {
 	show(statusText: string, state: ProgressState): void {
 		if (!this.progressBarContainer) return;
 
-		this.progressBarContainer.style.display = 'block';
+		this.progressBarContainer.removeClass('gemini-agent-progress-container--hidden');
 		// eslint-disable-next-line @microsoft/sdl/no-inner-html, no-unsanitized/property -- formatProgressText escapes HTML before adding <strong>
 		this.progressStatus.innerHTML = this.formatProgressText(statusText);
 
@@ -132,7 +132,8 @@ export class AgentViewProgress {
 	 * Updates the progress bar with new status
 	 */
 	update(statusText: string, state?: ProgressState): void {
-		if (!this.progressBarContainer || this.progressBarContainer.style.display === 'none') return;
+		if (!this.progressBarContainer || this.progressBarContainer.hasClass('gemini-agent-progress-container--hidden'))
+			return;
 
 		// eslint-disable-next-line @microsoft/sdl/no-inner-html, no-unsanitized/property -- formatProgressText escapes HTML before adding <strong>
 		this.progressStatus.innerHTML = this.formatProgressText(statusText);
@@ -149,12 +150,13 @@ export class AgentViewProgress {
 	 * The status line shows a truncated preview; the expanded section renders the full markdown.
 	 */
 	updateThought(accumulatedThought: string): void {
-		if (!this.progressBarContainer || this.progressBarContainer.style.display === 'none') return;
+		if (!this.progressBarContainer || this.progressBarContainer.hasClass('gemini-agent-progress-container--hidden'))
+			return;
 
 		this.hasThinkingContent = true;
 
 		// Show the chevron and make the row look clickable + keyboard-accessible
-		this.thinkingChevron.style.display = '';
+		this.thinkingChevron.removeClass('gemini-agent-thinking-chevron--hidden');
 		this.progressStatusContainer.addClass('gemini-agent-progress-clickable');
 		this.progressStatusContainer.setAttribute('tabindex', '0');
 		this.progressStatusContainer.setAttribute('role', 'button');
@@ -220,13 +222,13 @@ export class AgentViewProgress {
 	hide(): void {
 		if (!this.progressBarContainer) return;
 
-		this.progressBarContainer.style.display = 'none';
+		this.progressBarContainer.addClass('gemini-agent-progress-container--hidden');
 		this.chatTimer.stop();
 
 		// Reset thinking section
 		this.collapseThinkingSection();
 		this.thinkingContent.empty();
-		this.thinkingChevron.style.display = 'none';
+		this.thinkingChevron.addClass('gemini-agent-thinking-chevron--hidden');
 		this.hasThinkingContent = false;
 		// Invalidate any in-flight async renders
 		this.thinkingRenderVersion++;
@@ -240,7 +242,7 @@ export class AgentViewProgress {
 	 * Checks if progress is currently visible
 	 */
 	isVisible(): boolean {
-		return this.progressBarContainer && this.progressBarContainer.style.display !== 'none';
+		return this.progressBarContainer && !this.progressBarContainer.hasClass('gemini-agent-progress-container--hidden');
 	}
 
 	/**
@@ -259,7 +261,7 @@ export class AgentViewProgress {
 	 */
 	private expandThinkingSection(): void {
 		this.isThinkingExpanded = true;
-		this.thinkingSection.style.display = 'block';
+		this.thinkingSection.removeClass('gemini-agent-thinking-section--collapsed');
 		this.thinkingChevron.addClass('gemini-agent-thinking-chevron-expanded');
 		this.progressStatusContainer.setAttribute('aria-expanded', 'true');
 
@@ -275,7 +277,7 @@ export class AgentViewProgress {
 	private collapseThinkingSection(): void {
 		this.isThinkingExpanded = false;
 		if (this.thinkingSection) {
-			this.thinkingSection.style.display = 'none';
+			this.thinkingSection.addClass('gemini-agent-thinking-section--collapsed');
 		}
 		if (this.thinkingChevron) {
 			this.thinkingChevron.removeClass('gemini-agent-thinking-chevron-expanded');

--- a/src/ui/agent-view/agent-view-shelf.ts
+++ b/src/ui/agent-view/agent-view-shelf.ts
@@ -234,11 +234,11 @@ export class AgentViewShelf {
 		this.container.empty();
 
 		if (this.items.length === 0) {
-			this.container.style.display = 'none';
+			this.container.removeClass('gemini-agent-shelf--visible');
 			return;
 		}
 
-		this.container.style.display = 'flex';
+		this.container.addClass('gemini-agent-shelf--visible');
 
 		for (const item of this.items) {
 			const el = this.container.createDiv({ cls: 'gemini-shelf-item' });
@@ -260,7 +260,7 @@ export class AgentViewShelf {
 			// Click to open file in Obsidian (when the item has an openable path)
 			const openPath = item.path || item.attachment?.vaultPath;
 			if (openPath) {
-				el.style.cursor = 'pointer';
+				el.addClass('gemini-shelf-item-clickable');
 				el.addEventListener('click', (e) => {
 					if ((e.target as HTMLElement).closest('.gemini-shelf-remove')) return;
 					this.app.workspace.openLinkText(openPath, '', false);

--- a/src/ui/agent-view/agent-view-shelf.ts
+++ b/src/ui/agent-view/agent-view-shelf.ts
@@ -260,7 +260,7 @@ export class AgentViewShelf {
 			// Click to open file in Obsidian (when the item has an openable path)
 			const openPath = item.path || item.attachment?.vaultPath;
 			if (openPath) {
-				el.addClass('gemini-shelf-item-clickable');
+				el.addClass('gemini-shelf-item--clickable');
 				el.addEventListener('click', (e) => {
 					if ((e.target as HTMLElement).closest('.gemini-shelf-remove')) return;
 					this.app.workspace.openLinkText(openPath, '', false);

--- a/styles.css
+++ b/styles.css
@@ -4026,7 +4026,7 @@ body {
 }
 
 /* Clickable state — items with an openable path show a pointer cursor */
-.gemini-shelf-item-clickable {
+.gemini-shelf-item--clickable {
 	cursor: pointer;
 }
 

--- a/styles.css
+++ b/styles.css
@@ -1232,6 +1232,11 @@ body {
 	z-index: 10;
 }
 
+/* Hidden state — progress container is hidden until an agent operation starts */
+.gemini-agent-progress-container--hidden {
+	display: none;
+}
+
 /* Progress Bar Wrapper */
 .gemini-agent-progress-bar-wrapper {
 	width: 100%;
@@ -1343,6 +1348,11 @@ body {
 	transition: color 0.15s ease;
 }
 
+/* Hidden state — chevron only appears once thinking content is available */
+.gemini-agent-thinking-chevron--hidden {
+	display: none;
+}
+
 .gemini-agent-thinking-chevron svg {
 	transition: transform 0.2s ease;
 }
@@ -1360,6 +1370,11 @@ body {
 	border-top: 1px solid var(--gs-border);
 	margin-top: var(--size-2-2);
 	padding-top: var(--size-2-2);
+}
+
+/* Collapsed state — thinking section is hidden until expanded */
+.gemini-agent-thinking-section--collapsed {
+	display: none;
 }
 
 .gemini-agent-thinking-content {
@@ -3993,6 +4008,11 @@ body {
 	padding: 8px 0;
 }
 
+/* Visible state — shelf is shown only when it holds one or more items */
+.gemini-agent-shelf--visible {
+	display: flex;
+}
+
 .gemini-shelf-item {
 	position: relative;
 	display: inline-flex;
@@ -4003,6 +4023,11 @@ body {
 	background-color: var(--gs-surface);
 	overflow: hidden;
 	cursor: default;
+}
+
+/* Clickable state — items with an openable path show a pointer cursor */
+.gemini-shelf-item-clickable {
+	cursor: pointer;
 }
 
 .gemini-shelf-item:hover {

--- a/test/ui/agent-view/agent-view-progress.test.ts
+++ b/test/ui/agent-view/agent-view-progress.test.ts
@@ -111,30 +111,30 @@ describe('AgentViewProgress', () => {
 		});
 
 		it('should be hidden by default', () => {
-			expect(container.style.display).toBe('none');
+			expect(container.classList.contains('gemini-agent-progress-container--hidden')).toBe(true);
 		});
 
 		it('should have thinking chevron hidden by default', () => {
 			const chevron = container.querySelector('.gemini-agent-thinking-chevron') as HTMLElement;
-			expect(chevron.style.display).toBe('none');
+			expect(chevron.classList.contains('gemini-agent-thinking-chevron--hidden')).toBe(true);
 		});
 
 		it('should have thinking section hidden by default', () => {
 			const section = container.querySelector('.gemini-agent-thinking-section') as HTMLElement;
-			expect(section.style.display).toBe('none');
+			expect(section.classList.contains('gemini-agent-thinking-section--collapsed')).toBe(true);
 		});
 	});
 
 	describe('show/hide', () => {
 		it('should make container visible when shown', () => {
 			progress.show('Thinking...', 'thinking');
-			expect(container.style.display).toBe('block');
+			expect(container.classList.contains('gemini-agent-progress-container--hidden')).toBe(false);
 		});
 
 		it('should hide container', () => {
 			progress.show('Thinking...', 'thinking');
 			progress.hide();
-			expect(container.style.display).toBe('none');
+			expect(container.classList.contains('gemini-agent-progress-container--hidden')).toBe(true);
 		});
 
 		it('should set status text when shown', () => {
@@ -195,7 +195,7 @@ describe('AgentViewProgress', () => {
 			progress.updateThought('I need to consider...');
 
 			const chevron = container.querySelector('.gemini-agent-thinking-chevron') as HTMLElement;
-			expect(chevron.style.display).toBe('');
+			expect(chevron.classList.contains('gemini-agent-thinking-chevron--hidden')).toBe(false);
 		});
 
 		it('should make status row clickable when thought arrives', () => {
@@ -244,7 +244,7 @@ describe('AgentViewProgress', () => {
 			progress.updateThought('Should not appear');
 
 			const chevron = container.querySelector('.gemini-agent-thinking-chevron') as HTMLElement;
-			expect(chevron.style.display).toBe('none');
+			expect(chevron.classList.contains('gemini-agent-thinking-chevron--hidden')).toBe(true);
 		});
 	});
 
@@ -257,7 +257,7 @@ describe('AgentViewProgress', () => {
 			statusContainer.click();
 
 			const section = container.querySelector('.gemini-agent-thinking-section') as HTMLElement;
-			expect(section.style.display).toBe('block');
+			expect(section.classList.contains('gemini-agent-thinking-section--collapsed')).toBe(false);
 
 			const chevron = container.querySelector('.gemini-agent-thinking-chevron');
 			expect(chevron?.classList.contains('gemini-agent-thinking-chevron-expanded')).toBe(true);
@@ -274,7 +274,7 @@ describe('AgentViewProgress', () => {
 			statusContainer.click(); // collapse
 
 			const section = container.querySelector('.gemini-agent-thinking-section') as HTMLElement;
-			expect(section.style.display).toBe('none');
+			expect(section.classList.contains('gemini-agent-thinking-section--collapsed')).toBe(true);
 
 			const chevron = container.querySelector('.gemini-agent-thinking-chevron');
 			expect(chevron?.classList.contains('gemini-agent-thinking-chevron-expanded')).toBe(false);
@@ -289,7 +289,7 @@ describe('AgentViewProgress', () => {
 			statusContainer.click();
 
 			const section = container.querySelector('.gemini-agent-thinking-section') as HTMLElement;
-			expect(section.style.display).toBe('none');
+			expect(section.classList.contains('gemini-agent-thinking-section--collapsed')).toBe(true);
 		});
 
 		it('should reset thinking section on hide', () => {
@@ -302,10 +302,10 @@ describe('AgentViewProgress', () => {
 			progress.hide();
 
 			const section = container.querySelector('.gemini-agent-thinking-section') as HTMLElement;
-			expect(section.style.display).toBe('none');
+			expect(section.classList.contains('gemini-agent-thinking-section--collapsed')).toBe(true);
 
 			const chevron = container.querySelector('.gemini-agent-thinking-chevron') as HTMLElement;
-			expect(chevron.style.display).toBe('none');
+			expect(chevron.classList.contains('gemini-agent-thinking-chevron--hidden')).toBe(true);
 
 			expect(statusContainer.classList.contains('gemini-agent-progress-clickable')).toBe(false);
 			expect(statusContainer.getAttribute('tabindex')).toBeNull();
@@ -332,7 +332,7 @@ describe('AgentViewProgress', () => {
 			statusContainer.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
 
 			const section = container.querySelector('.gemini-agent-thinking-section') as HTMLElement;
-			expect(section.style.display).toBe('block');
+			expect(section.classList.contains('gemini-agent-thinking-section--collapsed')).toBe(false);
 		});
 
 		it('should expand when Space key is pressed', () => {
@@ -343,7 +343,7 @@ describe('AgentViewProgress', () => {
 			statusContainer.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true }));
 
 			const section = container.querySelector('.gemini-agent-thinking-section') as HTMLElement;
-			expect(section.style.display).toBe('block');
+			expect(section.classList.contains('gemini-agent-thinking-section--collapsed')).toBe(false);
 		});
 
 		it('should not toggle on other keys', () => {
@@ -354,7 +354,7 @@ describe('AgentViewProgress', () => {
 			statusContainer.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', bubbles: true }));
 
 			const section = container.querySelector('.gemini-agent-thinking-section') as HTMLElement;
-			expect(section.style.display).toBe('none');
+			expect(section.classList.contains('gemini-agent-thinking-section--collapsed')).toBe(true);
 		});
 
 		it('should not toggle via keyboard without thinking content', () => {
@@ -364,7 +364,7 @@ describe('AgentViewProgress', () => {
 			statusContainer.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
 
 			const section = container.querySelector('.gemini-agent-thinking-section') as HTMLElement;
-			expect(section.style.display).toBe('none');
+			expect(section.classList.contains('gemini-agent-thinking-section--collapsed')).toBe(true);
 		});
 
 		it('should remove tabindex and role on hide', () => {


### PR DESCRIPTION
<!-- auto-dev -->

## Summary

Migrates the first slice of `obsidianmd/no-static-styles-assignment` violations off direct `element.style.*` assignments and onto CSS classes. This PR covers `agent-view-progress.ts` and `agent-view-shelf.ts` — the two files named in the approved plan — to establish the naming convention; the remaining files ship in follow-up slices once the pattern is set.

Produced by the auto-dev pipeline from the approved plan on #1034.

Fixes #1034

## Changes

- **`src/ui/agent-view/agent-view-progress.ts`** — replace `style.display` writes (progress container, thinking chevron, thinking section) with `addClass`/`removeClass` toggling of new modifier classes; visibility reads (`update`, `updateThought`, `isVisible`) now check `hasClass` instead of inspecting `style.display`.
- **`src/ui/agent-view/agent-view-shelf.ts`** — replace the shelf's `style.display = 'none'/'flex'` show/hide with a `--visible` modifier class, and the per-item `style.cursor = 'pointer'` with a `gemini-shelf-item-clickable` class.
- **`styles.css`** — add the five new modifier classes following existing naming conventions: `.gemini-agent-progress-container--hidden`, `.gemini-agent-thinking-chevron--hidden`, `.gemini-agent-thinking-section--collapsed`, `.gemini-agent-shelf--visible`, `.gemini-shelf-item-clickable`.
- **`eslint.config.mjs`** — enforce `obsidianmd/no-static-styles-assignment` as an `error` scoped to these two now-clean files so they cannot regress, while leaving the rule globally disabled for the remaining unmigrated files (updated the TODO comment: ~81 → ~69 violations remaining). The rule is intentionally **not** re-enabled globally yet.
- **`test/ui/agent-view/agent-view-progress.test.ts`** — assert on the modifier classes (`hasClass`) instead of inline `style.display` values. All static values only; no runtime-computed styles were introduced, so no `setCssStyles` was needed.

## Screenshots / Screencast

N/A — no visual change. The migration reproduces the exact prior display behavior (hidden-by-default progress bar, expandable thinking section, shelf shown only when populated, pointer cursor on openable items) using CSS classes instead of inline styles.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer — approved plan on #1034
- [x] All CI checks pass (`npm test` — 3220 passing, `npm run build`, `npm run format-check`) — plus `npm run lint` (0 errors; `no-static-styles-assignment` enforced on the two files) and `npm run typecheck:test`
- [x] I have tested this change on Desktop — full unit suite passes; progress + shelf tests updated and green
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — pure DOM class-toggling and CSS, no platform-specific APIs
- [x] Documentation has been updated (if applicable) — N/A; internal refactor with no user-facing surface. Migration progress is tracked in the `eslint.config.mjs` TODO block.
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (auto-dev pipeline)
- [x] I have reviewed and understand all AI-generated code in this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_018QZBNnGSBJZGDLM4KjaEs8)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved agent progress, thinking, and unified shelf visibility handling by switching from inline `display` changes to CSS class state.
  * Made shelf items with an open path use a dedicated “clickable” styling state.
* **Tests**
  * Updated agent view UI tests to verify visibility and collapse behavior via CSS classes instead of inline styles.
* **Style**
  * Added new CSS modifier classes for hidden/collapsed/visible and clickable shelf item states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->