### PR TITLE
docs(design): capture migration/verification learnings from the design-system work

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -344,8 +344,9 @@ color or reaching for raw `var(--obsidian-var)` / magic numbers; keep the plugin
 theme-adaptive. Icons are Lucide via `setIcon()`, sized from `--gs-icon-*` (`lg` =
 18px is the default for toolbar/action icons — one size per context). The full
 reference and token table live in
-[docs/contributing/design-system.md](docs/contributing/design-system.md); the whole
-stylesheet is now on the tokens. When making a value-preserving CSS/token change,
+[docs/contributing/design-system.md](docs/contributing/design-system.md); every
+surface is now on the tokens (with a few intentional raw-var holdouts). When making
+a value-preserving CSS/token change,
 **verify no computed-value change in a live vault** (`obsidian eval` +
 `getComputedStyle`, or token-resolution equality) rather than eyeballing — that
 catches token mis-maps and theme-scope bugs a screenshot won't.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -343,9 +343,12 @@ When writing or modifying UI styles, **consume these tokens** rather than hardco
 color or reaching for raw `var(--obsidian-var)` / magic numbers; keep the plugin
 theme-adaptive. Icons are Lucide via `setIcon()`, sized from `--gs-icon-*` (`lg` =
 18px is the default for toolbar/action icons — one size per context). The full
-reference, token table, and migration status live in
-[docs/contributing/design-system.md](docs/contributing/design-system.md); migrating
-the rest of `styles.css` onto the tokens is ongoing, surface by surface.
+reference and token table live in
+[docs/contributing/design-system.md](docs/contributing/design-system.md); the whole
+stylesheet is now on the tokens. When making a value-preserving CSS/token change,
+**verify no computed-value change in a live vault** (`obsidian eval` +
+`getComputedStyle`, or token-resolution equality) rather than eyeballing — that
+catches token mis-maps and theme-scope bugs a screenshot won't.
 
 ## Security & Configuration
 

--- a/docs/contributing/design-system.md
+++ b/docs/contributing/design-system.md
@@ -80,10 +80,10 @@ stay as literals.
 
 ## Migrating & verifying
 
-The whole stylesheet is on the tokens. The raw `var(--…)` references that remain are
-deliberate holdouts — the font-size scale, Obsidian's sub-grid `--size-2-*`
-micro-spacing, and other Obsidian variables with no `--gs-` equivalent. When you
-touch a component's styles, keep it on the tokens.
+Every surface is migrated onto the tokens, with a few intentional raw-var holdouts:
+the font-size scale, Obsidian's sub-grid `--size-2-*` micro-spacing, and other
+Obsidian variables with no `--gs-` equivalent still use `var(--obsidian-var)`
+directly. When you touch a component's styles, keep it on the tokens.
 
 Two rules made the migration safe, and they apply to any future work here:
 

--- a/docs/contributing/design-system.md
+++ b/docs/contributing/design-system.md
@@ -48,6 +48,10 @@ writing or migrating styles.
   numbers. The `--gs-space-*` scale covers the 4px grid (4/8/12/16/24/32/48);
   sub-grid micro-spacing (Obsidian's 2px-based `--size-2-*`: 2/4/6px) has no token
   and stays on the Obsidian variable.
+- **Colored surfaces need colored elevation.** A neutral `--gs-shadow-*` gets
+  perceptually swamped by a strongly-coloured fill (the accent-filled user bubble
+  reads flat despite carrying the shadow). Lift such an element with a `color-mix`
+  accent shadow scoped to it; neutral surfaces keep the neutral `--gs-shadow-*` scale.
 
 ## Icons
 
@@ -74,13 +78,23 @@ modal headers / empty states (24px) and sub-scale **micro-icons** (chevrons, tin
 status badges at 10–12px). These are display sizes, not toolbar/action icons, and
 stay as literals.
 
-## Migration status
+## Migrating & verifying
 
-The token layer is in place and every major surface — agent chat messages, modals
-(rewrite/chat, tool confirmation), agent-view controls, buttons, status bar,
-thinking/reasoning blocks, the file picker, and the input area — has been migrated
-onto it. About 325 raw `var(--…)` references remain in `styles.css`; most are
-deliberate holdouts rather than unmigrated components — the font-size scale,
-Obsidian's sub-grid `--size-2-*` micro-spacing, and other Obsidian variables with no
-`--gs-` equivalent. When you touch a component's styles, prefer moving its
-declarations onto tokens as you go.
+The whole stylesheet is on the tokens. The raw `var(--…)` references that remain are
+deliberate holdouts — the font-size scale, Obsidian's sub-grid `--size-2-*`
+micro-spacing, and other Obsidian variables with no `--gs-` equivalent. When you
+touch a component's styles, keep it on the tokens.
+
+Two rules made the migration safe, and they apply to any future work here:
+
+- **Value-preserving first; visible changes are separate.** Migrate a surface onto
+  tokens with **zero visual change** — each token aliases the same value the code
+  already used — then make deliberate visual refinements in their own,
+  maintainer-directed commits. Mixing the two hides bugs and makes review hard.
+- **Verify by computed parity, not by eyeballing.** For a value-preserving change,
+  assert the computed result is unchanged in a _live vault_: `obsidian eval` +
+  `getComputedStyle`, or token-resolution equality (does `--gs-x` resolve to the same
+  value as the variable it replaced?). This is exactly what caught the two real bugs
+  during migration — the `--size-2-*` mis-map (2px vs 4px) and the `:root`-vs-`body`
+  scope bug where color tokens silently resolved to _invalid_. A screenshot would not
+  have caught either.


### PR DESCRIPTION
## Summary

Applies the durable learnings from the design-system session to the docs, so future contributors and the auto-dev pipeline benefit.

## Changes

- **`AGENTS.md`** (Design system subsection) — the whole stylesheet is now on the tokens (was "ongoing"), and a new directive: **verify value-preserving CSS/token changes by computed parity in a live vault** (`obsidian eval` + `getComputedStyle`, or token-resolution equality) rather than eyeballing.
- **`docs/contributing/design-system.md`**:
  - **Rules** — new rule: *colored surfaces need colored elevation* (a neutral `--gs-shadow-*` is swamped by a strong fill; lift with a scoped `color-mix` accent shadow).
  - **Migration status → Migrating & verifying** — records the two rules that made the migration safe: *value-preserving first, visible changes separate*, and *verify by computed parity, not eyeballing* — citing the two real bugs it caught (`--size-2-*` 2px-vs-4px mis-map; `:root`-vs-`body` scope bug where color tokens resolved to invalid). Marks the migration complete.

## Why these

These are the non-obvious, process-level learnings that the token reference didn't already capture. The computed-parity verification in particular is what surfaced bugs a screenshot never would have — worth making standard practice.

## Screenshots / Screencast

N/A — documentation only.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: maintainer-directed docs update, decided interactively
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — docs only; prettier clean
- [x] I have tested this change on Desktop — N/A: documentation only
- [x] I have verified this change does not break Mobile — N/A: documentation only
- [x] Documentation has been updated (if applicable) — this PR *is* the documentation update
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

---
https://claude.ai/code/session_01Dp5HWzyqpRBjrUce8FRATF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated design system guidance for token usage and migration expectations.
  * Added advice for using accent-aware shadows on colored surfaces so elevations remain visually clear.
  * Replaced migration notes with clearer steps for safe, verified stylesheet updates and token parity checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->