### PR TITLE
refactor(ui): use activeDocument/ownerDocument for popout-window compatibility (#1035)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -42,9 +42,10 @@ const PERVASIVE_OBSIDIANMD_RULES_TODO = {
 	// 207 violations: many false positives on acronyms (e.g. URL, HTTP) and brand
 	// names. Needs a brand allowlist + audit pass.
 	'obsidianmd/ui/sentence-case': 'off',
-	// 82 violations: pervasive `document` usage. Migrating to `activeDocument` is
-	// a separate refactor with cross-window implications.
-	'obsidianmd/prefer-active-doc': 'off',
+	// `obsidianmd/prefer-active-doc` was here (bare `document` usage) — now fixed:
+	// live-view DOM operations use the target element's `ownerDocument`, and the few
+	// genuinely detached nodes (escape-only, rasterization, test stubs) carry scoped
+	// inline disables. The rule is enforced again (left at the preset default).
 	// ~69 violations remaining: direct `style.X = ...` assignments. Needs CSS class
 	// migration. Cleaned so far and enforced per-file below (see the scoped override
 	// block): src/ui/agent-view/agent-view-progress.ts, agent-view-shelf.ts. Flip to

--- a/src/ui/agent-view/agent-view-messages.ts
+++ b/src/ui/agent-view/agent-view-messages.ts
@@ -400,7 +400,7 @@ export class AgentViewMessages {
 		if (messageDiv) {
 			// For streaming, append the new chunk as plain text to avoid re-rendering
 			// We'll do a final markdown render when streaming completes
-			const textNode = document.createTextNode(newChunk);
+			const textNode = messageDiv.ownerDocument.createTextNode(newChunk);
 			messageDiv.appendChild(textNode);
 		}
 	}

--- a/src/ui/agent-view/agent-view-progress.ts
+++ b/src/ui/agent-view/agent-view-progress.ts
@@ -182,8 +182,9 @@ export class AgentViewProgress {
 
 		if (this.app && this.renderComponent) {
 			// Render into a temporary container to avoid stale async renders
-			// mutating the live DOM node
-			const tempEl = document.createElement('div');
+			// mutating the live DOM node. Use the live node's document so the
+			// temp element matches its context in a popout window.
+			const tempEl = this.thinkingContent.ownerDocument.createElement('div');
 			try {
 				await MarkdownRenderer.render(this.app, text, tempEl, '', this.renderComponent);
 
@@ -301,6 +302,9 @@ export class AgentViewProgress {
 	 * Escape HTML entities to prevent XSS
 	 */
 	private escapeHtml(text: string): string {
+		// Detached node used only to HTML-escape a string; never inserted into a
+		// live view, so it isn't cross-window-relevant.
+		// eslint-disable-next-line obsidianmd/prefer-active-doc -- detached escape-only node, never attached
 		const div = document.createElement('div');
 		div.textContent = text;
 		return div.innerHTML;

--- a/src/ui/agent-view/agent-view-tools.ts
+++ b/src/ui/agent-view/agent-view-tools.ts
@@ -189,7 +189,7 @@ export class AgentViewTools {
 							if (!this.streamingFollowUpContainer) return;
 							const contentDiv = this.streamingFollowUpContainer.querySelector('.gemini-agent-message-content');
 							if (contentDiv) {
-								contentDiv.appendChild(document.createTextNode(chunk.text));
+								contentDiv.appendChild(contentDiv.ownerDocument.createTextNode(chunk.text));
 							}
 						},
 						onFollowUpStreamReady: (stream) => {

--- a/src/ui/agent-view/agent-view.ts
+++ b/src/ui/agent-view/agent-view.ts
@@ -112,7 +112,7 @@ export class AgentView extends ItemView {
 			'.mod-mobile-toolbar',
 		];
 		for (const sel of selectors) {
-			const el = document.querySelector<HTMLElement>(sel);
+			const el = this.containerEl.ownerDocument.querySelector<HTMLElement>(sel);
 			if (el && el.offsetHeight > 0) return el;
 		}
 		return null;

--- a/src/ui/background-tasks-modal.ts
+++ b/src/ui/background-tasks-modal.ts
@@ -74,7 +74,7 @@ export class BackgroundTasksModal extends Modal {
 				if (this.activeTab !== 'rag') return;
 				// Don't wipe the Files tab while the search box has focus — the
 				// debounce timer may still hold a reference to the old list container.
-				const active = document.activeElement;
+				const active = this.contentEl.ownerDocument.activeElement;
 				if (this.ragInnerTab === 'files' && active instanceof HTMLElement && active.hasClass('rag-status-search'))
 					return;
 				this.renderTabContent();

--- a/src/ui/settings-helpers.ts
+++ b/src/ui/settings-helpers.ts
@@ -12,6 +12,23 @@ export interface CollapsibleSectionOptions {
 }
 
 /**
+ * When `containerEl` isn't a real DOM node (unit tests pass a bare `{}` stub
+ * without `appendChild`), return a detached div so callers can keep handing the
+ * result to `new Setting(...)` without DOM side-effects. Returns `null` for a
+ * real container, signalling the caller to proceed with normal rendering.
+ *
+ * The returned node is never inserted into a live view, so it isn't
+ * cross-window-relevant — hence the scoped `document` use.
+ */
+function createDetachedStubIfNeeded(containerEl: HTMLElement): HTMLElement | null {
+	if (typeof (containerEl as { appendChild?: unknown })?.appendChild === 'function') {
+		return null;
+	}
+	// eslint-disable-next-line obsidianmd/prefer-active-doc -- detached test-stub node, never attached
+	return typeof document !== 'undefined' ? document.createElement('div') : containerEl;
+}
+
+/**
  * Render a collapsible settings section using a native `<details>` element.
  * Returns the inner content element; pass it as the container for any
  * `new Setting(...)` calls that belong inside the section.
@@ -32,13 +49,8 @@ export function createCollapsibleSection(
 	id: string,
 	options: CollapsibleSectionOptions = {}
 ): HTMLElement {
-	if (typeof (containerEl as { appendChild?: unknown })?.appendChild !== 'function') {
-		// Stub container in unit tests — return a detached div so callers can
-		// keep passing it to `new Setting(...)` without DOM side-effects. This
-		// node is never inserted into a live view, so it isn't cross-window-relevant.
-		// eslint-disable-next-line obsidianmd/prefer-active-doc -- detached test-stub node, never attached
-		return typeof document !== 'undefined' ? document.createElement('div') : containerEl;
-	}
+	const stub = createDetachedStubIfNeeded(containerEl);
+	if (stub) return stub;
 
 	const expanded = plugin.settings.expandedSettingsSections ?? [];
 	const isOpen = expanded.includes(id);
@@ -112,11 +124,8 @@ export function createCollapsibleSection(
  * the inner content element; visually matches the collapsibles minus chevron.
  */
 export function createAlwaysOpenSection(containerEl: HTMLElement, title: string, description?: string): HTMLElement {
-	if (typeof (containerEl as { appendChild?: unknown })?.appendChild !== 'function') {
-		// Detached test-stub node, never attached to a live view (see createCollapsibleSection).
-		// eslint-disable-next-line obsidianmd/prefer-active-doc -- detached test-stub node, never attached
-		return typeof document !== 'undefined' ? document.createElement('div') : containerEl;
-	}
+	const stub = createDetachedStubIfNeeded(containerEl);
+	if (stub) return stub;
 
 	// Create nodes in the container's own document for popout-window compatibility.
 	const doc = containerEl.ownerDocument;

--- a/src/ui/settings-helpers.ts
+++ b/src/ui/settings-helpers.ts
@@ -34,42 +34,48 @@ export function createCollapsibleSection(
 ): HTMLElement {
 	if (typeof (containerEl as { appendChild?: unknown })?.appendChild !== 'function') {
 		// Stub container in unit tests — return a detached div so callers can
-		// keep passing it to `new Setting(...)` without DOM side-effects.
+		// keep passing it to `new Setting(...)` without DOM side-effects. This
+		// node is never inserted into a live view, so it isn't cross-window-relevant.
+		// eslint-disable-next-line obsidianmd/prefer-active-doc -- detached test-stub node, never attached
 		return typeof document !== 'undefined' ? document.createElement('div') : containerEl;
 	}
 
 	const expanded = plugin.settings.expandedSettingsSections ?? [];
 	const isOpen = expanded.includes(id);
 
-	const details = document.createElement('details');
+	// Create nodes in the container's own document so the section renders correctly
+	// when the settings tab lives in a popout window.
+	const doc = containerEl.ownerDocument;
+
+	const details = doc.createElement('details');
 	details.classList.add('gemini-settings-section');
 	if (options.advanced) details.classList.add('gemini-settings-section--advanced');
 	details.dataset.sectionId = id;
 	if (isOpen) details.setAttribute('open', '');
 	containerEl.appendChild(details);
 
-	const summary = document.createElement('summary');
+	const summary = doc.createElement('summary');
 	summary.classList.add('gemini-settings-section-summary');
 
 	// HTML spec: <summary> only permits phrasing/heading content; <div> isn't
 	// valid here. Use <span>s styled with flex/block via CSS instead.
-	const header = document.createElement('span');
+	const header = doc.createElement('span');
 	header.classList.add('gemini-settings-section-header');
-	const titleRow = document.createElement('span');
+	const titleRow = doc.createElement('span');
 	titleRow.classList.add('gemini-settings-section-title-row');
-	const titleEl = document.createElement('span');
+	const titleEl = doc.createElement('span');
 	titleEl.classList.add('gemini-settings-section-title');
 	titleEl.textContent = title;
 	titleRow.appendChild(titleEl);
 	if (options.advanced) {
-		const badge = document.createElement('span');
+		const badge = doc.createElement('span');
 		badge.classList.add('gemini-settings-section-badge');
 		badge.textContent = t('settings.common.advancedBadge');
 		titleRow.appendChild(badge);
 	}
 	header.appendChild(titleRow);
 	if (options.description) {
-		const descEl = document.createElement('span');
+		const descEl = doc.createElement('span');
 		descEl.classList.add('gemini-settings-section-description');
 		descEl.textContent = options.description;
 		header.appendChild(descEl);
@@ -77,7 +83,7 @@ export function createCollapsibleSection(
 	summary.appendChild(header);
 	details.appendChild(summary);
 
-	const content = document.createElement('div');
+	const content = doc.createElement('div');
 	content.classList.add('gemini-settings-section-content');
 	details.appendChild(content);
 
@@ -107,33 +113,38 @@ export function createCollapsibleSection(
  */
 export function createAlwaysOpenSection(containerEl: HTMLElement, title: string, description?: string): HTMLElement {
 	if (typeof (containerEl as { appendChild?: unknown })?.appendChild !== 'function') {
+		// Detached test-stub node, never attached to a live view (see createCollapsibleSection).
+		// eslint-disable-next-line obsidianmd/prefer-active-doc -- detached test-stub node, never attached
 		return typeof document !== 'undefined' ? document.createElement('div') : containerEl;
 	}
 
-	const wrapper = document.createElement('div');
+	// Create nodes in the container's own document for popout-window compatibility.
+	const doc = containerEl.ownerDocument;
+
+	const wrapper = doc.createElement('div');
 	wrapper.classList.add('gemini-settings-section', 'gemini-settings-section--always-open');
 	containerEl.appendChild(wrapper);
 
 	// Use spans here too for parity with the collapsible variant (where the
 	// elements live inside <summary> and must be phrasing content).
-	const header = document.createElement('span');
+	const header = doc.createElement('span');
 	header.classList.add('gemini-settings-section-header');
-	const titleRow = document.createElement('span');
+	const titleRow = doc.createElement('span');
 	titleRow.classList.add('gemini-settings-section-title-row');
-	const titleEl = document.createElement('span');
+	const titleEl = doc.createElement('span');
 	titleEl.classList.add('gemini-settings-section-title');
 	titleEl.textContent = title;
 	titleRow.appendChild(titleEl);
 	header.appendChild(titleRow);
 	if (description) {
-		const descEl = document.createElement('span');
+		const descEl = doc.createElement('span');
 		descEl.classList.add('gemini-settings-section-description');
 		descEl.textContent = description;
 		header.appendChild(descEl);
 	}
 	wrapper.appendChild(header);
 
-	const content = document.createElement('div');
+	const content = doc.createElement('div');
 	content.classList.add('gemini-settings-section-content');
 	wrapper.appendChild(content);
 

--- a/src/utils/svg-rasterizer.ts
+++ b/src/utils/svg-rasterizer.ts
@@ -154,6 +154,9 @@ export async function rasterizeSvg(buffer: ArrayBuffer, isSvgz: boolean): Promis
 
 		const dims = computeScaledDimensions(width, height);
 
+		// Detached canvas used only to rasterize the SVG to a PNG data URL; it is
+		// never inserted into a view, so it isn't cross-window-relevant.
+		// eslint-disable-next-line obsidianmd/prefer-active-doc -- detached rasterization canvas, never attached
 		const canvas = document.createElement('canvas');
 		canvas.width = dims.width;
 		canvas.height = dims.height;


### PR DESCRIPTION
<!-- auto-dev -->

## Summary

Bare `document` references break when a view is opened in a popout window, because the global `document` still points at the main app window. This replaces each cross-window-relevant `document` use with the target element's `ownerDocument`, so DOM operations (element/text-node creation, `activeElement`, `querySelector`) resolve to the window the element actually lives in. Then re-enables the `obsidianmd/prefer-active-doc` ESLint rule (removed from the `PERVASIVE_OBSIDIANMD_RULES_TODO` block). Pure correctness/type-safety refactor; behavior is unchanged in the main window.

The true violation count was 23 across 7 files (the stale "82" in the rule comment). The four files named in the issue plus three additional files surfaced by re-enabling the rule (`agent-view-tools.ts`, `agent-view.ts`, `svg-rasterizer.ts`) are all fixed here so the rule can be enforced globally with green lint.

Fixes #1035

## Changes

- `src/ui/settings-helpers.ts` — both section builders create nodes via `containerEl.ownerDocument` (14 sites); the two test-stub detached-div fallbacks keep `document` behind a scoped inline disable.
- `src/ui/agent-view/agent-view-messages.ts` — streaming text node created via `messageDiv.ownerDocument`.
- `src/ui/agent-view/agent-view-progress.ts` — thinking-render temp element uses `this.thinkingContent.ownerDocument`; the escape-only detached div keeps `document` behind a scoped inline disable.
- `src/ui/agent-view/agent-view-tools.ts` — streaming follow-up text node created via `contentDiv.ownerDocument`.
- `src/ui/agent-view/agent-view.ts` — `findMobileNavbar` queries via `this.containerEl.ownerDocument`.
- `src/ui/background-tasks-modal.ts` — `activeElement` read from `this.contentEl.ownerDocument`.
- `src/utils/svg-rasterizer.ts` — rasterization canvas is a detached node; keeps `document` behind a scoped inline disable.
- `eslint.config.mjs` — remove `obsidianmd/prefer-active-doc` from the disabled TODO block (rule enforced again).

**Genuinely detached nodes** (never inserted into a live view — escape-only div, rasterization canvas, test-stub fallbacks) are not cross-window-relevant per the issue's caveat and carry scoped `eslint-disable-next-line obsidianmd/prefer-active-doc` comments with justification.

## Screenshots / Screencast

N/A — no visual change; the fix only affects DOM resolution when a view is popped out.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [ ] I have tested this change on Desktop — not manually verified in a popped-out window; automated pre-flight (lint with rule enabled, build, 3250 tests, `typecheck:test`) is green. Recommend a quick manual popout smoke test before merge.
- [x] I have verified this change does not break Mobile — mobile has no popout windows; `ownerDocument` resolves to the main document there, so behavior is identical.
- [x] Documentation has been updated (if applicable) — N/A, no user-facing surface changed.
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude (auto-dev pipeline)
- [x] I have reviewed and understand all AI-generated code in this PR

---

Produced by the auto-dev pipeline from the approved plan on #1035.

---
_Generated by [Claude Code](https://claude.ai/code/session_012Azmy16UqH6yGUqbjebENS)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved UI compatibility in popouts and multi-document views by creating DOM elements/text nodes from the owning container’s document rather than a global document.
  * Fixed background task progress focus checks to use the modal’s active element.
  * Updated streaming message rendering and markdown “thinking” rendering to avoid cross-document node issues, including safer detached handling when a real DOM node isn’t available.
* **Style / Chores**
  * Restored stricter linting for active-document usage and added clarifying comments around detached/off-screen DOM and HTML escaping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->