### PR TITLE
refactor: replace TFile/TFolder casts with instanceof narrowing (#1033)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -50,9 +50,11 @@ const PERVASIVE_OBSIDIANMD_RULES_TODO = {
 	// block): src/ui/agent-view/agent-view-progress.ts, agent-view-shelf.ts. Flip to
 	// 'error' globally once the remaining sites are migrated.
 	'obsidianmd/no-static-styles-assignment': 'off',
-	// 48 violations: `x as TFile` / `x as TFolder` casts scattered across vault
-	// helpers. Replacing each with `instanceof` checks is a careful refactor.
-	'obsidianmd/no-tfile-tfolder-cast': 'off',
+	// `obsidianmd/no-tfile-tfolder-cast` was here — now fixed: all `x as TFile`
+	// / `x as TFolder` casts replaced with `instanceof` narrowing (the sole
+	// remaining exception is a fabricated early-init folder stub in
+	// file-utils.ts with a scoped inline disable), so the rule is enforced
+	// again (left at the preset default).
 	// 28 violations: command IDs include the plugin ID (e.g. `gemini-scribe-foo`).
 	// Removing the prefix would break user hotkey bindings — needs a migration.
 	'obsidianmd/commands/no-plugin-id-in-command-id': 'off',
@@ -141,6 +143,11 @@ export default defineConfig([
 			// exclusion logic; the rule enforcing `vault.configDir` applies to production
 			// code in `src/`, not to fixture data.
 			'obsidianmd/hardcoded-config-path': 'off',
+			// Tests fabricate `TFile`/`TFolder` mocks via casts (`{ path } as TFile`,
+			// `as unknown as TFile` + `setPrototypeOf`); there is no real instance to
+			// narrow with `instanceof`. The rule guards production vault lookups in
+			// `src/`, not fabricated fixture objects.
+			'obsidianmd/no-tfile-tfolder-cast': 'off',
 		},
 	},
 ]);

--- a/src/services/hook-manager.ts
+++ b/src/services/hook-manager.ts
@@ -424,7 +424,7 @@ export class HookManager {
 		if (!hook) throw new Error(`Hook "${slug}" not found`);
 
 		const file = this.plugin.app.vault.getAbstractFileByPath(hook.filePath);
-		if (!file) throw new Error(`Hook file not found: ${hook.filePath}`);
+		if (!(file instanceof TFile)) throw new Error(`Hook file not found: ${hook.filePath}`);
 
 		// `toolPolicy` is genuinely optional (undefined == inherit global), so
 		// the merged shape can't use `Required<HookCreateParams>` like it used
@@ -454,7 +454,7 @@ export class HookManager {
 		};
 
 		const content = this.serializeHook(merged);
-		await this.plugin.app.vault.modify(file as TFile, content);
+		await this.plugin.app.vault.modify(file, content);
 
 		this.hooks.set(slug, this.toHook(slug, hook.filePath, merged));
 	}

--- a/src/services/scheduled-task-manager.ts
+++ b/src/services/scheduled-task-manager.ts
@@ -362,10 +362,11 @@ export class ScheduledTaskManager {
 		// Re-parse a task definition file whenever the metadata cache updates it
 		// (fires after Obsidian re-indexes the frontmatter, so values are current).
 		this.metadataCacheHandler = (...data: unknown[]) => {
-			const file = data[0] as TFile;
+			const file = data[0];
+			if (!(file instanceof TFile)) return;
 			const prefix = this.scheduledTasksFolder + '/';
 			const runsPrefix = this.runsFolder + '/';
-			if (file?.path?.startsWith(prefix) && !file.path.startsWith(runsPrefix) && file.extension === 'md') {
+			if (file.path.startsWith(prefix) && !file.path.startsWith(runsPrefix) && file.extension === 'md') {
 				const slug = file.basename;
 				// Skip if the vault create handler already claimed this slug — it will
 				// parse the file after its 500 ms defer, so we don't need to do it here.
@@ -608,7 +609,7 @@ export class ScheduledTaskManager {
 		}
 
 		const file = this.plugin.app.vault.getAbstractFileByPath(task.filePath);
-		if (!file) throw new Error(`Task file not found: ${task.filePath}`);
+		if (!(file instanceof TFile)) throw new Error(`Task file not found: ${task.filePath}`);
 
 		const merged = {
 			slug,
@@ -626,7 +627,7 @@ export class ScheduledTaskManager {
 		};
 
 		const content = this.serializeTask(merged);
-		await this.plugin.app.vault.modify(file as TFile, content);
+		await this.plugin.app.vault.modify(file, content);
 
 		// Immediately reflect the new values in the in-memory map so callers
 		// don't have to wait for the metadata cache listener to re-parse the file.

--- a/src/tools/vault/list-files-tool.ts
+++ b/src/tools/vault/list-files-tool.ts
@@ -71,7 +71,9 @@ export class ListFilesTool implements Tool {
 
 			const files = params.recursive
 				? plugin.app.vault.getFiles()
-				: (folder as TFolder)?.children || plugin.app.vault.getRoot().children;
+				: folder instanceof TFolder
+					? folder.children
+					: plugin.app.vault.getRoot().children;
 
 			const fileList = files
 				.filter((f) => {

--- a/src/ui/agent-view/file-picker-modal.ts
+++ b/src/ui/agent-view/file-picker-modal.ts
@@ -99,12 +99,11 @@ export class FilePickerModal extends SuggestModal<TAbstractFile> {
 					this.selectedFiles.add(f);
 				}
 			});
-		} else {
-			const file = item as TFile;
-			if (this.selectedFiles.has(file)) {
-				this.selectedFiles.delete(file);
+		} else if (item instanceof TFile) {
+			if (this.selectedFiles.has(item)) {
+				this.selectedFiles.delete(item);
 			} else {
-				this.selectedFiles.add(file);
+				this.selectedFiles.add(item);
 			}
 		}
 
@@ -114,7 +113,7 @@ export class FilePickerModal extends SuggestModal<TAbstractFile> {
 
 		if (suggestions && suggestions.length === this.lastSuggestions.length && this.lastSuggestions.length > 0) {
 			const affectedFiles: Set<TFile> = new Set(
-				item instanceof TFolder ? this.getFilesInFolder(item) : [item as TFile]
+				item instanceof TFolder ? this.getFilesInFolder(item) : item instanceof TFile ? [item] : []
 			);
 
 			for (let i = 0; i < this.lastSuggestions.length; i++) {
@@ -123,7 +122,7 @@ export class FilePickerModal extends SuggestModal<TAbstractFile> {
 					if (this.getFilesInFolder(suggestion).some((f) => affectedFiles.has(f))) {
 						this.updateCheckboxAt(suggestions, i);
 					}
-				} else if (affectedFiles.has(suggestion as TFile)) {
+				} else if (suggestion instanceof TFile && affectedFiles.has(suggestion)) {
 					this.updateCheckboxAt(suggestions, i);
 				}
 			}
@@ -152,7 +151,7 @@ export class FilePickerModal extends SuggestModal<TAbstractFile> {
 			const selectedCount = folderFiles.filter((f) => this.selectedFiles.has(f)).length;
 			return selectedCount === 0 ? 'square' : selectedCount === folderFiles.length ? 'check-square' : 'minus-square';
 		}
-		return this.selectedFiles.has(item as TFile) ? 'check-square' : 'square';
+		return item instanceof TFile && this.selectedFiles.has(item) ? 'check-square' : 'square';
 	}
 
 	private updateCheckboxAt(chooserSuggestions: HTMLElement[], index: number): void {

--- a/src/utils/file-utils.ts
+++ b/src/utils/file-utils.ts
@@ -84,6 +84,24 @@ export function createFileFilter(
 }
 
 /**
+ * Resolve a folder that is known to exist on disk to its `TFolder`.
+ *
+ * Prefers the metadata-cache entry (narrowed with `instanceof TFolder`). During
+ * early plugin init the cache may not be populated yet even though the folder
+ * exists on disk, so we fall back to a minimal stub carrying just the path.
+ * Callers only read `path`/`name` until the cache catches up; a fabricated
+ * object has no runtime kind to narrow, so the single cast here is unavoidable.
+ */
+function resolveExistingFolder(vault: Vault, normalized: string): TFolder {
+	const existing = vault.getAbstractFileByPath(normalized);
+	if (existing instanceof TFolder) {
+		return existing;
+	}
+	// eslint-disable-next-line obsidianmd/no-tfile-tfolder-cast -- fabricated early-init stub; nothing to narrow
+	return { path: normalized } as TFolder;
+}
+
+/**
  * Safely ensure a folder exists in the vault, creating it if needed.
  *
  * Uses vault.adapter.exists() as the primary existence check since it reads
@@ -115,11 +133,9 @@ export async function ensureFolderExists(
 
 	// Check filesystem directly — handles early init before metadata cache is populated
 	if (await vault.adapter.exists(normalized)) {
-		// Folder exists on disk. Return from cache if available, otherwise
-		// return a minimal TFolder-compatible object. Callers only use the
-		// path/name fields; full TFolder features become available once
-		// Obsidian's metadata cache catches up.
-		return (vault.getAbstractFileByPath(normalized) as TFolder) ?? ({ path: normalized } as TFolder);
+		// Folder exists on disk. Return from cache if available, otherwise a
+		// minimal stub until Obsidian's metadata cache catches up.
+		return resolveExistingFolder(vault, normalized);
 	}
 
 	// Folder doesn't exist — create it
@@ -130,7 +146,7 @@ export async function ensureFolderExists(
 
 		// Race condition: another process created it between our check and createFolder
 		if (await vault.adapter.exists(normalized)) {
-			return (vault.getAbstractFileByPath(normalized) as TFolder) ?? ({ path: normalized } as TFolder);
+			return resolveExistingFolder(vault, normalized);
 		}
 
 		const label = context ? ` (${context})` : '';
@@ -139,7 +155,7 @@ export async function ensureFolderExists(
 		throw new Error(`Failed to create folder "${normalized}"${label}: ${message}`);
 	}
 
-	return (vault.getAbstractFileByPath(normalized) as TFolder) ?? ({ path: normalized } as TFolder);
+	return resolveExistingFolder(vault, normalized);
 }
 
 /**

--- a/test/services/hook-manager.test.ts
+++ b/test/services/hook-manager.test.ts
@@ -231,7 +231,7 @@ describe('HookManager CRUD', () => {
 		});
 		plugin.app.vault.getAbstractFileByPath = vi
 			.fn()
-			.mockImplementation((path: string) => (files.has(path) ? { path } : null));
+			.mockImplementation((path: string) => (files.has(path) ? Object.assign(new MockTFile(), { path }) : null));
 		(plugin as any).__files = files;
 		return plugin as any;
 	}
@@ -782,7 +782,7 @@ describe('HookManager serializeHook – edge cases via createHook', () => {
 		});
 		plugin.app.vault.getAbstractFileByPath = vi
 			.fn()
-			.mockImplementation((path: string) => (files.has(path) ? { path } : null));
+			.mockImplementation((path: string) => (files.has(path) ? Object.assign(new MockTFile(), { path }) : null));
 		(plugin as any).__files = files;
 		return plugin as any;
 	}

--- a/test/services/scheduled-task-manager.test.ts
+++ b/test/services/scheduled-task-manager.test.ts
@@ -1298,7 +1298,10 @@ describe('ScheduledTaskManager', () => {
 	describe('updateTask', () => {
 		async function makeManagerWithTask() {
 			const plugin = createMockPlugin();
-			const fakeFile = { path: 'gemini-scribe/Scheduled-Tasks/editable.md', basename: 'editable' };
+			const fakeFile = Object.assign(new MockTFile(), {
+				path: 'gemini-scribe/Scheduled-Tasks/editable.md',
+				basename: 'editable',
+			});
 			plugin.app.vault.getMarkdownFiles.mockReturnValue([fakeFile]);
 			plugin.app.metadataCache.getFileCache.mockReturnValue({ frontmatter: { schedule: 'daily' } });
 			plugin.app.vault.read = vi.fn().mockResolvedValue('Original prompt.');


### PR DESCRIPTION
<!-- auto-dev -->

## Summary

Replace every `x as TFile` / `x as TFolder` cast in production code with `instanceof` narrowing guards, then re-enable the `obsidianmd/no-tfile-tfolder-cast` ESLint rule (removed from the `PERVASIVE_OBSIDIANMD_RULES_TODO` block). Casting bypasses type safety — a path that resolves to the wrong kind (or `null`) slips through — so each site now narrows properly, tightening the null/wrong-kind checks the casts previously masked. Pure type-safety improvement; no behavior change.

Fixes #1033

## Changes

- `src/services/hook-manager.ts` — `updateHook` now narrows the resolved file with `instanceof TFile` (replacing the `!file` null check + `as TFile` cast).
- `src/services/scheduled-task-manager.ts` — `updateTask` narrows with `instanceof TFile`; the metadata-cache handler early-returns when `data[0]` isn't a `TFile` (dropping the cast and the now-redundant optional chaining).
- `src/tools/vault/list-files-tool.ts` — folder children resolved via an `instanceof TFolder` branch instead of `(folder as TFolder)?.children`.
- `src/ui/agent-view/file-picker-modal.ts` — four sites: selection toggle, affected-file set construction, checkbox refresh, and icon selection now use `instanceof TFile`/`TFolder` guards.
- `src/utils/file-utils.ts` — extract a DRY `resolveExistingFolder` helper (used by the three identical folder-resolution sites); it narrows the cache hit with `instanceof TFolder`. The sole remaining cast is a fabricated early-init folder stub — no runtime instance exists to narrow — carrying a scoped, documented inline `eslint-disable`.
- `eslint.config.mjs` — remove `no-tfile-tfolder-cast` from the disabled TODO block (rule enforced again); scope it off for `test/**` fixtures, which fabricate `TFile`/`TFolder` mocks via casts (no real instance to narrow), mirroring the existing `hardcoded-config-path` test carve-out.
- `test/services/hook-manager.test.ts`, `test/services/scheduled-task-manager.test.ts` — update `getAbstractFileByPath` mocks to return real `TFile` instances so the production `instanceof` guards resolve correctly.

## Screenshots / Screencast

N/A — purely internal type-safety refactor, no UI or behavior change.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [ ] I have tested this change on Desktop
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards)
- [x] Documentation has been updated (if applicable) — N/A, no user-facing surface changed
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude (auto-dev pipeline)
- [x] I have reviewed and understand all AI-generated code in this PR

---

Produced by the auto-dev pipeline from the approved plan on #1033.

---
_Generated by [Claude Code](https://claude.ai/code/session_01F87rfXYF4UEzz4wLuxfL8g)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file and folder handling across the app to avoid issues when items aren’t the expected type.
  * Fixed several actions so they now fail safely when a target file can’t be found, instead of continuing with invalid data.
  * Refined folder listing and file selection behavior for more reliable results.
* **Tests**
  * Updated test coverage to better match real file and folder behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->