### PR TITLE
feat(design): unify elevation onto a 3-step shadow scale

### DIFF
--- a/docs/contributing/design-system.md
+++ b/docs/contributing/design-system.md
@@ -32,7 +32,7 @@ writing or migrating styles.
 | Status    | `--gs-success`, `--gs-warning`, `--gs-error`, `--gs-info`           | `--color-green/-orange/-red/-blue`                                              |
 | Spacing   | `--gs-space-1..8`                                                   | 4 / 8 / 12 / 16 / 24 / 32 / 48 px                                               |
 | Radius    | `--gs-radius-sm/-md/-lg/-pill`                                      | `--radius-s/-m/-l`                                                              |
-| Elevation | `--gs-shadow-sm/-md/-lg`                                            | `--shadow-s/-l`                                                                 |
+| Elevation | `--gs-shadow-sm/-md/-lg`                                            | custom 3-step scale, theme-aware (dark override on `body.theme-dark`)           |
 | Type      | `--gs-font-ui`, `--gs-font-mono`                                    | `--font-interface`, `--font-monospace`                                          |
 | Motion    | `--gs-dur-fast/-/-slow`, `--gs-ease`                                | 120 / 200 / 320 ms                                                              |
 | Icons     | `--gs-icon-sm/-md/-lg/-xl`, `--gs-icon-stroke`                      | `--icon-xs/-s/-m/-l`, `--icon-stroke`                                           |

--- a/styles.css
+++ b/styles.css
@@ -39,10 +39,12 @@ body {
 	--gs-radius-lg: var(--radius-l);
 	--gs-radius-pill: 999px;
 
-	/* Elevation */
-	--gs-shadow-sm: var(--shadow-s);
-	--gs-shadow-md: var(--shadow-l);
-	--gs-shadow-lg: var(--shadow-l);
+	/* Elevation — a 3-step scale. sm = resting content, md = interactive lift,
+	   lg = floating overlays. Dark-theme values are overridden below (a subtle
+	   light-mode shadow is invisible on a dark surface). */
+	--gs-shadow-sm: 0 1px 2px rgba(16, 22, 33, 0.07);
+	--gs-shadow-md: 0 4px 12px rgba(16, 22, 33, 0.1);
+	--gs-shadow-lg: 0 14px 40px rgba(16, 22, 33, 0.16);
 
 	/* Motion */
 	--gs-dur-fast: 120ms;
@@ -84,6 +86,13 @@ body {
 	--gs-warning: var(--color-orange);
 	--gs-error: var(--color-red);
 	--gs-info: var(--color-blue);
+}
+
+/* Elevation — deeper shadows for dark themes, where light-mode values vanish. */
+body.theme-dark {
+	--gs-shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.35);
+	--gs-shadow-md: 0 6px 18px rgba(0, 0, 0, 0.45);
+	--gs-shadow-lg: 0 16px 44px rgba(0, 0, 0, 0.6);
 }
 /* in your plugin's styles.css or a <style> tag in your view */
 
@@ -193,7 +202,7 @@ body {
 
 .gemini-scribe-submit-button.mod-cta:hover {
 	background-color: var(--gs-accent-hover);
-	box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+	box-shadow: var(--gs-shadow-md);
 }
 
 .gemini-scribe-chatbox {
@@ -932,7 +941,7 @@ body {
 .gemini-tool-confirm-btn:hover {
 	background: var(--gs-accent-hover);
 	transform: translateY(-1px);
-	box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+	box-shadow: var(--gs-shadow-md);
 }
 
 .gemini-tool-btn-icon {
@@ -1032,7 +1041,7 @@ body {
 
 .gemini-agent-btn-primary:hover {
 	background-color: var(--gs-accent-hover);
-	box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+	box-shadow: var(--gs-shadow-md);
 }
 
 .gemini-agent-btn-secondary {
@@ -1769,7 +1778,7 @@ body {
 	padding: var(--gs-space-3) var(--gs-space-4);
 	border-radius: var(--gs-radius-lg);
 	position: relative;
-	box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+	box-shadow: var(--gs-shadow-sm);
 	transition: box-shadow 0.15s ease;
 	user-select: text;
 	-webkit-user-select: text;
@@ -1777,7 +1786,7 @@ body {
 }
 
 .gemini-agent-message:hover .gemini-agent-message-content {
-	box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+	box-shadow: var(--gs-shadow-md);
 }
 
 .gemini-agent-message-user .gemini-agent-message-content {
@@ -2104,7 +2113,7 @@ body {
 }
 
 .gemini-tool-group-expanded {
-	box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
+	box-shadow: var(--gs-shadow-sm);
 }
 
 /* ============================================================
@@ -2125,7 +2134,7 @@ body {
 
 .gemini-agent-tool-message:hover {
 	border-color: var(--gs-border-strong);
-	box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+	box-shadow: var(--gs-shadow-sm);
 }
 
 .gemini-agent-tool-header {
@@ -2421,7 +2430,7 @@ body {
 
 /* Expanded state */
 .gemini-agent-tool-expanded {
-	box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+	box-shadow: var(--gs-shadow-sm);
 }
 
 /* Completion animation */
@@ -2805,7 +2814,7 @@ body {
 	border-color: var(--gs-accent);
 	color: var(--gs-text);
 	transform: translateY(-1px);
-	box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+	box-shadow: var(--gs-shadow-md);
 }
 
 .gemini-agent-suggestion-session {
@@ -2842,14 +2851,14 @@ body {
 	border-radius: var(--gs-radius-lg);
 	cursor: pointer;
 	transition: all 0.2s ease;
-	box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+	box-shadow: var(--gs-shadow-sm);
 	width: 100%;
 	max-width: 400px;
 }
 
 .gemini-agent-init-context-button:hover {
 	transform: translateY(-2px);
-	box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
+	box-shadow: var(--gs-shadow-md);
 	border-color: var(--gs-accent-hover);
 }
 
@@ -2895,13 +2904,13 @@ body {
 .gemini-agent-init-context-button-update {
 	background: var(--gs-surface-alt);
 	border: 1px solid var(--gs-border);
-	box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+	box-shadow: var(--gs-shadow-sm);
 }
 
 .gemini-agent-init-context-button-update:hover {
 	background: var(--gs-hover);
 	border-color: var(--gs-border-strong);
-	box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
+	box-shadow: var(--gs-shadow-md);
 }
 
 .gemini-agent-init-context-button-update .gemini-agent-init-icon {


### PR DESCRIPTION
## Summary

The first **visible** design refinement on top of the token foundation: replace the ad-hoc box-shadows scattered across surfaces with a coherent, theme-aware **3-step elevation scale**.

Previously `--gs-shadow-md` and `--gs-shadow-lg` both aliased Obsidian's heavy `--shadow-l` (not a real scale), and every surface used its own custom `box-shadow` value (`0 1px 3px rgba(...)`, `0 4px 16px rgba(...)`, …).

## Changes

- **`styles.css` — the scale.** Define real values for `--gs-shadow-sm/-md/-lg`, with a **`body.theme-dark` override** (a subtle light-mode shadow is invisible on a dark surface, so dark mode needs deeper shadows):
  - light: `sm 0 1px 2px /.07`, `md 0 4px 12px /.10`, `lg 0 14px 40px /.16`
  - dark: `sm 0 1px 2px /.35`, `md 0 6px 18px /.45`, `lg 0 16px 44px /.60`
- **`styles.css` — apply by intent.** 13 shadows moved onto the tokens:
  - **sm** (resting): message bubble rest, expanded tool/group panels, subtle row hover.
  - **md** (interactive lift): buttons / confirm / suggestion / init-context on hover, message bubble hover.
  - **lg**: reserved for floating overlays (none used yet).
  - **Left untouched:** focus rings (`0 0 0 2px …`), the thinking-pulse `@keyframes`, and `box-shadow: none` resets.
- **Docs:** design-system elevation row updated (no longer aliases `--shadow-*`).

## Verification (in-vault, light + dark)

- Shadow tokens resolve to the correct custom values in **both** themes (`--gs-shadow-md` → `rgba(16,22,33,.1) 0 4px 12px` light / `rgba(0,0,0,.45) 0 6px 18px` dark).
- Model message bubble now computes `--gs-shadow-sm` (exact match).
- Rendered the agent view in **light and dark** — both clean, shadows appropriately subtle, no heavy/broken elevation. Matches the elevation scale in the design-system artifact.

## Screenshots / Screencast

Subtle-by-intent visual change (elevation consistency). Verified via light + dark vault renders and token-resolution checks rather than a static diff.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: maintainer-directed design refinement, decided interactively
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — 3234 tests pass, build + prettier clean
- [x] I have tested this change on Desktop — verified in-vault in both light and dark themes
- [x] I have verified this change does not break Mobile — CSS-only; theme-aware tokens resolve on `body`/`body.theme-dark` (present on mobile)
- [x] Documentation has been updated (if applicable) — design-system elevation row
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

---
https://claude.ai/code/session_01Dp5HWzyqpRBjrUce8FRATF