### PR TITLE
feat(design): signature accent — bold user bubble, gradient send & brand mark

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1517,12 +1517,21 @@ body.theme-dark {
 	display: flex;
 	align-items: center;
 	justify-content: center;
+	/* Signature: the primary send action carries the Gemini brand gradient. */
+	background: var(--gs-brand-gradient);
+	border: none;
+}
+
+.gemini-agent-send-btn:hover {
+	/* keep the gradient on hover — otherwise btn-primary:hover repaints it accent */
+	background: var(--gs-brand-gradient);
+	filter: brightness(1.05);
 }
 
 .gemini-agent-send-btn svg {
 	width: var(--gs-icon-lg);
 	height: var(--gs-icon-lg);
-	fill: var(--gs-success, #10b981);
+	fill: var(--gs-on-accent);
 }
 
 .gemini-agent-stop-btn svg {
@@ -1790,8 +1799,11 @@ body.theme-dark {
 }
 
 .gemini-agent-message-user .gemini-agent-message-content {
-	background-color: var(--background-primary-alt);
-	color: var(--gs-text);
+	/* Bolder identity: your messages are a solid accent-filled bubble with
+	   white text (the border matches the fill, keeping box parity with the
+	   bordered model bubble). */
+	background-color: var(--gs-accent);
+	color: var(--gs-on-accent);
 	margin-left: var(--gs-space-6);
 	border-bottom-right-radius: var(--gs-radius-sm);
 	border: 1px solid var(--gs-accent);
@@ -2765,16 +2777,22 @@ body.theme-dark {
 }
 
 .gemini-agent-empty-icon {
-	width: 64px;
-	height: 64px;
+	/* Brand mark: a Gemini-gradient badge with a white sparkle. The gradient is
+	   reserved for this and the send button — the plugin's two signature spots. */
+	width: 56px;
+	height: 56px;
 	margin-bottom: var(--gs-space-4);
-	color: var(--gs-text-muted);
-	opacity: 0.3;
+	background: var(--gs-brand-gradient);
+	color: var(--gs-on-accent);
+	border-radius: var(--gs-radius-lg);
+	display: grid;
+	place-items: center;
+	box-shadow: var(--gs-shadow-md);
 }
 
 .gemini-agent-empty-icon svg {
-	width: 100%;
-	height: 100%;
+	width: 32px;
+	height: 32px;
 }
 
 .gemini-agent-empty-title {


### PR DESCRIPTION
## Summary

The **identity layer** of the design system — the first place we spend the Gemini brand gradient, and the point where the plugin starts to feel deliberately designed rather than just tidy. Three changes, all decided interactively:

- **User message bubble → solid accent fill.** Your messages become filled bubbles in the theme accent (`--gs-accent`) with white text (`--gs-on-accent`), replacing the near-white background + thin accent border. Instantly reads "you". The `--interactive-accent` / `--text-on-accent` pairing is contrast-safe by Obsidian's design, and it adapts to light/dark/custom themes.
- **Send button → the Gemini brand gradient** (`--gs-brand-gradient`) with a white icon — resolving the odd accent-bg/green-icon combo (the green-send question). A `:hover` keeps the gradient (brightness bump) so `btn-primary:hover` can't repaint it accent.
- **Empty-state sparkle → a gradient brand badge** (rounded, elevated) with a white sparkle, instead of a faint gray icon.

The gradient is **reserved for these two spots** — the primary action and the brand mark — so it stays a signature ("spend boldness in one place"). Everything else stays on the theme accent.

## Verification (in-vault)

- User bubble computes `rgb(152,115,247)` (accent) background + `rgb(255,255,255)` text.
- Send button computes `linear-gradient(95deg, rgb(73,137,245)…)` with a white icon fill.
- Empty badge computes the brand gradient, `12px` radius, `56×56`, elevated.
- Gradient send button visually confirmed in the agent view. Matches the design-system artifact (accent user bubble, gradient send, brand mark).

## Screenshots / Screencast

Visible design change (identity). The gradient send button and accent user bubble are the headline; the empty-state brand badge replaces a faint gray sparkle.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: maintainer-directed design refinement, decided interactively
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — 3234 tests pass, build + prettier clean
- [x] I have tested this change on Desktop — verified in-vault (computed styles for all three + gradient send rendered)
- [x] I have verified this change does not break Mobile — CSS-only; accent/on-accent/gradient tokens resolve on `body` (present on mobile)
- [x] Documentation has been updated (if applicable) — N/A: the design-system doc already states the gradient is "primary action & brand only," now actually true; the artifact already reflects these choices
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

---
https://claude.ai/code/session_01Dp5HWzyqpRBjrUce8FRATF