### PR TITLE
test(tools): add test mirror for vault-tools-extended (#1059)

### DIFF
--- a/test/tools/vault-tools-extended.test.ts
+++ b/test/tools/vault-tools-extended.test.ts
@@ -1,0 +1,255 @@
+import { TFile } from 'obsidian';
+import { getExtendedVaultTools } from '../../src/tools/vault-tools-extended';
+import { Tool, ToolExecutionContext } from '../../src/tools/types';
+import { resolvePathToFile } from '../../src/tools/vault/utils';
+
+// The two extended vault tools resolve paths through resolvePathToFile; mock it
+// so the tests exercise the tools' own branching (JSON parsing, newline handling,
+// replace-vs-append) without depending on the full vault-resolution machinery.
+vi.mock('../../src/tools/vault/utils', () => ({
+	resolvePathToFile: vi.fn(),
+}));
+
+const mockResolvePathToFile = vi.mocked(resolvePathToFile);
+
+// Captures the frontmatter object handed to the processFrontMatter callback so
+// tests can assert the native value that was written.
+let capturedFrontmatter: Record<string, any> = {};
+const mockProcessFrontMatter = vi.fn(async (_file: TFile, cb: (fm: Record<string, any>) => void) => {
+	capturedFrontmatter = {};
+	cb(capturedFrontmatter);
+});
+
+const mockVault = {
+	modify: vi.fn().mockResolvedValue(undefined),
+	append: vi.fn().mockResolvedValue(undefined),
+	read: vi.fn().mockResolvedValue(''),
+};
+
+const mockPlugin = {
+	app: {
+		fileManager: {
+			processFrontMatter: mockProcessFrontMatter,
+		},
+		vault: mockVault,
+	},
+	logger: {
+		debug: vi.fn(),
+		error: vi.fn(),
+	},
+} as any;
+
+const mockContext: ToolExecutionContext = {
+	plugin: mockPlugin,
+	session: {
+		id: 'test-session',
+		type: 'agent-session',
+		context: {
+			contextFiles: [],
+			contextDepth: 2,
+			enabledTools: [],
+			requireConfirmation: [],
+		},
+	},
+} as any;
+
+/** Build a TFile-shaped object with the fields the extended tools read. */
+function makeFile(path: string, extension = 'md'): TFile {
+	const file = new TFile();
+	file.path = path;
+	file.extension = extension;
+	return file;
+}
+
+function getTools(): { updateFrontmatter: Tool; appendContent: Tool } {
+	const tools = getExtendedVaultTools();
+	return { updateFrontmatter: tools[0], appendContent: tools[1] };
+}
+
+describe('vault-tools-extended', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockVault.modify.mockResolvedValue(undefined);
+		mockVault.append.mockResolvedValue(undefined);
+		mockVault.read.mockResolvedValue('');
+		mockProcessFrontMatter.mockImplementation(async (_file: TFile, cb: (fm: Record<string, any>) => void) => {
+			capturedFrontmatter = {};
+			cb(capturedFrontmatter);
+		});
+	});
+
+	describe('getExtendedVaultTools', () => {
+		it('returns exactly the two extended tools in the declared order', () => {
+			const tools = getExtendedVaultTools();
+			expect(tools).toHaveLength(2);
+			expect(tools[0].name).toBe('update_frontmatter');
+			expect(tools[1].name).toBe('append_content');
+		});
+	});
+
+	describe('UpdateFrontmatterTool', () => {
+		it('parses a stringified JSON array into a native list', async () => {
+			mockResolvePathToFile.mockReturnValue({ file: makeFile('notes/test.md') });
+
+			const result = await getTools().updateFrontmatter.execute(
+				{ path: 'notes/test', key: 'tags', value: '["a","b"]' },
+				mockContext
+			);
+
+			expect(result.success).toBe(true);
+			expect(result.data.value).toEqual(['a', 'b']);
+			expect(capturedFrontmatter.tags).toEqual(['a', 'b']);
+		});
+
+		it('parses a stringified JSON boolean into a native boolean', async () => {
+			mockResolvePathToFile.mockReturnValue({ file: makeFile('notes/test.md') });
+
+			const result = await getTools().updateFrontmatter.execute(
+				{ path: 'notes/test', key: 'published', value: 'true' },
+				mockContext
+			);
+
+			expect(result.success).toBe(true);
+			expect(result.data.value).toBe(true);
+			expect(capturedFrontmatter.published).toBe(true);
+		});
+
+		it('parses a stringified JSON number into a native number', async () => {
+			mockResolvePathToFile.mockReturnValue({ file: makeFile('notes/test.md') });
+
+			const result = await getTools().updateFrontmatter.execute(
+				{ path: 'notes/test', key: 'rating', value: '42' },
+				mockContext
+			);
+
+			expect(result.success).toBe(true);
+			expect(result.data.value).toBe(42);
+			expect(capturedFrontmatter.rating).toBe(42);
+		});
+
+		it('falls back to a plain string when the value is not valid JSON', async () => {
+			mockResolvePathToFile.mockReturnValue({ file: makeFile('notes/test.md') });
+
+			const result = await getTools().updateFrontmatter.execute(
+				{ path: 'notes/test', key: 'status', value: 'In Progress' },
+				mockContext
+			);
+
+			expect(result.success).toBe(true);
+			expect(result.data.value).toBe('In Progress');
+			expect(capturedFrontmatter.status).toBe('In Progress');
+		});
+
+		it('returns failure for a non-markdown file without touching frontmatter', async () => {
+			mockResolvePathToFile.mockReturnValue({ file: makeFile('notes/data.txt', 'txt') });
+
+			const result = await getTools().updateFrontmatter.execute(
+				{ path: 'notes/data.txt', key: 'status', value: 'done' },
+				mockContext
+			);
+
+			expect(result.success).toBe(false);
+			expect(result.error).toContain('not a markdown file');
+			expect(mockProcessFrontMatter).not.toHaveBeenCalled();
+		});
+
+		it('returns failure when the file cannot be resolved', async () => {
+			mockResolvePathToFile.mockReturnValue({ file: null });
+
+			const result = await getTools().updateFrontmatter.execute(
+				{ path: 'missing', key: 'status', value: 'done' },
+				mockContext
+			);
+
+			expect(result.success).toBe(false);
+			expect(result.error).toContain('File not found');
+			expect(mockProcessFrontMatter).not.toHaveBeenCalled();
+		});
+
+		it('propagates errors thrown by processFrontMatter as a failure result', async () => {
+			mockResolvePathToFile.mockReturnValue({ file: makeFile('notes/test.md') });
+			mockProcessFrontMatter.mockRejectedValueOnce(new Error('frontmatter blew up'));
+
+			const result = await getTools().updateFrontmatter.execute(
+				{ path: 'notes/test', key: 'status', value: 'done' },
+				mockContext
+			);
+
+			expect(result.success).toBe(false);
+			expect(result.error).toContain('frontmatter blew up');
+		});
+	});
+
+	describe('AppendContentTool', () => {
+		it('prepends a newline when the file is non-empty and lacks a trailing newline', async () => {
+			const file = makeFile('notes/log.md');
+			mockResolvePathToFile.mockReturnValue({ file });
+			mockVault.read.mockResolvedValue('existing content');
+
+			const result = await getTools().appendContent.execute({ path: 'notes/log', content: 'new line' }, mockContext);
+
+			expect(result.success).toBe(true);
+			expect(result.data.action).toBe('appended');
+			expect(mockVault.append).toHaveBeenCalledWith(file, '\nnew line');
+			expect(mockVault.modify).not.toHaveBeenCalled();
+		});
+
+		it('does not prepend a newline when the file already ends with one', async () => {
+			const file = makeFile('notes/log.md');
+			mockResolvePathToFile.mockReturnValue({ file });
+			mockVault.read.mockResolvedValue('existing content\n');
+
+			await getTools().appendContent.execute({ path: 'notes/log', content: 'new line' }, mockContext);
+
+			expect(mockVault.append).toHaveBeenCalledWith(file, 'new line');
+		});
+
+		it('does not prepend a newline when the appended content already starts with one', async () => {
+			const file = makeFile('notes/log.md');
+			mockResolvePathToFile.mockReturnValue({ file });
+			mockVault.read.mockResolvedValue('existing content');
+
+			await getTools().appendContent.execute({ path: 'notes/log', content: '\nnew line' }, mockContext);
+
+			expect(mockVault.append).toHaveBeenCalledWith(file, '\nnew line');
+		});
+
+		it('does not prepend a newline when the existing file is empty', async () => {
+			const file = makeFile('notes/log.md');
+			mockResolvePathToFile.mockReturnValue({ file });
+			mockVault.read.mockResolvedValue('');
+
+			await getTools().appendContent.execute({ path: 'notes/log', content: 'new line' }, mockContext);
+
+			expect(mockVault.append).toHaveBeenCalledWith(file, 'new line');
+		});
+
+		it('overwrites via vault.modify in _replaceFullContent mode', async () => {
+			const file = makeFile('notes/log.md');
+			mockResolvePathToFile.mockReturnValue({ file });
+
+			const result = await getTools().appendContent.execute(
+				{ path: 'notes/log', content: 'full edited body', _replaceFullContent: true, _userEdited: true },
+				mockContext
+			);
+
+			expect(result.success).toBe(true);
+			expect(result.data.action).toBe('replaced');
+			expect(result.data.userEdited).toBe(true);
+			expect(mockVault.modify).toHaveBeenCalledWith(file, 'full edited body');
+			expect(mockVault.append).not.toHaveBeenCalled();
+			expect(mockVault.read).not.toHaveBeenCalled();
+		});
+
+		it('returns failure when the file is missing', async () => {
+			mockResolvePathToFile.mockReturnValue({ file: null });
+
+			const result = await getTools().appendContent.execute({ path: 'missing', content: 'new line' }, mockContext);
+
+			expect(result.success).toBe(false);
+			expect(result.error).toContain('File not found');
+			expect(mockVault.append).not.toHaveBeenCalled();
+			expect(mockVault.modify).not.toHaveBeenCalled();
+		});
+	});
+});


### PR DESCRIPTION
<!-- auto-dev -->

## Summary

`src/tools/vault-tools-extended.ts` shipped two agent tools — `UpdateFrontmatterTool` and `AppendContentTool` — without a test file, the lone gap among the `src/tools/` implementations. This adds `test/tools/vault-tools-extended.test.ts` covering the non-obvious branching in both tools so a future regression can't slip through silently. Pure coverage fill: no production code changed.

Produced by the auto-dev pipeline from the approved plan on #1059.

Fixes #1059

## Changes

- `test/tools/vault-tools-extended.test.ts` (new) — mirrors the mocking style in `test/tools/image-tools.test.ts`, mocking `resolvePathToFile` so the tests exercise the tools' own logic:
  - **`UpdateFrontmatterTool`** — stringified JSON array / boolean / number values are parsed into native YAML types; a non-JSON value falls back to a plain string; a non-`.md` file and an unresolved file both fail without calling `processFrontMatter`; an error thrown by `processFrontMatter` propagates as `{ success: false, error }`.
  - **`AppendContentTool`** — the leading-newline rule (prepend `\n` when the file is non-empty and lacks a trailing newline; skip when the file ends with `\n`, the content starts with `\n`, or the file is empty); the `_replaceFullContent` path calls `vault.modify` instead of `vault.append` and reports `action: 'replaced'`; a missing file fails.
  - **`getExtendedVaultTools()`** — returns exactly the two tools in the declared order.

## Screenshots / Screencast

N/A — test-only change with no user-facing surface.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer — approved plan on #1059
- [x] All CI checks pass (`npm test` — 3234 passing, `npm run build`, `npm run format-check`) — plus `npm run typecheck:test`
- [x] I have tested this change on Desktop — full unit suite (143 files, 3234 tests) passes; the 14 new tests are green
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — test-only; no runtime or platform-specific code
- [x] Documentation has been updated (if applicable) — N/A; adds test coverage, no user-facing behavior or docs surface
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (auto-dev pipeline)
- [x] I have reviewed and understand all AI-generated code in this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_013aKtyD7FLYoeU83wmiCKLx)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for vault tool behaviors, including returned tool ordering and result handling.
  * Verified frontmatter updates correctly convert JSON-like values, handle invalid input safely, and reject unsupported file types.
  * Added checks for file resolution failures and error propagation during frontmatter processing.
  * Covered content appending behavior, including newline handling, full-content replacement, and missing-file failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->