### PR TITLE
fix: resolve no-misused-promises violations and enforce the rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -19,7 +19,8 @@ const SOFTENED_TS_RULES = {
 	'@typescript-eslint/no-unsafe-enum-comparison': 'error',
 	// #1039: cleared — enforced.
 	'@typescript-eslint/no-unnecessary-type-assertion': 'error',
-	'@typescript-eslint/no-misused-promises': 'off',
+	// #1038: cleared — enforced.
+	'@typescript-eslint/no-misused-promises': 'error',
 	// #1037: cleared — enforced.
 	'@typescript-eslint/no-floating-promises': 'error',
 	'@typescript-eslint/no-base-to-string': 'off',

--- a/src/commands/register-commands.ts
+++ b/src/commands/register-commands.ts
@@ -168,9 +168,9 @@ export function registerCommands(plugin: ObsidianGemini): void {
 			// Show picker for multiple projects
 			const { ProjectPickerModal } = await import('../ui/agent-view/project-picker-modal');
 			const modal = new ProjectPickerModal(plugin.app, plugin, {
-				onSelect: async (project) => {
+				onSelect: (project) => {
 					if (project) {
-						await plugin.app.workspace.openLinkText(project.filePath, '', true);
+						void plugin.app.workspace.openLinkText(project.filePath, '', true);
 					}
 				},
 			});
@@ -191,20 +191,22 @@ export function registerCommands(plugin: ObsidianGemini): void {
 			}
 			const { ProjectPickerModal } = await import('../ui/agent-view/project-picker-modal');
 			const modal = new ProjectPickerModal(plugin.app, plugin, {
-				onSelect: async (project) => {
-					if (!project) return;
-					// Find most recent session linked to this project
-					const sessions = await plugin.sessionManager.getRecentAgentSessions(50);
-					const projectSession = sessions.find((s) => s.projectPath === project.filePath);
-					if (projectSession) {
-						await plugin.activateAgentView();
-						// The agent view will load the session
-						if (plugin.agentView) {
-							await plugin.agentView.loadSession(projectSession);
+				onSelect: (project) => {
+					void (async () => {
+						if (!project) return;
+						// Find most recent session linked to this project
+						const sessions = await plugin.sessionManager.getRecentAgentSessions(50);
+						const projectSession = sessions.find((s) => s.projectPath === project.filePath);
+						if (projectSession) {
+							await plugin.activateAgentView();
+							// The agent view will load the session
+							if (plugin.agentView) {
+								await plugin.agentView.loadSession(projectSession);
+							}
+						} else {
+							new Notice(t('notice.main.noSessionsForProject', { name: project.name }));
 						}
-					} else {
-						new Notice(t('notice.main.noSessionsForProject', { name: project.name }));
-					}
+					})();
 				},
 			});
 			modal.open();
@@ -248,13 +250,15 @@ export function registerCommands(plugin: ObsidianGemini): void {
 			const modal = new RewriteInstructionsModal(
 				plugin.app,
 				textToRewrite,
-				async (instructions) => {
-					const rewriter = new SelectionRewriter(plugin);
-					if (isFullFile) {
-						await rewriter.rewriteFullFile(editor, instructions);
-					} else {
-						await rewriter.rewriteSelection(editor, selection, instructions);
-					}
+				(instructions) => {
+					void (async () => {
+						const rewriter = new SelectionRewriter(plugin);
+						if (isFullFile) {
+							await rewriter.rewriteFullFile(editor, instructions);
+						} else {
+							await rewriter.rewriteSelection(editor, selection, instructions);
+						}
+					})();
 				},
 				isFullFile
 			);

--- a/src/main.ts
+++ b/src/main.ts
@@ -364,9 +364,11 @@ export default class ObsidianGemini extends Plugin {
 								const modal = new RewriteInstructionsModal(
 									this.app,
 									selection,
-									async (instructions) => {
-										const rewriter = new SelectionRewriter(this);
-										await rewriter.rewriteSelection(editor, selection, instructions);
+									(instructions) => {
+										void (async () => {
+											const rewriter = new SelectionRewriter(this);
+											await rewriter.rewriteSelection(editor, selection, instructions);
+										})();
 									},
 									false // Context menu is always for selection, not full file
 								);

--- a/src/prompts/prompt-manager.ts
+++ b/src/prompts/prompt-manager.ts
@@ -198,35 +198,49 @@ Focus on being helpful while maintaining intellectual honesty.`;
 	async createNewCustomPrompt(): Promise<void> {
 		try {
 			// Open input modal for prompt name
-			const modal = new PromptNameModal(this.plugin.app, async (promptName: string) => {
-				if (!promptName || promptName.trim() === '') {
-					new Notice(t('notice.prompt.nameEmpty'));
-					return;
-				}
+			const modal = new PromptNameModal(this.plugin.app, (promptName: string) => {
+				// PromptNameModal expects a void-returning callback; run the async
+				// file creation as a fire-and-forget task with its own error handling.
+				void this.createPromptFromName(promptName);
+			});
 
-				// Sanitize filename (remove special characters, keep alphanumeric, spaces, hyphens, underscores)
-				const sanitizedName = promptName
-					.trim()
-					.replace(/[^\w\s-]/g, '')
-					.replace(/\s+/g, '-');
-				if (!sanitizedName) {
-					new Notice(t('notice.prompt.nameInvalid'));
-					return;
-				}
+			modal.open();
+		} catch (error) {
+			this.plugin.logger.error('Error creating new custom prompt:', error);
+			new Notice(t('notice.prompt.createFailed'));
+		}
+	}
 
-				const promptsDir = this.getPromptsDirectory();
-				const fileName = `${sanitizedName.toLowerCase()}.md`;
-				const filePath = normalizePath(`${promptsDir}/${fileName}`);
+	// Create the prompt file for a user-supplied name (invoked from the name modal).
+	private async createPromptFromName(promptName: string): Promise<void> {
+		if (!promptName || promptName.trim() === '') {
+			new Notice(t('notice.prompt.nameEmpty'));
+			return;
+		}
 
-				// Check if file already exists
-				const existingFile = this.vault.getAbstractFileByPath(filePath);
-				if (existingFile) {
-					new Notice(t('notice.prompt.alreadyExists', { fileName }));
-					return;
-				}
+		// Sanitize filename (remove special characters, keep alphanumeric, spaces, hyphens, underscores)
+		const sanitizedName = promptName
+			.trim()
+			.replace(/[^\w\s-]/g, '')
+			.replace(/\s+/g, '-');
+		if (!sanitizedName) {
+			new Notice(t('notice.prompt.nameInvalid'));
+			return;
+		}
 
-				// Create template content
-				const templateContent = `---
+		const promptsDir = this.getPromptsDirectory();
+		const fileName = `${sanitizedName.toLowerCase()}.md`;
+		const filePath = normalizePath(`${promptsDir}/${fileName}`);
+
+		// Check if file already exists
+		const existingFile = this.vault.getAbstractFileByPath(filePath);
+		if (existingFile) {
+			new Notice(t('notice.prompt.alreadyExists', { fileName }));
+			return;
+		}
+
+		// Create template content
+		const templateContent = `---
 name: "${promptName}"
 description: "Brief description of what this prompt does"
 version: 1
@@ -246,24 +260,17 @@ Your custom prompt content goes here. This will modify how the AI behaves when a
 ## Example Usage:
 This prompt will be applied to sessions and will supplement the default system prompt unless override_system_prompt is set to true.`;
 
-				try {
-					// Create the file
-					const newFile = await this.vault.create(filePath, templateContent);
+		try {
+			// Create the file
+			const newFile = await this.vault.create(filePath, templateContent);
 
-					// Open the file for editing
-					await this.plugin.app.workspace.openLinkText(newFile.path, '', true);
+			// Open the file for editing
+			await this.plugin.app.workspace.openLinkText(newFile.path, '', true);
 
-					new Notice(t('notice.prompt.created', { name: promptName }));
-				} catch (error) {
-					this.plugin.logger.error('Error creating prompt file:', error);
-					new Notice(t('notice.prompt.createFileFailed'));
-				}
-			});
-
-			modal.open();
+			new Notice(t('notice.prompt.created', { name: promptName }));
 		} catch (error) {
-			this.plugin.logger.error('Error creating new custom prompt:', error);
-			new Notice(t('notice.prompt.createFailed'));
+			this.plugin.logger.error('Error creating prompt file:', error);
+			new Notice(t('notice.prompt.createFileFailed'));
 		}
 	}
 }

--- a/src/services/background-status-bar.ts
+++ b/src/services/background-status-bar.ts
@@ -53,21 +53,23 @@ export class BackgroundStatusBar {
 		this.statusBarItem.createSpan({ cls: 'gemini-bg-status-text' });
 		this.statusBarItem.createSpan({ cls: 'gemini-bg-status-badge' });
 
-		this.statusBarItem.addEventListener('click', async () => {
-			// Pending catch-up approvals take priority — open the approval modal first
-			if (this._pendingCatchUpCount > 0 && this.plugin.scheduledTaskManager) {
-				const pending = this.plugin.scheduledTaskManager.detectMissedRuns();
-				if (pending.length > 0) {
-					const { CatchUpModal } = await import('../ui/catch-up-modal');
-					new CatchUpModal(this.plugin.app, this.plugin, pending).open();
-					return;
+		this.statusBarItem.addEventListener('click', () => {
+			void (async () => {
+				// Pending catch-up approvals take priority — open the approval modal first
+				if (this._pendingCatchUpCount > 0 && this.plugin.scheduledTaskManager) {
+					const pending = this.plugin.scheduledTaskManager.detectMissedRuns();
+					if (pending.length > 0) {
+						const { CatchUpModal } = await import('../ui/catch-up-modal');
+						new CatchUpModal(this.plugin.app, this.plugin, pending).open();
+						return;
+					}
+					// detectMissedRuns returned empty — stale badge; self-correct
+					this.setPendingCatchUpCount(0);
 				}
-				// detectMissedRuns returned empty — stale badge; self-correct
-				this.setPendingCatchUpCount(0);
-			}
-			const { BackgroundTasksModal } = await import('../ui/background-tasks-modal');
-			const defaultTab = this.taskManager.runningCount > 0 ? 'tasks' : 'rag';
-			new BackgroundTasksModal(this.plugin.app, this.plugin, defaultTab).open();
+				const { BackgroundTasksModal } = await import('../ui/background-tasks-modal');
+				const defaultTab = this.taskManager.runningCount > 0 ? 'tasks' : 'rag';
+				new BackgroundTasksModal(this.plugin.app, this.plugin, defaultTab).open();
+			})();
 		});
 
 		this.update();

--- a/src/services/rag-status-bar.ts
+++ b/src/services/rag-status-bar.ts
@@ -91,22 +91,24 @@ export class RagStatusBar {
 		// Create text element for file count
 		this.statusBarItem.createSpan({ cls: 'rag-status-text' });
 
-		this.statusBarItem.addEventListener('click', async () => {
-			try {
-				// Show progress modal if indexing, otherwise show status modal
-				if (this.provider.getStatus() === 'indexing') {
-					const { RagProgressModal } = await import('../ui/rag-progress-modal');
-					const modal = new RagProgressModal(this.plugin.app, this.provider, (result) => {
-						new Notice(t('notice.rag.indexingSummary', { indexed: result.indexed, skipped: result.skipped }));
-					});
-					modal.open();
-				} else {
-					await openRagStatusModal(this.plugin.app, this.provider, this.plugin.manifest.id);
+		this.statusBarItem.addEventListener('click', () => {
+			void (async () => {
+				try {
+					// Show progress modal if indexing, otherwise show status modal
+					if (this.provider.getStatus() === 'indexing') {
+						const { RagProgressModal } = await import('../ui/rag-progress-modal');
+						const modal = new RagProgressModal(this.plugin.app, this.provider, (result) => {
+							new Notice(t('notice.rag.indexingSummary', { indexed: result.indexed, skipped: result.skipped }));
+						});
+						modal.open();
+					} else {
+						await openRagStatusModal(this.plugin.app, this.provider, this.plugin.manifest.id);
+					}
+				} catch (error) {
+					this.plugin.logger.error('RAG Indexing: Failed to open status UI', error);
+					new Notice(t('notice.rag.uiError', { error: getErrorMessage(error) }));
 				}
-			} catch (error) {
-				this.plugin.logger.error('RAG Indexing: Failed to open status UI', error);
-				new Notice(t('notice.rag.uiError', { error: getErrorMessage(error) }));
-			}
+			})();
 		});
 	}
 

--- a/src/services/rag-vault-scanner.ts
+++ b/src/services/rag-vault-scanner.ts
@@ -249,17 +249,19 @@ export class RagVaultScanner {
 		const { RagResumeModal } = await import('../ui/rag-resume-modal');
 
 		return new Promise<void>((resolve) => {
-			const modal = new RagResumeModal(this.plugin.app, resumeInfo, async (resume: boolean) => {
-				if (resume) {
-					// Resume: just start indexing - smart sync will skip already-indexed files
-					new Notice(t('notice.rag.resuming'));
-					this.startResumeIndexing(progressProvider);
-				} else {
-					// Start fresh: clear cache and store, then reindex
-					new Notice(t('notice.rag.startingFresh'));
-					await this.startFresh(progressProvider);
-				}
-				resolve();
+			const modal = new RagResumeModal(this.plugin.app, resumeInfo, (resume: boolean) => {
+				void (async () => {
+					if (resume) {
+						// Resume: just start indexing - smart sync will skip already-indexed files
+						new Notice(t('notice.rag.resuming'));
+						this.startResumeIndexing(progressProvider);
+					} else {
+						// Start fresh: clear cache and store, then reindex
+						new Notice(t('notice.rag.startingFresh'));
+						await this.startFresh(progressProvider);
+					}
+					resolve();
+				})();
 			});
 			modal.open();
 		});
@@ -424,6 +426,12 @@ export class RagVaultScanner {
 					// alarming console noise for routine skips (empty files, inaccessible notes).
 					error: (msg: string, ...args: any[]) => this.plugin.logger.warn(msg, ...args),
 				},
+				// ProgressCallback is typed `(event) => void`, but this handler must be async:
+				// it awaits per-file hashing / incremental cache saves, and it *throws* to signal
+				// cancellation and rate-limit cooldown, which callers (including the uploader mock
+				// in tests) await and rely on propagating. Wrapping the body to void the promise
+				// would swallow those throws, so the async signature is intentional here.
+				// eslint-disable-next-line @typescript-eslint/no-misused-promises
 				onProgress: async (event: any) => {
 					// Check for cancellation
 					if (this.cancelRequested) {

--- a/src/ui/agent-view/agent-view-attachments.ts
+++ b/src/ui/agent-view/agent-view-attachments.ts
@@ -38,85 +38,91 @@ export class AgentViewAttachments {
 	async showFileMention(): Promise<void> {
 		const modal = new FileMentionModal(
 			this.ctx.app,
-			async (fileOrFolder: TAbstractFile) => {
-				// Remove the @ character that triggered the picker
-				this.removeTrailingTriggerChar('@');
+			(fileOrFolder: TAbstractFile) => {
+				// FileMentionModal expects a void-returning callback; run the async
+				// attachment handling as a fire-and-forget task.
+				void (async () => {
+					// Remove the @ character that triggered the picker
+					this.removeTrailingTriggerChar('@');
 
-				if (fileOrFolder instanceof TFolder) {
-					this.ctx.getShelf().addFolder(fileOrFolder);
-					// Seed session context with current folder contents. Subsequent turns
-					// re-expand the folder via the shelf so new files are picked up (#127).
-					const files = getTextFilesFromFolder(fileOrFolder, (path) =>
-						shouldExcludePathForPlugin(path, this.ctx.plugin)
-					);
-					for (const file of files) {
-						this.ctx.context.addFileToContext(file, this.ctx.getCurrentSession());
-					}
-					this.ctx.updateSessionHeader();
-					await this.ctx.updateSessionMetadata();
-					return;
-				}
-
-				if (!(fileOrFolder instanceof TFile)) return;
-
-				// Classify the file to determine text vs binary handling
-				const { classifyFile, FileCategory, arrayBufferToBase64, detectWebmMimeType, GEMINI_INLINE_DATA_LIMIT } =
-					await import('../../utils/file-classification');
-				const classification = classifyFile(fileOrFolder.extension);
-
-				if (classification.category === FileCategory.TEXT) {
-					this.ctx.getShelf().addTextFile(fileOrFolder);
-					this.ctx.context.addFileToContext(fileOrFolder, this.ctx.getCurrentSession());
-					this.ctx.updateSessionHeader();
-					await this.ctx.updateSessionMetadata();
-				} else if (
-					classification.category === FileCategory.GEMINI_BINARY ||
-					classification.category === FileCategory.SVG
-				) {
-					// Handle binary/SVG file — create inline attachment (same as drag-drop).
-					// SVG is rasterized to PNG; other binaries are inlined as-is.
-					try {
-						const buffer = await this.ctx.app.vault.readBinary(fileOrFolder);
-						const existing = this.ctx.getShelf().getPendingAttachments();
-						const cumulativeSize =
-							existing.reduce((sum, a) => sum + Math.ceil((a.base64.length * 3) / 4), 0) + buffer.byteLength;
-
-						if (cumulativeSize > GEMINI_INLINE_DATA_LIMIT) {
-							new Notice(t('agent.attachments.fileTooLarge', { name: fileOrFolder.name }), 5000);
-							return;
+					if (fileOrFolder instanceof TFolder) {
+						this.ctx.getShelf().addFolder(fileOrFolder);
+						// Seed session context with current folder contents. Subsequent turns
+						// re-expand the folder via the shelf so new files are picked up (#127).
+						const files = getTextFilesFromFolder(fileOrFolder, (path) =>
+							shouldExcludePathForPlugin(path, this.ctx.plugin)
+						);
+						for (const file of files) {
+							this.ctx.context.addFileToContext(file, this.ctx.getCurrentSession());
 						}
+						this.ctx.updateSessionHeader();
+						await this.ctx.updateSessionMetadata();
+						return;
+					}
 
-						let base64: string;
-						let mimeType: string;
-						if (classification.category === FileCategory.SVG) {
-							try {
-								base64 = await rasterizeSvg(buffer, fileOrFolder.extension.toLowerCase() === 'svgz');
-								mimeType = 'image/png';
-							} catch (rasterErr) {
-								this.ctx.plugin.logger.error(`Failed to rasterize SVG ${fileOrFolder.path}:`, rasterErr);
-								new Notice(t('agent.attachments.attachFailed', { name: fileOrFolder.name }));
+					if (!(fileOrFolder instanceof TFile)) return;
+
+					// Classify the file to determine text vs binary handling
+					const { classifyFile, FileCategory, arrayBufferToBase64, detectWebmMimeType, GEMINI_INLINE_DATA_LIMIT } =
+						await import('../../utils/file-classification');
+					const classification = classifyFile(fileOrFolder.extension);
+
+					if (classification.category === FileCategory.TEXT) {
+						this.ctx.getShelf().addTextFile(fileOrFolder);
+						this.ctx.context.addFileToContext(fileOrFolder, this.ctx.getCurrentSession());
+						this.ctx.updateSessionHeader();
+						await this.ctx.updateSessionMetadata();
+					} else if (
+						classification.category === FileCategory.GEMINI_BINARY ||
+						classification.category === FileCategory.SVG
+					) {
+						// Handle binary/SVG file — create inline attachment (same as drag-drop).
+						// SVG is rasterized to PNG; other binaries are inlined as-is.
+						try {
+							const buffer = await this.ctx.app.vault.readBinary(fileOrFolder);
+							const existing = this.ctx.getShelf().getPendingAttachments();
+							const cumulativeSize =
+								existing.reduce((sum, a) => sum + Math.ceil((a.base64.length * 3) / 4), 0) + buffer.byteLength;
+
+							if (cumulativeSize > GEMINI_INLINE_DATA_LIMIT) {
+								new Notice(t('agent.attachments.fileTooLarge', { name: fileOrFolder.name }), 5000);
 								return;
 							}
-						} else {
-							base64 = arrayBufferToBase64(buffer);
-							mimeType =
-								fileOrFolder.extension.toLowerCase() === 'webm' ? detectWebmMimeType(buffer) : classification.mimeType;
+
+							let base64: string;
+							let mimeType: string;
+							if (classification.category === FileCategory.SVG) {
+								try {
+									base64 = await rasterizeSvg(buffer, fileOrFolder.extension.toLowerCase() === 'svgz');
+									mimeType = 'image/png';
+								} catch (rasterErr) {
+									this.ctx.plugin.logger.error(`Failed to rasterize SVG ${fileOrFolder.path}:`, rasterErr);
+									new Notice(t('agent.attachments.attachFailed', { name: fileOrFolder.name }));
+									return;
+								}
+							} else {
+								base64 = arrayBufferToBase64(buffer);
+								mimeType =
+									fileOrFolder.extension.toLowerCase() === 'webm'
+										? detectWebmMimeType(buffer)
+										: classification.mimeType;
+							}
+							const { generateAttachmentId } = await import('./inline-attachment');
+							const attachment: InlineAttachment = {
+								base64,
+								mimeType,
+								id: generateAttachmentId(),
+								vaultPath: fileOrFolder.path,
+								fileName: fileOrFolder.name,
+							};
+							this.addAttachment(attachment);
+							new Notice(t('agent.attachments.attached', { name: fileOrFolder.name }), 2000);
+						} catch (err) {
+							this.ctx.plugin.logger.error(`Failed to attach ${fileOrFolder.path}:`, err);
+							new Notice(t('agent.attachments.attachFailed', { name: fileOrFolder.name }));
 						}
-						const { generateAttachmentId } = await import('./inline-attachment');
-						const attachment: InlineAttachment = {
-							base64,
-							mimeType,
-							id: generateAttachmentId(),
-							vaultPath: fileOrFolder.path,
-							fileName: fileOrFolder.name,
-						};
-						this.addAttachment(attachment);
-						new Notice(t('agent.attachments.attached', { name: fileOrFolder.name }), 2000);
-					} catch (err) {
-						this.ctx.plugin.logger.error(`Failed to attach ${fileOrFolder.path}:`, err);
-						new Notice(t('agent.attachments.attachFailed', { name: fileOrFolder.name }));
 					}
-				}
+				})();
 			},
 			this.ctx.plugin
 		);

--- a/src/ui/agent-view/agent-view-messages.ts
+++ b/src/ui/agent-view/agent-view-messages.ts
@@ -467,7 +467,7 @@ export class AgentViewMessages {
 		const images = container.findAll('img');
 		for (const img of images) {
 			img.addClass('gemini-agent-clickable-image');
-			img.addEventListener('click', async (e) => {
+			img.addEventListener('click', (e) => {
 				e.stopPropagation();
 
 				// Try to get file path from alt text (standard Obsidian behavior)
@@ -476,7 +476,7 @@ export class AgentViewMessages {
 					const file = this.app.metadataCache.getFirstLinkpathDest(altText, sourcePath);
 					if (file) {
 						const leaf = this.app.workspace.getLeaf('tab');
-						await leaf.openFile(file);
+						void leaf.openFile(file);
 					}
 				}
 			});
@@ -604,13 +604,15 @@ export class AgentViewMessages {
 				});
 			}
 
-			initButton.addEventListener('click', async () => {
-				// Run the vault analyzer
-				if (this.plugin.vaultAnalyzer) {
-					await this.plugin.vaultAnalyzer.initializeAgentsMemory();
-					// Refresh the empty state to update the button
-					await this.showEmptyState(currentSession, onLoadSession, onSendMessage);
-				}
+			initButton.addEventListener('click', () => {
+				void (async () => {
+					// Run the vault analyzer
+					if (this.plugin.vaultAnalyzer) {
+						await this.plugin.vaultAnalyzer.initializeAgentsMemory();
+						// Refresh the empty state to update the button
+						await this.showEmptyState(currentSession, onLoadSession, onSendMessage);
+					}
+				})();
 			});
 
 			// Try to get recent sessions (excluding the current session)
@@ -644,8 +646,8 @@ export class AgentViewMessages {
 						cls: 'gemini-agent-suggestion-date',
 					});
 
-					suggestion.addEventListener('click', async () => {
-						await onLoadSession(session);
+					suggestion.addEventListener('click', () => {
+						void onLoadSession(session);
 					});
 				});
 			}
@@ -673,9 +675,9 @@ export class AgentViewMessages {
 					cls: 'gemini-agent-example-text',
 				});
 
-				suggestion.addEventListener('click', async () => {
+				suggestion.addEventListener('click', () => {
 					this.userInput.textContent = example.text;
-					await onSendMessage();
+					void onSendMessage();
 				});
 			});
 
@@ -881,8 +883,8 @@ export class AgentViewMessages {
 					text: diffContext.isNewFile ? t('agent.confirm.previewFile') : t('agent.confirm.viewChanges'),
 				});
 
-				viewChangesBtn.addEventListener('click', async () => {
-					await this.openDiffView(
+				viewChangesBtn.addEventListener('click', () => {
+					void this.openDiffView(
 						diffContext,
 						handleResponse,
 						(view) => {

--- a/src/ui/agent-view/agent-view-tool-display.ts
+++ b/src/ui/agent-view/agent-view-tool-display.ts
@@ -42,20 +42,22 @@ export class AgentViewToolDisplay {
 			attr: { 'aria-label': t('agent.tools.copySectionAria', { section: title }), type: 'button' },
 		});
 		setIcon(copyBtn, 'copy');
-		copyBtn.addEventListener('click', async (e) => {
+		copyBtn.addEventListener('click', (e) => {
 			// Sections live inside the expandable details; don't let the click
 			// bubble up and collapse the row.
 			e.stopPropagation();
-			// getCopyText() can throw synchronously (e.g. JSON.stringify on
-			// circular data), so keep it inside the try with the clipboard write.
-			try {
-				const text = getCopyText();
-				await navigator.clipboard.writeText(text);
-				setIcon(copyBtn, 'check');
-				window.setTimeout(() => setIcon(copyBtn, 'copy'), 1500);
-			} catch (err) {
-				this.plugin.logger.error('Failed to copy tool detail to clipboard:', err);
-			}
+			void (async () => {
+				// getCopyText() can throw synchronously (e.g. JSON.stringify on
+				// circular data), so keep it inside the try with the clipboard write.
+				try {
+					const text = getCopyText();
+					await navigator.clipboard.writeText(text);
+					setIcon(copyBtn, 'check');
+					window.setTimeout(() => setIcon(copyBtn, 'copy'), 1500);
+				} catch (err) {
+					this.plugin.logger.error('Failed to copy tool detail to clipboard:', err);
+				}
+			})();
 		});
 	}
 

--- a/src/ui/agent-view/agent-view-ui.ts
+++ b/src/ui/agent-view/agent-view-ui.ts
@@ -207,7 +207,9 @@ export class AgentViewUI {
 				}
 			};
 
-			input.addEventListener('blur', saveTitle);
+			input.addEventListener('blur', () => {
+				void saveTitle();
+			});
 			input.addEventListener('keydown', (e) => {
 				if (e.key === 'Enter') {
 					e.preventDefault();
@@ -397,12 +399,12 @@ export class AgentViewUI {
 				// Defer to next microtask so the browser commits the @ character first.
 				// If user selects a file, the @ will be removed before inserting the chip.
 				// If user dismisses the picker, the @ stays as a literal character.
-				window.setTimeout(() => callbacks.showFileMention(), 0);
+				window.setTimeout(() => void callbacks.showFileMention(), 0);
 			} else if (e.key === '/') {
 				// Trigger skill picker only when input is empty (slash command, not mid-sentence slash)
 				const text = userInput.innerText || '';
 				if (text.trim().length === 0) {
-					window.setTimeout(() => callbacks.showSkillPicker(), 0);
+					window.setTimeout(() => void callbacks.showSkillPicker(), 0);
 				}
 			}
 		});
@@ -421,399 +423,341 @@ export class AgentViewUI {
 			userInput.removeClass('gemini-agent-input-dragover');
 		});
 
-		userInput.addEventListener('drop', async (e) => {
-			userInput.removeClass('gemini-agent-input-dragover');
+		userInput.addEventListener('drop', (e) => {
+			void (async () => {
+				userInput.removeClass('gemini-agent-input-dragover');
 
-			// --- Handle Vault File Drops ---
-			const droppedFiles: (TFile | TFolder)[] = [];
+				// --- Handle Vault File Drops ---
+				const droppedFiles: (TFile | TFolder)[] = [];
 
-			// Debug: log all dataTransfer types and data
-			if (e.dataTransfer) {
-				this.plugin.logger.debug('[AgentViewUI] Drop event dataTransfer types:', Array.from(e.dataTransfer.types));
-				for (const type of Array.from(e.dataTransfer.types)) {
-					if (type !== 'Files') {
-						this.plugin.logger.debug(`[AgentViewUI] dataTransfer[${type}]:`, e.dataTransfer.getData(type));
-					}
-				}
-				if (e.dataTransfer.files?.length) {
-					this.plugin.logger.debug(
-						'[AgentViewUI] dataTransfer files:',
-						Array.from(e.dataTransfer.files).map((f) => ({
-							name: f.name,
-							type: f.type,
-							size: f.size,
-							path: (f as any).path,
-						}))
-					);
-				}
-			}
-
-			// Helper to resolve path to file/folder
-			const resolvePath = (path: string): TFile | TFolder | null => {
-				const abstractFile = this.app.vault.getAbstractFileByPath(path);
-				if (abstractFile instanceof TFile || abstractFile instanceof TFolder) {
-					return abstractFile;
-				}
-				// Try to resolve as a link (closest match)
-				const resolved = this.app.metadataCache.getFirstLinkpathDest(path, '');
-				return resolved;
-			};
-
-			// 1. Check for File objects (Electron drag from file system)
-			if (e.dataTransfer?.files?.length) {
-				const adapter = this.app.vault.adapter;
-				if (adapter && 'basePath' in adapter) {
-					const basePath = (adapter as any).basePath;
-					// Normalize slashes for cross-platform consistency (Windows backslashes vs POSIX)
-					// Using explicit replace instead of normalizePath which is intended for vault-relative paths
-					const normalizedBase = basePath.replace(/\\/g, '/');
-
-					for (const file of Array.from(e.dataTransfer.files)) {
-						// (file as any).path is an Electron extension that provides the full filesystem path
-						const rawPath = (file as any).path;
-
-						if (rawPath && typeof rawPath === 'string') {
-							const normalizedRaw = rawPath.replace(/\\/g, '/');
-
-							if (normalizedRaw.startsWith(normalizedBase)) {
-								let relPath = normalizedRaw.substring(normalizedBase.length);
-								if (relPath.startsWith('/')) relPath = relPath.substring(1);
-
-								const validFile = resolvePath(relPath);
-								if (validFile) {
-									droppedFiles.push(validFile);
-								} else {
-									this.plugin.logger.debug(`[AgentViewUI] Failed to resolve dropped file path: ${relPath}`);
-								}
-							}
+				// Debug: log all dataTransfer types and data
+				if (e.dataTransfer) {
+					this.plugin.logger.debug('[AgentViewUI] Drop event dataTransfer types:', Array.from(e.dataTransfer.types));
+					for (const type of Array.from(e.dataTransfer.types)) {
+						if (type !== 'Files') {
+							this.plugin.logger.debug(`[AgentViewUI] dataTransfer[${type}]:`, e.dataTransfer.getData(type));
 						}
 					}
+					if (e.dataTransfer.files?.length) {
+						this.plugin.logger.debug(
+							'[AgentViewUI] dataTransfer files:',
+							Array.from(e.dataTransfer.files).map((f) => ({
+								name: f.name,
+								type: f.type,
+								size: f.size,
+								path: (f as any).path,
+							}))
+						);
+					}
 				}
-			}
 
-			// 2. Check for Text links (Obsidian internal drag)
-			// Skip internal link parsing if we already found filesystem files to prevent double-counting
-			// (Obsidian sometimes puts both File objects and text links in the same drop)
-			if (droppedFiles.length === 0 && e.dataTransfer) {
-				const text = e.dataTransfer.getData('text/plain');
-				if (text) {
-					const lines = text.split('\n');
-					for (const line of lines) {
-						const trimmed = line.trim();
-						if (!trimmed) continue;
+				// Helper to resolve path to file/folder
+				const resolvePath = (path: string): TFile | TFolder | null => {
+					const abstractFile = this.app.vault.getAbstractFileByPath(path);
+					if (abstractFile instanceof TFile || abstractFile instanceof TFolder) {
+						return abstractFile;
+					}
+					// Try to resolve as a link (closest match)
+					const resolved = this.app.metadataCache.getFirstLinkpathDest(path, '');
+					return resolved;
+				};
 
-						// Check Obsidian URI: obsidian://open?vault=...&file=...
-						if (trimmed.startsWith('obsidian://')) {
-							try {
-								const url = new URL(trimmed);
-								const filePath = url.searchParams.get('file');
-								if (filePath) {
-									const decoded = decodeURIComponent(filePath);
-									const resolved = resolvePath(decoded);
-									if (resolved) {
-										droppedFiles.push(resolved);
+				// 1. Check for File objects (Electron drag from file system)
+				if (e.dataTransfer?.files?.length) {
+					const adapter = this.app.vault.adapter;
+					if (adapter && 'basePath' in adapter) {
+						const basePath = (adapter as any).basePath;
+						// Normalize slashes for cross-platform consistency (Windows backslashes vs POSIX)
+						// Using explicit replace instead of normalizePath which is intended for vault-relative paths
+						const normalizedBase = basePath.replace(/\\/g, '/');
+
+						for (const file of Array.from(e.dataTransfer.files)) {
+							// (file as any).path is an Electron extension that provides the full filesystem path
+							const rawPath = (file as any).path;
+
+							if (rawPath && typeof rawPath === 'string') {
+								const normalizedRaw = rawPath.replace(/\\/g, '/');
+
+								if (normalizedRaw.startsWith(normalizedBase)) {
+									let relPath = normalizedRaw.substring(normalizedBase.length);
+									if (relPath.startsWith('/')) relPath = relPath.substring(1);
+
+									const validFile = resolvePath(relPath);
+									if (validFile) {
+										droppedFiles.push(validFile);
 									} else {
-										this.plugin.logger.debug(`[AgentViewUI] Failed to resolve obsidian URI file param: ${decoded}`);
+										this.plugin.logger.debug(`[AgentViewUI] Failed to resolve dropped file path: ${relPath}`);
 									}
 								}
-							} catch (_err) {
-								this.plugin.logger.debug(`[AgentViewUI] Failed to parse obsidian URI: ${trimmed}`);
 							}
-							continue;
 						}
+					}
+				}
 
-						// Check Wikilink: [[Path|Name]] or [[Path]]
-						const wikiMatch = trimmed.match(/^\[\[(.*?)(\|.*)?\]\]$/);
-						if (wikiMatch) {
-							const resolved = resolvePath(wikiMatch[1]);
-							// Note: getFirstLinkpathDest only resolves TFile, so folders linked this way won't be resolved
-							if (resolved) {
-								droppedFiles.push(resolved);
-							} else {
-								this.plugin.logger.debug(`[AgentViewUI] Failed to resolve wikilink: ${wikiMatch[1]}`);
+				// 2. Check for Text links (Obsidian internal drag)
+				// Skip internal link parsing if we already found filesystem files to prevent double-counting
+				// (Obsidian sometimes puts both File objects and text links in the same drop)
+				if (droppedFiles.length === 0 && e.dataTransfer) {
+					const text = e.dataTransfer.getData('text/plain');
+					if (text) {
+						const lines = text.split('\n');
+						for (const line of lines) {
+							const trimmed = line.trim();
+							if (!trimmed) continue;
+
+							// Check Obsidian URI: obsidian://open?vault=...&file=...
+							if (trimmed.startsWith('obsidian://')) {
+								try {
+									const url = new URL(trimmed);
+									const filePath = url.searchParams.get('file');
+									if (filePath) {
+										const decoded = decodeURIComponent(filePath);
+										const resolved = resolvePath(decoded);
+										if (resolved) {
+											droppedFiles.push(resolved);
+										} else {
+											this.plugin.logger.debug(`[AgentViewUI] Failed to resolve obsidian URI file param: ${decoded}`);
+										}
+									}
+								} catch (_err) {
+									this.plugin.logger.debug(`[AgentViewUI] Failed to parse obsidian URI: ${trimmed}`);
+								}
+								continue;
 							}
-							continue;
-						}
 
-						// Check Markdown Link: [Name](Path)
-						const mdMatch = trimmed.match(/^\[(.*?)\]\((.*?)\)$/);
-						if (mdMatch) {
-							try {
-								const path = decodeURIComponent(mdMatch[2]);
-								const resolved = resolvePath(path);
+							// Check Wikilink: [[Path|Name]] or [[Path]]
+							const wikiMatch = trimmed.match(/^\[\[(.*?)(\|.*)?\]\]$/);
+							if (wikiMatch) {
+								const resolved = resolvePath(wikiMatch[1]);
 								// Note: getFirstLinkpathDest only resolves TFile, so folders linked this way won't be resolved
 								if (resolved) {
 									droppedFiles.push(resolved);
 								} else {
-									this.plugin.logger.debug(`[AgentViewUI] Failed to resolve markdown link: ${path}`);
+									this.plugin.logger.debug(`[AgentViewUI] Failed to resolve wikilink: ${wikiMatch[1]}`);
 								}
-							} catch (_err) {
-								// Ignore decoding errors
-								this.plugin.logger.debug(`[AgentViewUI] Failed to decode markdown link path: ${mdMatch[2]}`);
+								continue;
 							}
-							continue;
-						}
 
-						// Fallback: try resolving as a plain vault path
-						const plainResolved = resolvePath(trimmed);
-						if (plainResolved) {
-							droppedFiles.push(plainResolved);
-						} else {
-							this.plugin.logger.debug(`[AgentViewUI] Could not resolve dropped text as vault path: ${trimmed}`);
+							// Check Markdown Link: [Name](Path)
+							const mdMatch = trimmed.match(/^\[(.*?)\]\((.*?)\)$/);
+							if (mdMatch) {
+								try {
+									const path = decodeURIComponent(mdMatch[2]);
+									const resolved = resolvePath(path);
+									// Note: getFirstLinkpathDest only resolves TFile, so folders linked this way won't be resolved
+									if (resolved) {
+										droppedFiles.push(resolved);
+									} else {
+										this.plugin.logger.debug(`[AgentViewUI] Failed to resolve markdown link: ${path}`);
+									}
+								} catch (_err) {
+									// Ignore decoding errors
+									this.plugin.logger.debug(`[AgentViewUI] Failed to decode markdown link path: ${mdMatch[2]}`);
+								}
+								continue;
+							}
+
+							// Fallback: try resolving as a plain vault path
+							const plainResolved = resolvePath(trimmed);
+							if (plainResolved) {
+								droppedFiles.push(plainResolved);
+							} else {
+								this.plugin.logger.debug(`[AgentViewUI] Could not resolve dropped text as vault path: ${trimmed}`);
+							}
 						}
 					}
 				}
-			}
 
-			// If valid vault files were found, classify and route them
-			if (droppedFiles.length > 0) {
-				e.preventDefault();
-				e.stopPropagation();
+				// If valid vault files were found, classify and route them
+				if (droppedFiles.length > 0) {
+					e.preventDefault();
+					e.stopPropagation();
 
-				// Deduplicate files
-				const uniqueFiles = [...new Map(droppedFiles.map((f) => [f.path, f])).values()];
+					// Deduplicate files
+					const uniqueFiles = [...new Map(droppedFiles.map((f) => [f.path, f])).values()];
 
-				// Filter out system folders and excluded files
-				const filteredFiles = uniqueFiles.filter((f) => !shouldExcludePathForPlugin(f.path, this.plugin));
+					// Filter out system folders and excluded files
+					const filteredFiles = uniqueFiles.filter((f) => !shouldExcludePathForPlugin(f.path, this.plugin));
 
-				if (filteredFiles.length === 0) {
-					if (uniqueFiles.length > 0) {
-						new Notice(t('agent.attachments.droppedExcluded'), 3000);
+					if (filteredFiles.length === 0) {
+						if (uniqueFiles.length > 0) {
+							new Notice(t('agent.attachments.droppedExcluded'), 3000);
+						}
+						return;
+					}
+
+					// Expand folders → collect all child TFiles recursively, pruning
+					// any subtree that lives inside the plugin state folder or `.obsidian`.
+					const allTFiles: TFile[] = [];
+					for (const file of filteredFiles) {
+						if (file instanceof TFolder) {
+							allTFiles.push(
+								...collectFilesFromFolder(file, {
+									prune: (item) => shouldExcludePathForPlugin(item.path, this.plugin),
+								})
+							);
+						} else if (file instanceof TFile) {
+							allTFiles.push(file);
+						}
+					}
+
+					// Deduplicate again after folder expansion
+					const dedupedFiles = [...new Map(allTFiles.map((f) => [f.path, f])).values()];
+
+					// Classify each file
+					const textFiles: TFile[] = [];
+					// Binary + SVG both inline as base64; SVG is rasterized to PNG first.
+					const binaryFiles: TFile[] = [];
+					const unsupportedExts: string[] = [];
+
+					for (const file of dedupedFiles) {
+						const result = classifyFile(file.extension);
+						switch (result.category) {
+							case FileCategory.TEXT:
+								textFiles.push(file);
+								break;
+							case FileCategory.GEMINI_BINARY:
+							case FileCategory.SVG:
+								binaryFiles.push(file);
+								break;
+							case FileCategory.UNSUPPORTED:
+								unsupportedExts.push(`.${file.extension}`);
+								break;
+						}
+					}
+
+					// Route text files → context chips
+					if (textFiles.length > 0) {
+						callbacks.handleDroppedFiles(textFiles);
+					}
+
+					// Route binary files → inline attachments
+					let binaryCount = 0;
+					let cumulativeSize = this.getCurrentAttachmentSize(callbacks);
+					const sizeLimitExceeded: string[] = [];
+
+					for (const file of binaryFiles) {
+						try {
+							const buffer = await this.app.vault.readBinary(file);
+							cumulativeSize += buffer.byteLength;
+
+							if (cumulativeSize > GEMINI_INLINE_DATA_LIMIT) {
+								sizeLimitExceeded.push(file.name);
+								cumulativeSize -= buffer.byteLength;
+								continue;
+							}
+
+							const classification = classifyFile(file.extension);
+							let base64: string;
+							let mimeType: string;
+							if (classification.category === FileCategory.SVG) {
+								// SVG can't be inlined directly — rasterize to PNG. On failure
+								// (malformed SVG, unresolvable refs), fall back to the
+								// unsupported-file notice rather than sending raw XML.
+								try {
+									base64 = await rasterizeSvg(buffer, file.extension.toLowerCase() === 'svgz');
+									mimeType = 'image/png';
+								} catch (rasterErr) {
+									this.plugin.logger.error(`Failed to rasterize SVG ${file.path}:`, rasterErr);
+									unsupportedExts.push(`.${file.extension}`);
+									cumulativeSize -= buffer.byteLength;
+									continue;
+								}
+							} else {
+								base64 = arrayBufferToBase64(buffer);
+								// For .webm files, detect audio vs video from container header
+								mimeType =
+									file.extension.toLowerCase() === 'webm' ? detectWebmMimeType(buffer) : classification.mimeType;
+							}
+							const attachment: InlineAttachment = {
+								base64,
+								mimeType,
+								id: generateAttachmentId(),
+								vaultPath: file.path,
+								fileName: file.name,
+							};
+							callbacks.addAttachment(attachment);
+							binaryCount++;
+						} catch (err) {
+							this.plugin.logger.error(`Failed to read binary file ${file.path}:`, err);
+							new Notice(t('agent.attachments.attachFailed', { name: file.name }));
+						}
+					}
+
+					// Show notices
+					const parts: string[] = [];
+					if (textFiles.length > 0) {
+						parts.push(
+							textFiles.length === 1
+								? t('agent.attachments.textFileAddedOne')
+								: t('agent.attachments.textFilesAdded', { count: textFiles.length })
+						);
+					}
+					if (binaryCount > 0) {
+						parts.push(
+							binaryCount === 1
+								? t('agent.attachments.fileAttachedOne')
+								: t('agent.attachments.filesAttached', { count: binaryCount })
+						);
+					}
+					if (parts.length > 0) {
+						new Notice(parts.join(', '), 3000);
+					}
+
+					if (sizeLimitExceeded.length > 0) {
+						new Notice(
+							sizeLimitExceeded.length === 1
+								? t('agent.attachments.skippedSizeOne', { files: sizeLimitExceeded.join(', ') })
+								: t('agent.attachments.skippedSize', {
+										count: sizeLimitExceeded.length,
+										files: sizeLimitExceeded.join(', '),
+									}),
+							5000
+						);
+					}
+
+					if (unsupportedExts.length > 0) {
+						const uniqueExts = [...new Set(unsupportedExts)];
+						new Notice(
+							uniqueExts.length === 1
+								? t('agent.attachments.skippedUnsupportedOne', { exts: uniqueExts.join(', ') })
+								: t('agent.attachments.skippedUnsupported', { exts: uniqueExts.join(', ') }),
+							4000
+						);
+					}
+
+					return;
+				}
+				// --- End Vault File Drops ---
+
+				// Non-vault drops: handle images from external sources (browser, desktop)
+				const files = e.dataTransfer?.files;
+				const fileArray = files?.length ? Array.from(files) : [];
+				const hasImages = fileArray.some((file) => isSupportedImageType(file.type) || this.isSvgFile(file));
+
+				// Only prevent default behavior if we have images to handle
+				if (!hasImages) {
+					const unsupportedImages = fileArray.filter(
+						(file) => file.type?.startsWith('image/') && !isSupportedImageType(file.type)
+					);
+					if (unsupportedImages.length > 0) {
+						new Notice(t('agent.attachments.unsupportedImageFormat'));
 					}
 					return;
 				}
 
-				// Expand folders → collect all child TFiles recursively, pruning
-				// any subtree that lives inside the plugin state folder or `.obsidian`.
-				const allTFiles: TFile[] = [];
-				for (const file of filteredFiles) {
-					if (file instanceof TFolder) {
-						allTFiles.push(
-							...collectFilesFromFolder(file, {
-								prune: (item) => shouldExcludePathForPlugin(item.path, this.plugin),
-							})
-						);
-					} else if (file instanceof TFile) {
-						allTFiles.push(file);
-					}
-				}
+				e.preventDefault();
+				e.stopPropagation();
 
-				// Deduplicate again after folder expansion
-				const dedupedFiles = [...new Map(allTFiles.map((f) => [f.path, f])).values()];
-
-				// Classify each file
-				const textFiles: TFile[] = [];
-				// Binary + SVG both inline as base64; SVG is rasterized to PNG first.
-				const binaryFiles: TFile[] = [];
-				const unsupportedExts: string[] = [];
-
-				for (const file of dedupedFiles) {
-					const result = classifyFile(file.extension);
-					switch (result.category) {
-						case FileCategory.TEXT:
-							textFiles.push(file);
-							break;
-						case FileCategory.GEMINI_BINARY:
-						case FileCategory.SVG:
-							binaryFiles.push(file);
-							break;
-						case FileCategory.UNSUPPORTED:
-							unsupportedExts.push(`.${file.extension}`);
-							break;
-					}
-				}
-
-				// Route text files → context chips
-				if (textFiles.length > 0) {
-					callbacks.handleDroppedFiles(textFiles);
-				}
-
-				// Route binary files → inline attachments
-				let binaryCount = 0;
+				// Process all supported images from non-vault sources
+				let imagesProcessed = 0;
+				let unsupportedCount = 0;
 				let cumulativeSize = this.getCurrentAttachmentSize(callbacks);
-				const sizeLimitExceeded: string[] = [];
-
-				for (const file of binaryFiles) {
-					try {
-						const buffer = await this.app.vault.readBinary(file);
-						cumulativeSize += buffer.byteLength;
-
-						if (cumulativeSize > GEMINI_INLINE_DATA_LIMIT) {
-							sizeLimitExceeded.push(file.name);
-							cumulativeSize -= buffer.byteLength;
-							continue;
-						}
-
-						const classification = classifyFile(file.extension);
-						let base64: string;
-						let mimeType: string;
-						if (classification.category === FileCategory.SVG) {
-							// SVG can't be inlined directly — rasterize to PNG. On failure
-							// (malformed SVG, unresolvable refs), fall back to the
-							// unsupported-file notice rather than sending raw XML.
-							try {
-								base64 = await rasterizeSvg(buffer, file.extension.toLowerCase() === 'svgz');
-								mimeType = 'image/png';
-							} catch (rasterErr) {
-								this.plugin.logger.error(`Failed to rasterize SVG ${file.path}:`, rasterErr);
-								unsupportedExts.push(`.${file.extension}`);
-								cumulativeSize -= buffer.byteLength;
-								continue;
-							}
-						} else {
-							base64 = arrayBufferToBase64(buffer);
-							// For .webm files, detect audio vs video from container header
-							mimeType = file.extension.toLowerCase() === 'webm' ? detectWebmMimeType(buffer) : classification.mimeType;
-						}
-						const attachment: InlineAttachment = {
-							base64,
-							mimeType,
-							id: generateAttachmentId(),
-							vaultPath: file.path,
-							fileName: file.name,
-						};
-						callbacks.addAttachment(attachment);
-						binaryCount++;
-					} catch (err) {
-						this.plugin.logger.error(`Failed to read binary file ${file.path}:`, err);
-						new Notice(t('agent.attachments.attachFailed', { name: file.name }));
-					}
-				}
-
-				// Show notices
-				const parts: string[] = [];
-				if (textFiles.length > 0) {
-					parts.push(
-						textFiles.length === 1
-							? t('agent.attachments.textFileAddedOne')
-							: t('agent.attachments.textFilesAdded', { count: textFiles.length })
-					);
-				}
-				if (binaryCount > 0) {
-					parts.push(
-						binaryCount === 1
-							? t('agent.attachments.fileAttachedOne')
-							: t('agent.attachments.filesAttached', { count: binaryCount })
-					);
-				}
-				if (parts.length > 0) {
-					new Notice(parts.join(', '), 3000);
-				}
-
-				if (sizeLimitExceeded.length > 0) {
-					new Notice(
-						sizeLimitExceeded.length === 1
-							? t('agent.attachments.skippedSizeOne', { files: sizeLimitExceeded.join(', ') })
-							: t('agent.attachments.skippedSize', {
-									count: sizeLimitExceeded.length,
-									files: sizeLimitExceeded.join(', '),
-								}),
-						5000
-					);
-				}
-
-				if (unsupportedExts.length > 0) {
-					const uniqueExts = [...new Set(unsupportedExts)];
-					new Notice(
-						uniqueExts.length === 1
-							? t('agent.attachments.skippedUnsupportedOne', { exts: uniqueExts.join(', ') })
-							: t('agent.attachments.skippedUnsupported', { exts: uniqueExts.join(', ') }),
-						4000
-					);
-				}
-
-				return;
-			}
-			// --- End Vault File Drops ---
-
-			// Non-vault drops: handle images from external sources (browser, desktop)
-			const files = e.dataTransfer?.files;
-			const fileArray = files?.length ? Array.from(files) : [];
-			const hasImages = fileArray.some((file) => isSupportedImageType(file.type) || this.isSvgFile(file));
-
-			// Only prevent default behavior if we have images to handle
-			if (!hasImages) {
-				const unsupportedImages = fileArray.filter(
-					(file) => file.type?.startsWith('image/') && !isSupportedImageType(file.type)
-				);
-				if (unsupportedImages.length > 0) {
-					new Notice(t('agent.attachments.unsupportedImageFormat'));
-				}
-				return;
-			}
-
-			e.preventDefault();
-			e.stopPropagation();
-
-			// Process all supported images from non-vault sources
-			let imagesProcessed = 0;
-			let unsupportedCount = 0;
-			let cumulativeSize = this.getCurrentAttachmentSize(callbacks);
-			for (const file of fileArray) {
-				if (isSupportedImageType(file.type)) {
-					if (cumulativeSize + file.size > GEMINI_INLINE_DATA_LIMIT) {
-						new Notice(t('agent.attachments.sizeLimitReached'));
-						break;
-					}
-					try {
-						const base64 = await fileToBase64(file);
-						const attachment: InlineAttachment = {
-							base64,
-							mimeType: getMimeType(file),
-							id: generateAttachmentId(),
-						};
-						callbacks.addAttachment(attachment);
-						cumulativeSize += file.size;
-						imagesProcessed++;
-					} catch (err) {
-						this.plugin.logger.error('Failed to process dropped image:', err);
-						new Notice(t('agent.attachments.imageAttachFailed'));
-					}
-				} else if (this.isSvgFile(file)) {
-					// External SVG/SVGZ — rasterize to PNG before inlining.
-					if (cumulativeSize + file.size > GEMINI_INLINE_DATA_LIMIT) {
-						new Notice(t('agent.attachments.sizeLimitReached'));
-						break;
-					}
-					if (await this.attachExternalSvgFile(file, callbacks)) {
-						cumulativeSize += file.size;
-						imagesProcessed++;
-					} else {
-						unsupportedCount++;
-					}
-				} else if (file.type.startsWith('image/')) {
-					unsupportedCount++;
-				}
-			}
-
-			if (imagesProcessed > 0) {
-				new Notice(
-					imagesProcessed === 1
-						? t('agent.attachments.imageAttachedOne')
-						: t('agent.attachments.imagesAttached', { count: imagesProcessed })
-				);
-			}
-			if (unsupportedCount > 0) {
-				new Notice(t('agent.attachments.imagesSkippedUnsupportedHint', { count: unsupportedCount }));
-			}
-		});
-
-		// Handle paste - check for images first, then text
-		userInput.addEventListener('paste', async (e) => {
-			// Check for image files in clipboard
-			let imagesProcessed = 0;
-			let unsupportedCount = 0;
-			if (e.clipboardData?.files?.length) {
-				let cumulativeSize = this.getCurrentAttachmentSize(callbacks);
-				for (const file of Array.from(e.clipboardData.files)) {
+				for (const file of fileArray) {
 					if (isSupportedImageType(file.type)) {
 						if (cumulativeSize + file.size > GEMINI_INLINE_DATA_LIMIT) {
 							new Notice(t('agent.attachments.sizeLimitReached'));
 							break;
-						}
-						// Prevent default once when we find the first image
-						if (imagesProcessed === 0) {
-							e.preventDefault();
 						}
 						try {
 							const base64 = await fileToBase64(file);
@@ -826,17 +770,14 @@ export class AgentViewUI {
 							cumulativeSize += file.size;
 							imagesProcessed++;
 						} catch (err) {
-							this.plugin.logger.error('Failed to process pasted image:', err);
+							this.plugin.logger.error('Failed to process dropped image:', err);
 							new Notice(t('agent.attachments.imageAttachFailed'));
 						}
 					} else if (this.isSvgFile(file)) {
-						// External SVG/SVGZ paste — rasterize to PNG before inlining.
+						// External SVG/SVGZ — rasterize to PNG before inlining.
 						if (cumulativeSize + file.size > GEMINI_INLINE_DATA_LIMIT) {
 							new Notice(t('agent.attachments.sizeLimitReached'));
 							break;
-						}
-						if (imagesProcessed === 0) {
-							e.preventDefault();
 						}
 						if (await this.attachExternalSvgFile(file, callbacks)) {
 							cumulativeSize += file.size;
@@ -848,84 +789,150 @@ export class AgentViewUI {
 						unsupportedCount++;
 					}
 				}
-			}
 
-			// Notify about unsupported formats
-			if (unsupportedCount > 0 && imagesProcessed === 0) {
-				new Notice(t('agent.attachments.unsupportedImageFormat'));
-			} else if (unsupportedCount > 0) {
-				new Notice(t('agent.attachments.imagesSkippedUnsupported', { count: unsupportedCount }));
-			}
-
-			// If images were processed, show notice and skip text handling
-			if (imagesProcessed > 0) {
-				new Notice(
-					imagesProcessed === 1
-						? t('agent.attachments.imageAttachedOne')
-						: t('agent.attachments.imagesAttached', { count: imagesProcessed })
-				);
-				return;
-			}
-
-			// No images found, handle as text paste
-			e.preventDefault();
-
-			let text = '';
-
-			// Method 1: Try standard clipboardData (works in main window)
-			if (e.clipboardData && e.clipboardData.getData) {
-				try {
-					text = e.clipboardData.getData('text/plain') || '';
-				} catch (err) {
-					// Clipboard access might fail in popout
-					this.plugin.logger.debug('Standard clipboard access failed:', err);
+				if (imagesProcessed > 0) {
+					new Notice(
+						imagesProcessed === 1
+							? t('agent.attachments.imageAttachedOne')
+							: t('agent.attachments.imagesAttached', { count: imagesProcessed })
+					);
 				}
-			}
+				if (unsupportedCount > 0) {
+					new Notice(t('agent.attachments.imagesSkippedUnsupportedHint', { count: unsupportedCount }));
+				}
+			})();
+		});
 
-			// Method 2: If no text yet, try the async Clipboard API
-			// This might work better in popout windows
-			if (!text && navigator.clipboard && navigator.clipboard.readText) {
-				try {
-					text = await navigator.clipboard.readText();
-				} catch (err) {
-					this.plugin.logger.debug('Async clipboard access failed:', err);
-
-					// Method 3: As last resort, get the selection and use execCommand
-					// This is a fallback that might help in some browsers
-					try {
-						// Focus the input first
-						userInput.focus();
-
-						// Try using execCommand as absolute fallback
-						// This will paste with formatting, but we'll clean it up after
-						execContextCommand(userInput, 'paste');
-
-						// Give it a moment to paste, then clean up formatting
-						window.setTimeout(() => {
-							// Get just the text content, removing all HTML
-							const plainText = userInput.innerText || userInput.textContent || '';
-
-							// Clear and set plain text
-							userInput.textContent = plainText;
-
-							// Move cursor to end
-							moveCursorToEnd(userInput);
-						}, 10);
-
-						return; // Exit early since we handled it with the timeout
-					} catch (execErr) {
-						this.plugin.logger.warn('All paste methods failed:', execErr);
-						// If all else fails, we can't paste
-						new Notice(t('agent.input.pasteFailed'));
-						return;
+		// Handle paste - check for images first, then text
+		userInput.addEventListener('paste', (e) => {
+			void (async () => {
+				// Check for image files in clipboard
+				let imagesProcessed = 0;
+				let unsupportedCount = 0;
+				if (e.clipboardData?.files?.length) {
+					let cumulativeSize = this.getCurrentAttachmentSize(callbacks);
+					for (const file of Array.from(e.clipboardData.files)) {
+						if (isSupportedImageType(file.type)) {
+							if (cumulativeSize + file.size > GEMINI_INLINE_DATA_LIMIT) {
+								new Notice(t('agent.attachments.sizeLimitReached'));
+								break;
+							}
+							// Prevent default once when we find the first image
+							if (imagesProcessed === 0) {
+								e.preventDefault();
+							}
+							try {
+								const base64 = await fileToBase64(file);
+								const attachment: InlineAttachment = {
+									base64,
+									mimeType: getMimeType(file),
+									id: generateAttachmentId(),
+								};
+								callbacks.addAttachment(attachment);
+								cumulativeSize += file.size;
+								imagesProcessed++;
+							} catch (err) {
+								this.plugin.logger.error('Failed to process pasted image:', err);
+								new Notice(t('agent.attachments.imageAttachFailed'));
+							}
+						} else if (this.isSvgFile(file)) {
+							// External SVG/SVGZ paste — rasterize to PNG before inlining.
+							if (cumulativeSize + file.size > GEMINI_INLINE_DATA_LIMIT) {
+								new Notice(t('agent.attachments.sizeLimitReached'));
+								break;
+							}
+							if (imagesProcessed === 0) {
+								e.preventDefault();
+							}
+							if (await this.attachExternalSvgFile(file, callbacks)) {
+								cumulativeSize += file.size;
+								imagesProcessed++;
+							} else {
+								unsupportedCount++;
+							}
+						} else if (file.type.startsWith('image/')) {
+							unsupportedCount++;
+						}
 					}
 				}
-			}
 
-			// If we got text, insert it
-			if (text) {
-				insertTextAtCursor(userInput, text);
-			}
+				// Notify about unsupported formats
+				if (unsupportedCount > 0 && imagesProcessed === 0) {
+					new Notice(t('agent.attachments.unsupportedImageFormat'));
+				} else if (unsupportedCount > 0) {
+					new Notice(t('agent.attachments.imagesSkippedUnsupported', { count: unsupportedCount }));
+				}
+
+				// If images were processed, show notice and skip text handling
+				if (imagesProcessed > 0) {
+					new Notice(
+						imagesProcessed === 1
+							? t('agent.attachments.imageAttachedOne')
+							: t('agent.attachments.imagesAttached', { count: imagesProcessed })
+					);
+					return;
+				}
+
+				// No images found, handle as text paste
+				e.preventDefault();
+
+				let text = '';
+
+				// Method 1: Try standard clipboardData (works in main window)
+				if (e.clipboardData && e.clipboardData.getData) {
+					try {
+						text = e.clipboardData.getData('text/plain') || '';
+					} catch (err) {
+						// Clipboard access might fail in popout
+						this.plugin.logger.debug('Standard clipboard access failed:', err);
+					}
+				}
+
+				// Method 2: If no text yet, try the async Clipboard API
+				// This might work better in popout windows
+				if (!text && navigator.clipboard && navigator.clipboard.readText) {
+					try {
+						text = await navigator.clipboard.readText();
+					} catch (err) {
+						this.plugin.logger.debug('Async clipboard access failed:', err);
+
+						// Method 3: As last resort, get the selection and use execCommand
+						// This is a fallback that might help in some browsers
+						try {
+							// Focus the input first
+							userInput.focus();
+
+							// Try using execCommand as absolute fallback
+							// This will paste with formatting, but we'll clean it up after
+							execContextCommand(userInput, 'paste');
+
+							// Give it a moment to paste, then clean up formatting
+							window.setTimeout(() => {
+								// Get just the text content, removing all HTML
+								const plainText = userInput.innerText || userInput.textContent || '';
+
+								// Clear and set plain text
+								userInput.textContent = plainText;
+
+								// Move cursor to end
+								moveCursorToEnd(userInput);
+							}, 10);
+
+							return; // Exit early since we handled it with the timeout
+						} catch (execErr) {
+							this.plugin.logger.warn('All paste methods failed:', execErr);
+							// If all else fails, we can't paste
+							new Notice(t('agent.input.pasteFailed'));
+							return;
+						}
+					}
+				}
+
+				// If we got text, insert it
+				if (text) {
+					insertTextAtCursor(userInput, text);
+				}
+			})();
 		});
 
 		sendButton.addEventListener('click', () => {

--- a/src/ui/agent-view/agent-view.ts
+++ b/src/ui/agent-view/agent-view.ts
@@ -519,8 +519,8 @@ export class AgentView extends ItemView {
 			this.app,
 			this.plugin,
 			{
-				onSelect: async (session: ChatSession) => {
-					await this.loadSession(session);
+				onSelect: (session: ChatSession) => {
+					void this.loadSession(session);
 				},
 				onDelete: (session: ChatSession) => {
 					// If the deleted session is the current one, create a new session
@@ -599,22 +599,24 @@ export class AgentView extends ItemView {
 			this.app,
 			this.plugin,
 			{
-				onSelect: async (project) => {
-					if (!this.currentSession) return;
+				onSelect: (project) => {
+					void (async () => {
+						if (!this.currentSession) return;
 
-					const previousProjectPath = this.currentSession.projectPath;
-					this.currentSession.projectPath = project?.filePath ?? undefined;
+						const previousProjectPath = this.currentSession.projectPath;
+						this.currentSession.projectPath = project?.filePath ?? undefined;
 
-					try {
-						await this.plugin.sessionHistory.updateSessionMetadata(this.currentSession);
-						this.updateSessionHeader();
-						this.plugin.logger.log(`Switched project to: ${project?.name ?? 'none'}`);
-					} catch (error) {
-						// Rollback on persistence failure
-						this.currentSession.projectPath = previousProjectPath;
-						this.updateSessionHeader();
-						this.plugin.logger.error('Failed to persist project change:', error);
-					}
+						try {
+							await this.plugin.sessionHistory.updateSessionMetadata(this.currentSession);
+							this.updateSessionHeader();
+							this.plugin.logger.log(`Switched project to: ${project?.name ?? 'none'}`);
+						} catch (error) {
+							// Rollback on persistence failure
+							this.currentSession.projectPath = previousProjectPath;
+							this.updateSessionHeader();
+							this.plugin.logger.error('Failed to persist project change:', error);
+						}
+					})();
 				},
 			},
 			this.currentSession.projectPath ?? null

--- a/src/ui/agent-view/session-list-modal.ts
+++ b/src/ui/agent-view/session-list-modal.ts
@@ -73,13 +73,15 @@ export class SessionListModal extends Modal {
 			text: t('agent.menu.newSession'),
 			cls: 'mod-cta',
 		});
-		newSessionBtn.addEventListener('click', async () => {
+		newSessionBtn.addEventListener('click', () => {
 			this.close();
-			// Create a new session by passing null
-			if (this.callbacks.onSelect) {
-				const newSession = await this.plugin.sessionManager.createAgentSession();
-				this.callbacks.onSelect(newSession);
-			}
+			void (async () => {
+				// Create a new session by passing null
+				if (this.callbacks.onSelect) {
+					const newSession = await this.plugin.sessionManager.createAgentSession();
+					this.callbacks.onSelect(newSession);
+				}
+			})();
 		});
 	}
 
@@ -236,11 +238,11 @@ export class SessionListModal extends Modal {
 				});
 				setIcon(deleteBtn, 'trash-2');
 
-				deleteBtn.addEventListener('click', async (e) => {
+				deleteBtn.addEventListener('click', (e) => {
 					e.stopPropagation();
 					// eslint-disable-next-line no-alert -- TODO: replace with Obsidian confirmation Modal
 					if (confirm(t('agent.sessionList.deleteConfirm', { title: session.title }))) {
-						await this.deleteSession(session);
+						void this.deleteSession(session);
 					}
 				});
 			}

--- a/src/ui/agent-view/session-settings-modal.ts
+++ b/src/ui/agent-view/session-settings-modal.ts
@@ -38,7 +38,11 @@ export class SessionSettingsModal extends Modal {
 			.setName(t('agent.sessionSettings.model'))
 			.setDesc(t('agent.sessionSettings.modelDesc'));
 
-		let modelDropdown: DropdownComponent;
+		// `| undefined` + an explicit `!== undefined` check below: Obsidian's
+		// BaseComponent exposes a builder-style `then()` method, which makes
+		// DropdownComponent structurally Promise-like, so a bare truthiness test
+		// trips @typescript-eslint/no-misused-promises.
+		let modelDropdown: DropdownComponent | undefined;
 		modelSetting
 			.addDropdown((dropdown: DropdownComponent) => {
 				modelDropdown = dropdown;
@@ -68,8 +72,8 @@ export class SessionSettingsModal extends Modal {
 				button
 					.setIcon('reset')
 					.setTooltip(t('agent.sessionSettings.resetToDefault'))
-					.onClick(async () => {
-						if (modelDropdown) {
+					.onClick(() => {
+						if (modelDropdown !== undefined) {
 							// Update the dropdown value
 							modelDropdown.setValue('__default__');
 							// Trigger the onChange handler by simulating a change event
@@ -180,7 +184,9 @@ export class SessionSettingsModal extends Modal {
 			.setName(t('agent.sessionSettings.promptTemplate'))
 			.setDesc(t('agent.sessionSettings.promptTemplateDesc'));
 
-		let promptDropdown: DropdownComponent;
+		// See modelDropdown above: `| undefined` + explicit `!== undefined` avoids a
+		// no-misused-promises false positive from BaseComponent's builder `then()`.
+		let promptDropdown: DropdownComponent | undefined;
 		promptSetting
 			.addDropdown((dropdown: DropdownComponent) => {
 				promptDropdown = dropdown;
@@ -220,8 +226,8 @@ export class SessionSettingsModal extends Modal {
 				button
 					.setIcon('reset')
 					.setTooltip(t('agent.sessionSettings.resetToDefault'))
-					.onClick(async () => {
-						if (promptDropdown) {
+					.onClick(() => {
+						if (promptDropdown !== undefined) {
 							// Update the dropdown value
 							promptDropdown.setValue('__default__');
 							// Trigger the onChange handler by simulating a change event

--- a/src/ui/catch-up-modal.ts
+++ b/src/ui/catch-up-modal.ts
@@ -45,38 +45,42 @@ export class CatchUpModal extends Modal {
 			cls: 'mod-cta',
 			attr: { type: 'button' },
 		});
-		runAllBtn.addEventListener('click', async () => {
-			runAllBtn.disabled = true;
-			skipAllBtn.disabled = true;
-			try {
-				await this.approveAll();
-				this.pending = [];
-				this.close();
-			} catch (err) {
-				this.plugin.logger.error('[CatchUpModal] Run all failed:', err);
-				new Notice(t('catchUp.runAllFailed'));
-				runAllBtn.disabled = false;
-				skipAllBtn.disabled = false;
-			}
+		runAllBtn.addEventListener('click', () => {
+			void (async () => {
+				runAllBtn.disabled = true;
+				skipAllBtn.disabled = true;
+				try {
+					await this.approveAll();
+					this.pending = [];
+					this.close();
+				} catch (err) {
+					this.plugin.logger.error('[CatchUpModal] Run all failed:', err);
+					new Notice(t('catchUp.runAllFailed'));
+					runAllBtn.disabled = false;
+					skipAllBtn.disabled = false;
+				}
+			})();
 		});
 
 		const skipAllBtn = actions.createEl('button', {
 			text: t('catchUp.skipAllButton'),
 			attr: { type: 'button' },
 		});
-		skipAllBtn.addEventListener('click', async () => {
-			runAllBtn.disabled = true;
-			skipAllBtn.disabled = true;
-			try {
-				await this.skipAll();
-				this.pending = [];
-				this.close();
-			} catch (err) {
-				this.plugin.logger.error('[CatchUpModal] Skip all failed:', err);
-				new Notice(t('catchUp.skipAllFailed'));
-				runAllBtn.disabled = false;
-				skipAllBtn.disabled = false;
-			}
+		skipAllBtn.addEventListener('click', () => {
+			void (async () => {
+				runAllBtn.disabled = true;
+				skipAllBtn.disabled = true;
+				try {
+					await this.skipAll();
+					this.pending = [];
+					this.close();
+				} catch (err) {
+					this.plugin.logger.error('[CatchUpModal] Skip all failed:', err);
+					new Notice(t('catchUp.skipAllFailed'));
+					runAllBtn.disabled = false;
+					skipAllBtn.disabled = false;
+				}
+			})();
 		});
 	}
 
@@ -118,46 +122,50 @@ export class CatchUpModal extends Modal {
 				cls: 'mod-cta gemini-catchup-approve',
 				attr: { type: 'button' },
 			});
-			approveBtn.addEventListener('click', async () => {
-				approveBtn.disabled = true;
-				skipBtn.disabled = true;
-				try {
-					await this.approveOne(entry);
-					this.pending = this.pending.filter((p) => p.task.slug !== entry.task.slug);
-					if (this.pending.length === 0) {
-						this.close();
-					} else {
-						this.renderList(list);
+			approveBtn.addEventListener('click', () => {
+				void (async () => {
+					approveBtn.disabled = true;
+					skipBtn.disabled = true;
+					try {
+						await this.approveOne(entry);
+						this.pending = this.pending.filter((p) => p.task.slug !== entry.task.slug);
+						if (this.pending.length === 0) {
+							this.close();
+						} else {
+							this.renderList(list);
+						}
+					} catch (err) {
+						this.plugin.logger.error(`[CatchUpModal] Failed to run "${entry.task.slug}":`, err);
+						new Notice(t('catchUp.runFailed', { slug: entry.task.slug }));
+						approveBtn.disabled = false;
+						skipBtn.disabled = false;
 					}
-				} catch (err) {
-					this.plugin.logger.error(`[CatchUpModal] Failed to run "${entry.task.slug}":`, err);
-					new Notice(t('catchUp.runFailed', { slug: entry.task.slug }));
-					approveBtn.disabled = false;
-					skipBtn.disabled = false;
-				}
+				})();
 			});
 
 			const skipBtn = btns.createEl('button', {
 				text: t('catchUp.skipButton'),
 				attr: { type: 'button' },
 			});
-			skipBtn.addEventListener('click', async () => {
-				approveBtn.disabled = true;
-				skipBtn.disabled = true;
-				try {
-					await this.skipOne(entry);
-					this.pending = this.pending.filter((p) => p.task.slug !== entry.task.slug);
-					if (this.pending.length === 0) {
-						this.close();
-					} else {
-						this.renderList(list);
+			skipBtn.addEventListener('click', () => {
+				void (async () => {
+					approveBtn.disabled = true;
+					skipBtn.disabled = true;
+					try {
+						await this.skipOne(entry);
+						this.pending = this.pending.filter((p) => p.task.slug !== entry.task.slug);
+						if (this.pending.length === 0) {
+							this.close();
+						} else {
+							this.renderList(list);
+						}
+					} catch (err) {
+						this.plugin.logger.error(`[CatchUpModal] Failed to skip "${entry.task.slug}":`, err);
+						new Notice(t('catchUp.skipFailed', { slug: entry.task.slug }));
+						approveBtn.disabled = false;
+						skipBtn.disabled = false;
 					}
-				} catch (err) {
-					this.plugin.logger.error(`[CatchUpModal] Failed to skip "${entry.task.slug}":`, err);
-					new Notice(t('catchUp.skipFailed', { slug: entry.task.slug }));
-					approveBtn.disabled = false;
-					skipBtn.disabled = false;
-				}
+				})();
 			});
 		}
 	}

--- a/src/ui/components/management-modal-base.ts
+++ b/src/ui/components/management-modal-base.ts
@@ -171,18 +171,20 @@ export abstract class ManagementModalBase<TEntity, TEntityState> extends Modal {
 			cls: 'gemini-scheduler-confirm-delete',
 			attr: { type: 'button' },
 		});
-		confirmBtn.addEventListener('click', async () => {
-			confirmBtn.disabled = true;
-			confirmBtn.setText(t('component.managementModalBase.deleting'));
-			try {
-				await this.deleteEntity(slug);
-				new Notice(t('component.managementModalBase.deleted', { label: this.capitalizedEntityLabel, slug }));
-				this.render();
-			} catch (err) {
-				this.plugin.logger.error(`[${this.constructor.name}] Delete failed for "${slug}":`, err);
-				new Notice(t('component.managementModalBase.deleteFailed', { slug }));
-				this.render();
-			}
+		confirmBtn.addEventListener('click', () => {
+			void (async () => {
+				confirmBtn.disabled = true;
+				confirmBtn.setText(t('component.managementModalBase.deleting'));
+				try {
+					await this.deleteEntity(slug);
+					new Notice(t('component.managementModalBase.deleted', { label: this.capitalizedEntityLabel, slug }));
+					this.render();
+				} catch (err) {
+					this.plugin.logger.error(`[${this.constructor.name}] Delete failed for "${slug}":`, err);
+					new Notice(t('component.managementModalBase.deleteFailed', { slug }));
+					this.render();
+				}
+			})();
 		});
 	}
 
@@ -250,7 +252,9 @@ export abstract class ManagementModalBase<TEntity, TEntityState> extends Modal {
 			cls: 'mod-cta',
 			attr: { type: 'button' },
 		});
-		saveBtn.addEventListener('click', () => this.handleSave(isEdit));
+		saveBtn.addEventListener('click', () => {
+			void this.handleSave(isEdit);
+		});
 
 		const cancelBtn = footer.createEl('button', {
 			text: t('component.managementModalBase.cancel'),

--- a/src/ui/explain-prompt-modal.ts
+++ b/src/ui/explain-prompt-modal.ts
@@ -10,9 +10,14 @@ import { t } from '../i18n';
 export class ExplainPromptSelectionModal extends SuggestModal<PromptInfo> {
 	private plugin: ObsidianGemini;
 	private prompts: PromptInfo[];
-	private onSelect: (prompt: CustomPrompt) => void;
+	private onSelect: (prompt: CustomPrompt) => void | Promise<void>;
 
-	constructor(app: App, plugin: ObsidianGemini, prompts: PromptInfo[], onSelect: (prompt: CustomPrompt) => void) {
+	constructor(
+		app: App,
+		plugin: ObsidianGemini,
+		prompts: PromptInfo[],
+		onSelect: (prompt: CustomPrompt) => void | Promise<void>
+	) {
 		super(app);
 		this.plugin = plugin;
 		this.prompts = prompts;
@@ -41,11 +46,17 @@ export class ExplainPromptSelectionModal extends SuggestModal<PromptInfo> {
 		}
 	}
 
-	async onChooseSuggestion(promptInfo: PromptInfo): Promise<void> {
+	onChooseSuggestion(promptInfo: PromptInfo): void {
+		// SuggestModal.onChooseSuggestion expects a void return; run the async
+		// prompt load as a fire-and-forget task.
+		void this.chooseSuggestion(promptInfo);
+	}
+
+	private async chooseSuggestion(promptInfo: PromptInfo): Promise<void> {
 		// Load the full prompt content
 		const prompt = await this.plugin.promptManager.loadPrompt(promptInfo.path);
 		if (prompt) {
-			this.onSelect(prompt);
+			await this.onSelect(prompt);
 		} else {
 			this.plugin.logger.error('Failed to load prompt:', promptInfo.path);
 		}

--- a/src/ui/hook-management-modal.ts
+++ b/src/ui/hook-management-modal.ts
@@ -153,18 +153,20 @@ export class HookManagementModal extends ManagementModalBase<Hook, HookState> {
 			cls: 'gemini-scheduler-action',
 			attr: { type: 'button' },
 		});
-		toggleBtn.addEventListener('click', async () => {
-			toggleBtn.disabled = true;
-			toggleBtn.setText('…');
-			try {
-				await this.plugin.hookManager?.toggleHook(hook.slug, !hook.enabled);
-				this.render();
-			} catch (err) {
-				this.plugin.logger.error(`[HookManagementModal] Toggle failed for "${hook.slug}":`, err);
-				new Notice(t('hooks.toggleFailed', { slug: hook.slug }));
-				toggleBtn.setText(isDisabled ? t('hooks.enableButton') : t('hooks.disableButton'));
-				toggleBtn.disabled = false;
-			}
+		toggleBtn.addEventListener('click', () => {
+			void (async () => {
+				toggleBtn.disabled = true;
+				toggleBtn.setText('…');
+				try {
+					await this.plugin.hookManager?.toggleHook(hook.slug, !hook.enabled);
+					this.render();
+				} catch (err) {
+					this.plugin.logger.error(`[HookManagementModal] Toggle failed for "${hook.slug}":`, err);
+					new Notice(t('hooks.toggleFailed', { slug: hook.slug }));
+					toggleBtn.setText(isDisabled ? t('hooks.enableButton') : t('hooks.disableButton'));
+					toggleBtn.disabled = false;
+				}
+			})();
 		});
 
 		if (isPaused) {
@@ -173,10 +175,12 @@ export class HookManagementModal extends ManagementModalBase<Hook, HookState> {
 				cls: 'gemini-scheduler-action',
 				attr: { type: 'button', title: t('hooks.resetTooltip') },
 			});
-			resetBtn.addEventListener('click', async () => {
-				resetBtn.disabled = true;
-				await this.plugin.hookManager?.resetHook(hook.slug);
-				this.render();
+			resetBtn.addEventListener('click', () => {
+				void (async () => {
+					resetBtn.disabled = true;
+					await this.plugin.hookManager?.resetHook(hook.slug);
+					this.render();
+				})();
 			});
 		}
 

--- a/src/ui/rag-status-modal.ts
+++ b/src/ui/rag-status-modal.ts
@@ -26,7 +26,7 @@ type TabId = 'overview' | 'files' | 'failures';
 export class RagStatusModal extends Modal {
 	private statusInfo: RagDetailedStatus;
 	private onOpenSettings: () => void;
-	private onReindex: () => void;
+	private onReindex: () => void | Promise<void>;
 	private onSyncNow: () => Promise<boolean>;
 
 	private activeTab: TabId = 'overview';
@@ -39,7 +39,7 @@ export class RagStatusModal extends Modal {
 		app: App,
 		statusInfo: RagDetailedStatus,
 		onOpenSettings: () => void,
-		onReindex: () => void,
+		onReindex: () => void | Promise<void>,
 		onSyncNow: () => Promise<boolean>
 	) {
 		super(app);
@@ -207,7 +207,7 @@ export class RagStatusModal extends Modal {
 					.setDisabled(isIndexing)
 					.onClick(() => {
 						this.close();
-						this.onReindex();
+						void this.onReindex();
 					})
 			)
 			.addButton((btn) =>

--- a/src/ui/scheduled-tasks-modal.ts
+++ b/src/ui/scheduled-tasks-modal.ts
@@ -107,11 +107,13 @@ export class ScheduledTasksModal extends Modal {
 				text: t('scheduledTasks.resetButton'),
 				cls: 'gemini-scheduled-task-reset',
 			});
-			resetBtn.addEventListener('click', async () => {
-				resetBtn.disabled = true;
-				resetBtn.setText(t('scheduledTasks.resetting'));
-				await this.plugin.scheduledTaskManager?.resetTask(task.slug);
-				this.onOpen(); // re-render
+			resetBtn.addEventListener('click', () => {
+				void (async () => {
+					resetBtn.disabled = true;
+					resetBtn.setText(t('scheduledTasks.resetting'));
+					await this.plugin.scheduledTaskManager?.resetTask(task.slug);
+					this.onOpen(); // re-render
+				})();
 			});
 		}
 
@@ -122,16 +124,18 @@ export class ScheduledTasksModal extends Modal {
 		});
 		if (isPaused || isDisabled) runBtn.disabled = true;
 
-		runBtn.addEventListener('click', async () => {
-			runBtn.disabled = true;
-			runBtn.setText(t('scheduledTasks.running'));
-			try {
-				await this.plugin.scheduledTaskManager?.runNow(task.slug);
-				runBtn.setText(t('scheduledTasks.submitted'));
-			} catch (error) {
-				runBtn.setText(t('scheduledTasks.runError'));
-				this.plugin.logger.error(`[ScheduledTasksModal] runNow failed for "${task.slug}":`, error);
-			}
+		runBtn.addEventListener('click', () => {
+			void (async () => {
+				runBtn.disabled = true;
+				runBtn.setText(t('scheduledTasks.running'));
+				try {
+					await this.plugin.scheduledTaskManager?.runNow(task.slug);
+					runBtn.setText(t('scheduledTasks.submitted'));
+				} catch (error) {
+					runBtn.setText(t('scheduledTasks.runError'));
+					this.plugin.logger.error(`[ScheduledTasksModal] runNow failed for "${task.slug}":`, error);
+				}
+			})();
 		});
 	}
 

--- a/src/ui/scheduler-management-modal.ts
+++ b/src/ui/scheduler-management-modal.ts
@@ -134,18 +134,20 @@ export class SchedulerManagementModal extends ManagementModalBase<ScheduledTask,
 			cls: 'gemini-scheduler-action',
 			attr: { type: 'button', title: isDisabled ? t('scheduler.enableTooltip') : t('scheduler.disableTooltip') },
 		});
-		toggleBtn.addEventListener('click', async () => {
-			toggleBtn.disabled = true;
-			toggleBtn.setText('…');
-			try {
-				await this.plugin.scheduledTaskManager?.updateTask(task.slug, { enabled: !task.enabled });
-				this.render();
-			} catch (err) {
-				this.plugin.logger.error(`[SchedulerManagementModal] Toggle failed for "${task.slug}":`, err);
-				new Notice(t('scheduler.toggleFailed', { slug: task.slug }));
-				toggleBtn.setText(isDisabled ? t('scheduler.enableButton') : t('scheduler.disableButton'));
-				toggleBtn.disabled = false;
-			}
+		toggleBtn.addEventListener('click', () => {
+			void (async () => {
+				toggleBtn.disabled = true;
+				toggleBtn.setText('…');
+				try {
+					await this.plugin.scheduledTaskManager?.updateTask(task.slug, { enabled: !task.enabled });
+					this.render();
+				} catch (err) {
+					this.plugin.logger.error(`[SchedulerManagementModal] Toggle failed for "${task.slug}":`, err);
+					new Notice(t('scheduler.toggleFailed', { slug: task.slug }));
+					toggleBtn.setText(isDisabled ? t('scheduler.enableButton') : t('scheduler.disableButton'));
+					toggleBtn.disabled = false;
+				}
+			})();
 		});
 
 		if (isPaused) {
@@ -154,10 +156,12 @@ export class SchedulerManagementModal extends ManagementModalBase<ScheduledTask,
 				cls: 'gemini-scheduler-action',
 				attr: { type: 'button', title: t('scheduler.resetTooltip') },
 			});
-			resetBtn.addEventListener('click', async () => {
-				resetBtn.disabled = true;
-				await this.plugin.scheduledTaskManager?.resetTask(task.slug);
-				this.render();
+			resetBtn.addEventListener('click', () => {
+				void (async () => {
+					resetBtn.disabled = true;
+					await this.plugin.scheduledTaskManager?.resetTask(task.slug);
+					this.render();
+				})();
 			});
 		}
 
@@ -168,18 +172,20 @@ export class SchedulerManagementModal extends ManagementModalBase<ScheduledTask,
 			attr: { type: 'button' },
 		});
 		if (isPaused || isDisabled) runBtn.disabled = true;
-		runBtn.addEventListener('click', async () => {
-			runBtn.disabled = true;
-			runBtn.setText(t('scheduler.running'));
-			try {
-				await this.plugin.scheduledTaskManager?.runNow(task.slug);
-				runBtn.setText(t('scheduler.submitted'));
-			} catch (err) {
-				this.plugin.logger.error(`[SchedulerManagementModal] runNow failed for "${task.slug}":`, err);
-				new Notice(t('scheduler.runFailed', { slug: task.slug }));
-				runBtn.disabled = false;
-				runBtn.setText(t('scheduler.runNowButton'));
-			}
+		runBtn.addEventListener('click', () => {
+			void (async () => {
+				runBtn.disabled = true;
+				runBtn.setText(t('scheduler.running'));
+				try {
+					await this.plugin.scheduledTaskManager?.runNow(task.slug);
+					runBtn.setText(t('scheduler.submitted'));
+				} catch (err) {
+					this.plugin.logger.error(`[SchedulerManagementModal] runNow failed for "${task.slug}":`, err);
+					new Notice(t('scheduler.runFailed', { slug: task.slug }));
+					runBtn.disabled = false;
+					runBtn.setText(t('scheduler.runNowButton'));
+				}
+			})();
 		});
 
 		// Edit

--- a/src/ui/selection-response-modal.ts
+++ b/src/ui/selection-response-modal.ts
@@ -242,10 +242,10 @@ export class SelectionResponseModal extends Modal {
  */
 export class AskQuestionModal extends Modal {
 	private questionInput!: HTMLTextAreaElement;
-	private onSubmit: (question: string) => void;
+	private onSubmit: (question: string) => void | Promise<void>;
 	private selectedText: string;
 
-	constructor(app: App, selectedText: string, onSubmit: (question: string) => void) {
+	constructor(app: App, selectedText: string, onSubmit: (question: string) => void | Promise<void>) {
 		super(app);
 		this.selectedText = selectedText;
 		this.onSubmit = onSubmit;
@@ -298,7 +298,7 @@ export class AskQuestionModal extends Modal {
 		const question = this.questionInput.value.trim();
 		if (question) {
 			this.close();
-			this.onSubmit(question);
+			void this.onSubmit(question);
 		}
 	}
 

--- a/src/ui/settings-agent-config.ts
+++ b/src/ui/settings-agent-config.ts
@@ -244,40 +244,42 @@ async function createTemperatureSetting(containerEl: HTMLElement, plugin: Obsidi
 
 					const runId = ++temperatureRunId;
 
-					temperatureDebounceTimer = window.setTimeout(async () => {
-						try {
-							// Validate the current value against model capabilities. Read from
-							// settings rather than the captured `value` so the validation always
-							// matches the most recent user input.
-							const validation = await modelManager.validateParameters(
-								plugin.settings.temperature,
-								plugin.settings.topP
-							);
+					temperatureDebounceTimer = window.setTimeout(() => {
+						void (async () => {
+							try {
+								// Validate the current value against model capabilities. Read from
+								// settings rather than the captured `value` so the validation always
+								// matches the most recent user input.
+								const validation = await modelManager.validateParameters(
+									plugin.settings.temperature,
+									plugin.settings.topP
+								);
 
-							// A newer slider change has superseded this run — discard the
-							// stale result instead of clobbering the current slider/value.
-							if (runId !== temperatureRunId) {
-								return;
-							}
-
-							if (!validation.temperature.isValid && validation.temperature.adjustedValue !== undefined) {
-								slider.setValue(validation.temperature.adjustedValue);
-								plugin.settings.temperature = validation.temperature.adjustedValue;
-								if (validation.temperature.warning) {
-									new Notice(validation.temperature.warning);
+								// A newer slider change has superseded this run — discard the
+								// stale result instead of clobbering the current slider/value.
+								if (runId !== temperatureRunId) {
+									return;
 								}
-							}
 
-							await plugin.saveSettings();
-						} catch (error) {
-							// If a newer run has superseded us, drop this stale failure silently —
-							// surfacing it would contradict whatever the current run is doing.
-							if (runId !== temperatureRunId) {
-								return;
+								if (!validation.temperature.isValid && validation.temperature.adjustedValue !== undefined) {
+									slider.setValue(validation.temperature.adjustedValue);
+									plugin.settings.temperature = validation.temperature.adjustedValue;
+									if (validation.temperature.warning) {
+										new Notice(validation.temperature.warning);
+									}
+								}
+
+								await plugin.saveSettings();
+							} catch (error) {
+								// If a newer run has superseded us, drop this stale failure silently —
+								// surfacing it would contradict whatever the current run is doing.
+								if (runId !== temperatureRunId) {
+									return;
+								}
+								plugin.logger.error('Failed to validate/save temperature setting:', error);
+								new Notice(t('settings.agentConfig.temperatureSaveFailedNotice'));
 							}
-							plugin.logger.error('Failed to validate/save temperature setting:', error);
-							new Notice(t('settings.agentConfig.temperatureSaveFailedNotice'));
-						}
+						})();
 					}, 300);
 				})
 		);
@@ -309,33 +311,35 @@ async function createTopPSetting(containerEl: HTMLElement, plugin: ObsidianGemin
 
 					const runId = ++topPRunId;
 
-					topPDebounceTimer = window.setTimeout(async () => {
-						try {
-							const validation = await modelManager.validateParameters(
-								plugin.settings.temperature,
-								plugin.settings.topP
-							);
+					topPDebounceTimer = window.setTimeout(() => {
+						void (async () => {
+							try {
+								const validation = await modelManager.validateParameters(
+									plugin.settings.temperature,
+									plugin.settings.topP
+								);
 
-							if (runId !== topPRunId) {
-								return;
-							}
-
-							if (!validation.topP.isValid && validation.topP.adjustedValue !== undefined) {
-								slider.setValue(validation.topP.adjustedValue);
-								plugin.settings.topP = validation.topP.adjustedValue;
-								if (validation.topP.warning) {
-									new Notice(validation.topP.warning);
+								if (runId !== topPRunId) {
+									return;
 								}
-							}
 
-							await plugin.saveSettings();
-						} catch (error) {
-							if (runId !== topPRunId) {
-								return;
+								if (!validation.topP.isValid && validation.topP.adjustedValue !== undefined) {
+									slider.setValue(validation.topP.adjustedValue);
+									plugin.settings.topP = validation.topP.adjustedValue;
+									if (validation.topP.warning) {
+										new Notice(validation.topP.warning);
+									}
+								}
+
+								await plugin.saveSettings();
+							} catch (error) {
+								if (runId !== topPRunId) {
+									return;
+								}
+								plugin.logger.error('Failed to validate/save topP setting:', error);
+								new Notice(t('settings.agentConfig.topPSaveFailedNotice'));
 							}
-							plugin.logger.error('Failed to validate/save topP setting:', error);
-							new Notice(t('settings.agentConfig.topPSaveFailedNotice'));
-						}
+						})();
 					}, 300);
 				})
 		);

--- a/src/ui/settings-helpers.ts
+++ b/src/ui/settings-helpers.ts
@@ -99,21 +99,23 @@ export function createCollapsibleSection(
 	content.classList.add('gemini-settings-section-content');
 	details.appendChild(content);
 
-	details.addEventListener('toggle', async () => {
-		const current = plugin.settings.expandedSettingsSections ?? [];
-		const next = details.open ? Array.from(new Set([...current, id])) : current.filter((x) => x !== id);
-		// Skip the save if nothing actually changed (e.g. a programmatic toggle that
-		// fires after setAttribute('open') without altering the user's persisted set).
-		if (next.length === current.length && next.every((x, i) => x === current[i])) return;
-		plugin.settings.expandedSettingsSections = next;
-		// Persist directly via saveData rather than saveSettings — this is UI-only
-		// state and shouldn't trigger plugin.saveSettings()'s lifecycle reconciliation
-		// (re-init on api-key/provider/RAG changes).
-		try {
-			await plugin.saveData(plugin.settings);
-		} catch (error) {
-			plugin.logger.error('Failed to save expandedSettingsSections:', error);
-		}
+	details.addEventListener('toggle', () => {
+		void (async () => {
+			const current = plugin.settings.expandedSettingsSections ?? [];
+			const next = details.open ? Array.from(new Set([...current, id])) : current.filter((x) => x !== id);
+			// Skip the save if nothing actually changed (e.g. a programmatic toggle that
+			// fires after setAttribute('open') without altering the user's persisted set).
+			if (next.length === current.length && next.every((x, i) => x === current[i])) return;
+			plugin.settings.expandedSettingsSections = next;
+			// Persist directly via saveData rather than saveSettings — this is UI-only
+			// state and shouldn't trigger plugin.saveSettings()'s lifecycle reconciliation
+			// (re-init on api-key/provider/RAG changes).
+			try {
+				await plugin.saveData(plugin.settings);
+			} catch (error) {
+				plugin.logger.error('Failed to save expandedSettingsSections:', error);
+			}
+		})();
 	});
 
 	return content;

--- a/src/ui/settings-rag.ts
+++ b/src/ui/settings-rag.ts
@@ -50,13 +50,15 @@ export async function renderRAGSettings(
 					// Show cleanup modal when disabling
 					try {
 						const { RagCleanupModal } = await import('./rag-cleanup-modal');
-						const modal = new RagCleanupModal(app, async (deleteData) => {
-							if (deleteData && plugin.ragIndexing) {
-								await plugin.ragIndexing.deleteFileSearchStore();
-							}
-							plugin.settings.ragIndexing.enabled = false;
-							await plugin.saveSettings();
-							context.redisplay();
+						const modal = new RagCleanupModal(app, (deleteData) => {
+							void (async () => {
+								if (deleteData && plugin.ragIndexing) {
+									await plugin.ragIndexing.deleteFileSearchStore();
+								}
+								plugin.settings.ragIndexing.enabled = false;
+								await plugin.saveSettings();
+								context.redisplay();
+							})();
 						});
 						modal.open();
 					} catch (error) {
@@ -127,22 +129,24 @@ export async function renderRAGSettings(
 						// Show confirmation modal
 						try {
 							const { RagCleanupModal } = await import('./rag-cleanup-modal');
-							const modal = new RagCleanupModal(app, async (deleteData) => {
-								if (deleteData && plugin.ragIndexing) {
-									button.setButtonText(t('settings.rag.deletingButton'));
-									button.setDisabled(true);
+							const modal = new RagCleanupModal(app, (deleteData) => {
+								void (async () => {
+									if (deleteData && plugin.ragIndexing) {
+										button.setButtonText(t('settings.rag.deletingButton'));
+										button.setDisabled(true);
 
-									try {
-										await plugin.ragIndexing.deleteFileSearchStore();
-										new Notice(t('settings.rag.indexDeletedNotice'));
-										context.redisplay();
-									} catch (error) {
-										new Notice(t('settings.rag.deleteIndexFailed', { error: getErrorMessage(error) }));
-									} finally {
-										button.setButtonText(t('settings.rag.deleteIndexButton'));
-										button.setDisabled(false);
+										try {
+											await plugin.ragIndexing.deleteFileSearchStore();
+											new Notice(t('settings.rag.indexDeletedNotice'));
+											context.redisplay();
+										} catch (error) {
+											new Notice(t('settings.rag.deleteIndexFailed', { error: getErrorMessage(error) }));
+										} finally {
+											button.setButtonText(t('settings.rag.deleteIndexButton'));
+											button.setDisabled(false);
+										}
 									}
-								}
+								})();
 							});
 							modal.open();
 						} catch (error) {

--- a/src/ui/settings.ts
+++ b/src/ui/settings.ts
@@ -28,7 +28,14 @@ export default class ObsidianGeminiSettingTab extends PluginSettingTab {
 		this.plugin = plugin;
 	}
 
-	async display(): Promise<void> {
+	// PluginSettingTab.display() must return void; delegate the async rendering
+	// to a fire-and-forget helper. The redisplay callback below also calls the
+	// void-returning display(), matching the void-typed `redisplay` contract.
+	display(): void {
+		void this.renderSettings();
+	}
+
+	private async renderSettings(): Promise<void> {
 		// Each call claims a fresh token; concurrent calls (e.g. Obsidian opening
 		// the tab while a redisplay() is mid-await) compare against this and bail
 		// out before re-appending into the now-cleared container.

--- a/test/agent/session-manager.test.ts
+++ b/test/agent/session-manager.test.ts
@@ -376,7 +376,7 @@ describe('SessionManager', () => {
 			vi.spyOn(sessionManager as any, 'getAgentSessionsFolder').mockReturnValue(mockFolder);
 
 			// Mock loadSessionFromFile to return mock sessions
-			vi.spyOn(sessionManager as any, 'loadSessionFromFile').mockImplementation(async (...args: unknown[]) =>
+			vi.spyOn(sessionManager as any, 'loadSessionFromFile').mockImplementation((...args: unknown[]) =>
 				createMockSession(args[0] as TFile)
 			);
 		});
@@ -425,9 +425,11 @@ describe('SessionManager', () => {
 
 		it('should handle errors loading individual sessions gracefully', async () => {
 			// Override mock to throw for one file, reuse createMockSession for others
-			vi.spyOn(sessionManager as any, 'loadSessionFromFile').mockImplementation(async (...args: unknown[]) => {
+			vi.spyOn(sessionManager as any, 'loadSessionFromFile').mockImplementation((...args: unknown[]) => {
 				const file = args[0] as TFile;
 				if (file.basename === 'session2') {
+					// Synchronous throw is caught by the consumer's try/catch the same
+					// way a rejected promise would be — and keeps the mock void-returning.
 					throw new Error('Failed to load session');
 				}
 				return createMockSession(file);

--- a/test/ui/settings-display-race.test.ts
+++ b/test/ui/settings-display-race.test.ts
@@ -109,6 +109,13 @@ vi.mock('obsidian', () => {
 
 import ObsidianGeminiSettingTab from '../../src/ui/settings';
 
+// `display()` returns void (it must, to satisfy PluginSettingTab's void-typed
+// override); the awaitable rendering — including the token-based race guard —
+// lives in the private `renderSettings()`, which `display()` kicks off
+// fire-and-forget. Tests reach it directly to observe render completion.
+const invokeRender = (tab: ObsidianGeminiSettingTab): Promise<void> =>
+	(tab as unknown as { renderSettings(): Promise<void> }).renderSettings();
+
 describe('ObsidianGeminiSettingTab.display() concurrent-call guard', () => {
 	beforeEach(() => {
 		generalCalls = 0;
@@ -134,7 +141,7 @@ describe('ObsidianGeminiSettingTab.display() concurrent-call guard', () => {
 
 		// Kick off the first render — it will block inside renderGeneralSettings
 		// until we resolve the gate. Don't await yet.
-		const first = tab.display();
+		const first = invokeRender(tab);
 		// Yield so renderGeneralSettings starts and bumps generalCalls.
 		await Promise.resolve();
 		expect(generalCalls).toBe(1);
@@ -146,7 +153,7 @@ describe('ObsidianGeminiSettingTab.display() concurrent-call guard', () => {
 		// arrives. With the token guard, the first render must abort after the
 		// gate resolves and the second render owns the container.
 		gate = null; // second render does not block
-		const second = tab.display();
+		const second = invokeRender(tab);
 
 		// Release the first render. With the guard, it should bail out before
 		// running renderUISettings / renderContextSettings.
@@ -167,7 +174,7 @@ describe('ObsidianGeminiSettingTab.display() concurrent-call guard', () => {
 		const plugin = { settings: { debugMode: false }, saveSettings: vi.fn() };
 		const tab = new ObsidianGeminiSettingTab({} as never, plugin as never);
 
-		await tab.display();
+		await invokeRender(tab);
 
 		expect(generalCalls).toBe(1);
 		expect(uiCalls).toBe(1);


### PR DESCRIPTION
<!-- auto-dev -->

## Summary

Re-enables `@typescript-eslint/no-misused-promises` (previously softened off) after clearing all 53 violations. Part of the strict-typing pass tracked in #1032. These were async functions passed where a `void` return is expected — DOM/Obsidian event handlers, lifecycle callbacks, and modal callbacks — where the returned promise was implicitly discarded.

This PR was produced by the auto-dev pipeline from the approved plan on the issue.

Fixes #1038

## Changes

- **`eslint.config.mjs`** — flip `no-misused-promises` from `off` to `error` (with the `#1038: cleared` marker matching sibling rules).
- **Void-return callbacks** — async handlers passed to `addEventListener`, `.onClick`, `setTimeout`, and our modal constructors are made synchronous, running the async work as a fire-and-forget task: inline `void call()` for single calls, a `void (async () => {…})()` wrapper for multi-statement bodies.
- **Lifecycle overrides** — `PluginSettingTab.display()` and `SuggestModal.onChooseSuggestion` are now void-returning and delegate to a private async helper (`renderSettings()` / `chooseSuggestion()`).
- **Redundant async** — fully-synchronous `onClick` handlers in `session-settings-modal` just drop the `async` keyword.
- **Widened our own callback types** — `ExplainPromptSelectionModal`, `AskQuestionModal`, and `RagStatusModal` callback params are now `() => void | Promise<void>` so genuinely-async handlers stay awaitable (their call sites `void`/`await` as appropriate). This keeps the behavior tests assert on intact.
- **`session-settings-modal`** — dropdown guards use `!== undefined` instead of a bare truthiness test: Obsidian's `BaseComponent` exposes a builder-style `then()`, which makes `DropdownComponent` structurally Promise-like and trips the rule on `if (dropdown)`.
- **`rag-vault-scanner` `onProgress`** — keeps its async signature via a scoped inline disable with justification: the external `ProgressCallback` type is `(event) => void`, but the handler awaits per-file hashing/cache saves and *throws* to signal cancellation and rate-limit cooldown, which callers await and rely on propagating.

## Screenshots / Screencast

N/A — internal lint/typing refactor with no user-visible behavior change.

## Checklist

### Required

- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — plus `npm run lint` and `npm run typecheck:test`
- [ ] I have tested this change on Desktop
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards)
- [x] Documentation has been updated (if applicable) — N/A, no user-facing change

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude (auto-dev pipeline)
- [x] I have reviewed and understand all AI-generated code in this PR

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CTuuP8cFkMDJwmG9TVKQVs

---
_Generated by [Claude Code](https://claude.ai/code/session_01CTuuP8cFkMDJwmG9TVKQVs)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved session, project, and prompt workflows with smoother, non-blocking dialogs and actions.
  * Added more responsive handling for drag-and-drop, paste, copy, and attachment-related interactions in the chat view.
  * Enhanced settings and RAG management flows with clearer update behavior and better modal handling.

* **Bug Fixes**
  * Fixed several UI actions so they complete reliably without freezing or blocking the interface.
  * Improved error handling and feedback for background tasks, indexing, deletion, and file creation.

* **Tests**
  * Updated automated coverage for session loading and settings rendering race conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->