### PR TITLE
feat(design): accent-tinted elevation + tidier copy button on user bubbles

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1805,6 +1805,13 @@ body.theme-dark {
 	margin-left: var(--gs-space-6);
 	border-bottom-right-radius: var(--gs-radius-sm);
 	border: 1px solid var(--gs-accent);
+	/* Accent-tinted elevation: the neutral --gs-shadow-sm is swamped by the
+	   bubble's own colour, so lift it with a soft accent glow instead. */
+	box-shadow: 0 2px 8px color-mix(in srgb, var(--gs-accent) 25%, transparent);
+}
+
+.gemini-agent-message-user:hover .gemini-agent-message-content {
+	box-shadow: 0 4px 14px color-mix(in srgb, var(--gs-accent) 32%, transparent);
 }
 
 .gemini-agent-message-model .gemini-agent-message-content {
@@ -1907,10 +1914,15 @@ body.theme-dark {
 	position: absolute;
 	top: var(--size-2-2);
 	right: var(--size-2-2);
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
 	background-color: var(--interactive-normal);
 	border: 1px solid var(--gs-border);
-	border-radius: var(--gs-radius-sm);
-	padding: var(--size-2-1);
+	/* Circular so it echoes the bubble's rounding rather than a mismatched
+	   square corner tucked into a rounded corner. */
+	border-radius: var(--gs-radius-pill);
+	padding: var(--size-2-2);
 	cursor: pointer;
 	opacity: 0;
 	transition: opacity var(--gs-dur) var(--gs-ease);
@@ -1928,6 +1940,22 @@ body.theme-dark {
 	width: var(--gs-icon-sm);
 	height: var(--gs-icon-sm);
 	color: var(--gs-text-muted);
+}
+
+/* On the accent-filled user bubble, the neutral light chip clashes. Make the
+   copy button a translucent-white overlay with a white icon so it sits on the
+   accent instead of standing out. */
+.gemini-agent-message-user .gemini-agent-copy-button {
+	background-color: color-mix(in srgb, var(--gs-on-accent) 16%, transparent);
+	border-color: color-mix(in srgb, var(--gs-on-accent) 30%, transparent);
+}
+
+.gemini-agent-message-user .gemini-agent-copy-button:hover {
+	background-color: color-mix(in srgb, var(--gs-on-accent) 30%, transparent);
+}
+
+.gemini-agent-message-user .gemini-agent-copy-button svg {
+	color: var(--gs-on-accent);
 }
 
 /* Collapsible tool messages */


### PR DESCRIPTION
## Summary

Two refinements to the accent-filled user bubble (follow-ups noticed while reviewing #1107):

- **Accent-tinted elevation.** The user bubble carried the same neutral `--gs-shadow-sm` as everything else, but the bubble's strong accent colour swamped that faint shadow so it read flat. Replace it with a soft **accent glow** (`color-mix` of `--gs-accent`) at rest and a slightly stronger one on hover — the bubble now visibly lifts, and the elevation ties to the accent rather than a barely-visible neutral shadow. (Neutral surfaces keep the standard `--gs-shadow-*` scale; the colored shadow is scoped to the one accent-filled element.)
- **Copy button.** On the accent bubble the neutral light chip stood out harshly, and its square 4px corner clashed with the rounded bubble tucked behind it. Two fixes: make the copy button **circular** (`--gs-radius-pill`, flex-centered) so it mirrors the bubble's rounding, and on user bubbles give it a **translucent-white** background + white icon so it sits *on* the accent instead of fighting it. The model-bubble copy button (on a light surface) is unchanged apart from the shared circular shape.

## Verification (in-vault)

- User bubble computes an accent-tinted shadow (`color(srgb …/0.25) 0 2px 8px`).
- Copy button computes `border-radius: 999px` (circular); on user bubbles its bg is `rgba(255,255,255,0.16)` with a white icon.
- Confirmed visually: user bubbles float with a soft purple glow; the copy button is a subtle translucent circle in the corner.

## Screenshots / Screencast

Visible refinement to user messages — soft accent elevation + a circular, translucent copy button that blends into the bubble.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: maintainer-directed design refinement, decided interactively
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — 3242 tests pass, build + prettier clean
- [x] I have tested this change on Desktop — verified in-vault (computed styles + rendered bubbles)
- [x] I have verified this change does not break Mobile — CSS-only; accent / on-accent tokens + translucent white resolve on `body` (present on mobile)
- [x] Documentation has been updated (if applicable) — N/A: refinement within the existing accent-bubble/signature design already documented
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

---
https://claude.ai/code/session_01Dp5HWzyqpRBjrUce8FRATF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined the appearance of user message bubbles with a more prominent accent-tinted glow and stronger hover emphasis.
  * Updated copy buttons to feel more pill-shaped, with adjusted padding and rounded corners.
  * Improved copy button contrast for user messages by using accent-based icon and background colors, including a clearer hover state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->