### PR TITLE
feat(design): progress bar uses the Gemini gradient across all states

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1273,33 +1273,14 @@ body.theme-dark {
 	animation: progress-slide 1.5s ease-in-out infinite;
 }
 
-/* State Colors */
-.gemini-agent-progress-thinking {
-	background: linear-gradient(90deg, var(--gs-accent), color-mix(in srgb, var(--gs-accent) 80%, white));
-}
-
-.gemini-agent-progress-tool {
-	background: linear-gradient(
-		90deg,
-		color-mix(in srgb, var(--gs-success) 70%, var(--gs-accent) 30%),
-		color-mix(in srgb, var(--gs-success) 50%, white)
-	);
-}
-
-.gemini-agent-progress-waiting {
-	background: linear-gradient(
-		90deg,
-		color-mix(in srgb, var(--color-yellow) 70%, var(--gs-accent) 30%),
-		color-mix(in srgb, var(--color-yellow) 50%, white)
-	);
-}
-
+/* State colors — every state uses the Gemini brand gradient. The running agent
+   is a signature moment; the specific state (thinking / tool / waiting /
+   streaming) is conveyed by the adjacent status text, not the bar color. */
+.gemini-agent-progress-thinking,
+.gemini-agent-progress-tool,
+.gemini-agent-progress-waiting,
 .gemini-agent-progress-streaming {
-	background: linear-gradient(
-		90deg,
-		color-mix(in srgb, var(--color-purple) 70%, var(--gs-accent) 30%),
-		color-mix(in srgb, var(--color-purple) 50%, white)
-	);
+	background: var(--gs-brand-gradient);
 }
 
 /* Indeterminate Animation */


### PR DESCRIPTION
## Summary

The indeterminate progress bar (the scrolling line while the agent loop runs) had **per-state colors** — thinking = accent, **tool = green**, waiting = yellow, streaming = purple. The green "tool" state is the line you notice most while the agent works. Replace all four states with the **Gemini brand gradient**: a running agent is a signature moment, and the specific state is already conveyed by the adjacent status text ("Running tools…", "Thinking…"). No information is lost, and the off-palette green/yellow/purple go away.

## Changes

- **`styles.css`** — consolidate the four `.gemini-agent-progress-<state>` rules into one that sets `background: var(--gs-brand-gradient)`. Removes the `--gs-success` / `--color-yellow` / `--color-purple` usages here. The slide animation (a loop) is unchanged, so it's now a gradient chip sliding across.

## Verification (in-vault)

- All four progress states (`thinking`, `tool`, `waiting`, `streaming`) compute to `linear-gradient(95deg, rgb(73,137,245)…)` — the brand gradient.

## Screenshots / Screencast

Visible only while an agent operation runs. The bar is now the Gemini gradient in every state instead of green/yellow/purple.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: maintainer-directed design refinement, decided interactively
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — 3242 tests pass, build + prettier clean
- [x] I have tested this change on Desktop — verified in-vault (all states compute the gradient)
- [x] I have verified this change does not break Mobile — CSS-only; the gradient token resolves on `body` (present on mobile)
- [x] Documentation has been updated (if applicable) — N/A: the design-system doc already states the gradient is for "primary action & brand"; the running agent fits that
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

---
https://claude.ai/code/session_01Dp5HWzyqpRBjrUce8FRATF