### PR TITLE
refactor: split scheduled-task-manager into a scheduled-tasks/ package

### DIFF
--- a/src/services/scheduled-task-manager.ts
+++ b/src/services/scheduled-task-manager.ts
@@ -12,6 +12,15 @@ import {
 	resolveFeatureToolPolicy,
 } from './feature-definition';
 import { FailurePauseTracker, MAX_CONSECUTIVE_FAILURES } from './failure-pause-tracker';
+import { computeNextRunAt } from './scheduled-tasks/schedule';
+import { detectMissedRuns as detectMissedRunsInWindow } from './scheduled-tasks/missed-runs';
+import { submitTask as submitTaskDispatch, type ExecutionDeps } from './scheduled-tasks/execution';
+import type { PendingCatchUp, ScheduledTask, ScheduledTasksState, TaskState } from './scheduled-tasks/types';
+
+// Re-export the task types and the pure schedule helper from their new module
+// homes so existing import paths (`from '.../scheduled-task-manager'`) keep working.
+export type { PendingCatchUp, ScheduledTask, ScheduledTasksState, TaskState } from './scheduled-tasks/types';
+export { computeNextRunAt } from './scheduled-tasks/schedule';
 
 // ─── Folder / file layout ─────────────────────────────────────────────────────
 
@@ -21,227 +30,6 @@ const STATE_FILE = 'scheduled-tasks-state.json';
 
 /** Milliseconds between scheduler ticks (60 s). Same cadence as ChatTimer. */
 const TICK_INTERVAL_MS = 60_000;
-
-// ─── Public types ─────────────────────────────────────────────────────────────
-
-/**
- * A scheduled task definition parsed from a markdown file.
- * The file lives at {historyFolder}/Scheduled-Tasks/<slug>.md.
- * Frontmatter controls scheduling; the file body is the prompt text.
- */
-export interface ScheduledTask {
-	/** Derived from the file basename (no extension). */
-	slug: string;
-	/**
-	 * Schedule string. Supported values:
-	 *   once               — run exactly once, then the task is considered exhausted
-	 *   daily              — every 24 h from creation
-	 *   daily@HH:MM        — every day at the given local time (e.g. daily@16:30)
-	 *   weekly             — every 7 d from creation
-	 *   weekly@HH:MM:DAYS  — at the given local time on the listed weekdays
-	 *                        (DAYS is comma-separated, e.g. weekly@16:30:mon,tue,wed)
-	 *   interval:Xm        — every X minutes (e.g. interval:30m)
-	 *   interval:Xh        — every X hours   (e.g. interval:2h)
-	 */
-	schedule: string;
-	/**
-	 * Tool policy applied for the duration of each run. Layered on top of the
-	 * global plugin policy via FeatureToolPolicy. Undefined means inherit the
-	 * global policy.
-	 */
-	toolPolicy?: FeatureToolPolicy;
-	/**
-	 * Output path template. Supports {slug} and {date} placeholders.
-	 * Default: Scheduled-Tasks/Runs/{slug}/{date}.md
-	 */
-	outputPath: string;
-	/**
-	 * Model override for this task (e.g. 'gemini-2.0-flash').
-	 * Defaults to the plugin's chat model when omitted.
-	 */
-	model?: string;
-	/**
-	 * Cap on agent tool-execution iterations for this run. Each iteration is one
-	 * tool-call batch, not a single tool call. Omitted means use
-	 * DEFAULT_HEADLESS_MAX_ITERATIONS. Raise this for long multi-step tasks that
-	 * legitimately need more than the default before producing a final response.
-	 */
-	maxIterations?: number;
-	/** When false the scheduler skips this task entirely. Default: true. */
-	enabled: boolean;
-	/**
-	 * When true and the task missed its window (plugin was offline), run once
-	 * immediately on the next tick instead of skipping the missed run.
-	 * Default: false.
-	 */
-	runIfMissed: boolean;
-	/** Prompt text — the file body after the closing frontmatter delimiter. */
-	prompt: string;
-	/** Vault path of the task definition file. */
-	filePath: string;
-}
-
-/** Per-task volatile runtime state stored in the sidecar JSON. */
-export interface TaskState {
-	/** ISO-8601 date string for the next scheduled run. */
-	nextRunAt: string;
-	/** ISO-8601 date string for the last successful run, if any. */
-	lastRunAt?: string;
-	/** Error message from the most recent failed run, if any. */
-	lastError?: string;
-	/** Number of consecutive failures since the last success. */
-	consecutiveFailures?: number;
-	/**
-	 * When true the scheduler skips this task until the user manually resets it.
-	 * Set automatically after MAX_CONSECUTIVE_FAILURES failures in a row.
-	 */
-	pausedDueToErrors?: boolean;
-}
-
-/** The full sidecar state file — a map of slug → TaskState. */
-export type ScheduledTasksState = Record<string, TaskState>;
-
-/** A single missed-run entry returned by detectMissedRuns(). */
-export interface PendingCatchUp {
-	task: ScheduledTask;
-	/** The nextRunAt instant that was missed. */
-	missedAt: Date;
-}
-
-// ─── Pure helper ─────────────────────────────────────────────────────────────
-
-// Day-of-week codes accepted in `weekly@HH:MM:DAYS` schedules. Order matches
-// JS Date.getDay() so the array index doubles as the weekday number.
-const WEEKDAY_CODES = ['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat'] as const;
-type WeekdayCode = (typeof WEEKDAY_CODES)[number];
-
-/**
- * Compute the next run time given a schedule string and a reference instant.
- * Pure function — no I/O — safe to unit-test in isolation.
- *
- * @throws {Error} if the schedule string is not recognised
- */
-export function computeNextRunAt(schedule: string, from: Date): Date {
-	switch (schedule) {
-		case 'once':
-			// Far-future sentinel: task has run once and should not fire again
-			return new Date(8640000000000000);
-		case 'daily':
-			return new Date(from.getTime() + 24 * 60 * 60 * 1000);
-		case 'weekly':
-			return new Date(from.getTime() + 7 * 24 * 60 * 60 * 1000);
-		default: {
-			if (schedule.startsWith('interval:')) {
-				const spec = schedule.slice('interval:'.length);
-				const match = /^(\d+)(m|h)$/.exec(spec);
-				if (!match) {
-					throw new Error(`Invalid interval schedule: "${schedule}". Expected format: interval:Xm or interval:Xh`);
-				}
-				const value = parseInt(match[1], 10);
-				if (value <= 0) {
-					throw new Error(`Invalid interval schedule: "${schedule}". Interval must be greater than zero`);
-				}
-				const ms = match[2] === 'h' ? value * 60 * 60 * 1000 : value * 60 * 1000;
-				return new Date(from.getTime() + ms);
-			}
-			if (schedule.startsWith('daily@')) {
-				const { hour, minute } = parseHourMinute(schedule, schedule.slice('daily@'.length));
-				return nextOccurrenceAtTime(from, hour, minute);
-			}
-			if (schedule.startsWith('weekly@')) {
-				const rest = schedule.slice('weekly@'.length).toLowerCase();
-				const match = /^(\d{1,2}:\d{2}):(.+)$/.exec(rest);
-				if (!match) {
-					throw new Error(
-						`Invalid weekly schedule: "${schedule}". Expected format: weekly@HH:MM:days (e.g. weekly@16:30:mon,tue,wed)`
-					);
-				}
-				const { hour, minute } = parseHourMinute(schedule, match[1]);
-				const allowedDays = parseWeekdayList(schedule, match[2]);
-				return nextOccurrenceOnAllowedDay(from, hour, minute, allowedDays);
-			}
-			throw new Error(
-				`Unknown schedule type: "${schedule}". Expected: once, daily, weekly, interval:Xm, interval:Xh, daily@HH:MM, weekly@HH:MM:days`
-			);
-		}
-	}
-}
-
-/**
- * Parse a `HH:MM` time component out of a `daily@…` or `weekly@…` schedule
- * and validate that hour/minute are in range. The full schedule string is
- * passed in only so the error messages can quote the offending value.
- */
-function parseHourMinute(schedule: string, time: string): { hour: number; minute: number } {
-	const match = /^(\d{1,2}):(\d{2})$/.exec(time);
-	if (!match) {
-		throw new Error(`Invalid schedule time in "${schedule}". Expected HH:MM (24-hour, e.g. 16:30)`);
-	}
-	const hour = parseInt(match[1], 10);
-	const minute = parseInt(match[2], 10);
-	if (hour < 0 || hour > 23 || minute < 0 || minute > 59) {
-		throw new Error(`Invalid schedule time in "${schedule}". Hour must be 0-23 and minute must be 0-59`);
-	}
-	return { hour, minute };
-}
-
-/**
- * Parse the comma-separated weekday list from a `weekly@HH:MM:days` schedule
- * into a Set of weekday numbers (0 = Sunday … 6 = Saturday). Empty lists,
- * unknown codes, and stray separators are all rejected.
- */
-function parseWeekdayList(schedule: string, days: string): Set<number> {
-	const tokens = days.split(',').map((d) => d.trim());
-	if (tokens.some((t) => t.length === 0)) {
-		throw new Error(`Invalid weekly schedule "${schedule}": days list contains empty entries`);
-	}
-	const result = new Set<number>();
-	for (const token of tokens) {
-		const idx = WEEKDAY_CODES.indexOf(token as WeekdayCode);
-		if (idx === -1) {
-			throw new Error(`Invalid weekday "${token}" in "${schedule}". Expected one of: ${WEEKDAY_CODES.join(', ')}`);
-		}
-		result.add(idx);
-	}
-	return result;
-}
-
-/**
- * Return the next Date strictly after `from` whose local time is `hour:minute`.
- * Today's slot is preferred when it's still in the future; otherwise tomorrow's.
- */
-function nextOccurrenceAtTime(from: Date, hour: number, minute: number): Date {
-	const candidate = new Date(from);
-	candidate.setHours(hour, minute, 0, 0);
-	if (candidate.getTime() > from.getTime()) return candidate;
-	candidate.setDate(candidate.getDate() + 1);
-	return candidate;
-}
-
-/**
- * Return the next Date strictly after `from` whose local time is `hour:minute`
- * AND whose weekday is in `allowedDays`. The set is non-empty (validated by
- * the caller), so the search terminates within 8 days: each weekday-and-time
- * pair is checked once over the next 7 days, plus a final wrap-around for the
- * case where today's allowed slot has already passed and no later day in the
- * week qualifies.
- */
-function nextOccurrenceOnAllowedDay(from: Date, hour: number, minute: number, allowedDays: Set<number>): Date {
-	for (let offset = 0; offset <= 7; offset++) {
-		const candidate = new Date(from);
-		candidate.setDate(candidate.getDate() + offset);
-		candidate.setHours(hour, minute, 0, 0);
-		if (allowedDays.has(candidate.getDay()) && candidate.getTime() > from.getTime()) {
-			return candidate;
-		}
-	}
-	// Unreachable: with a non-empty allowedDays set, one of the 8 candidates
-	// above always matches. Throw rather than return a wrong value if the
-	// invariant ever breaks.
-	throw new Error(
-		`Internal error: failed to compute next run for weekly schedule (allowedDays=${[...allowedDays].join(',')})`
-	);
-}
 
 // ─── Manager ─────────────────────────────────────────────────────────────────
 
@@ -285,6 +73,8 @@ export class ScheduledTaskManager {
 	private readonly stateStore: JsonSidecarStateStore<ScheduledTasksState>;
 	/** Shared auto-pause-after-N-failures ladder over the per-task sidecar state. */
 	private readonly failureTracker: FailurePauseTracker<TaskState>;
+	/** Dependencies handed to the execution-dispatch module (submit/execute/advance). */
+	private readonly execDeps: ExecutionDeps;
 
 	constructor(private plugin: ObsidianGemini) {
 		this.stateStore = new JsonSidecarStateStore<ScheduledTasksState>(
@@ -302,6 +92,15 @@ export class ScheduledTaskManager {
 			label: '[ScheduledTaskManager]',
 			entityNoun: 'Task',
 		});
+		this.execDeps = {
+			plugin: this.plugin,
+			tasks: this.tasks,
+			submitting: this.submitting,
+			failureTracker: this.failureTracker,
+			// `state` is reassigned on load, so read it lazily rather than capturing it.
+			getState: () => this.state,
+			saveState: () => this.saveState(),
+		};
 	}
 
 	// ── Folder path helpers ──────────────────────────────────────────────────
@@ -490,7 +289,7 @@ export class ScheduledTaskManager {
 			if (now < nextRunAt) continue;
 
 			this.plugin.logger.log(`[ScheduledTaskManager] Task "${task.slug}" is due — submitting`);
-			await this.submitTask(task, now);
+			await submitTaskDispatch(this.execDeps, task, now);
 		}
 	}
 
@@ -502,7 +301,7 @@ export class ScheduledTaskManager {
 		const task = this.tasks.get(slug);
 		if (!task) throw new Error(`Scheduled task "${slug}" not found`);
 		this.catchUpPending.delete(slug);
-		return this.submitTask(task, new Date());
+		return submitTaskDispatch(this.execDeps, task, new Date());
 	}
 
 	/** Returns a snapshot of all known task definitions. */
@@ -654,26 +453,7 @@ export class ScheduledTaskManager {
 	 *                  excluded — they missed their window entirely.
 	 */
 	detectMissedRuns(windowMs = 7 * 24 * 60 * 60 * 1000): PendingCatchUp[] {
-		const now = new Date();
-		const cutoff = new Date(now.getTime() - windowMs);
-		const result: PendingCatchUp[] = [];
-
-		for (const task of this.tasks.values()) {
-			if (!task.enabled || !task.runIfMissed) continue;
-			if (task.schedule === 'once') continue;
-
-			const taskState = this.state[task.slug];
-			if (!taskState) continue;
-			if (taskState.pausedDueToErrors) continue;
-
-			const nextRunAt = new Date(taskState.nextRunAt);
-			// Due in the past AND within the catch-up window
-			if (nextRunAt < now && nextRunAt >= cutoff) {
-				result.push({ task, missedAt: nextRunAt });
-			}
-		}
-
-		return result;
+		return detectMissedRunsInWindow(this.tasks.values(), this.state, new Date(), windowMs);
 	}
 
 	/**
@@ -735,69 +515,6 @@ export class ScheduledTaskManager {
 	}
 
 	// ── Private ──────────────────────────────────────────────────────────────
-
-	private async submitTask(task: ScheduledTask, triggeredAt: Date): Promise<string> {
-		if (this.submitting.has(task.slug)) {
-			throw new Error(`[ScheduledTaskManager] Task "${task.slug}" is already being submitted`);
-		}
-		this.submitting.add(task.slug);
-
-		try {
-			const bgManager = this.plugin.backgroundTaskManager;
-			if (!bgManager) {
-				throw new Error('[ScheduledTaskManager] BackgroundTaskManager not available');
-			}
-
-			// Advance nextRunAt immediately — prevents re-firing on the next tick even
-			// if the background execution takes longer than 60 s or fails.
-			await this.advanceState(task.slug, triggeredAt);
-
-			const taskId = bgManager.submit(`scheduled-task`, task.slug, async (isCancelled) => {
-				try {
-					return await this.executeTask(task, isCancelled);
-				} finally {
-					// Guard is held for the full background run duration to prevent
-					// a concurrent tick or runNow from double-submitting the same slug.
-					this.submitting.delete(task.slug);
-				}
-			});
-
-			return taskId;
-		} catch (error) {
-			this.submitting.delete(task.slug);
-			throw error;
-		}
-	}
-
-	private async executeTask(task: ScheduledTask, isCancelled: () => boolean): Promise<string | undefined> {
-		try {
-			const { ScheduledTaskRunner } = await import('./scheduled-task-runner');
-			const runner = new ScheduledTaskRunner(this.plugin, task);
-			const outputPath = await runner.run(isCancelled);
-
-			// undefined means the run was cancelled — don't record as a successful
-			// completion so lastRunAt only reflects genuine completions.
-			if (outputPath !== undefined) {
-				await this.failureTracker.recordSuccess(task.slug, { lastRunAt: new Date().toISOString() });
-			}
-			return outputPath;
-		} catch (error) {
-			await this.failureTracker.recordFailure(task.slug, error);
-			throw error;
-		}
-	}
-
-	private async advanceState(slug: string, from: Date): Promise<void> {
-		const task = this.tasks.get(slug);
-		if (!task) return;
-
-		const nextRunAt = computeNextRunAt(task.schedule, from);
-		this.state[slug] = {
-			...this.state[slug],
-			nextRunAt: nextRunAt.toISOString(),
-		};
-		await this.saveState();
-	}
 
 	private async discoverTasks(): Promise<void> {
 		this.tasks.clear();

--- a/src/services/scheduled-tasks/execution.ts
+++ b/src/services/scheduled-tasks/execution.ts
@@ -29,7 +29,7 @@ export interface ExecutionDeps {
  * slow or failed run can't re-fire on the next tick) and by the catch-up
  * "Skip" action indirectly. No-op when the slug is unknown.
  */
-export async function advanceState(deps: ExecutionDeps, slug: string, from: Date): Promise<void> {
+async function advanceState(deps: ExecutionDeps, slug: string, from: Date): Promise<void> {
 	const task = deps.tasks.get(slug);
 	if (!task) return;
 
@@ -47,7 +47,7 @@ export async function advanceState(deps: ExecutionDeps, slug: string, from: Date
  * shared failure tracker. Returns the output path, or `undefined` when the run
  * was cancelled (which is deliberately not recorded as a success).
  */
-export async function executeTask(
+async function executeTask(
 	deps: ExecutionDeps,
 	task: ScheduledTask,
 	isCancelled: () => boolean

--- a/src/services/scheduled-tasks/execution.ts
+++ b/src/services/scheduled-tasks/execution.ts
@@ -1,0 +1,110 @@
+import type ObsidianGemini from '../../main';
+import type { FailurePauseTracker } from '../failure-pause-tracker';
+import { computeNextRunAt } from './schedule';
+import type { ScheduledTask, ScheduledTasksState, TaskState } from './types';
+
+/**
+ * Everything the execution-dispatch functions need from the owning
+ * `ScheduledTaskManager`, injected so the dispatch logic stays free of the
+ * manager class. `getState` is an accessor (not a captured reference) because
+ * the manager reassigns `this.state` on load; `tasks` and `submitting` are
+ * stable collection references that are only mutated in place.
+ */
+export interface ExecutionDeps {
+	plugin: ObsidianGemini;
+	/** Live task map, keyed by slug. */
+	tasks: Map<string, ScheduledTask>;
+	/** Slugs currently being submitted — guards against tick + runNow double-fire. */
+	submitting: Set<string>;
+	/** Shared auto-pause-after-N-failures ladder over the per-task sidecar state. */
+	failureTracker: FailurePauseTracker<TaskState>;
+	/** Accessor for the live sidecar state (reassigned on load, so read lazily). */
+	getState: () => ScheduledTasksState;
+	/** Persist the current sidecar state to disk. */
+	saveState: () => Promise<void>;
+}
+
+/**
+ * Advance a task's nextRunAt without running it — used before dispatch (so a
+ * slow or failed run can't re-fire on the next tick) and by the catch-up
+ * "Skip" action indirectly. No-op when the slug is unknown.
+ */
+export async function advanceState(deps: ExecutionDeps, slug: string, from: Date): Promise<void> {
+	const task = deps.tasks.get(slug);
+	if (!task) return;
+
+	const nextRunAt = computeNextRunAt(task.schedule, from);
+	const state = deps.getState();
+	state[slug] = {
+		...state[slug],
+		nextRunAt: nextRunAt.toISOString(),
+	};
+	await deps.saveState();
+}
+
+/**
+ * Run a task via the ScheduledTaskRunner and record success/failure against the
+ * shared failure tracker. Returns the output path, or `undefined` when the run
+ * was cancelled (which is deliberately not recorded as a success).
+ */
+export async function executeTask(
+	deps: ExecutionDeps,
+	task: ScheduledTask,
+	isCancelled: () => boolean
+): Promise<string | undefined> {
+	try {
+		const { ScheduledTaskRunner } = await import('../scheduled-task-runner');
+		const runner = new ScheduledTaskRunner(deps.plugin, task);
+		const outputPath = await runner.run(isCancelled);
+
+		// undefined means the run was cancelled — don't record as a successful
+		// completion so lastRunAt only reflects genuine completions.
+		if (outputPath !== undefined) {
+			await deps.failureTracker.recordSuccess(task.slug, { lastRunAt: new Date().toISOString() });
+		}
+		return outputPath;
+	} catch (error) {
+		await deps.failureTracker.recordFailure(task.slug, error);
+		throw error;
+	}
+}
+
+/**
+ * Advance the task's schedule then submit it to BackgroundTaskManager for
+ * fire-and-forget execution. The `submitting` guard is held for the full
+ * background run so a concurrent tick or runNow can't double-submit the slug.
+ *
+ * @returns The background task ID returned by BackgroundTaskManager.
+ */
+export async function submitTask(deps: ExecutionDeps, task: ScheduledTask, triggeredAt: Date): Promise<string> {
+	if (deps.submitting.has(task.slug)) {
+		throw new Error(`[ScheduledTaskManager] Task "${task.slug}" is already being submitted`);
+	}
+	deps.submitting.add(task.slug);
+
+	try {
+		const bgManager = deps.plugin.backgroundTaskManager;
+		if (!bgManager) {
+			throw new Error('[ScheduledTaskManager] BackgroundTaskManager not available');
+		}
+
+		// Advance nextRunAt immediately — prevents re-firing on the next tick even
+		// if the background execution takes longer than 60 s or fails.
+		await advanceState(deps, task.slug, triggeredAt);
+
+		const taskId = bgManager.submit(`scheduled-task`, task.slug, async (isCancelled) => {
+			try {
+				return await executeTask(deps, task, isCancelled);
+			} finally {
+				// Guard is held for the full background run duration to prevent
+				// a concurrent tick or runNow from double-submitting the same slug.
+				deps.submitting.delete(task.slug);
+			}
+		});
+
+		return taskId;
+	} catch (error) {
+		deps.submitting.delete(task.slug);
+		throw error;
+	}
+}

--- a/src/services/scheduled-tasks/missed-runs.ts
+++ b/src/services/scheduled-tasks/missed-runs.ts
@@ -1,0 +1,46 @@
+import type { PendingCatchUp, ScheduledTask, ScheduledTasksState } from './types';
+
+/**
+ * Returns one entry per task that missed its scheduled run while the plugin
+ * was offline. Only tasks with `runIfMissed: true` and `enabled: true` are
+ * included. Multiple missed windows for the same task are collapsed into a
+ * single entry — the caller just needs to know "this task needs a catch-up
+ * run", not how many it missed.
+ *
+ * Pure function — no plugin/vault state — so it can be unit-tested in isolation.
+ * `ScheduledTaskManager.detectMissedRuns` is a thin wrapper that supplies its
+ * live task map, sidecar state, and the current instant.
+ *
+ * @param tasks     The known task definitions to consider.
+ * @param state     The sidecar runtime state keyed by slug.
+ * @param now       The reference instant treated as "now".
+ * @param windowMs  How far back to look. Tasks whose nextRunAt is older than
+ *                  this are considered stale and excluded — they missed their
+ *                  window entirely.
+ */
+export function detectMissedRuns(
+	tasks: Iterable<ScheduledTask>,
+	state: ScheduledTasksState,
+	now: Date,
+	windowMs: number
+): PendingCatchUp[] {
+	const cutoff = new Date(now.getTime() - windowMs);
+	const result: PendingCatchUp[] = [];
+
+	for (const task of tasks) {
+		if (!task.enabled || !task.runIfMissed) continue;
+		if (task.schedule === 'once') continue;
+
+		const taskState = state[task.slug];
+		if (!taskState) continue;
+		if (taskState.pausedDueToErrors) continue;
+
+		const nextRunAt = new Date(taskState.nextRunAt);
+		// Due in the past AND within the catch-up window
+		if (nextRunAt < now && nextRunAt >= cutoff) {
+			result.push({ task, missedAt: nextRunAt });
+		}
+	}
+
+	return result;
+}

--- a/src/services/scheduled-tasks/schedule.ts
+++ b/src/services/scheduled-tasks/schedule.ts
@@ -1,0 +1,136 @@
+// Pure schedule-math helpers extracted from ScheduledTaskManager. No I/O and no
+// dependency on plugin/vault state, so every function here is safe to unit-test
+// in isolation.
+
+// Day-of-week codes accepted in `weekly@HH:MM:DAYS` schedules. Order matches
+// JS Date.getDay() so the array index doubles as the weekday number.
+const WEEKDAY_CODES = ['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat'] as const;
+type WeekdayCode = (typeof WEEKDAY_CODES)[number];
+
+/**
+ * Compute the next run time given a schedule string and a reference instant.
+ * Pure function — no I/O — safe to unit-test in isolation.
+ *
+ * @throws {Error} if the schedule string is not recognised
+ */
+export function computeNextRunAt(schedule: string, from: Date): Date {
+	switch (schedule) {
+		case 'once':
+			// Far-future sentinel: task has run once and should not fire again
+			return new Date(8640000000000000);
+		case 'daily':
+			return new Date(from.getTime() + 24 * 60 * 60 * 1000);
+		case 'weekly':
+			return new Date(from.getTime() + 7 * 24 * 60 * 60 * 1000);
+		default: {
+			if (schedule.startsWith('interval:')) {
+				const spec = schedule.slice('interval:'.length);
+				const match = /^(\d+)(m|h)$/.exec(spec);
+				if (!match) {
+					throw new Error(`Invalid interval schedule: "${schedule}". Expected format: interval:Xm or interval:Xh`);
+				}
+				const value = parseInt(match[1], 10);
+				if (value <= 0) {
+					throw new Error(`Invalid interval schedule: "${schedule}". Interval must be greater than zero`);
+				}
+				const ms = match[2] === 'h' ? value * 60 * 60 * 1000 : value * 60 * 1000;
+				return new Date(from.getTime() + ms);
+			}
+			if (schedule.startsWith('daily@')) {
+				const { hour, minute } = parseHourMinute(schedule, schedule.slice('daily@'.length));
+				return nextOccurrenceAtTime(from, hour, minute);
+			}
+			if (schedule.startsWith('weekly@')) {
+				const rest = schedule.slice('weekly@'.length).toLowerCase();
+				const match = /^(\d{1,2}:\d{2}):(.+)$/.exec(rest);
+				if (!match) {
+					throw new Error(
+						`Invalid weekly schedule: "${schedule}". Expected format: weekly@HH:MM:days (e.g. weekly@16:30:mon,tue,wed)`
+					);
+				}
+				const { hour, minute } = parseHourMinute(schedule, match[1]);
+				const allowedDays = parseWeekdayList(schedule, match[2]);
+				return nextOccurrenceOnAllowedDay(from, hour, minute, allowedDays);
+			}
+			throw new Error(
+				`Unknown schedule type: "${schedule}". Expected: once, daily, weekly, interval:Xm, interval:Xh, daily@HH:MM, weekly@HH:MM:days`
+			);
+		}
+	}
+}
+
+/**
+ * Parse a `HH:MM` time component out of a `daily@…` or `weekly@…` schedule
+ * and validate that hour/minute are in range. The full schedule string is
+ * passed in only so the error messages can quote the offending value.
+ */
+function parseHourMinute(schedule: string, time: string): { hour: number; minute: number } {
+	const match = /^(\d{1,2}):(\d{2})$/.exec(time);
+	if (!match) {
+		throw new Error(`Invalid schedule time in "${schedule}". Expected HH:MM (24-hour, e.g. 16:30)`);
+	}
+	const hour = parseInt(match[1], 10);
+	const minute = parseInt(match[2], 10);
+	if (hour < 0 || hour > 23 || minute < 0 || minute > 59) {
+		throw new Error(`Invalid schedule time in "${schedule}". Hour must be 0-23 and minute must be 0-59`);
+	}
+	return { hour, minute };
+}
+
+/**
+ * Parse the comma-separated weekday list from a `weekly@HH:MM:days` schedule
+ * into a Set of weekday numbers (0 = Sunday … 6 = Saturday). Empty lists,
+ * unknown codes, and stray separators are all rejected.
+ */
+function parseWeekdayList(schedule: string, days: string): Set<number> {
+	const tokens = days.split(',').map((d) => d.trim());
+	if (tokens.some((t) => t.length === 0)) {
+		throw new Error(`Invalid weekly schedule "${schedule}": days list contains empty entries`);
+	}
+	const result = new Set<number>();
+	for (const token of tokens) {
+		const idx = WEEKDAY_CODES.indexOf(token as WeekdayCode);
+		if (idx === -1) {
+			throw new Error(`Invalid weekday "${token}" in "${schedule}". Expected one of: ${WEEKDAY_CODES.join(', ')}`);
+		}
+		result.add(idx);
+	}
+	return result;
+}
+
+/**
+ * Return the next Date strictly after `from` whose local time is `hour:minute`.
+ * Today's slot is preferred when it's still in the future; otherwise tomorrow's.
+ */
+function nextOccurrenceAtTime(from: Date, hour: number, minute: number): Date {
+	const candidate = new Date(from);
+	candidate.setHours(hour, minute, 0, 0);
+	if (candidate.getTime() > from.getTime()) return candidate;
+	candidate.setDate(candidate.getDate() + 1);
+	return candidate;
+}
+
+/**
+ * Return the next Date strictly after `from` whose local time is `hour:minute`
+ * AND whose weekday is in `allowedDays`. The set is non-empty (validated by
+ * the caller), so the search terminates within 8 days: each weekday-and-time
+ * pair is checked once over the next 7 days, plus a final wrap-around for the
+ * case where today's allowed slot has already passed and no later day in the
+ * week qualifies.
+ */
+function nextOccurrenceOnAllowedDay(from: Date, hour: number, minute: number, allowedDays: Set<number>): Date {
+	for (let offset = 0; offset <= 7; offset++) {
+		const candidate = new Date(from);
+		candidate.setDate(candidate.getDate() + offset);
+		candidate.setHours(hour, minute, 0, 0);
+		if (allowedDays.has(candidate.getDay()) && candidate.getTime() > from.getTime()) {
+			return candidate;
+		}
+	}
+	// Unreachable: with a non-empty allowedDays set, one of the 8 candidates
+	// above always matches. Throw rather than return a wrong value if the
+	// invariant ever breaks.
+	throw new Error(
+		`Internal error: failed to compute next run for weekly schedule (allowedDays=${[...allowedDays].join(',')})`
+	);
+}

--- a/src/services/scheduled-tasks/types.ts
+++ b/src/services/scheduled-tasks/types.ts
@@ -1,0 +1,85 @@
+import type { FeatureToolPolicy } from '../../types/tool-policy';
+
+/**
+ * A scheduled task definition parsed from a markdown file.
+ * The file lives at {historyFolder}/Scheduled-Tasks/<slug>.md.
+ * Frontmatter controls scheduling; the file body is the prompt text.
+ */
+export interface ScheduledTask {
+	/** Derived from the file basename (no extension). */
+	slug: string;
+	/**
+	 * Schedule string. Supported values:
+	 *   once               — run exactly once, then the task is considered exhausted
+	 *   daily              — every 24 h from creation
+	 *   daily@HH:MM        — every day at the given local time (e.g. daily@16:30)
+	 *   weekly             — every 7 d from creation
+	 *   weekly@HH:MM:DAYS  — at the given local time on the listed weekdays
+	 *                        (DAYS is comma-separated, e.g. weekly@16:30:mon,tue,wed)
+	 *   interval:Xm        — every X minutes (e.g. interval:30m)
+	 *   interval:Xh        — every X hours   (e.g. interval:2h)
+	 */
+	schedule: string;
+	/**
+	 * Tool policy applied for the duration of each run. Layered on top of the
+	 * global plugin policy via FeatureToolPolicy. Undefined means inherit the
+	 * global policy.
+	 */
+	toolPolicy?: FeatureToolPolicy;
+	/**
+	 * Output path template. Supports {slug} and {date} placeholders.
+	 * Default: Scheduled-Tasks/Runs/{slug}/{date}.md
+	 */
+	outputPath: string;
+	/**
+	 * Model override for this task (e.g. 'gemini-2.0-flash').
+	 * Defaults to the plugin's chat model when omitted.
+	 */
+	model?: string;
+	/**
+	 * Cap on agent tool-execution iterations for this run. Each iteration is one
+	 * tool-call batch, not a single tool call. Omitted means use
+	 * DEFAULT_HEADLESS_MAX_ITERATIONS. Raise this for long multi-step tasks that
+	 * legitimately need more than the default before producing a final response.
+	 */
+	maxIterations?: number;
+	/** When false the scheduler skips this task entirely. Default: true. */
+	enabled: boolean;
+	/**
+	 * When true and the task missed its window (plugin was offline), run once
+	 * immediately on the next tick instead of skipping the missed run.
+	 * Default: false.
+	 */
+	runIfMissed: boolean;
+	/** Prompt text — the file body after the closing frontmatter delimiter. */
+	prompt: string;
+	/** Vault path of the task definition file. */
+	filePath: string;
+}
+
+/** Per-task volatile runtime state stored in the sidecar JSON. */
+export interface TaskState {
+	/** ISO-8601 date string for the next scheduled run. */
+	nextRunAt: string;
+	/** ISO-8601 date string for the last successful run, if any. */
+	lastRunAt?: string;
+	/** Error message from the most recent failed run, if any. */
+	lastError?: string;
+	/** Number of consecutive failures since the last success. */
+	consecutiveFailures?: number;
+	/**
+	 * When true the scheduler skips this task until the user manually resets it.
+	 * Set automatically after MAX_CONSECUTIVE_FAILURES failures in a row.
+	 */
+	pausedDueToErrors?: boolean;
+}
+
+/** The full sidecar state file — a map of slug → TaskState. */
+export type ScheduledTasksState = Record<string, TaskState>;
+
+/** A single missed-run entry returned by detectMissedRuns(). */
+export interface PendingCatchUp {
+	task: ScheduledTask;
+	/** The nextRunAt instant that was missed. */
+	missedAt: Date;
+}

--- a/test/services/scheduled-tasks/missed-runs.test.ts
+++ b/test/services/scheduled-tasks/missed-runs.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { detectMissedRuns } from '../../../src/services/scheduled-tasks/missed-runs';
+import type { ScheduledTask, ScheduledTasksState } from '../../../src/services/scheduled-tasks/types';
+
+function makeTask(overrides: Partial<ScheduledTask> & { slug: string }): ScheduledTask {
+	return {
+		schedule: 'daily',
+		outputPath: `Scheduled-Tasks/Runs/${overrides.slug}/{date}.md`,
+		enabled: true,
+		runIfMissed: true,
+		prompt: 'do the thing',
+		filePath: `Scheduled-Tasks/${overrides.slug}.md`,
+		...overrides,
+	};
+}
+
+const NOW = new Date(2026, 5, 1, 12, 0);
+const WINDOW = 7 * 24 * 60 * 60 * 1000;
+const oneHourAgo = new Date(NOW.getTime() - 60 * 60 * 1000).toISOString();
+const inOneHour = new Date(NOW.getTime() + 60 * 60 * 1000).toISOString();
+
+describe('scheduled-tasks/missed-runs · detectMissedRuns', () => {
+	it('includes an enabled runIfMissed task whose nextRunAt is past but within the window', () => {
+		const task = makeTask({ slug: 'a' });
+		const state: ScheduledTasksState = { a: { nextRunAt: oneHourAgo } };
+		const result = detectMissedRuns([task], state, NOW, WINDOW);
+		expect(result).toHaveLength(1);
+		expect(result[0].task.slug).toBe('a');
+		expect(result[0].missedAt).toEqual(new Date(oneHourAgo));
+	});
+
+	it('excludes disabled tasks and tasks with runIfMissed=false', () => {
+		const disabled = makeTask({ slug: 'disabled', enabled: false });
+		const noCatchUp = makeTask({ slug: 'noCatchUp', runIfMissed: false });
+		const state: ScheduledTasksState = {
+			disabled: { nextRunAt: oneHourAgo },
+			noCatchUp: { nextRunAt: oneHourAgo },
+		};
+		expect(detectMissedRuns([disabled, noCatchUp], state, NOW, WINDOW)).toEqual([]);
+	});
+
+	it('excludes once schedules, paused tasks, and tasks with no state entry', () => {
+		const once = makeTask({ slug: 'once', schedule: 'once' });
+		const paused = makeTask({ slug: 'paused' });
+		const stateless = makeTask({ slug: 'stateless' });
+		const state: ScheduledTasksState = {
+			once: { nextRunAt: oneHourAgo },
+			paused: { nextRunAt: oneHourAgo, pausedDueToErrors: true },
+			// no entry for `stateless`
+		};
+		expect(detectMissedRuns([once, paused, stateless], state, NOW, WINDOW)).toEqual([]);
+	});
+
+	it('excludes future runs and runs older than the catch-up window', () => {
+		const future = makeTask({ slug: 'future' });
+		const stale = makeTask({ slug: 'stale' });
+		const state: ScheduledTasksState = {
+			future: { nextRunAt: inOneHour },
+			stale: { nextRunAt: new Date(NOW.getTime() - WINDOW - 60_000).toISOString() },
+		};
+		expect(detectMissedRuns([future, stale], state, NOW, WINDOW)).toEqual([]);
+	});
+});

--- a/test/services/scheduled-tasks/schedule.test.ts
+++ b/test/services/scheduled-tasks/schedule.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { computeNextRunAt } from '../../../src/services/scheduled-tasks/schedule';
+
+// The exhaustive schedule-parsing matrix lives in
+// test/services/scheduled-task-manager.test.ts (exercising the re-export). These
+// cases verify the pure helper works at its new module home and that each
+// schedule family + validation branch is reachable through the direct import.
+describe('scheduled-tasks/schedule · computeNextRunAt', () => {
+	it('returns the far-future sentinel for a once schedule', () => {
+		const result = computeNextRunAt('once', new Date(2026, 0, 1, 12, 0));
+		expect(result.getTime()).toBe(8640000000000000);
+	});
+
+	it('advances 24h for daily', () => {
+		const base = new Date(2026, 0, 1, 12, 0);
+		expect(computeNextRunAt('daily', base)).toEqual(new Date(base.getTime() + 24 * 60 * 60 * 1000));
+	});
+
+	it('advances 7d for weekly', () => {
+		const base = new Date(2026, 0, 1, 12, 0);
+		expect(computeNextRunAt('weekly', base)).toEqual(new Date(base.getTime() + 7 * 24 * 60 * 60 * 1000));
+	});
+
+	it('advances by minutes/hours for interval schedules', () => {
+		const base = new Date(2026, 0, 1, 12, 0);
+		expect(computeNextRunAt('interval:30m', base)).toEqual(new Date(base.getTime() + 30 * 60 * 1000));
+		expect(computeNextRunAt('interval:2h', base)).toEqual(new Date(base.getTime() + 2 * 60 * 60 * 1000));
+	});
+
+	it('resolves the next daily@HH:MM slot, rolling to tomorrow when passed', () => {
+		const before = new Date(2026, 0, 1, 9, 0);
+		expect(computeNextRunAt('daily@16:30', before)).toEqual(new Date(2026, 0, 1, 16, 30));
+		const after = new Date(2026, 0, 1, 17, 0);
+		expect(computeNextRunAt('daily@16:30', after)).toEqual(new Date(2026, 0, 2, 16, 30));
+	});
+
+	it('resolves the next weekly@HH:MM:DAYS occurrence (case-insensitive)', () => {
+		// 2026-04-14 is a Tuesday; ask for Saturday.
+		const tue = new Date(2026, 3, 14, 9, 0);
+		expect(computeNextRunAt('weekly@16:30:SAT', tue)).toEqual(new Date(2026, 3, 18, 16, 30));
+	});
+
+	it('throws on unknown and malformed schedules', () => {
+		expect(() => computeNextRunAt('hourly', new Date())).toThrow();
+		expect(() => computeNextRunAt('interval:0m', new Date())).toThrow('greater than zero');
+		expect(() => computeNextRunAt('daily@25:00', new Date())).toThrow(/Hour must be 0-23/);
+		expect(() => computeNextRunAt('weekly@16:30:funday', new Date())).toThrow(/Invalid weekday "funday"/);
+		expect(() => computeNextRunAt('weekly@16:30:mon,,tue', new Date())).toThrow(/empty entries/);
+	});
+});


### PR DESCRIPTION
<!-- auto-dev -->

## Summary

Sub-issue of #801 (oversized files). `src/services/scheduled-task-manager.ts` was 919 lines that mixed four distinct responsibilities in one file: pure schedule math, missed-run detection, execution dispatch, and task/state persistence. This is a **pure code-motion refactor** — no behavior changes, and the public surface (`ScheduledTaskManager` class API, exported types, `computeNextRunAt`) is unchanged, so consumers (`lifecycle-service.ts`, `background-status-bar.ts`, the UI modals, `scheduled-task-runner.ts`) need no changes.

This PR was produced by the auto-dev pipeline from the approved plan on the issue.

Fixes #1071

## Changes

- **New `src/services/scheduled-tasks/` package:**
  - `types.ts` — `ScheduledTask`, `TaskState`, `ScheduledTasksState`, `PendingCatchUp`.
  - `schedule.ts` — `computeNextRunAt` and the weekday/time helpers (pure, no I/O).
  - `missed-runs.ts` — `detectMissedRuns` as a pure `(tasks, state, now, windowMs)` function.
  - `execution.ts` — `submitTask` / `executeTask` / `advanceState` dispatch, parameterized over an injected `ExecutionDeps`. `getState` is passed as an accessor (not a captured reference) because the manager reassigns `this.state` on load; `tasks` and `submitting` are stable in-place-mutated collections.
- **`src/services/scheduled-task-manager.ts` (929 → 646 lines)** — now a thinner manager that keeps task discovery/parsing, state load/save, the tick loop, and lifecycle wiring, composing the new modules. `detectMissedRuns` and the former private dispatch methods are now thin wrappers. Re-exports the task types and `computeNextRunAt` from their new homes so existing import paths (`from '.../scheduled-task-manager'`) keep working.
- **Tests** — existing `test/services/scheduled-task-manager.test.ts` continues to pass unchanged via the re-exports (integration coverage of the public surface). Added focused direct-import unit tests under `test/services/scheduled-tasks/` (`schedule.test.ts`, `missed-runs.test.ts`) so the extracted pure logic gets coverage at its new module home.

**Plan deviation (minor):** the approved plan suggested splitting the existing manager test's cases across the new test files. I chose to leave the 1838-line manager test intact (it remains valid as integration coverage via the re-exports) and *add* new direct-import unit tests instead — this strictly increases coverage and avoids churn/transcription risk in a large test file. A shared `scheduled-tasks/types.ts` was also added (the plan left types in the manager) so the new modules avoid even type-level coupling back to the manager; the manager re-exports them for backward compatibility.

## Screenshots / Screencast

N/A — internal refactor with no user-visible or behavioral change.

## Checklist

### Required

- [x] I have read and agree to the Contributing Guidelines
- [x] I have read and agree to the AI Policy
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — plus `npm run lint` and `npm run typecheck:test`
- [ ] I have tested this change on Desktop
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards)
- [x] Documentation has been updated (if applicable) — N/A, no user-facing or public-API change
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude (auto-dev pipeline)
- [x] I have reviewed and understand all AI-generated code in this PR

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BKoHDMkge35Jy8MM3f2srJ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Scheduled tasks now support more schedule formats, including one-time, daily, weekly, interval-based, and time-specific daily/weekly patterns.
  * The system can detect missed scheduled runs during downtime and queue pending catch-up work.

* **Bug Fixes**
  * Improved execution flow to reduce duplicate firing by guarding per-task submissions during background execution.
  * Missed-run detection and scheduling decisions now correctly exclude disabled/paused/once tasks and tasks outside the catch-up window.

* **Tests**
  * Added unit tests for missed-run detection and schedule computation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->