### PR TITLE
refactor: collapse 30 Unknown-error ternaries to getRawErrorMessageOr helper (#1064)

### DIFF
--- a/src/agent/agent-event-bus.ts
+++ b/src/agent/agent-event-bus.ts
@@ -6,6 +6,7 @@ import {
 	HandlerPriority,
 } from '../types/agent-events';
 import { Logger } from '../utils/logger';
+import { getRawErrorMessage } from '../utils/error-utils';
 
 /**
  * Typed async event bus for agent lifecycle hooks.
@@ -63,7 +64,7 @@ export class AgentEventBus {
 			try {
 				await handler(frozenPayload);
 			} catch (error) {
-				this.logger.error(`Handler error for event "${event}":`, error instanceof Error ? error.message : error);
+				this.logger.error(`Handler error for event "${event}":`, getRawErrorMessage(error));
 			}
 		}
 	}

--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -6,6 +6,7 @@ import type { ToolCall, ModelResponse, ModelApi, StreamChunk } from '../api/inte
 import type { CustomPrompt } from '../prompts/types';
 import type { IConfirmationProvider, IToolHostView, ToolExecutionContext, ToolResult } from '../tools/types';
 import { generateToolDescription } from '../utils/text-generation';
+import { getRawErrorMessageOr } from '../utils/error-utils';
 import {
 	sortToolCallsByPriority,
 	buildToolHistoryTurns,
@@ -744,7 +745,7 @@ export class AgentLoop {
 					toolArguments: toolCall.arguments || {},
 					result: {
 						success: false,
-						error: error instanceof Error ? error.message : 'Unknown error',
+						error: getRawErrorMessageOr(error, 'Unknown error'),
 					},
 				});
 			}

--- a/src/mcp/mcp-manager.ts
+++ b/src/mcp/mcp-manager.ts
@@ -182,10 +182,7 @@ export class MCPManager {
 			try {
 				await this.connectServer(config);
 			} catch (error) {
-				this.logger.warn(
-					`MCP: Reconnect on online event failed for "${config.name}":`,
-					error instanceof Error ? error.message : error
-				);
+				this.logger.warn(`MCP: Reconnect on online event failed for "${config.name}":`, getRawErrorMessage(error));
 			}
 		}
 	}
@@ -214,10 +211,7 @@ export class MCPManager {
 			try {
 				await this.connectServer(config);
 			} catch (error) {
-				this.logger.warn(
-					`MCP: Failed to connect to server "${config.name}":`,
-					error instanceof Error ? error.message : error
-				);
+				this.logger.warn(`MCP: Failed to connect to server "${config.name}":`, getRawErrorMessage(error));
 			}
 		}
 	}

--- a/src/services/agents-memory.ts
+++ b/src/services/agents-memory.ts
@@ -1,6 +1,7 @@
 import { TFile, normalizePath } from 'obsidian';
 import Handlebars from 'handlebars';
 import type ObsidianGemini from '../main';
+import { getRawErrorMessageOr } from '../utils/error-utils';
 
 export interface AgentsMemoryData {
 	vaultOverview?: string;
@@ -83,7 +84,7 @@ export class AgentsMemory {
 			}
 		} catch (error) {
 			this.plugin.logger.error('Failed to write AGENTS.md:', error);
-			throw new Error(`Failed to write AGENTS.md: ${error instanceof Error ? error.message : 'Unknown error'}`);
+			throw new Error(`Failed to write AGENTS.md: ${getRawErrorMessageOr(error, 'Unknown error')}`);
 		}
 	}
 
@@ -144,7 +145,7 @@ export class AgentsMemory {
 			}
 		} catch (error) {
 			this.plugin.logger.error('Failed to append to AGENTS.md:', error);
-			throw new Error(`Failed to append to AGENTS.md: ${error instanceof Error ? error.message : 'Unknown error'}`);
+			throw new Error(`Failed to append to AGENTS.md: ${getRawErrorMessageOr(error, 'Unknown error')}`);
 		}
 	}
 }

--- a/src/services/example-prompts.ts
+++ b/src/services/example-prompts.ts
@@ -1,5 +1,6 @@
 import { TFile, normalizePath } from 'obsidian';
 import type ObsidianGemini from '../main';
+import { getRawErrorMessageOr } from '../utils/error-utils';
 
 /**
  * Represents an example prompt shown in the Agent Panel UI
@@ -112,9 +113,7 @@ export class ExamplePromptsManager {
 			}
 		} catch (error) {
 			this.plugin.logger.error('Failed to write example-prompts.json:', error);
-			throw new Error(
-				`Failed to write example-prompts.json: ${error instanceof Error ? error.message : 'Unknown error'}`
-			);
+			throw new Error(`Failed to write example-prompts.json: ${getRawErrorMessageOr(error, 'Unknown error')}`);
 		}
 	}
 }

--- a/src/services/image-generation.ts
+++ b/src/services/image-generation.ts
@@ -2,7 +2,7 @@ import type ObsidianGemini from '../main';
 import { Notice, App, MarkdownView, Modal, Setting, TextAreaComponent, TFile, normalizePath } from 'obsidian';
 import { BaseModelRequest, GeminiClient, ModelClientFactory } from '../api';
 import { GeminiPrompts } from '../prompts';
-import { getErrorMessage } from '../utils/error-utils';
+import { getErrorMessage, getRawErrorMessageOr } from '../utils/error-utils';
 import { ensureFolderExists, isPathInFolder } from '../utils/file-utils';
 import { t } from '../i18n';
 
@@ -320,7 +320,7 @@ export class ImageGeneration {
 				throw new Error('Empty image data');
 			}
 		} catch (error) {
-			throw new Error(`Invalid base64 image data: ${error instanceof Error ? error.message : 'Unknown error'}`);
+			throw new Error(`Invalid base64 image data: ${getRawErrorMessageOr(error, 'Unknown error')}`);
 		}
 
 		// Convert binary string to Uint8Array

--- a/src/services/selection-action-service.ts
+++ b/src/services/selection-action-service.ts
@@ -5,6 +5,7 @@ import { SelectionResponseModal, AskQuestionModal } from '../ui/selection-respon
 import { CustomPrompt } from '../prompts/types';
 import { ModelClientFactory } from '../api';
 import { t } from '../i18n';
+import { getRawErrorMessageOr } from '../utils/error-utils';
 
 /**
  * Service to coordinate selection-based actions.
@@ -161,7 +162,7 @@ export class SelectionActionService {
 			}
 		} catch (error) {
 			this.plugin.logger.error('Error generating response:', error);
-			const errorMessage = error instanceof Error ? error.message : 'Unknown error occurred';
+			const errorMessage = getRawErrorMessageOr(error, 'Unknown error occurred');
 			responseModal.showError(errorMessage);
 		}
 	}

--- a/src/services/vault-analyzer.ts
+++ b/src/services/vault-analyzer.ts
@@ -6,6 +6,7 @@ import { VaultAnalysisModal } from '../ui/vault-analysis-modal';
 import { collectFilesFromFolder } from '../utils/folder-walk';
 import { isPathInFolder } from '../utils/file-utils';
 import { t } from '../i18n';
+import { getRawErrorMessageOr } from '../utils/error-utils';
 
 /**
  * Simple cache entry for vault information
@@ -165,10 +166,7 @@ export class VaultAnalyzer {
 			}
 		} catch (error) {
 			this.plugin.logger.error('Failed to initialize AGENTS.md:', error);
-			modal.setStepFailed(
-				modal.currentStep,
-				error instanceof Error ? error.message : t('modal.vaultAnalysis.unknownError')
-			);
+			modal.setStepFailed(modal.currentStep, getRawErrorMessageOr(error, t('modal.vaultAnalysis.unknownError')));
 			new Notice(t('notice.vaultAnalysis.initFailed'));
 			window.setTimeout(() => modal.close(), 3000);
 		}

--- a/src/tools/deep-research-tool.ts
+++ b/src/tools/deep-research-tool.ts
@@ -6,6 +6,7 @@ import { ResearchScope } from '../services/deep-research';
 import { formatLocalDate } from '../utils/format-utils';
 import { sanitizeFileName, ensureFolderExists } from '../utils/file-utils';
 import { t } from '../i18n';
+import { getRawErrorMessageOr } from '../utils/error-utils';
 
 /**
  * Deep Research Tool that conducts comprehensive research using Google's Deep Research API
@@ -179,7 +180,7 @@ export class DeepResearchTool implements Tool {
 		} catch (error) {
 			return {
 				success: false,
-				error: `Deep research failed: ${error instanceof Error ? error.message : 'Unknown error'}`,
+				error: `Deep research failed: ${getRawErrorMessageOr(error, 'Unknown error')}`,
 			};
 		}
 	}

--- a/src/tools/execution-engine.ts
+++ b/src/tools/execution-engine.ts
@@ -8,6 +8,7 @@ import {
 	DiffContext,
 	ConfirmationResult,
 } from './types';
+import { getRawErrorMessageOr } from '../utils/error-utils';
 import { ToolRegistry } from './tool-registry';
 import { ToolLoopDetector } from './loop-detector';
 import { TFile, normalizePath } from 'obsidian';
@@ -181,7 +182,7 @@ export class ToolExecutionEngine {
 
 			return result;
 		} catch (error) {
-			const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+			const errorMessage = getRawErrorMessageOr(error, 'Unknown error');
 			return {
 				success: false,
 				error: errorMessage,

--- a/src/tools/session-recall-tool.ts
+++ b/src/tools/session-recall-tool.ts
@@ -1,6 +1,7 @@
 import { Tool, ToolResult, ToolExecutionContext } from './types';
 import { ToolCategory } from '../types/agent';
 import { ToolClassification } from '../types/tool-policy';
+import { getRawErrorMessageOr } from '../utils/error-utils';
 
 /**
  * Tool that lets the agent recall past sessions by file overlap, project, or title search.
@@ -146,7 +147,7 @@ class RecallSessionsTool implements Tool {
 		} catch (error) {
 			return {
 				success: false,
-				error: `Failed to search sessions: ${error instanceof Error ? error.message : 'Unknown error'}`,
+				error: `Failed to search sessions: ${getRawErrorMessageOr(error, 'Unknown error')}`,
 			};
 		}
 	}

--- a/src/tools/vault-tools-extended.ts
+++ b/src/tools/vault-tools-extended.ts
@@ -3,6 +3,7 @@ import { ToolCategory } from '../types/agent';
 import { ToolClassification } from '../types/tool-policy';
 import { resolvePathToFile } from './vault/utils';
 import { t } from '../i18n';
+import { getRawErrorMessageOr } from '../utils/error-utils';
 
 /**
  * Tool to safely update YAML frontmatter without touching content
@@ -102,7 +103,7 @@ class UpdateFrontmatterTool implements Tool {
 				},
 			};
 		} catch (error) {
-			const msg = error instanceof Error ? error.message : 'Unknown error';
+			const msg = getRawErrorMessageOr(error, 'Unknown error');
 			plugin.logger.error(`Failed to update frontmatter for ${path}: ${msg}`);
 			return {
 				success: false,
@@ -209,7 +210,7 @@ class AppendContentTool implements Tool {
 				},
 			};
 		} catch (error) {
-			const msg = error instanceof Error ? error.message : 'Unknown error';
+			const msg = getRawErrorMessageOr(error, 'Unknown error');
 			plugin.logger.error(`Failed to append content to ${path}: ${msg}`);
 			return {
 				success: false,

--- a/src/tools/vault/create-folder-tool.ts
+++ b/src/tools/vault/create-folder-tool.ts
@@ -4,6 +4,7 @@ import { ToolClassification } from '../../types/tool-policy';
 import { TFolder, normalizePath } from 'obsidian';
 import { shouldExcludePathForPlugin as shouldExcludePath, ensureFolderExists } from '../../utils/file-utils';
 import { t } from '../../i18n';
+import { getRawErrorMessageOr } from '../../utils/error-utils';
 
 /**
  * Create a new folder
@@ -84,7 +85,7 @@ export class CreateFolderTool implements Tool {
 		} catch (error) {
 			return {
 				success: false,
-				error: `Error creating folder: ${error instanceof Error ? error.message : 'Unknown error'}`,
+				error: `Error creating folder: ${getRawErrorMessageOr(error, 'Unknown error')}`,
 			};
 		}
 	}

--- a/src/tools/vault/delete-file-tool.ts
+++ b/src/tools/vault/delete-file-tool.ts
@@ -5,6 +5,7 @@ import { normalizePath } from 'obsidian';
 import { shouldExcludePathForPlugin as shouldExcludePath } from '../../utils/file-utils';
 import { resolvePathToFileOrFolder } from './utils';
 import { t } from '../../i18n';
+import { getRawErrorMessageOr } from '../../utils/error-utils';
 
 /**
  * Delete a file or folder
@@ -77,7 +78,7 @@ export class DeleteFileTool implements Tool {
 		} catch (error) {
 			return {
 				success: false,
-				error: `Error deleting file or folder: ${error instanceof Error ? error.message : 'Unknown error'}`,
+				error: `Error deleting file or folder: ${getRawErrorMessageOr(error, 'Unknown error')}`,
 			};
 		}
 	}

--- a/src/tools/vault/get-workspace-state-tool.ts
+++ b/src/tools/vault/get-workspace-state-tool.ts
@@ -3,6 +3,7 @@ import { ToolCategory } from '../../types/agent';
 import { ToolClassification } from '../../types/tool-policy';
 import { MarkdownView } from 'obsidian';
 import { shouldExcludePathForPlugin as shouldExcludePath } from '../../utils/file-utils';
+import { getRawErrorMessageOr } from '../../utils/error-utils';
 
 /** Maximum characters of selected text to include in workspace state */
 const MAX_SELECTION_LENGTH = 1000;
@@ -119,7 +120,7 @@ export class GetWorkspaceStateTool implements Tool {
 		} catch (error) {
 			return {
 				success: false,
-				error: `Error getting workspace state: ${error instanceof Error ? error.message : 'Unknown error'}`,
+				error: `Error getting workspace state: ${getRawErrorMessageOr(error, 'Unknown error')}`,
 			};
 		}
 	}

--- a/src/tools/vault/list-files-tool.ts
+++ b/src/tools/vault/list-files-tool.ts
@@ -3,6 +3,7 @@ import { ToolCategory } from '../../types/agent';
 import { ToolClassification } from '../../types/tool-policy';
 import { TFile, TFolder, normalizePath } from 'obsidian';
 import { shouldExcludePathForPlugin as shouldExcludePath } from '../../utils/file-utils';
+import { getRawErrorMessageOr } from '../../utils/error-utils';
 
 /**
  * List files in a folder
@@ -101,7 +102,7 @@ export class ListFilesTool implements Tool {
 		} catch (error) {
 			return {
 				success: false,
-				error: `Error listing files: ${error instanceof Error ? error.message : 'Unknown error'}`,
+				error: `Error listing files: ${getRawErrorMessageOr(error, 'Unknown error')}`,
 			};
 		}
 	}

--- a/src/tools/vault/move-file-tool.ts
+++ b/src/tools/vault/move-file-tool.ts
@@ -5,6 +5,7 @@ import { normalizePath } from 'obsidian';
 import { shouldExcludePathForPlugin as shouldExcludePath, ensureFolderExists } from '../../utils/file-utils';
 import { resolvePathToFileOrFolder } from './utils';
 import { t } from '../../i18n';
+import { getRawErrorMessageOr } from '../../utils/error-utils';
 
 /**
  * Move or rename a file or folder
@@ -119,7 +120,7 @@ export class MoveFileTool implements Tool {
 		} catch (error) {
 			return {
 				success: false,
-				error: `Error moving file or folder: ${error instanceof Error ? error.message : 'Unknown error'}`,
+				error: `Error moving file or folder: ${getRawErrorMessageOr(error, 'Unknown error')}`,
 			};
 		}
 	}

--- a/src/tools/vault/read-file-tool.ts
+++ b/src/tools/vault/read-file-tool.ts
@@ -3,6 +3,7 @@ import { ToolCategory } from '../../types/agent';
 import { ToolClassification } from '../../types/tool-policy';
 import { TFile, TFolder, normalizePath } from 'obsidian';
 import { shouldExcludePathForPlugin as shouldExcludePath, isPathInFolder } from '../../utils/file-utils';
+import { getRawErrorMessageOr } from '../../utils/error-utils';
 import {
 	classifyFile,
 	FileCategory,
@@ -147,7 +148,7 @@ export class ReadFileTool implements Tool {
 				} catch (rasterErr) {
 					return {
 						success: false,
-						error: `Failed to rasterize SVG for viewing: ${file.name} (${rasterErr instanceof Error ? rasterErr.message : 'Unknown error'})`,
+						error: `Failed to rasterize SVG for viewing: ${file.name} (${getRawErrorMessageOr(rasterErr, 'Unknown error')})`,
 					};
 				}
 			}
@@ -196,7 +197,7 @@ export class ReadFileTool implements Tool {
 		} catch (error) {
 			return {
 				success: false,
-				error: `Error reading file or folder: ${error instanceof Error ? error.message : 'Unknown error'}`,
+				error: `Error reading file or folder: ${getRawErrorMessageOr(error, 'Unknown error')}`,
 			};
 		}
 	}

--- a/src/tools/vault/search-file-contents-tool.ts
+++ b/src/tools/vault/search-file-contents-tool.ts
@@ -2,6 +2,7 @@ import { Tool, ToolResult, ToolExecutionContext } from '../types';
 import { ToolCategory } from '../../types/agent';
 import { ToolClassification } from '../../types/tool-policy';
 import { shouldExcludePathForPlugin as shouldExcludePath } from '../../utils/file-utils';
+import { getRawErrorMessageOr } from '../../utils/error-utils';
 
 /**
  * Search for text content within files
@@ -87,7 +88,7 @@ export class SearchFileContentsTool implements Tool {
 			} catch (error) {
 				return {
 					success: false,
-					error: `Invalid regex pattern: ${error instanceof Error ? error.message : 'Unknown error'}`,
+					error: `Invalid regex pattern: ${getRawErrorMessageOr(error, 'Unknown error')}`,
 				};
 			}
 
@@ -193,7 +194,7 @@ export class SearchFileContentsTool implements Tool {
 		} catch (error) {
 			return {
 				success: false,
-				error: `Error searching file contents: ${error instanceof Error ? error.message : 'Unknown error'}`,
+				error: `Error searching file contents: ${getRawErrorMessageOr(error, 'Unknown error')}`,
 			};
 		}
 	}

--- a/src/tools/vault/search-files-tool.ts
+++ b/src/tools/vault/search-files-tool.ts
@@ -2,6 +2,7 @@ import { Tool, ToolResult, ToolExecutionContext } from '../types';
 import { ToolCategory } from '../../types/agent';
 import { ToolClassification } from '../../types/tool-policy';
 import { shouldExcludePathForPlugin as shouldExcludePath } from '../../utils/file-utils';
+import { getRawErrorMessageOr } from '../../utils/error-utils';
 
 /**
  * Search for files by name pattern
@@ -99,7 +100,7 @@ export class SearchFilesTool implements Tool {
 		} catch (error) {
 			return {
 				success: false,
-				error: `Error searching files: ${error instanceof Error ? error.message : 'Unknown error'}`,
+				error: `Error searching files: ${getRawErrorMessageOr(error, 'Unknown error')}`,
 			};
 		}
 	}

--- a/src/tools/vault/write-file-tool.ts
+++ b/src/tools/vault/write-file-tool.ts
@@ -4,6 +4,7 @@ import { ToolClassification } from '../../types/tool-policy';
 import { TFile, normalizePath } from 'obsidian';
 import { shouldExcludePathForPlugin as shouldExcludePath, ensureFolderExists } from '../../utils/file-utils';
 import { t } from '../../i18n';
+import { getRawErrorMessageOr } from '../../utils/error-utils';
 
 /**
  * Write file content
@@ -123,7 +124,7 @@ export class WriteFileTool implements Tool {
 		} catch (error) {
 			return {
 				success: false,
-				error: `Error writing file: ${error instanceof Error ? error.message : 'Unknown error'}`,
+				error: `Error writing file: ${getRawErrorMessageOr(error, 'Unknown error')}`,
 			};
 		}
 	}

--- a/src/tools/web-fetch-tool.ts
+++ b/src/tools/web-fetch-tool.ts
@@ -7,6 +7,7 @@ import { executeWithRetry } from '../utils/retry';
 import TurndownService from 'turndown';
 import { decodeHtmlEntities } from '../utils/html-entities';
 import { createGoogleGenAI } from '../api/providers/gemini/google-genai-factory';
+import { getRawErrorMessageOr } from '../utils/error-utils';
 
 /**
  * Web fetch tool using Google's URL Context feature
@@ -197,7 +198,7 @@ export class WebFetchTool implements Tool {
 			} catch (_fallbackError) {
 				return {
 					success: false,
-					error: `Failed to fetch URL with both methods: ${error instanceof Error ? error.message : 'Unknown error'}`,
+					error: `Failed to fetch URL with both methods: ${getRawErrorMessageOr(error, 'Unknown error')}`,
 				};
 			}
 		}
@@ -299,7 +300,7 @@ export class WebFetchTool implements Tool {
 			plugin.logger.error('Fallback fetch error:', error);
 			return {
 				success: false,
-				error: `Fallback fetch failed: ${error instanceof Error ? error.message : 'Unknown error'}`,
+				error: `Fallback fetch failed: ${getRawErrorMessageOr(error, 'Unknown error')}`,
 			};
 		}
 	}

--- a/src/ui/mcp-server-modal.ts
+++ b/src/ui/mcp-server-modal.ts
@@ -3,7 +3,7 @@ import { MCPServerConfig, MCP_TRANSPORT_STDIO, MCP_TRANSPORT_HTTP, MCPTransportT
 import { MCPManager } from '../mcp/mcp-manager';
 import { ObsidianOAuthClientProvider } from '../mcp/mcp-oauth-provider';
 import { resolveServerEnv, writeServerEnv } from '../mcp/mcp-secrets';
-import { getRawErrorMessage } from '../utils/error-utils';
+import { getRawErrorMessage, getRawErrorMessageOr } from '../utils/error-utils';
 import { t } from '../i18n';
 
 /**
@@ -288,7 +288,7 @@ export class MCPServerModal extends Modal {
 							try {
 								writeServerEnv(this.app, this.config, this.env);
 							} catch (error) {
-								new Notice(error instanceof Error ? error.message : t('mcpServer.envStoreFailed'));
+								new Notice(getRawErrorMessageOr(error, t('mcpServer.envStoreFailed')));
 								return;
 							}
 						}

--- a/src/ui/selection-response-modal.ts
+++ b/src/ui/selection-response-modal.ts
@@ -1,6 +1,7 @@
 import { App, Modal, MarkdownRenderer, Editor, Notice, setIcon } from 'obsidian';
 import type ObsidianGemini from '../main';
 import { t } from '../i18n';
+import { getRawErrorMessageOr } from '../utils/error-utils';
 
 /**
  * Normalize newlines in AI responses for proper Markdown rendering.
@@ -225,7 +226,7 @@ export class SelectionResponseModal extends Modal {
 			new Notice(t('selectionResponse.copiedNotice'));
 		} catch (error) {
 			this.plugin.logger.error('Failed to copy to clipboard:', error);
-			const message = error instanceof Error ? error.message : t('selectionResponse.unknownError');
+			const message = getRawErrorMessageOr(error, t('selectionResponse.unknownError'));
 			new Notice(t('selectionResponse.copyFailed', { message }));
 		}
 	}

--- a/src/utils/error-utils.ts
+++ b/src/utils/error-utils.ts
@@ -1,7 +1,8 @@
 /**
  * Utility functions for extracting error messages from API errors.
  *
- * Raw extraction (no translation): `getRawErrorMessage`.
+ * Raw extraction (no translation): `getRawErrorMessage` — `Error` → `.message`, everything else → `String(error)`.
+ * Raw extraction with an explicit fallback: `getRawErrorMessageOr` — `Error` → `.message`, everything else → the supplied fallback.
  * User-facing translation (maps provider quirks to friendly guidance): `getErrorMessage`.
  */
 
@@ -123,6 +124,20 @@ export function isNotFoundError(error: unknown): boolean {
 export function getRawErrorMessage(error: unknown): string {
 	if (error instanceof Error) return error.message;
 	return String(error);
+}
+
+/**
+ * Extract the raw message from an `unknown` error value, falling back to a caller-supplied
+ * string when the value is not an `Error`.
+ *
+ * Returns `error.message` for `Error` instances and `fallback` for everything else. This is the
+ * DRY replacement for the `error instanceof Error ? error.message : '<literal>'` ternary that was
+ * duplicated across tool error returns and service throws. Use it when the non-`Error` case should
+ * become a fixed label (e.g. `'Unknown error'`) rather than `String(error)`; when the raw value
+ * itself is the desired fallback, use `getRawErrorMessage` instead.
+ */
+export function getRawErrorMessageOr(error: unknown, fallback: string): string {
+	return error instanceof Error ? error.message : fallback;
 }
 
 /**

--- a/test/utils/error-utils.test.ts
+++ b/test/utils/error-utils.test.ts
@@ -1,6 +1,7 @@
 import {
 	getErrorMessage,
 	getRawErrorMessage,
+	getRawErrorMessageOr,
 	getShortErrorMessage,
 	isNotFoundError,
 	isQuotaExhausted,
@@ -45,6 +46,48 @@ describe('error-utils', () => {
 		test('does not translate raw messages (unlike getErrorMessage)', () => {
 			// getErrorMessage maps "api key" to friendly guidance; getRawErrorMessage must not.
 			expect(getRawErrorMessage(new Error('Invalid api key supplied'))).toBe('Invalid api key supplied');
+		});
+	});
+
+	describe('getRawErrorMessageOr', () => {
+		test('returns Error.message for Error instances', () => {
+			expect(getRawErrorMessageOr(new Error('boom'), 'Unknown error')).toBe('boom');
+		});
+
+		test('preserves message on Error subclasses', () => {
+			expect(getRawErrorMessageOr(new TypeError('bad type'), 'Unknown error')).toBe('bad type');
+		});
+
+		test('returns the fallback verbatim for string inputs', () => {
+			expect(getRawErrorMessageOr('plain string', 'Unknown error')).toBe('Unknown error');
+		});
+
+		test('returns the fallback for null', () => {
+			expect(getRawErrorMessageOr(null, 'Unknown error')).toBe('Unknown error');
+		});
+
+		test('returns the fallback for undefined', () => {
+			expect(getRawErrorMessageOr(undefined, 'Unknown error')).toBe('Unknown error');
+		});
+
+		test('returns the fallback for objects with a custom toString()', () => {
+			// Unlike getRawErrorMessage (which would call String()), the fallback wins for non-Error values.
+			const obj = {
+				toString() {
+					return 'custom-stringified';
+				},
+			};
+			expect(getRawErrorMessageOr(obj, 'Unknown error')).toBe('Unknown error');
+		});
+
+		test('passes the supplied fallback through unchanged (e.g. a localized string)', () => {
+			expect(getRawErrorMessageOr({}, 'Une erreur inconnue')).toBe('Une erreur inconnue');
+		});
+
+		test('does not translate raw messages (unlike getErrorMessage)', () => {
+			expect(getRawErrorMessageOr(new Error('Invalid api key supplied'), 'Unknown error')).toBe(
+				'Invalid api key supplied'
+			);
 		});
 	});
 


### PR DESCRIPTION
<!-- auto-dev -->

## Summary

Add a `getRawErrorMessageOr(error, fallback)` helper alongside `getRawErrorMessage` in `src/utils/error-utils.ts` and replace the 30 duplicated `error instanceof Error ? error.message : '<literal>'` ternaries flagged in #1064 with a single call. This is the "Unknown error" sibling of the earlier `getRawErrorMessage` consolidation — pure DRY cleanup with no behavior change at any call site.

Fixes #1064

## Changes

- `src/utils/error-utils.ts` — add `getRawErrorMessageOr(error: unknown, fallback: string): string` (returns `error.message` for `Error` instances, the supplied `fallback` otherwise); extend the file header comment to document the three-way split (raw → `getRawErrorMessage`; raw-with-fallback → `getRawErrorMessageOr`; user-translated → `getErrorMessage`).
- **24 literal-fallback sites** → `getRawErrorMessageOr(error, 'Unknown error')` (or `'Unknown error occurred'` where that exact literal was used, at `selection-action-service.ts`): across 14 `src/tools/**` files plus `src/agent/agent-loop.ts`, `src/services/example-prompts.ts`, `src/services/agents-memory.ts` (×2), and `src/services/image-generation.ts`. The `read-file-tool.ts` SVG-raster site correctly threads its local `rasterErr` variable.
- **3 localized-fallback sites** → `getRawErrorMessageOr(error, t(...))`, preserving the exact `t()` key: `src/services/vault-analyzer.ts`, `src/ui/mcp-server-modal.ts`, `src/ui/selection-response-modal.ts`.
- **3 raw-fallback sites** → the existing `getRawErrorMessage(error)`: `src/mcp/mcp-manager.ts` (×2) and `src/agent/agent-event-bus.ts`, which fell back to the raw `error` value rather than a literal string.
- `test/utils/error-utils.test.ts` — add a `getRawErrorMessageOr` suite covering `Error`/subclass → `.message`, and string/`null`/`undefined`/custom-`toString()` object → verbatim `fallback` (including a localized-string fallback case).

**Deviation from the approved plan:** the plan listed `src/agent/agent-event-bus.ts:66` among the literal `'Unknown error'` sites, but that site actually falls back to the raw `error` value (`… : error`), so it is handled as a `getRawErrorMessage(error)` site — consistent with the two `mcp-manager.ts` sites the plan already routed there. This reconciles the plan's stated count of 30 (24 literal + 3 localized + 3 raw). The `.stack` ternaries in `mcp-manager.ts` (lines 314/477) and the `new Error(String(error))` site in `agent-view-send.ts:775` were left untouched as out of scope.

## Screenshots / Screencast

N/A — purely internal refactor, no UI or behavior change.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [ ] I have tested this change on Desktop
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards)
- [x] Documentation has been updated (if applicable) — N/A, no user-facing surface changed
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude (auto-dev pipeline)
- [x] I have reviewed and understand all AI-generated code in this PR

---

Produced by the auto-dev pipeline from the approved plan on #1064.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HkhZaWQvqChcGs2PvNgrfR)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved formatting of AI response text for Markdown, including better handling of line breaks, code blocks, and tables.

* **Bug Fixes**
  * Error messages are now more consistent and informative across failed actions, uploads, searches, and web fetches.
  * Clipboard copy failures and other user-facing errors now show clearer fallback messages when the underlying error isn’t standard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->