### PR TITLE
feat(design): motion polish + fixed icon-size scale

### DIFF
--- a/docs/contributing/design-system.md
+++ b/docs/contributing/design-system.md
@@ -35,7 +35,7 @@ writing or migrating styles.
 | Elevation | `--gs-shadow-sm/-md/-lg`                                            | custom 3-step scale, theme-aware (dark override on `body.theme-dark`)           |
 | Type      | `--gs-font-ui`, `--gs-font-mono`                                    | `--font-interface`, `--font-monospace`                                          |
 | Motion    | `--gs-dur-fast/-/-slow`, `--gs-ease`                                | 120 / 200 / 320 ms                                                              |
-| Icons     | `--gs-icon-sm/-md/-lg/-xl`, `--gs-icon-stroke`                      | `--icon-xs/-s/-m/-l`, `--icon-stroke`                                           |
+| Icons     | `--gs-icon-sm/-md/-lg/-xl`, `--gs-icon-stroke`                      | fixed 14/16/18/20; stroke aliases `--icon-stroke`                               |
 
 ### Rules
 

--- a/styles.css
+++ b/styles.css
@@ -193,7 +193,7 @@ body.theme-dark {
 	font-weight: 500;
 	border-radius: 4px;
 	cursor: pointer;
-	transition: all 0.15s ease;
+	transition: all var(--gs-dur-fast) var(--gs-ease);
 }
 
 .gemini-scribe-submit-button.mod-cta {
@@ -819,7 +819,7 @@ body.theme-dark {
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	transition: all 0.1s ease;
+	transition: all var(--gs-dur-fast) var(--gs-ease);
 }
 
 .gemini-tool-expand-btn:hover {
@@ -920,7 +920,7 @@ body.theme-dark {
 	font-size: 14px;
 	font-weight: 500;
 	cursor: pointer;
-	transition: all 0.15s ease;
+	transition: all var(--gs-dur-fast) var(--gs-ease);
 }
 
 .gemini-tool-cancel-btn {
@@ -987,7 +987,7 @@ body.theme-dark {
 	cursor: text;
 	padding: 2px 4px;
 	border-radius: var(--gs-radius-sm);
-	transition: background-color 0.15s ease;
+	transition: background-color var(--gs-dur-fast) var(--gs-ease);
 }
 
 .gemini-agent-title:hover {
@@ -1027,7 +1027,7 @@ body.theme-dark {
 	font-size: var(--font-ui-small);
 	font-weight: 500;
 	cursor: pointer;
-	transition: all 0.15s ease;
+	transition: all var(--gs-dur-fast) var(--gs-ease);
 	border: none;
 }
 
@@ -1092,7 +1092,7 @@ body.theme-dark {
 	color: var(--gs-text-muted);
 	display: flex;
 	align-items: center;
-	transition: all 0.15s ease;
+	transition: all var(--gs-dur-fast) var(--gs-ease);
 }
 
 .gemini-agent-toggle-btn:hover {
@@ -1121,7 +1121,7 @@ body.theme-dark {
 	cursor: text;
 	padding: var(--size-2-1) var(--size-2-2);
 	border-radius: var(--gs-radius-sm);
-	transition: background-color 0.15s ease;
+	transition: background-color var(--gs-dur-fast) var(--gs-ease);
 	white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;
@@ -1342,7 +1342,7 @@ body.theme-dark {
 .gemini-agent-progress-clickable {
 	cursor: pointer;
 	border-radius: var(--gs-radius-sm);
-	transition: background-color 0.15s ease;
+	transition: background-color var(--gs-dur-fast) var(--gs-ease);
 }
 
 .gemini-agent-progress-clickable:hover {
@@ -1356,7 +1356,7 @@ body.theme-dark {
 	justify-content: center;
 	flex-shrink: 0;
 	color: var(--gs-text-muted);
-	transition: color 0.15s ease;
+	transition: color var(--gs-dur-fast) var(--gs-ease);
 }
 
 /* Hidden state — chevron only appears once thinking content is available */
@@ -1365,7 +1365,7 @@ body.theme-dark {
 }
 
 .gemini-agent-thinking-chevron svg {
-	transition: transform 0.2s ease;
+	transition: transform var(--gs-dur) var(--gs-ease);
 }
 
 .gemini-agent-thinking-chevron-expanded svg {
@@ -1489,7 +1489,7 @@ body.theme-dark {
 	font-family: var(--font-interface);
 	font-size: var(--font-text-size);
 	resize: vertical;
-	transition: border-color 0.15s ease;
+	transition: border-color var(--gs-dur-fast) var(--gs-ease);
 }
 
 .gemini-agent-input:focus {
@@ -1636,7 +1636,7 @@ body.theme-dark {
 	border-radius: var(--gs-radius-md);
 	margin-bottom: var(--size-2-2);
 	cursor: pointer;
-	transition: all 0.15s ease;
+	transition: all var(--gs-dur-fast) var(--gs-ease);
 	overflow: hidden;
 	width: 100%;
 	box-sizing: border-box;
@@ -1690,7 +1690,7 @@ body.theme-dark {
 	color: var(--gs-text-muted);
 	cursor: pointer;
 	border-radius: var(--gs-radius-sm);
-	transition: all 0.15s ease;
+	transition: all var(--gs-dur-fast) var(--gs-ease);
 }
 
 .gemini-session-action-btn:hover {
@@ -1752,7 +1752,7 @@ body.theme-dark {
 
 .gemini-agent-message {
 	margin-bottom: var(--gs-space-4);
-	animation: fadeIn 0.3s ease-in;
+	animation: fadeIn var(--gs-dur-slow) var(--gs-ease);
 }
 
 @keyframes fadeIn {
@@ -1805,7 +1805,7 @@ body.theme-dark {
 	border-radius: var(--gs-radius-lg);
 	position: relative;
 	box-shadow: var(--gs-shadow-sm);
-	transition: box-shadow 0.15s ease;
+	transition: box-shadow var(--gs-dur-fast) var(--gs-ease);
 	user-select: text;
 	-webkit-user-select: text;
 	-ms-user-select: text;
@@ -1932,7 +1932,7 @@ body.theme-dark {
 	padding: var(--size-2-1);
 	cursor: pointer;
 	opacity: 0;
-	transition: opacity 0.2s ease-in-out;
+	transition: opacity var(--gs-dur) var(--gs-ease);
 }
 
 .gemini-agent-message:hover .gemini-agent-copy-button {
@@ -1960,7 +1960,7 @@ body.theme-dark {
 	border-radius: var(--gs-radius-md);
 	overflow: hidden;
 	background-color: var(--gs-surface-alt);
-	transition: all 0.2s ease;
+	transition: all var(--gs-dur) var(--gs-ease);
 }
 
 .gemini-tool-group:hover {
@@ -1975,7 +1975,7 @@ body.theme-dark {
 	padding: var(--size-2-3) var(--gs-space-3);
 	cursor: pointer;
 	user-select: none;
-	transition: background-color 0.15s ease;
+	transition: background-color var(--gs-dur-fast) var(--gs-ease);
 }
 
 .gemini-tool-group-summary:hover {
@@ -2022,7 +2022,7 @@ body.theme-dark {
 	display: flex;
 	align-items: center;
 	color: var(--gs-text-muted);
-	transition: transform 0.2s ease;
+	transition: transform var(--gs-dur) var(--gs-ease);
 }
 
 .gemini-tool-group-chevron svg {
@@ -2033,13 +2033,13 @@ body.theme-dark {
 /* Group body (expandable) */
 .gemini-tool-group-body {
 	border-top: 1px solid var(--gs-border);
-	animation: slideDown 0.2s ease-out;
+	animation: slideDown var(--gs-dur) var(--gs-ease);
 }
 
 /* Individual tool rows */
 .gemini-tool-row {
 	border-bottom: 1px solid var(--gs-border);
-	transition: background-color 0.15s ease;
+	transition: background-color var(--gs-dur-fast) var(--gs-ease);
 }
 
 .gemini-tool-row:last-child {
@@ -2053,7 +2053,7 @@ body.theme-dark {
 	padding: var(--size-2-2) var(--gs-space-3);
 	cursor: pointer;
 	user-select: none;
-	transition: background-color 0.15s ease;
+	transition: background-color var(--gs-dur-fast) var(--gs-ease);
 }
 
 .gemini-tool-row-header:hover {
@@ -2133,7 +2133,7 @@ body.theme-dark {
 	border-top: 1px solid var(--gs-border);
 	padding: var(--gs-space-2) var(--gs-space-3);
 	background-color: var(--gs-surface);
-	animation: slideDown 0.2s ease-out;
+	animation: slideDown var(--gs-dur) var(--gs-ease);
 }
 
 /* Expanded state */
@@ -2158,7 +2158,7 @@ body.theme-dark {
 	border: 1px solid var(--gs-border);
 	border-radius: var(--gs-radius-md);
 	overflow: hidden;
-	transition: all 0.2s ease;
+	transition: all var(--gs-dur) var(--gs-ease);
 }
 
 .gemini-agent-tool-message:hover {
@@ -2173,7 +2173,7 @@ body.theme-dark {
 	padding: var(--gs-space-2) var(--gs-space-3);
 	cursor: pointer;
 	user-select: none;
-	transition: background-color 0.15s ease;
+	transition: background-color var(--gs-dur-fast) var(--gs-ease);
 }
 
 .gemini-agent-tool-header:hover {
@@ -2188,7 +2188,7 @@ body.theme-dark {
 	color: var(--gs-text-muted);
 	display: flex;
 	align-items: center;
-	transition: color 0.15s ease;
+	transition: color var(--gs-dur-fast) var(--gs-ease);
 }
 
 .gemini-agent-tool-toggle:hover {
@@ -2198,7 +2198,7 @@ body.theme-dark {
 .gemini-agent-tool-toggle svg {
 	width: var(--gs-icon-md);
 	height: var(--gs-icon-md);
-	transition: transform 0.2s ease;
+	transition: transform var(--gs-dur) var(--gs-ease);
 }
 
 .gemini-agent-tool-icon {
@@ -2305,7 +2305,7 @@ body.theme-dark {
 	border-top: 1px solid var(--gs-border);
 	padding: var(--gs-space-3);
 	background-color: var(--gs-surface);
-	animation: slideDown 0.2s ease-out;
+	animation: slideDown var(--gs-dur) var(--gs-ease);
 }
 
 @keyframes slideDown {
@@ -2356,7 +2356,7 @@ body.theme-dark {
 	border-radius: var(--gs-radius-sm);
 	cursor: pointer;
 	color: var(--gs-text-muted);
-	transition: all 0.15s ease;
+	transition: all var(--gs-dur-fast) var(--gs-ease);
 }
 
 .gemini-agent-tool-copy-section:hover {
@@ -2464,7 +2464,7 @@ body.theme-dark {
 
 /* Completion animation */
 .gemini-agent-tool-completed {
-	animation: toolComplete 0.5s ease;
+	animation: toolComplete var(--gs-dur-slow) var(--gs-ease);
 }
 
 @keyframes toolComplete {
@@ -2509,7 +2509,7 @@ body.theme-dark {
 	border-radius: var(--gs-radius-sm);
 	font-size: var(--font-ui-small);
 	cursor: pointer;
-	transition: all 0.15s ease;
+	transition: all var(--gs-dur-fast) var(--gs-ease);
 }
 
 .gemini-agent-tool-expand-content:hover {
@@ -2708,7 +2708,7 @@ body.theme-dark {
 	cursor: pointer;
 	font-size: var(--font-ui-medium);
 	font-weight: 500;
-	transition: all 0.2s ease;
+	transition: all var(--gs-dur) var(--gs-ease);
 }
 
 .gemini-agent-confirmation-btn:hover {
@@ -2769,7 +2769,7 @@ body.theme-dark {
 	padding: var(--size-2-3);
 	border-radius: var(--gs-radius-sm);
 	background: var(--gs-surface-alt);
-	animation: fadeIn 0.2s ease-in;
+	animation: fadeIn var(--gs-dur) var(--gs-ease);
 }
 
 .gemini-agent-result-icon {
@@ -2790,7 +2790,7 @@ body.theme-dark {
 	text-align: center;
 	padding: var(--gs-space-6);
 	min-height: 300px;
-	animation: fadeIn 0.5s ease-in;
+	animation: fadeIn var(--gs-dur-slow) var(--gs-ease);
 }
 
 .gemini-agent-empty-icon {
@@ -2839,7 +2839,7 @@ body.theme-dark {
 	border: 1px solid var(--gs-border);
 	border-radius: var(--gs-radius-md);
 	cursor: pointer;
-	transition: all 0.15s ease;
+	transition: all var(--gs-dur-fast) var(--gs-ease);
 	font-size: var(--font-ui-small);
 	color: var(--gs-text-muted);
 }
@@ -2885,7 +2885,7 @@ body.theme-dark {
 	border: 1px solid var(--gs-accent);
 	border-radius: var(--gs-radius-lg);
 	cursor: pointer;
-	transition: all 0.2s ease;
+	transition: all var(--gs-dur) var(--gs-ease);
 	box-shadow: var(--gs-shadow-sm);
 	width: 100%;
 	max-width: 400px;
@@ -3029,7 +3029,7 @@ body.theme-dark {
 	color: var(--gs-accent);
 	text-decoration: none;
 	cursor: pointer;
-	transition: color 0.15s ease;
+	transition: color var(--gs-dur-fast) var(--gs-ease);
 }
 
 .gemini-agent-docs-link-text:hover {
@@ -3510,7 +3510,7 @@ body.theme-dark {
 	color: var(--gs-accent);
 	text-decoration: none;
 	font-size: 14px;
-	transition: color 0.15s ease;
+	transition: color var(--gs-dur-fast) var(--gs-ease);
 }
 
 .gemini-update-links a:hover {
@@ -3729,7 +3729,7 @@ body.theme-dark {
 	align-items: center;
 	padding: 8px 12px;
 	border-bottom: 1px solid var(--gs-border);
-	transition: background 0.15s ease;
+	transition: background var(--gs-dur-fast) var(--gs-ease);
 	/* reset <button> browser defaults */
 	width: 100%;
 	background: none;
@@ -3916,7 +3916,7 @@ body.theme-dark {
 	height: 100%;
 	background: var(--gs-accent);
 	border-radius: 4px;
-	transition: width 0.3s ease;
+	transition: width var(--gs-dur-slow) var(--gs-ease);
 }
 
 .rag-progress-text {
@@ -4022,7 +4022,7 @@ body.theme-dark {
 
 .gemini-agent-clickable-image {
 	cursor: pointer;
-	transition: opacity 0.2s ease;
+	transition: opacity var(--gs-dur) var(--gs-ease);
 }
 
 .gemini-agent-clickable-image:hover {
@@ -4129,7 +4129,7 @@ body.theme-dark {
 }
 
 .gemini-shelf-item {
-	animation: shelf-slide-in 0.15s ease-out;
+	animation: shelf-slide-in var(--gs-dur-fast) var(--gs-ease);
 }
 
 /* Keyboard focus styling */
@@ -4166,7 +4166,7 @@ body.theme-dark {
 	align-items: center;
 	justify-content: center;
 	opacity: 0;
-	transition: opacity 0.15s ease;
+	transition: opacity var(--gs-dur-fast) var(--gs-ease);
 }
 
 .gemini-shelf-item:hover .gemini-shelf-remove,
@@ -4304,7 +4304,7 @@ body.theme-dark {
 	border: 1px solid var(--gs-border);
 	background-color: var(--gs-surface);
 	color: var(--gs-text);
-	transition: all 0.15s ease;
+	transition: all var(--gs-dur-fast) var(--gs-ease);
 }
 
 .gemini-scribe-actions button:hover {
@@ -5294,7 +5294,7 @@ body.theme-dark {
 	border-top: 5px solid transparent;
 	border-bottom: 5px solid transparent;
 	border-left: 6px solid var(--gs-text-muted);
-	transition: transform 0.15s ease;
+	transition: transform var(--gs-dur-fast) var(--gs-ease);
 	flex-shrink: 0;
 }
 

--- a/styles.css
+++ b/styles.css
@@ -52,12 +52,14 @@ body {
 	--gs-dur-slow: 320ms;
 	--gs-ease: cubic-bezier(0.2, 0.7, 0.2, 1);
 
-	/* Icons — aliases Obsidian's icon size + stroke tokens.
-	   lg (18px) is the default for toolbar & action icons. */
-	--gs-icon-sm: var(--icon-xs, 14px);
-	--gs-icon-md: var(--icon-s, 16px);
-	--gs-icon-lg: var(--icon-m, 18px);
-	--gs-icon-xl: var(--icon-l, 20px);
+	/* Icons — a fixed, definitive scale. lg (18px) is the default for toolbar &
+	   action icons. (Fixed literals rather than aliasing Obsidian's --icon-*
+	   steps, whose values don't match this scale — e.g. --icon-l is 18px, not 20.)
+	   Stroke still aliases Obsidian's for a native-light feel. */
+	--gs-icon-sm: 14px;
+	--gs-icon-md: 16px;
+	--gs-icon-lg: 18px;
+	--gs-icon-xl: 20px;
 	--gs-icon-stroke: var(--icon-stroke, 1.75px);
 
 	/* Gemini brand — the single signature, for primary actions & brand only */


### PR DESCRIPTION
## Summary

The last item on the design roadmap — **motion polish** — plus the small **icon-token fix** we flagged in #1108. Two commits.

### 1. Fixed icon-size scale
`--gs-icon-*` aliased Obsidian's `--icon-*` steps, whose values don't match the documented scale (Obsidian's `--icon-l` is 18px, so `--gs-icon-xl` resolved to **18, not 20**). Switched to **fixed literals (14/16/18/20)** so the scale is definitive. `sm/md/lg` unchanged (Obsidian's `--icon-xs/-s/-m` were already 14/16/18); `xl` corrected 18 → 20 (unused today, so no visual change). Stroke still aliases `--icon-stroke`.

### 2. Motion onto the tokens
Normalized ad-hoc timings onto the motion scale for coherent movement:
- **37 transition timing/easing pairs** → `var(--gs-dur-*) var(--gs-ease)` (0.1/0.15s → fast 120ms, 0.2s → base 200ms, 0.3s → slow 320ms). Hovers are a touch quicker and share one snappy easing curve.
- **8 entrance animations** (fadeIn / slideDown / toolComplete / shelf-slide-in) tokenized the same way.
- **10 continuous loop animations** (spinners, pulses, thinking-bounce — the `infinite` keyframes) intentionally left on their own durations.

## Verification (in-vault)

- Icon tokens compute `sm:14, md:16, lg:18, **xl:20**`.
- Buttons/suggestions compute `transition: 0.12s cubic-bezier(0.2, 0.7, 0.2, 1)` — the fast duration + custom ease.
- Loops untouched; entrances tokenized.

## Screenshots / Screencast

Motion is timing, not a static frame — verified via computed values. The perceptible change is subtly quicker, more consistent hover/entrance movement on one easing curve.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: maintainer-directed design refinement, decided interactively
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — 3242 tests pass, build + prettier clean
- [x] I have tested this change on Desktop — verified in-vault (icon tokens + computed transitions)
- [x] I have verified this change does not break Mobile — CSS-only; tokens resolve on `body` (present on mobile)
- [x] Documentation has been updated (if applicable) — icon-token row updated (fixed scale)
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

---
https://claude.ai/code/session_01Dp5HWzyqpRBjrUce8FRATF