### PR TITLE
test(gemini): cover Interactions API error path (#1017)

### DIFF
--- a/test/api/providers/gemini/client.test.ts
+++ b/test/api/providers/gemini/client.test.ts
@@ -1258,5 +1258,66 @@ describe('GeminiClient', () => {
 			expect(params.input).toBe('just answer');
 			expect(params.system_instruction).toBeUndefined();
 		});
+
+		describe('error handling', () => {
+			test('generateModelResponse logs and rethrows when interactions.create rejects', async () => {
+				const apiError = new Error('interactions boom');
+				interactionsCreateMock.mockReset();
+				interactionsCreateMock.mockRejectedValue(apiError);
+
+				const client = makeInteractionsClient();
+				await expect(
+					client.generateModelResponse({
+						prompt: '',
+						userMessage: 'hi',
+						kind: 'extended',
+						conversationHistory: [],
+					})
+				).rejects.toBe(apiError);
+
+				expect(mockLogger.error).toHaveBeenCalledWith('[GeminiClient] Error creating interaction:', apiError);
+			});
+
+			test('streaming logs and rethrows when interactions.create rejects', async () => {
+				const apiError = new Error('interactions stream boom');
+				interactionsCreateMock.mockReset();
+				interactionsCreateMock.mockRejectedValue(apiError);
+
+				const client = makeInteractionsClient();
+				const chunks: Array<{ text: string }> = [];
+				const stream = client.generateStreamingResponse(
+					{ prompt: '', userMessage: 'hi', kind: 'extended', conversationHistory: [] },
+					(chunk) => chunks.push(chunk)
+				);
+
+				await expect(stream.complete).rejects.toBe(apiError);
+				expect(chunks).toEqual([]);
+				expect(mockLogger.error).toHaveBeenCalledWith('[GeminiClient] Error streaming interaction:', apiError);
+			});
+
+			test('streaming logs and rethrows when the stream throws mid-iteration', async () => {
+				const apiError = new Error('mid-stream boom');
+				interactionsCreateMock.mockReset();
+				interactionsCreateMock.mockImplementation(async () => {
+					return (async function* () {
+						yield { event_type: 'step.start', index: 0, step: { type: 'model_output' } };
+						yield { event_type: 'step.delta', index: 0, delta: { type: 'text', text: 'partial' } };
+						throw apiError;
+					})();
+				});
+
+				const client = makeInteractionsClient();
+				const chunks: Array<{ text: string }> = [];
+				const stream = client.generateStreamingResponse(
+					{ prompt: '', userMessage: 'hi', kind: 'extended', conversationHistory: [] },
+					(chunk) => chunks.push(chunk)
+				);
+
+				await expect(stream.complete).rejects.toBe(apiError);
+				// The pre-error chunk was still emitted before the stream faulted.
+				expect(chunks).toEqual([{ text: 'partial' }]);
+				expect(mockLogger.error).toHaveBeenCalledWith('[GeminiClient] Error streaming interaction:', apiError);
+			});
+		});
 	});
 });


### PR DESCRIPTION
<!-- auto-dev -->

## Summary

Adds the one genuine coverage gap identified on #1017: unit tests for the Interactions transport's error path. When `interactions.create` rejects — or the SSE stream throws mid-iteration — `generateViaInteractions` / `streamViaInteractions` log via `logger.error` and rethrow. Until now that path had no test.

Per the maintainer's direction on #1017 (option 2: "build the interactions error-path test as a standalone slice"), this PR **references but does not close** #1017 — the eval-harness soak on a real Obsidian instance and the release-timed `useInteractionsApi` default-flip remain maintainer-owned, so the issue stays open for that work.

Refs #1017

## Changes

- `test/api/providers/gemini/client.test.ts` — new `error handling` block inside the existing `Interactions API transport (useInteractionsApi)` suite, with three tests:
  - `generateModelResponse` rejects with the original error and logs `[GeminiClient] Error creating interaction:` when `interactions.create` rejects (non-streaming path).
  - `generateStreamingResponse` (`stream.complete`) rejects with the original error and logs `[GeminiClient] Error streaming interaction:` when `interactions.create` rejects at request setup, emitting no chunks.
  - The streaming path also rejects and logs when the SSE stream throws **mid-iteration**, after a pre-error chunk was already emitted — exercising the `for await` fault path distinctly from the setup-reject path.

## Screenshots / Screencast

N/A — test-only change, no UI or runtime behavior surface.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer — #1017, maintainer approved building the error-path test as a standalone slice
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — locally green: `npm test` (3261 passed), `npm run build`, `npm run typecheck:test`, `npm run format-check`
- [x] I have tested this change on Desktop — N/A: test-only change, no runtime surface; full unit suite passes
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A: no plugin code changed
- [x] Documentation has been updated (if applicable) — N/A: `useInteractionsApi` is already documented; this adds test coverage only
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude (auto-dev pipeline)
- [x] I have reviewed and understand all AI-generated code in this PR

---

Produced by the auto-dev pipeline from the maintainer's approved direction on #1017 (build the error-path test as a standalone slice; does not close the issue).

---
_Generated by [Claude Code](https://claude.ai/code/session_01FGwjQtLxP42z4BjxFMWADs)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for error handling in AI response generation, including non-streaming failures, streaming startup failures, and errors that occur mid-stream.
  * Verified that existing streamed output is preserved when an error happens after partial delivery.
  * Confirmed errors are surfaced consistently when response creation fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->