### PR TITLE
refactor: clear small TS-strictness one-offs and enforce their rules (#1041)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,7 +5,9 @@ import obsidianmd from 'eslint-plugin-obsidianmd';
 // `eslint-plugin-obsidianmd@0.3.0`'s recommended preset bundles a large set of
 // strict `@typescript-eslint/*` rules (no-explicit-any, no-unsafe-*, etc.) in
 // addition to its Obsidian-specific rules. We only want the obsidianmd/* rules
-// enforced; the bundled TS-strictness can be tightened in a follow-up.
+// enforced; the bundled TS-strictness is being tightened rule-by-rule as the
+// remaining violations are cleared (the `'error'` entries below are already
+// enforced; the `'off'` entries are tracked in sibling #1032 issues).
 const SOFTENED_TS_RULES = {
 	'@typescript-eslint/no-explicit-any': 'off',
 	'@typescript-eslint/no-unsafe-argument': 'off',
@@ -13,15 +15,18 @@ const SOFTENED_TS_RULES = {
 	'@typescript-eslint/no-unsafe-call': 'off',
 	'@typescript-eslint/no-unsafe-member-access': 'off',
 	'@typescript-eslint/no-unsafe-return': 'off',
-	'@typescript-eslint/no-unsafe-enum-comparison': 'off',
+	// #1041: cleared — enforced.
+	'@typescript-eslint/no-unsafe-enum-comparison': 'error',
 	'@typescript-eslint/no-unnecessary-type-assertion': 'off',
 	'@typescript-eslint/no-misused-promises': 'off',
 	'@typescript-eslint/no-floating-promises': 'off',
 	'@typescript-eslint/no-base-to-string': 'off',
 	'@typescript-eslint/restrict-template-expressions': 'off',
-	'@typescript-eslint/no-redundant-type-constituents': 'off',
+	// #1041: cleared — enforced.
+	'@typescript-eslint/no-redundant-type-constituents': 'error',
 	'@typescript-eslint/no-require-imports': 'off',
-	'@typescript-eslint/no-unused-expressions': 'off',
+	// #1041: cleared — enforced.
+	'@typescript-eslint/no-unused-expressions': 'error',
 	'@typescript-eslint/no-deprecated': 'off',
 	'@typescript-eslint/unbound-method': 'off',
 	'@typescript-eslint/no-unused-vars': [

--- a/src/tools/web-fetch-tool.ts
+++ b/src/tools/web-fetch-tool.ts
@@ -194,7 +194,7 @@ export class WebFetchTool implements Tool {
 			plugin.logger.log('Primary web fetch failed, attempting fallback...');
 			try {
 				return await this.fallbackFetch(params, plugin);
-			} catch (fallbackError) {
+			} catch (_fallbackError) {
 				return {
 					success: false,
 					error: `Failed to fetch URL with both methods: ${error instanceof Error ? error.message : 'Unknown error'}`,

--- a/src/ui/agent-view/agent-view-ui.ts
+++ b/src/ui/agent-view/agent-view-ui.ts
@@ -514,7 +514,7 @@ export class AgentViewUI {
 										this.plugin.logger.debug(`[AgentViewUI] Failed to resolve obsidian URI file param: ${decoded}`);
 									}
 								}
-							} catch (err) {
+							} catch (_err) {
 								this.plugin.logger.debug(`[AgentViewUI] Failed to parse obsidian URI: ${trimmed}`);
 							}
 							continue;
@@ -545,7 +545,7 @@ export class AgentViewUI {
 								} else {
 									this.plugin.logger.debug(`[AgentViewUI] Failed to resolve markdown link: ${path}`);
 								}
-							} catch (err) {
+							} catch (_err) {
 								// Ignore decoding errors
 								this.plugin.logger.debug(`[AgentViewUI] Failed to decode markdown link path: ${mdMatch[2]}`);
 							}

--- a/src/ui/agent-view/file-picker-modal.ts
+++ b/src/ui/agent-view/file-picker-modal.ts
@@ -101,7 +101,11 @@ export class FilePickerModal extends SuggestModal<TAbstractFile> {
 			});
 		} else {
 			const file = item as TFile;
-			this.selectedFiles.has(file) ? this.selectedFiles.delete(file) : this.selectedFiles.add(file);
+			if (this.selectedFiles.has(file)) {
+				this.selectedFiles.delete(file);
+			} else {
+				this.selectedFiles.add(file);
+			}
 		}
 
 		// In-place checkbox update: touch only affected DOM elements

--- a/src/ui/agent-view/inline-attachment.ts
+++ b/src/ui/agent-view/inline-attachment.ts
@@ -154,7 +154,7 @@ export async function saveAttachmentToVault(app: App, attachment: InlineAttachme
 		for (let i = 0; i < binaryString.length; i++) {
 			bytes[i] = binaryString.charCodeAt(i);
 		}
-	} catch (error) {
+	} catch (_error) {
 		throw new Error('Failed to decode base64 data');
 	}
 

--- a/src/ui/components/management-modal-base.ts
+++ b/src/ui/components/management-modal-base.ts
@@ -312,7 +312,7 @@ export abstract class ManagementModalBase<TEntity, TEntityState> extends Modal {
 	// ── Abstract: data access ────────────────────────────────────────────────
 
 	/** Return the entity manager, or null/undefined if unavailable. */
-	protected abstract getManager(): unknown | null | undefined;
+	protected abstract getManager(): unknown;
 	/** Return all entities for the list view. */
 	protected abstract getEntities(): TEntity[];
 	/** Return the state map keyed by slug. */

--- a/src/ui/settings-mcp.ts
+++ b/src/ui/settings-mcp.ts
@@ -2,6 +2,7 @@ import type ObsidianGemini from '../main';
 import { App, Setting, Notice, setIcon } from 'obsidian';
 import { sanitizeKeySegment } from '../mcp/mcp-oauth-provider';
 import { clearServerEnv } from '../mcp/mcp-secrets';
+import { MCPConnectionStatus } from '../mcp/types';
 import { getErrorMessage, getRawErrorMessage } from '../utils/error-utils';
 import { createCollapsibleSection } from './settings-helpers';
 import { t } from '../i18n';
@@ -74,9 +75,9 @@ async function createMCPSettings(
 			const statusText = status?.status || 'disconnected';
 
 			let iconName: string;
-			if (status?.status === 'connected') {
+			if (status?.status === MCPConnectionStatus.CONNECTED) {
 				iconName = 'check-circle';
-			} else if (status?.status === 'error') {
+			} else if (status?.status === MCPConnectionStatus.ERROR) {
 				iconName = 'alert-circle';
 			} else {
 				iconName = 'circle';

--- a/test/services/skill-manager.test.ts
+++ b/test/services/skill-manager.test.ts
@@ -442,7 +442,7 @@ describe('SkillManager', () => {
 		it('should create a skill directory and SKILL.md using processFrontMatter', async () => {
 			const createdFile = new TFile('gemini-scribe/Skills/new-skill/SKILL.md');
 			// createSkill flow: duplicate check + ensureFolderExists (skill dir)
-			const folderResponses: Record<string, InstanceType<typeof TFolder> | null> = {};
+			const folderResponses: Record<string, TFolderBase | null> = {};
 			mockVault.createFolder.mockImplementation(async (path: string) => {
 				// After createFolder, mark the folder as existing
 				folderResponses[path] = new TFolder(path);


### PR DESCRIPTION
<!-- auto-dev -->

## Summary

Clears the bundle of low-count strict-TS violations tracked in #1041 and flips each now-cleared ESLint rule from `'off'` to `'error'` so they can't regress. Purely a type-safety / lint hygiene change with no runtime behavior change.

Produced by the auto-dev pipeline from the approved plan on #1041.

Fixes #1041

## Changes

- **`src/ui/settings-mcp.ts`** — compare `status.status` against `MCPConnectionStatus` enum members (`CONNECTED`/`ERROR`) instead of the string literals `'connected'`/`'error'` (`no-unsafe-enum-comparison`). Behavior-preserving, since the enum values equal the compared literals; adds the `MCPConnectionStatus` import.
- **`src/ui/agent-view/file-picker-modal.ts`** — replace the selection-toggle ternary-as-statement with an explicit `if/else` (`no-unused-expressions`). (The neighbouring `as TFile` cast is left for #1033.)
- **`src/ui/components/management-modal-base.ts`** — `getManager()` return type `unknown | null | undefined` → `unknown`, since `unknown` already subsumes `null`/`undefined` (`no-redundant-type-constituents`).
- **`src/tools/web-fetch-tool.ts`, `src/ui/agent-view/agent-view-ui.ts` (×2), `src/ui/agent-view/inline-attachment.ts`** — prefix the unused caught-error bindings with `_` (`no-unused-vars`, allowed by the existing `caughtErrorsIgnorePattern: '^_'`).
- **`test/services/skill-manager.test.ts`** — type the folder-response map as `TFolderBase | null` instead of `InstanceType<typeof TFolder> | null`; the mock `TFolder` is `any`, which made the union redundant (`no-redundant-type-constituents`).
- **`eslint.config.mjs`** — enforce `no-unsafe-enum-comparison`, `no-redundant-type-constituents`, and `no-unused-expressions` as `error` now that `src` and `test` are clean of them. `no-unused-vars` intentionally stays `'warn'` (a few pre-existing test-only warnings remain, so the rule isn't fully cleared).

## Screenshots / Screencast

N/A — internal type-safety / lint change with no visual or behavioral surface.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer — approved plan on #1041
- [x] All CI checks pass (`npm test` — 3234 passing, `npm run build`, `npm run format-check`) — plus `npm run lint` (0 errors) and `npm run typecheck:test`
- [x] I have tested this change on Desktop — full unit suite passes; the changes are compile-time/lint-time only
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — no runtime or platform-specific changes
- [x] Documentation has been updated (if applicable) — N/A; internal refactor with no user-facing surface
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (auto-dev pipeline)
- [x] I have reviewed and understand all AI-generated code in this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01EhfK5cNyimjQwT58kDtAsh)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved settings status icons to more reliably reflect connection states.
  * Fixed file selection behavior in the picker so selected items toggle on and off consistently.
  * Tightened handling of pasted and attached content to better skip invalid input without disrupting the flow.
  * Updated linting rules for stricter TypeScript checks, helping catch more issues before release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->