### PR TITLE
chore(daily): 2026-07-02 daily update

### DIFF
--- a/docs/contributing/design-system.md
+++ b/docs/contributing/design-system.md
@@ -71,7 +71,11 @@ button (`list-checks`) and send button (`play`) now match at 18px instead of the
 
 ## Migration status
 
-The token layer is in place and the icon scale is applied to the agent input row.
-The remaining ~1,000 raw `var(--…)` references in `styles.css` are being migrated
-onto the semantic tokens **surface by surface** in follow-up PRs. When you touch a
-component's styles, prefer moving its declarations onto tokens as you go.
+The token layer is in place and every major surface — agent chat messages, modals
+(rewrite/chat, tool confirmation), agent-view controls, buttons, status bar,
+thinking/reasoning blocks, the file picker, and the input area — has been migrated
+onto it. About 325 raw `var(--…)` references remain in `styles.css`; most are
+deliberate holdouts rather than unmigrated components — the font-size scale,
+Obsidian's sub-grid `--size-2-*` micro-spacing, and other Obsidian variables with no
+`--gs-` equivalent. When you touch a component's styles, prefer moving its
+declarations onto tokens as you go.

--- a/docs/guide/agent-mode.md
+++ b/docs/guide/agent-mode.md
@@ -398,7 +398,7 @@ Analyze this blog post and summarize key points
 
 #### deep_research
 
-Conduct multi-source research with citations and (optionally) save the report to your vault. Distinct from `google_search` — Deep Research runs iterative multi-turn investigation that takes minutes rather than seconds. See the [Deep Research guide](/guide/deep-research) for scope options (`web_only`, `vault_only`, `both`) and example prompts.
+Conduct multi-source research with citations and (optionally) save the report to your vault. Distinct from `google_search` — Deep Research runs iterative multi-turn investigation that takes minutes rather than seconds. By default it runs as a background task so it doesn't block the conversation; the agent only waits inline when the report is the direct answer to your current question. See the [Deep Research guide](/guide/deep-research#background-mode) for scope options (`web_only`, `vault_only`, `both`), background mode, and example prompts.
 
 ```text
 Research the latest developments in quantum error correction and save it to Research/quantum.md
@@ -406,7 +406,7 @@ Research the latest developments in quantum error correction and save it to Rese
 
 #### generate_image
 
-Generate an image from a prompt and save it to your vault. The agent picks a default attachment path if you don't specify one. Available on the Gemini provider only.
+Generate an image from a prompt and save it to your vault. The agent picks a default attachment path if you don't specify one. Like `deep_research`, it defaults to running as a background task — the agent only generates inline when the image needs to appear in the same turn. Available on the Gemini provider only.
 
 ```text
 Generate a watercolor diagram of a Zettelkasten workflow and embed it in my notes

--- a/docs/guide/agent-skills.md
+++ b/docs/guide/agent-skills.md
@@ -107,11 +107,12 @@ Skill names must follow these rules:
 
 - Lowercase letters, numbers, and hyphens only
 - 1–64 characters
+- Must start with a lowercase letter (not a digit or hyphen)
 - No consecutive hyphens (`--`)
-- Cannot start or end with a hyphen
+- Cannot end with a hyphen
 
 **Valid:** `code-review`, `daily-planner`, `research-assistant`
-**Invalid:** `Code Review`, `--my-skill`, `my--skill-`
+**Invalid:** `Code Review`, `--my-skill`, `my--skill-`, `2024-review` (starts with a digit)
 
 ## Using Skills
 

--- a/docs/guide/deep-research.md
+++ b/docs/guide/deep-research.md
@@ -111,15 +111,13 @@ The agent has both tools available and will choose the right one based on your r
 
 ## Background Mode
 
-Because Deep Research takes several minutes, the agent can run it as a background task so it doesn't block your editing session. To trigger background mode, ask:
+Because Deep Research takes several minutes, the agent runs it as a background task by default so it doesn't block your editing session — you don't need to ask for background mode explicitly. The agent only runs it in the foreground (blocking the conversation until the report is ready) when the report itself is the direct inline answer to your current question, or when you ask it to run inline:
 
 ```text
-Run deep research on quantum error correction in the background and save it to Research/quantum.md
+Research quantum error correction and show me the results inline
 ```
 
-When the task starts, the agent returns immediately with a task ID. A notification appears in the bottom-right corner when the research completes, with an **Open result** link. You can track progress (or cancel) from the **Background tasks** panel (Command Palette → **View background tasks**).
-
-If you don't specify an output file, results land in `[state-folder]/Background-Tasks/YYYY-MM-DD <topic>.md` by default.
+If you don't specify an output file for a background run, the report lands in `[state-folder]/Background-Tasks/YYYY-MM-DD <topic>.md` by default. When the task starts, the agent returns immediately with a task ID. A notification appears in the bottom-right corner when the research completes, with an **Open result** link. You can track progress (or cancel) from the **Background tasks** panel (Command Palette → **View background tasks**).
 
 See [Background tasks](/guide/background-tasks) for more on the status bar indicator, the task panel, and cancellation.
 

--- a/docs/reference/advanced-settings.md
+++ b/docs/reference/advanced-settings.md
@@ -73,7 +73,7 @@ Route all Google API requests through a proxy or gateway instead of hitting the 
   - Corporate networks that block `generativelanguage.googleapis.com` or `aiplatform.googleapis.com`
   - Local reverse proxies for API key management or cost tracking
   - Regional mirrors for latency or compliance requirements
-- **Scope**: All seven Google GenAI SDK call sites are covered — chat, streaming, web fetch, Google Search grounding, RAG embedding, deep research, and token counting. Leaving one path unproxied while routing others is not possible with this setting.
+- **Scope**: Every Google GenAI SDK call site is covered — chat, streaming, image generation, web fetch, Google Search/Maps grounding, RAG embedding, deep research, and context management (token counting). Leaving one path unproxied while routing others is not possible with this setting.
 - **Validation**: The value is validated on blur; invalid URLs will show a warning notice and be cleared automatically.
 
 ### Retry Settings

--- a/docs/reference/advanced-settings.md
+++ b/docs/reference/advanced-settings.md
@@ -73,7 +73,7 @@ Route all Google API requests through a proxy or gateway instead of hitting the 
   - Corporate networks that block `generativelanguage.googleapis.com` or `aiplatform.googleapis.com`
   - Local reverse proxies for API key management or cost tracking
   - Regional mirrors for latency or compliance requirements
-- **Scope**: Every Google GenAI SDK call site is covered — chat, streaming, image generation, web fetch, Google Search/Maps grounding, RAG embedding, deep research, and context management (token counting). Leaving one path unproxied while routing others is not possible with this setting.
+- **Scope**: Every Google GenAI SDK call site is covered — chat, streaming, image generation, web fetch, Google Search/Maps grounding, RAG indexing, deep research, and context management (token counting). Leaving one path unproxied while routing others is not possible with this setting.
 - **Validation**: The value is validated on blur; invalid URLs will show a warning notice and be cleared automatically.
 
 ### Retry Settings

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -310,7 +310,7 @@ Advanced settings for developers and power users. Access by clicking "Show advan
 - **Only applies when**: Provider is `gemini`
 - **Description**: Overrides the default Google API base URL for all SDK calls. Use this to route requests through a corporate proxy, local gateway, or regional mirror.
 - **Example**: `https://my-proxy.example.com`
-- **Scope**: Applies to all Google API call sites in the plugin (chat, search, web fetch, image generation, RAG indexing, deep research, context management).
+- **Scope**: Applies to every Google API call site in the plugin (chat, streaming, image generation, web fetch, Google Search/Maps grounding, RAG indexing, deep research, context management).
 - **Note**: Leave blank to use the official Google endpoint. Invalid URLs will show a warning and be cleared automatically.
 - **Security note**: Requests routed through this proxy will include your Google API key in the `x-goog-api-key` header.
 

--- a/planning/changelog/2026-07-02.md
+++ b/planning/changelog/2026-07-02.md
@@ -1,0 +1,72 @@
+# Daily changelog — July 02, 2026
+
+**Date:** 2026-07-02
+**PRs merged:** 15
+
+---
+
+## Summary
+
+A heavy day spanning the tail of one auto-dev batch and the start of a new design-system initiative. The morning cleared out a run of small auto-dev-produced follow-ups (init-error generalization, i18n localization, background-task defaults, test coverage, SVG rasterization, the grounding-tool extraction, and a bundled-skill drift tracker), plus two daily-update PRs catching up prior days. The evening opened **Phase 1 and 2 of a new design token layer** for `styles.css` — three PRs that introduce theme-adaptive `--gs-*` tokens and migrate every surface in the plugin onto them, fixing a scoping bug along the way. Also landed a real bug fix: tool-execution logs were folding into the wrong reasoning callout in agent session history.
+
+## What shipped
+
+### [#1080 chore(daily): 2026-07-02 daily update](https://github.com/allenhutchison/obsidian-gemini/pull/1080)
+
+Automated daily housekeeping run bundling `daily-changelog`, `audit-docs`, and `triage-issues` for 2026-07-02: wrote the changelog for 2026-07-01 (3 PRs), and patched 6 docs files for conceptual drift — permission-override enum values in `settings.md`, a fabricated loop-abort notice string in `loop-detection.md`, the bundled Explain-Selection prompt count/mechanism in `ai-writing.md`, and a new "Turn Budget" section in `agent-mode.md`.
+
+### [#1079 refactor: localize empty-response Notice via t()](https://github.com/allenhutchison/obsidian-gemini/pull/1079)
+
+Architecture-audit nightly sweep flagged a missed i18n migration: the non-streaming fallback path in `AgentViewSend.sendMessage` printed a hardcoded English `Notice` for empty model responses, while two other call sites in the same file already used `t('agent.send.emptyResponse')`. This wraps the remaining site so all three empty-response paths localize consistently.
+
+### [#1078 refactor(providers): generalize init-error surfacing across providers](https://github.com/allenhutchison/obsidian-gemini/pull/1078)
+
+Bundle of small follow-ups from the #694 (Ollama integration) review, scoped by the maintainer on #709. Extracts `getApiKeyErrorMessage` into a new provider-agnostic `src/utils/init-error-message.ts`, so a captured `lastInitError` now wins for any provider (previously Ollama-only). Also shortens a rationale comment in `OllamaModelsService.getModels`. Filed #1077 separately after confirming Ollama use-case model resolution does _not_ currently collapse to a single configured model.
+
+### [#1081 chore(daily): 2026-06-30 daily update](https://github.com/allenhutchison/obsidian-gemini/pull/1081)
+
+Catch-up daily-update run for 2026-06-30: wrote the changelog (4 PRs: Ollama vision auto-detection, `openPluginSettingsTab` extraction, the prior daily-update PR, and the new provider-capabilities reference page) and fixed 2 doc drift items — stale "Jest" references corrected to Vitest, and a gap in `agent-mode.md`'s Gemini-only web tool list (all of `google_search`/`google_maps`/`fetch_url`/`deep_research` are gated, not just maps/image-gen).
+
+### [#1083 docs(auto-dev): allow N PRs in flight (cap 6) + orphan age-gate](https://github.com/allenhutchison/obsidian-gemini/pull/1083)
+
+Governance/docs-only change to the auto-dev pipeline: relaxes the one-PR-in-flight rule to a configurable `MAX_PRS_IN_FLIGHT` (default 6), so scheduled ticks keep building the approved queue overnight instead of idling on the human merge gate. Merging remains exclusively the maintainer's act. Also fixes a concurrency race that hourly scheduling had made worse.
+
+### [#1085 feat(agent): prefer background execution for long-running tools by default (#658)](https://github.com/allenhutchison/obsidian-gemini/pull/1085)
+
+Flips `deep_research` and `generate_image` from opt-in to opt-out background execution in `prompts/agentRulesPrompt.hbs`: both now default to `background: true`, with foreground reserved for cases where the very next step depends on the output or the user explicitly asks to see it inline. Prompt/guidance only. Produced by the auto-dev pipeline from the approved plan on #658.
+
+### [#1084 fix(history): stop tool logs folding into the preceding reasoning callout](https://github.com/allenhutchison/obsidian-gemini/pull/1084)
+
+Fixes #1050. Root cause was in `mergeToolBlock` (`src/subscribers/tool-execution-logger.ts`): its backward scan for a trailing `[!tools]-` header walked straight over an intervening `[!reasoning]-` callout (every line starts with `>`), matching a stale header and splicing new tool-log lines into the wrong callout. The scan now stops at the first callout header it meets, starting a fresh `[!tools]-` block when that header isn't already a tools header.
+
+### [#1086 test: cover provider routing and image-gen provider-switch transitions (#710)](https://github.com/allenhutchison/obsidian-gemini/pull/1086)
+
+Test-only PR adding the two untested paths flagged in the #694 review: `resolveModelName` provider routing for Ollama across all five `ModelUseCase` values, and `LifecycleService` provider-switch transitions (gemini → ollama → gemini) for image generation setup/teardown. Produced by the auto-dev pipeline from the approved plan on #710.
+
+### [#1087 feat(evals): model orchestration — preload, swap, and multi-model sweep (#716)](https://github.com/allenhutchison/obsidian-gemini/pull/1087)
+
+Teaches `npm run eval` three orchestration behaviors that PR #694's Ollama runs surfaced as friction: a warmup generation to exclude cold-start latency from timed tasks, auto-swap-with-unload so a model change doesn't briefly double-load two large Ollama models, and a `--models=A,B,C` multi-model sweep mode producing a side-by-side comparison table. `--model=` now sets all three model-role fields instead of chat only.
+
+### [#1088 docs(skills): track upstream drift for kepano-adapted bundled skills (#966)](https://github.com/allenhutchison/obsidian-gemini/pull/1088)
+
+Adds a durable pinned baseline (`SKILL_SOURCES.md`) and a report-only drift check for the three kepano-adapted bundled skills (`obsidian-markdown`, `json-canvas`, `obsidian-bases`), wired into `daily-update`'s sub-skill list. The check finds the newest upstream commit touching each pinned path and reports (but never applies) drift. Produced by the auto-dev pipeline from the approved plan on #966.
+
+### [#1082 feat(attachments): rasterize SVG/SVGZ to PNG before inlining (#641)](https://github.com/allenhutchison/obsidian-gemini/pull/1082)
+
+Gemini's inline-data endpoint rejects `image/svg+xml` outright, so `.svg`/`.svgz` files (e.g. Obsidian Ink handwriting exports) could never reach the model. Adds client-side rasterization (`src/utils/svg-rasterizer.ts`) via an off-screen `<canvas>`, scaled to at most 2048px on the longest edge over a white background, wired into every inline entry point (drag-drop, paste, `@`-mention) as one shared path. Produced by the auto-dev pipeline from the approved plan on #641.
+
+### [#1089 refactor(tools): extract shared grounding-tool runner (#974)](https://github.com/allenhutchison/obsidian-gemini/pull/1089)
+
+`google-search-tool.ts` and `google-maps-tool.ts` were ~85% duplicated, including the subtlest logic in either file — reverse-`endIndex`-sorted citation splicing. Extracts the shared pipeline into a new `runGroundingTool()` helper (`src/tools/grounding-tool-runner.ts`); both tools become thin wrappers supplying only their grounding-tool config and citation accessor. Produced by the auto-dev pipeline from the approved plan on #974.
+
+### [#1090 feat(design): introduce design token layer, unify agent input icon scale](https://github.com/allenhutchison/obsidian-gemini/pull/1090)
+
+Phase 1 of codifying the Gemini Scribe design system: adds a theme-adaptive `--gs-*` token layer to `styles.css` (semantic color/surface/border/accent tokens plus spacing/radius/icon/motion scales) and applies it to the icon size scale, fixing a visible plan-vs-send icon size mismatch in the agent input row (16px/20px → both 18px via `--gs-icon-lg`).
+
+### [#1091 refactor(design): migrate agent chat message surface to design tokens](https://github.com/allenhutchison/obsidian-gemini/pull/1091)
+
+Phase 2, second PR: migrates the agent chat message surface (bubbles, roles, content, copy button) onto the token layer — value-preserving, no visual change. Also fixes a latent bug from #1090: tokens were defined on `:root`, but Obsidian's theme variables are scoped to `body.theme-light`/`body.theme-dark`, so aliasing from `:root` resolved to invalid values. This first surfaced with color tokens (icon tokens have `px` fallbacks that masked it). Moved the token block to `body`.
+
+### [#1092 refactor(design): migrate all remaining surfaces to design tokens](https://github.com/allenhutchison/obsidian-gemini/pull/1092)
+
+Phase 2, final migration: moves every remaining `styles.css` surface (14 areas, one commit each — rewrite/chat modal, agent-mode controls, tool-confirmation modal, settings, and more) onto the `--gs-*` tokens via a scripted, value-preserving substitution anchored on full `var(--name)` tokens. Colors, radii, and the 4px-grid `--size-4-*` scale are migrated; the 2px-based `--size-2-*` micro-spacing and a handful of vars with no token equivalent are deliberately left as-is. Completes the token migration begun in #1090/#1091.


### PR DESCRIPTION
## Summary

Automated daily housekeeping run bundling `daily-changelog`, `audit-docs`, and `triage-issues` for 2026-07-02. Docs-only + one new changelog file; no plugin code changes.

## Changes

- **daily-changelog**: wrote `planning/changelog/2026-07-02.md` — 15 PRs merged on 2026-07-02. The day mixed the tail of an auto-dev cleanup batch (init-error generalization #1078, i18n localization #1079, background-task defaults #1085, provider-routing test coverage #1086, SVG rasterization #1082, grounding-tool extraction #1089, bundled-skill drift tracker #1088), a real bug fix (#1084 — tool-execution logs folding into the wrong reasoning callout), two catch-up daily-update PRs (#1080, #1081), and the start of a new design-token-layer initiative across `styles.css` (#1090, #1091, #1092).
- **audit-docs**: patched 6 doc files:
  - `docs/contributing/design-system.md` — **conceptual drift**: "Migration status" claimed ~1,000 unmigrated `var()` references and only the icon scale done; PR #1092 migrated every major surface and actual remaining count is ~325 (deliberate holdouts, not stragglers).
  - `docs/guide/deep-research.md` — **conceptual drift**: "Background Mode" said background execution required explicitly asking for it; PR #1085 flipped `deep_research`/`generate_image` to background-by-default, so the doc described the opposite of current behavior.
  - `docs/guide/agent-mode.md` — updated the `deep_research`/`generate_image` tool blurbs to match the same background-by-default behavior.
  - `docs/guide/agent-skills.md` — the skill-naming rules omitted that names must start with a lowercase letter (not a digit); added the missing rule + an invalid example.
  - `docs/reference/settings.md` and `docs/reference/advanced-settings.md` — reconciled two different, both-incomplete enumerations of the Custom API Endpoint's scope (call sites) into one accurate list.
  - No new docs were warranted — no genuinely uncovered, load-bearing, user-visible feature turned up.
- **triage-issues**: 0 unlabeled open issues found (38 open issues checked, all already labeled) — no action taken.
- **bundled skill drift check**: errored — this session's GitHub access is scoped to `allenhutchison/obsidian-gemini` only, and the check requires querying the upstream `kepano/obsidian-skills` repo, which is out of scope for this session. Not run; flagging so a session with broader GitHub access can pick it up.

## Screenshots / Screencast

N/A — docs and changelog only, no UI change.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A, this is the recurring automated `daily-update` housekeeping run
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [ ] I have tested this change on Desktop — N/A, docs/changelog-only change with no runtime surface
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A, no code change
- [x] Documentation has been updated (if applicable) — this PR *is* the documentation update
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR


---
_Generated by [Claude Code](https://claude.ai/code/session_01SFssocmiRZos6ijzPfkYuD)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved long-running agent tools to default to background mode, and clarified inline-vs-background behavior.
  * Expanded support for the theme-adaptive design token rollout across more UI surfaces.

* **Bug Fixes**
  * Fixed token scoping issues and unified icon sizing for more consistent visuals.
  * Improved handling of tool logs so they appear in the correct reasoning context.

* **Documentation**
  * Updated guides and reference docs for migration status, agent skills naming rules, deep research behavior, and API endpoint scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->