### PR TITLE
ci(security): pin all GitHub Actions to commit SHAs + enforce (#1052)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,10 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Use Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '24.x'
 
@@ -68,7 +68,7 @@ jobs:
         run: npm test -- --coverage
 
       - name: Upload coverage report
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-report
           path: coverage/
@@ -81,13 +81,13 @@ jobs:
       contents: write # Allow GITHUB_TOKEN to write to gh-pages branch
     steps:
       - name: Download coverage report artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: coverage-report
           path: coverage # Download to a directory named 'coverage'
 
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4.1.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./coverage/lcov-report # Directory containing HTML files

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,12 +23,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '24.x'
           cache: npm
@@ -40,10 +40,10 @@ jobs:
         run: npm run docs:build
 
       - name: Setup Pages
-        uses: actions/configure-pages@v6
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: docs/.vitepress/dist
 
@@ -56,4 +56,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/i18n-translate.yml
+++ b/.github/workflows/i18n-translate.yml
@@ -24,14 +24,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           # create-pull-request uses its own token, so the checkout token does
           # not need to persist in git config where npm ci / translate could read it.
           persist-credentials: false
 
       - name: Use Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '24.x'
 
@@ -61,7 +61,7 @@ jobs:
 
       - name: Create PR if translations changed
         if: always() && steps.translate.outcome != 'cancelled'
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           commit-message: 'chore(i18n): update AI translations'
           title: 'chore(i18n): Update UI translations'

--- a/.github/workflows/knip.yml
+++ b/.github/workflows/knip.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '24.x'
           cache: 'npm'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,16 +14,19 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '24.x'
           cache: 'npm'
 
       - name: Install dependencies
         run: npm ci
+
+      - name: Check GitHub Actions are SHA-pinned
+        run: npm run lint:actions
 
       - name: Check formatting with Prettier
         run: npm run format-check

--- a/.github/workflows/model-update.yml
+++ b/.github/workflows/model-update.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Use Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '24.x'
 
@@ -38,7 +38,7 @@ jobs:
 
       - name: Create PR if models changed
         if: steps.update.outcome == 'success'
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           commit-message: 'chore: update models.json with new Gemini models'
           title: 'chore: Update available Gemini models'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,9 +14,9 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Use Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '24.x'
       - name: Install dependencies
@@ -33,10 +33,10 @@ jobs:
       attestations: write
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Use Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '24.x'
 
@@ -46,7 +46,7 @@ jobs:
           npm run build
 
       - name: Attest build provenance
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
           subject-path: |
             main.js

--- a/docs/contributing/contributing.md
+++ b/docs/contributing/contributing.md
@@ -31,6 +31,7 @@ npm run dev    # Development build with watch mode
 | `npm test`             | Generate refs and run Vitest tests       |
 | `npm run format`       | Format code with Prettier                |
 | `npm run format-check` | Check formatting without changes         |
+| `npm run lint:actions` | Verify GitHub Actions are SHA-pinned     |
 
 ## Pull Request Requirements
 
@@ -49,6 +50,14 @@ npm test               # Generate refs and run Vitest test suite
 ```
 
 PRs with failing CI will not be reviewed. Fix the failures first.
+
+**GitHub Actions must be SHA-pinned.** Every third-party action referenced in `.github/workflows/*` must be pinned to a full commit SHA with a version comment (tags are mutable and can be silently re-pointed upstream). The `Lint & Format` workflow runs `npm run lint:actions` and fails on any unpinned reference, so if you add or edit a workflow, pin new actions like this:
+
+```yaml
+- uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+```
+
+Resolve the SHA for a tag with `git ls-remote https://github.com/<owner>/<repo> <tag>`. Dependabot (configured for the `github-actions` ecosystem) keeps the pins current with automated update PRs.
 
 ### 3. Proof of Functionality
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
 		"format-check": "prettier --check .",
 		"lint": "eslint .",
 		"lint:fix": "eslint . --fix",
+		"lint:actions": "node scripts/check-action-pins.mjs",
 		"knip": "knip",
 		"install:test-vault": "node scripts/install-test-vault.mjs",
 		"translate": "node scripts/translate.mjs",

--- a/scripts/check-action-pins.mjs
+++ b/scripts/check-action-pins.mjs
@@ -59,7 +59,7 @@ for (const file of files) {
 }
 
 if (files.length === 0) {
-	console.error(`No workflow files found in ${WORKFLOWS_DIR}/ — nothing to check.`);
+	console.warn(`No workflow files found in ${WORKFLOWS_DIR}/ — nothing to check.`);
 	process.exit(0);
 }
 

--- a/scripts/check-action-pins.mjs
+++ b/scripts/check-action-pins.mjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+// Enforce that every third-party GitHub Action referenced in .github/workflows/*
+// is pinned to an immutable 40-character commit SHA (not a mutable tag or
+// branch). Tags can be silently re-pointed upstream, so a tag pin lets a
+// compromised or retargeted action run in CI with our GITHUB_TOKEN and secrets
+// in scope. This gate keeps the repo-wide SHA-pinning policy (issue #1052) from
+// regressing the next time a workflow is added or edited.
+//
+// A pinned reference looks like:  owner/repo@<40-hex-sha>  # v1.2.3
+// Local (`./…`) and Docker (`docker://…`) references are exempt.
+//
+// Usage: node scripts/check-action-pins.mjs
+// Exits 0 when every reference is pinned, 1 (listing violations) otherwise.
+
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+const WORKFLOWS_DIR = '.github/workflows';
+const SHA_RE = /^[0-9a-f]{40}$/;
+// Capture the value after `uses:` up to whitespace, a comment, or a quote.
+const USES_RE = /^\s*(?:-\s*)?uses:\s*['"]?([^'"\s#]+)/;
+
+function listWorkflowFiles(dir) {
+	let entries;
+	try {
+		entries = readdirSync(dir);
+	} catch {
+		return [];
+	}
+	return entries
+		.filter((name) => name.endsWith('.yml') || name.endsWith('.yaml'))
+		.map((name) => join(dir, name))
+		.filter((p) => statSync(p).isFile());
+}
+
+const violations = [];
+const files = listWorkflowFiles(WORKFLOWS_DIR);
+
+for (const file of files) {
+	const lines = readFileSync(file, 'utf8').split('\n');
+	lines.forEach((line, i) => {
+		const match = line.match(USES_RE);
+		if (!match) return;
+		const ref = match[1];
+
+		// Exempt local composite/reusable references and Docker image refs.
+		if (ref.startsWith('./') || ref.startsWith('docker://')) return;
+
+		const atIndex = ref.lastIndexOf('@');
+		if (atIndex === -1) {
+			violations.push({ file, line: i + 1, ref, reason: 'no version/SHA pin' });
+			return;
+		}
+		const gitRef = ref.slice(atIndex + 1);
+		if (!SHA_RE.test(gitRef)) {
+			violations.push({ file, line: i + 1, ref, reason: `pinned to "${gitRef}" (not a 40-char commit SHA)` });
+		}
+	});
+}
+
+if (files.length === 0) {
+	console.error(`No workflow files found in ${WORKFLOWS_DIR}/ — nothing to check.`);
+	process.exit(0);
+}
+
+if (violations.length > 0) {
+	console.error('❌ Unpinned GitHub Action reference(s) detected:\n');
+	for (const v of violations) {
+		console.error(`  ${v.file}:${v.line}  ${v.ref}  — ${v.reason}`);
+	}
+	console.error(
+		'\nPin each action to a full commit SHA with a version comment, e.g.:\n' +
+			'  uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0\n\n' +
+			'Resolve the SHA for a tag with:  git ls-remote https://github.com/<owner>/<repo> <tag>\n' +
+			'Tags are mutable; SHAs are not. See .github/workflows and issue #1052 for context.'
+	);
+	process.exit(1);
+}
+
+console.log(
+	`✅ All GitHub Action references in ${WORKFLOWS_DIR}/ are pinned to commit SHAs (${files.length} workflow file(s) checked).`
+);
+process.exit(0);


### PR DESCRIPTION
<!-- auto-dev -->

## Summary

Every workflow in `.github/workflows/` referenced third-party actions by **mutable tag** (`@v7`, `@v8`, …). Tags can be silently re-pointed upstream (or the action repo compromised), which would change what runs in CI with our `GITHUB_TOKEN` and secrets in scope. This pins every `uses:` to an **immutable commit SHA** to close that supply-chain vector, and adds a CI gate so the policy can't silently regress the next time a workflow is added.

Produced by the auto-dev pipeline from the approved plan on #1052.

Fixes #1052

## Changes

- **Pinned all 25 `uses:` references (10 distinct actions)** across `ci.yml`, `docs.yml`, `i18n-translate.yml`, `knip.yml`, `lint.yml`, `model-update.yml`, and `release.yml` to full commit SHAs, each with a human-readable version comment. SHAs were resolved from each action's currently-referenced tag via `git ls-remote`:
  - `actions/checkout` → `9c091bb…` # v7.0.0
  - `actions/setup-node` → `48b55a0…` # v6.4.0
  - `actions/upload-artifact` → `043fb46…` # v7.0.1
  - `actions/download-artifact` → `3e5f45b…` # v8.0.1
  - `actions/configure-pages` → `45bfe01…` # v6.0.0
  - `actions/upload-pages-artifact` → `fc324d3…` # v5.0.0
  - `actions/deploy-pages` → `cd2ce8f…` # v5.0.0
  - `actions/attest-build-provenance` → `0f67c3f…` # v4.1.1
  - `peaceiris/actions-gh-pages` → `84c30a8…` # v4.1.0
  - `peter-evans/create-pull-request` → `5f6978f…` # v8.1.1
- **`scripts/check-action-pins.mjs` + `npm run lint:actions`** — a focused, zero-dependency Node gate that fails if any `uses:` in `.github/workflows/*` references an action by tag/branch instead of a 40-char commit SHA (local `./…` and `docker://…` refs are exempt). Wired into the **Lint & Format** workflow so it gates every push/PR.
- **`docs/contributing/contributing.md`** — documented the SHA-pinning policy (with a worked example and the `git ls-remote` resolution command) and added `npm run lint:actions` to the commands table.

**On the enforcement tool:** the approved plan named `zizmor` first but explicitly allowed "zizmor **or equivalent** … actionlint + pinning check." Running `zizmor`'s full audit suite surfaces ~11 pre-existing findings unrelated to pinning (e.g. `artipacked`, `cache-poisoning`), which would make the gate fail on out-of-scope issues, and it has no clean "only the pinning audit" mode. The focused check enforces *exactly* the issue's acceptance criterion — fail on any unpinned action reference — deterministically and with no external tool/token dependency. Adopting `zizmor`'s broader workflow-security audits (and fixing the findings it surfaces) is a good follow-up issue.

**Dependabot:** `.github/dependabot.yml` already tracks the `github-actions` ecosystem, so the pinned SHAs still receive automated update PRs — no change needed there.

## Screenshots / Screencast

N/A — CI/security change only, no user-facing surface.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer — approved plan on #1052
- [x] All CI checks pass (`npm test` — 3220 passing, `npm run build`, `npm run format-check`) — plus `npm run lint` (0 errors), `npm run typecheck:test`, and the new `npm run lint:actions`
- [x] I have tested this change on Desktop — N/A (CI config); pinning gate verified locally to pass on the pinned workflows and fail on an unpinned reference
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A; no plugin code touched
- [x] Documentation has been updated (if applicable) — contributing guide updated
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (auto-dev pipeline)
- [x] I have reviewed and understand all AI-generated code in this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_013waZhaKrauJp3umJJcSZb5)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new `lint:actions` check to verify CI workflow actions use fixed commit hashes.
* **Documentation**
  * Updated contributor guidance with the new workflow-pinning requirement and how to run the validation command.
* **Chores**
  * Updated multiple automation workflows (CI, docs deploy, release/coverage, i18n, model checks, and reporting) to use SHA-pinned GitHub Actions instead of floating version tags.
  * CI workflows now run the new action-pinning validation during lint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->