### PR TITLE
refactor: replace no-explicit-any in src/utils and src/mcp (#1036)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -120,6 +120,13 @@ export default defineConfig([
 		rules: { ...SOFTENED_TS_RULES, ...PERVASIVE_OBSIDIANMD_RULES_TODO },
 	},
 	{
+		// #1036: `no-explicit-any` is cleared for these directories, so enforce it here
+		// to prevent regressions while the rule stays globally softened for the rest of
+		// `src/` (remaining areas — src/tools, src/api, src/ui — tracked in #1036).
+		files: ['src/utils/**/*.ts', 'src/mcp/**/*.ts'],
+		rules: { '@typescript-eslint/no-explicit-any': 'error' },
+	},
+	{
 		// Files fully migrated off direct `style.X = ...` assignments to CSS classes.
 		// Enforce `no-static-styles-assignment` here so they cannot regress while the
 		// rule stays globally disabled for the remaining unmigrated files (#1034).

--- a/src/mcp/mcp-manager.ts
+++ b/src/mcp/mcp-manager.ts
@@ -49,19 +49,21 @@ function patchSetTimeoutForElectron(): void {
 	if (typeof origSetTimeout === 'function') {
 		// Test if unref already works (true Node.js environment)
 		const testTimer = origSetTimeout(() => {}, 0);
-		if (typeof (testTimer as any).unref === 'function') {
+		if (typeof (testTimer as unknown as { unref?: unknown }).unref === 'function') {
 			// Already has .unref() — no patch needed
 			window.clearTimeout(testTimer);
 			return;
 		}
 		window.clearTimeout(testTimer);
 
-		// Patch: wrap return value to add .unref() and .ref() as no-ops
-		(window as any).setTimeout = function patchedSetTimeout(
-			callback: (...args: any[]) => void,
+		// Patch: wrap return value to add .unref() and .ref() as no-ops. The wrapper
+		// deliberately does not match the native `number` return type, so the
+		// assignment is bridged through `unknown` — a genuine monkey-patch boundary.
+		window.setTimeout = function patchedSetTimeout(
+			callback: (...args: unknown[]) => void,
 			ms?: number,
-			...args: any[]
-		): any {
+			...args: unknown[]
+		) {
 			const id = origSetTimeout(callback, ms, ...args);
 			return {
 				[Symbol.toPrimitive]() {
@@ -76,17 +78,17 @@ function patchSetTimeoutForElectron(): void {
 				// Preserve the raw id so clearTimeout still works
 				__timerId: id,
 			};
-		} as any;
+		} as unknown as typeof window.setTimeout;
 
 		// Also patch clearTimeout to handle our wrapper objects
 		const origClearTimeout = window.clearTimeout;
-		(window as any).clearTimeout = function patchedClearTimeout(id: any): void {
+		window.clearTimeout = function patchedClearTimeout(id?: unknown): void {
 			if (id && typeof id === 'object' && '__timerId' in id) {
-				origClearTimeout(id.__timerId);
+				origClearTimeout((id as { __timerId?: number }).__timerId);
 			} else {
-				origClearTimeout(id);
+				origClearTimeout(id as number | undefined);
 			}
-		} as any;
+		};
 	}
 }
 

--- a/src/mcp/mcp-tool-wrapper.ts
+++ b/src/mcp/mcp-tool-wrapper.ts
@@ -4,19 +4,23 @@ import { ToolCategory } from '../types/agent';
 import { ToolClassification } from '../types/tool-policy';
 import { MCP_CALL_TOOL_TIMEOUT_MS } from './mcp-constants';
 import { withTimeout } from '../utils/timeout';
-import { getRawErrorMessage } from '../utils/error-utils';
+import { asRecord, getRawErrorMessage } from '../utils/error-utils';
 
 /**
- * MCP tool definition as returned by client.listTools()
+ * MCP tool definition as returned by client.listTools().
+ *
+ * The `inputSchema` is external JSON Schema (the SDK types property values as
+ * bare `object`), so `properties` values stay `unknown` and are narrowed at the
+ * point of use (see `convertInputSchema`).
  */
 interface MCPToolDefinition {
 	name: string;
 	description?: string;
 	inputSchema?: {
 		type?: string;
-		properties?: Record<string, any>;
+		properties?: Record<string, unknown>;
 		required?: string[];
-		[key: string]: any;
+		[key: string]: unknown;
 	};
 }
 
@@ -43,7 +47,7 @@ export class MCPToolWrapper implements Tool {
 		this.parameters = convertInputSchema(toolDef.inputSchema);
 	}
 
-	async execute(params: any, _context: ToolExecutionContext): Promise<ToolResult> {
+	async execute(params: Record<string, unknown>, _context: ToolExecutionContext): Promise<ToolResult> {
 		try {
 			// Bound the wait — a hung MCP server must not freeze the agent loop.
 			// Timeout surfaces as `{ success: false, error }` via the catch below,
@@ -85,7 +89,7 @@ export class MCPToolWrapper implements Tool {
 		}
 	}
 
-	confirmationMessage(params: any): string {
+	confirmationMessage(params: Record<string, unknown>): string {
 		const paramSummary = Object.entries(params || {})
 			.map(([key, value]) => {
 				const strValue = typeof value === 'string' ? value : JSON.stringify(value);
@@ -97,7 +101,7 @@ export class MCPToolWrapper implements Tool {
 		return `Run MCP tool "${this.displayName}"${paramSummary ? `\n${paramSummary}` : ''}`;
 	}
 
-	getProgressDescription(_params: any): string {
+	getProgressDescription(_params: Record<string, unknown>): string {
 		return `Running ${this.displayName}...`;
 	}
 }
@@ -171,12 +175,16 @@ function convertInputSchema(inputSchema?: MCPToolDefinition['inputSchema']): Too
 
 	const properties: ToolParameterSchema['properties'] = {};
 
-	for (const [key, schema] of Object.entries(inputSchema.properties)) {
+	for (const [key, rawSchema] of Object.entries(inputSchema.properties)) {
+		const schema = asRecord(rawSchema);
+		const rawDescription = schema.description;
+		const enumValues = schema.enum;
+		const items = schema.items;
 		properties[key] = {
-			type: mapJsonSchemaType(schema?.type),
-			description: schema?.description || `Parameter "${key}"`,
-			...(schema?.enum ? { enum: schema.enum } : {}),
-			...(schema?.items ? { items: { type: mapJsonSchemaType(schema.items.type) } } : {}),
+			type: mapJsonSchemaType(schema.type),
+			description: typeof rawDescription === 'string' && rawDescription ? rawDescription : `Parameter "${key}"`,
+			...(Array.isArray(enumValues) ? { enum: enumValues } : {}),
+			...(items ? { items: { type: mapJsonSchemaType(asRecord(items).type) } } : {}),
 		};
 	}
 
@@ -190,7 +198,7 @@ function convertInputSchema(inputSchema?: MCPToolDefinition['inputSchema']): Too
 /**
  * Map JSON Schema types to the plugin's simpler type system.
  */
-function mapJsonSchemaType(type: any): 'string' | 'number' | 'boolean' | 'array' {
+function mapJsonSchemaType(type: unknown): 'string' | 'number' | 'boolean' | 'array' {
 	switch (type) {
 		case 'string':
 			return 'string';

--- a/src/utils/accessed-files.ts
+++ b/src/utils/accessed-files.ts
@@ -13,7 +13,7 @@ const TRACKED_TOOLS = new Set([
 
 interface ToolResultEntry {
 	toolName: string;
-	toolArguments: any;
+	toolArguments: unknown;
 	result: ToolResult;
 }
 

--- a/src/utils/error-utils.ts
+++ b/src/utils/error-utils.ts
@@ -7,29 +7,43 @@
  */
 
 /**
+ * Coerce an unknown value to a string-keyed record for safe property probing.
+ *
+ * Error values arriving from SDKs, `fetch`, and JSON payloads are structurally
+ * dynamic, so we navigate them as `Record<string, unknown>` and narrow each
+ * field at the point of use. Non-objects (including `null`) yield an empty
+ * record so property access never throws.
+ */
+export function asRecord(value: unknown): Record<string, unknown> {
+	return value !== null && typeof value === 'object' ? (value as Record<string, unknown>) : {};
+}
+
+/**
  * Extract the `details` array from various Google API error shapes.
  * Google errors may carry details at `error.details`, `error.error.details`,
  * `error.response.data.error.details`, or embedded as JSON in `error.message`.
  */
-export function extractErrorDetails(error: unknown): any[] {
+export function extractErrorDetails(error: unknown): unknown[] {
 	if (!error || typeof error !== 'object') return [];
-	const err = error as any;
+	const err = asRecord(error);
 
 	// Direct details array
 	if (Array.isArray(err.details)) return err.details;
 	// Nested under .error
-	if (Array.isArray(err.error?.details)) return err.error.details;
+	const nestedError = asRecord(err.error);
+	if (Array.isArray(nestedError.details)) return nestedError.details;
 	// Nested under .response.data.error
-	if (Array.isArray(err.response?.data?.error?.details)) return err.response.data.error.details;
+	const responseError = asRecord(asRecord(asRecord(err.response).data).error);
+	if (Array.isArray(responseError.details)) return responseError.details;
 
 	// Try to parse details from the error message (Google SDK sometimes embeds JSON)
-	if (err.message && typeof err.message === 'string') {
+	if (typeof err.message === 'string') {
 		try {
 			const start = err.message.indexOf('{');
 			const end = err.message.lastIndexOf('}');
 			if (start !== -1 && end > start) {
-				const parsed = JSON.parse(err.message.slice(start, end + 1));
-				const details = parsed.details ?? parsed.error?.details;
+				const parsed = asRecord(JSON.parse(err.message.slice(start, end + 1)));
+				const details = parsed.details ?? asRecord(parsed.error).details;
 				if (Array.isArray(details)) return details;
 			}
 		} catch {
@@ -51,17 +65,20 @@ export function isQuotaExhausted(error: unknown): boolean {
 	// Check structured details for QuotaFailure with limit: 0
 	const details = extractErrorDetails(error);
 	for (const detail of details) {
-		if (detail['@type']?.includes('QuotaFailure') || detail['@type']?.includes('quotaFailure')) {
-			const violations = detail.violations || [];
+		const d = asRecord(detail);
+		const type = d['@type'];
+		if (typeof type === 'string' && (type.includes('QuotaFailure') || type.includes('quotaFailure'))) {
+			const violations = Array.isArray(d.violations) ? d.violations : [];
 			for (const v of violations) {
-				if (v.limit === 0 || v.limit === '0') return true;
+				const limit = asRecord(v).limit;
+				if (limit === 0 || limit === '0') return true;
 			}
 		}
 	}
 
 	// Fall back to message-based detection for SDK errors that flatten details
 	if (error && typeof error === 'object') {
-		const message = (error as any).message || String(error);
+		const message: unknown = asRecord(error).message || String(error);
 		const messageLower = typeof message === 'string' ? message.toLowerCase() : '';
 		if (
 			messageLower.includes('resource_exhausted') &&
@@ -88,7 +105,7 @@ export function isRateLimitError(error: unknown): boolean {
 	if (statusCode === 429) return true;
 
 	if (typeof error === 'object') {
-		const message = (error as any).message || '';
+		const message: unknown = asRecord(error).message || '';
 		const messageLower = typeof message === 'string' ? message.toLowerCase() : String(error).toLowerCase();
 		return (
 			messageLower.includes('429') ||
@@ -282,7 +299,7 @@ export function getErrorMessage(error: unknown): string {
 
 	// Handle objects with error information
 	if (typeof error === 'object') {
-		const err = error as any;
+		const err = asRecord(error);
 
 		// Check for status code using the extraction function
 		const statusCode = extractStatusCode(err);
@@ -301,12 +318,13 @@ export function getErrorMessage(error: unknown): string {
 		}
 
 		// Check for error description
-		if (err.error?.message) {
+		const nestedError = asRecord(err.error);
+		if (nestedError.message) {
 			// Process nested error message
-			if (typeof err.error.message === 'string') {
-				return `API error: ${err.error.message}`;
+			if (typeof nestedError.message === 'string') {
+				return `API error: ${nestedError.message}`;
 			}
-			return getErrorMessage(err.error.message);
+			return getErrorMessage(nestedError.message);
 		}
 
 		// Try to stringify the error
@@ -327,50 +345,51 @@ export function getErrorMessage(error: unknown): string {
 /**
  * Extract HTTP status code from error object
  */
-export function extractStatusCode(error: any): number | null {
+export function extractStatusCode(error: unknown): number | null {
 	// Guard non-object inputs so callers passing `null`, `undefined`, or a
-	// primitive (this is an exported helper typed as `any`) don't trigger a
+	// primitive (this is an exported helper accepting `unknown`) don't trigger a
 	// secondary TypeError inside an already-failing error path.
 	if (!error || (typeof error !== 'object' && typeof error !== 'function')) {
 		return null;
 	}
+	const err = asRecord(error);
 
 	// Check common status code properties
-	if (typeof error.status === 'number') {
-		return error.status;
+	if (typeof err.status === 'number') {
+		return err.status;
 	}
-	if (typeof error.statusCode === 'number') {
-		return error.statusCode;
+	if (typeof err.statusCode === 'number') {
+		return err.statusCode;
 	}
 	// ollama-js throws ResponseError with `status_code`
-	if (typeof error.status_code === 'number') {
-		return error.status_code;
+	if (typeof err.status_code === 'number') {
+		return err.status_code;
 	}
-	if (typeof error.code === 'number') {
-		return error.code;
+	if (typeof err.code === 'number') {
+		return err.code;
 	}
 
 	// Check in nested error object
-	if (error.error) {
-		if (typeof error.error.status === 'number') {
-			return error.error.status;
-		}
-		if (typeof error.error.code === 'number') {
-			return error.error.code;
-		}
+	const nestedError = asRecord(err.error);
+	if (typeof nestedError.status === 'number') {
+		return nestedError.status;
+	}
+	if (typeof nestedError.code === 'number') {
+		return nestedError.code;
 	}
 
 	// Check in response object (fetch API pattern)
-	if (error.response) {
-		if (typeof error.response.status === 'number') {
-			return error.response.status;
-		}
+	const response = asRecord(err.response);
+	if (typeof response.status === 'number') {
+		return response.status;
 	}
 
 	// Try to extract from error message
-	const match = error.message?.match(/(?:status|code)[\s:]+(\d{3})/i);
-	if (match) {
-		return parseInt(match[1], 10);
+	if (typeof err.message === 'string') {
+		const match = err.message.match(/(?:status|code)[\s:]+(\d{3})/i);
+		if (match) {
+			return parseInt(match[1], 10);
+		}
 	}
 
 	return null;
@@ -379,8 +398,9 @@ export function extractStatusCode(error: any): number | null {
 /**
  * Get user-friendly message for HTTP status codes
  */
-function getHttpErrorMessage(statusCode: number, error: any): string {
-	const errorMessage = error.message || '';
+function getHttpErrorMessage(statusCode: number, error: unknown): string {
+	const rawMessage = asRecord(error).message;
+	const errorMessage = typeof rawMessage === 'string' ? rawMessage : '';
 
 	switch (statusCode) {
 		case 400:

--- a/src/utils/file-log-writer.ts
+++ b/src/utils/file-log-writer.ts
@@ -38,7 +38,7 @@ export class FileLogWriter {
 	 * Buffer a log entry for writing. Synchronous — never blocks the caller.
 	 * Checks the fileLogging setting so Logger doesn't need to.
 	 */
-	write(level: string, prefix: string, args: any[]): void {
+	write(level: string, prefix: string, args: unknown[]): void {
 		if (!this.plugin.settings?.fileLogging) return;
 
 		const timestamp = formatLocalTimestamp();
@@ -144,7 +144,7 @@ export class FileLogWriter {
 		}
 	}
 
-	private formatArgs(args: any[]): string {
+	private formatArgs(args: unknown[]): string {
 		return args
 			.map((arg) => {
 				if (arg === null || arg === undefined) return String(arg);

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -22,7 +22,7 @@ export class Logger {
 	/**
 	 * Debug log - only shown when debug mode is enabled
 	 */
-	log(...args: any[]): void {
+	log(...args: unknown[]): void {
 		if (this.plugin.settings?.debugMode) {
 			// eslint-disable-next-line obsidianmd/rule-custom-message -- central console wrapper; see AGENTS.md
 			console.log(this.prefix, ...args);
@@ -33,7 +33,7 @@ export class Logger {
 	/**
 	 * Debug log - only shown when debug mode is enabled
 	 */
-	debug(...args: any[]): void {
+	debug(...args: unknown[]): void {
 		if (this.plugin.settings?.debugMode) {
 			console.debug(this.prefix, ...args);
 			this.plugin.fileLogWriter?.write('DEBUG', this.prefix, args);
@@ -43,7 +43,7 @@ export class Logger {
 	/**
 	 * Error log - always shown
 	 */
-	error(...args: any[]): void {
+	error(...args: unknown[]): void {
 		console.error(this.prefix, ...args);
 		this.plugin.fileLogWriter?.write('ERROR', this.prefix, args);
 	}
@@ -51,7 +51,7 @@ export class Logger {
 	/**
 	 * Warning log - always shown
 	 */
-	warn(...args: any[]): void {
+	warn(...args: unknown[]): void {
 		console.warn(this.prefix, ...args);
 		this.plugin.fileLogWriter?.write('WARN', this.prefix, args);
 	}

--- a/src/utils/retry.ts
+++ b/src/utils/retry.ts
@@ -4,7 +4,7 @@
  */
 
 import { Logger } from './logger';
-import { extractErrorDetails, extractStatusCode, isQuotaExhausted } from './error-utils';
+import { asRecord, extractErrorDetails, extractStatusCode, isQuotaExhausted } from './error-utils';
 
 /**
  * Configuration for retry behavior
@@ -179,8 +179,10 @@ export function parseRetryDelay(error: unknown): number | null {
 	const details = extractErrorDetails(error);
 
 	for (const detail of details) {
-		if (detail['@type']?.includes('RetryInfo') || detail['@type']?.includes('retryInfo')) {
-			const delay = detail.retryDelay;
+		const d = asRecord(detail);
+		const type = d['@type'];
+		if (typeof type === 'string' && (type.includes('RetryInfo') || type.includes('retryInfo'))) {
+			const delay = d.retryDelay;
 			if (typeof delay === 'string') {
 				// Parse duration strings like "17s", "1.5s"
 				const match = delay.match(/^(\d+(?:\.\d+)?)s$/);
@@ -233,7 +235,7 @@ export function isRetryableApiError(error: unknown): boolean {
 	// For errors with rate-limit/quota messages but no status code,
 	// check if it's a permanent quota issue
 	if (error && typeof error === 'object') {
-		const message = (error as any).message || '';
+		const message: unknown = asRecord(error).message || '';
 		const messageLower = typeof message === 'string' ? message.toLowerCase() : '';
 		if (
 			messageLower.includes('resource_exhausted') ||

--- a/src/utils/text-generation.ts
+++ b/src/utils/text-generation.ts
@@ -15,7 +15,7 @@ import type ObsidianGemini from '../main';
 export function generateToolDescription(
 	plugin: ObsidianGemini,
 	toolName: string,
-	_toolArguments: Record<string, any>,
+	_toolArguments: Record<string, unknown>,
 	displayName: string
 ): string {
 	const fallback = `Executing: ${displayName}`;

--- a/test/services/rag-vault-scanner.test.ts
+++ b/test/services/rag-vault-scanner.test.ts
@@ -53,6 +53,7 @@ vi.mock('@allenhutchison/gemini-utils', () => ({
 }));
 
 vi.mock('../../src/utils/error-utils', () => ({
+	asRecord: vi.fn((value: unknown) => (value !== null && typeof value === 'object' ? value : {})),
 	getErrorMessage: vi.fn((err: any) => (err instanceof Error ? err.message : String(err))),
 	getRawErrorMessage: vi.fn((err: any) => (err instanceof Error ? err.message : String(err))),
 	isQuotaExhausted: vi.fn().mockReturnValue(false),


### PR DESCRIPTION
<!-- auto-dev -->

## Summary

First slice of the `@typescript-eslint/no-explicit-any` strict-typing pass tracked in #1036. It clears `any` from `src/utils/` and `src/mcp/` — the two clusters the approved plan identified as least entangled with Obsidian's dynamic API surfaces — and enforces the rule per-directory so they can't regress. `src/tools/`, `src/api/`, and `src/ui/` remain out of scope and follow in later PRs, as the plan states.

The change is type-only; runtime behavior is unchanged. `any` is replaced with `unknown` + narrowing (via a new shared `asRecord` helper) or precise types, with no surviving `any` and no blanket disables.

Produced by the auto-dev pipeline from the plan approved on #1036.

Fixes #1036

## Changes

- `src/utils/error-utils.ts` — add a shared `asRecord(unknown): Record<string, unknown>` helper and navigate the various API error shapes through it; `extractErrorDetails` now returns `unknown[]`; `extractStatusCode` and `getHttpErrorMessage` accept `unknown`. All property probing narrows at the point of use.
- `src/utils/retry.ts` — consume `asRecord` for detail/message narrowing now that `extractErrorDetails` returns `unknown[]`.
- `src/utils/logger.ts`, `src/utils/file-log-writer.ts` — variadic log `...args: any[]` → `unknown[]`.
- `src/utils/accessed-files.ts`, `src/utils/text-generation.ts` — `any` field/param → `unknown`.
- `src/mcp/mcp-tool-wrapper.ts` — type the MCP wire schema and the `Tool` method params (`execute`/`confirmationMessage`/`getProgressDescription`) without `any`; narrow each JSON Schema property via `asRecord`.
- `src/mcp/mcp-manager.ts` — type the Electron `setTimeout`/`clearTimeout` monkey-patch through `unknown` bridges instead of `any` (a genuine dynamic boundary; the `setTimeout` wrapper's non-`number` return is bridged via `as unknown as`).
- `eslint.config.mjs` — add a scoped override enforcing `@typescript-eslint/no-explicit-any: 'error'` for `src/utils/**` and `src/mcp/**`, mirroring the existing per-directory `no-static-styles-assignment` pattern.
- `test/services/rag-vault-scanner.test.ts` — the `error-utils` mock gains the new `asRecord` export it now reaches through the (real, `importActual`) retry module.

## Checklist

### Required

- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — locally green: lint (0 errors), `npm run build`, `npm run typecheck:test`, `npm test` (3258 passed), `npm run format-check`.
- [ ] I have tested this change on Desktop
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards)
- [x] Documentation has been updated (if applicable) — n/a: internal typing-only refactor with no user-facing surface, settings, or commands changed.
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer — #1036, plan approved.

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude (auto-dev pipeline)
- [x] I have reviewed and understand all AI-generated code in this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01HoCf7Uyuw954EC28GwgRea)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling and retry detection so a wider range of API error shapes are interpreted more reliably.
  * Made timeout handling in Electron more robust in renderer environments.
  * Tightened tool input and logging type handling to reduce unexpected payload issues.

* **Refactor**
  * Strengthened TypeScript safety across utility and MCP-related code paths by reducing reliance on loosely typed values.
  * Applied stricter linting for utility and MCP source files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->