### PR TITLE
feat(ollama): collapse per-use-case model resolution to a single model

### DIFF
--- a/docs/guide/ollama-setup.md
+++ b/docs/guide/ollama-setup.md
@@ -12,7 +12,7 @@ Gemini Scribe can route chat, summary, completions, rewrite, and agent tool-call
    ollama pull llava:13b      # for vision (image input)
    ```
 3. **Switch the provider in Gemini Scribe** — Open Settings → Gemini Scribe → Provider and choose **Ollama (local)**.
-4. **Pick a model** — The Chat / Summary / Completion dropdowns now list whatever you have pulled. In Settings → General, click **Refresh** in the **Refresh model list** row if a new pull doesn't show up.
+4. **Pick a model** — Under Ollama the settings show a single **Ollama model** picker (one model serves chat, summary, completions, and rewrite — Ollama keeps only one model resident at a time, so per-use-case models would just thrash memory). It lists whatever you have pulled. In Settings → General, click **Refresh** in the **Refresh model list** row if a new pull doesn't show up.
 
 If the daemon runs on a different host or port, edit the **Ollama base URL** field (e.g. `http://10.0.0.5:11434`).
 

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -102,7 +102,7 @@ UI sections without a dedicated topic in this reference: _Vault search index_ (c
 The active model list depends on the [`provider`](#provider) setting:
 
 - **Gemini (default)** — models are loaded from the bundled list and auto-refreshed from GitHub on startup (cached for 24h). `imageModelName` is only available on this provider. Click **Refresh model list** in Settings → General — or run the **Gemini Scribe: Refresh model list** command — to fetch the latest list immediately (bypasses the cache).
-- **Ollama** — the chat / summary / completion dropdowns are populated from `GET <ollamaBaseUrl>/api/tags`, listing whatever you have pulled. Click "Refresh model list" in settings if a freshly pulled model doesn't appear. Image generation is unavailable in this mode.
+- **Ollama** — a single **Ollama model** picker is shown (bound to `chatModelName`); that one model serves every use case — chat, summary, completions, and rewrite. Ollama keeps only one model resident at a time, so diverging models per use case would just thrash RAM/VRAM on each switch; the separate `summaryModelName` / `completionsModelName` values are ignored while Ollama is active. The dropdown is populated from `GET <ollamaBaseUrl>/api/tags`, listing whatever you have pulled. Click "Refresh model list" in settings if a freshly pulled model doesn't appear. Image generation is unavailable in this mode.
 
 ### Chat model
 
@@ -127,6 +127,7 @@ The active model list depends on the [`provider`](#provider) setting:
 - **Default**: `gemini-flash-latest`
 - **Description**: Model used for document summarization
 - **Used by**: Summarize active file command
+- **Note**: Gemini only. Under Ollama every use case resolves to `chatModelName`, so this value is ignored and its picker is hidden.
 
 ### Completions Model
 
@@ -135,6 +136,7 @@ The active model list depends on the [`provider`](#provider) setting:
 - **Default**: `gemini-flash-lite-latest`
 - **Description**: Model used for IDE-style auto-completions
 - **Note**: Completions must be enabled via command palette
+- **Note**: Gemini only. Under Ollama every use case resolves to `chatModelName`, so this value is ignored and its picker is hidden.
 
 ### Image model
 

--- a/src/api/factory.ts
+++ b/src/api/factory.ts
@@ -80,6 +80,13 @@ export class ModelClientFactory {
 	private static resolveModelName(plugin: ObsidianGemini, useCase: ModelUseCase): string {
 		const settings = plugin.settings;
 		const provider = settings.provider ?? 'gemini';
+		// Ollama keeps a single model resident at a time, so diverging models
+		// across use cases just thrashes RAM/VRAM on every switch for no benefit.
+		// Collapse every use case to the one configured chat model; the
+		// per-use-case summary/completions settings are ignored under Ollama. (#1077)
+		if (provider === 'ollama') {
+			return settings.chatModelName || getDefaultModelForRole('chat', 'ollama');
+		}
 		switch (useCase) {
 			case ModelUseCase.CHAT:
 				return settings.chatModelName || getDefaultModelForRole('chat', provider);

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -216,6 +216,15 @@ export const en = {
 		message: 'Model used for IDE-style inline completions as you type in notes.',
 		context: 'Settings field description for the completion model dropdown.',
 	},
+	'settings.general.ollamaModelName': {
+		message: 'Ollama model',
+		context: 'Settings field name for the single model Ollama uses for every use case.',
+	},
+	'settings.general.ollamaModelDesc': {
+		message: 'Model used for all Ollama use cases: chat, summarization, completions, and rewriting.',
+		context:
+			'Settings field description for the single Ollama model dropdown shown when the Ollama provider is selected.',
+	},
 	'settings.general.imageModelName': {
 		message: 'Image model',
 		context: 'Settings field name for the model used to generate images.',

--- a/src/ui/settings-general.ts
+++ b/src/ui/settings-general.ts
@@ -139,28 +139,39 @@ async function renderGeneralSection(
 			);
 	}
 
-	await selectModelSetting(
-		sectionEl,
-		plugin,
-		'chatModelName',
-		t('settings.general.chatModelName'),
-		t('settings.general.chatModelDesc')
-	);
-	await selectModelSetting(
-		sectionEl,
-		plugin,
-		'summaryModelName',
-		t('settings.general.summaryModelName'),
-		t('settings.general.summaryModelDesc')
-	);
-	await selectModelSetting(
-		sectionEl,
-		plugin,
-		'completionsModelName',
-		t('settings.general.completionModelName'),
-		t('settings.general.completionModelDesc')
-	);
-	if (plugin.settings.provider === 'gemini') {
+	if (plugin.settings.provider === 'ollama') {
+		// Ollama keeps a single model resident at a time, so one model applies to
+		// every use case (chat / summary / completions / rewrite). Show just the
+		// one picker, bound to chatModelName. (#1077)
+		await selectModelSetting(
+			sectionEl,
+			plugin,
+			'chatModelName',
+			t('settings.general.ollamaModelName'),
+			t('settings.general.ollamaModelDesc')
+		);
+	} else {
+		await selectModelSetting(
+			sectionEl,
+			plugin,
+			'chatModelName',
+			t('settings.general.chatModelName'),
+			t('settings.general.chatModelDesc')
+		);
+		await selectModelSetting(
+			sectionEl,
+			plugin,
+			'summaryModelName',
+			t('settings.general.summaryModelName'),
+			t('settings.general.summaryModelDesc')
+		);
+		await selectModelSetting(
+			sectionEl,
+			plugin,
+			'completionsModelName',
+			t('settings.general.completionModelName'),
+			t('settings.general.completionModelDesc')
+		);
 		await selectModelSetting(
 			sectionEl,
 			plugin,

--- a/test/api/factory.test.ts
+++ b/test/api/factory.test.ts
@@ -209,38 +209,49 @@ describe('ModelClientFactory', () => {
 		});
 
 		describe('Ollama provider', () => {
-			// Mirrors the Gemini rows above but routes through the Ollama branch of
-			// createFromPlugin, asserting the resolved model lands on the
-			// OllamaClient config. resolveModelName reads the same settings keys
-			// regardless of provider (chatModelName / summaryModelName /
-			// completionsModelName); only the default fallback is provider-aware.
-			const cases: Array<{ useCase: ModelUseCase; settingKey: string; expected: string }> = [
-				{ useCase: ModelUseCase.CHAT, settingKey: 'chatModelName', expected: 'ollama-chat' },
-				{ useCase: ModelUseCase.SUMMARY, settingKey: 'summaryModelName', expected: 'ollama-summary' },
-				{ useCase: ModelUseCase.COMPLETIONS, settingKey: 'completionsModelName', expected: 'ollama-completions' },
-				{ useCase: ModelUseCase.REWRITE, settingKey: 'chatModelName', expected: 'ollama-chat' },
-				{ useCase: ModelUseCase.SEARCH, settingKey: 'chatModelName', expected: 'ollama-chat' },
+			// Ollama keeps a single model resident at a time, so every use case
+			// resolves to the one configured chatModelName — the per-use-case
+			// summary/completions settings are ignored under Ollama. (#1077)
+			const useCases: ModelUseCase[] = [
+				ModelUseCase.CHAT,
+				ModelUseCase.SUMMARY,
+				ModelUseCase.COMPLETIONS,
+				ModelUseCase.REWRITE,
+				ModelUseCase.SEARCH,
 			];
 
-			it.each(cases)('resolves $useCase to the configured Ollama model', ({ useCase, settingKey, expected }) => {
-				const plugin = createMockPlugin({ provider: 'ollama', [settingKey]: expected });
+			it.each(useCases)('resolves %s to the single chatModelName', (useCase) => {
+				// Divergent summary/completions values are set but must be ignored.
+				const plugin = createMockPlugin({
+					provider: 'ollama',
+					chatModelName: 'ollama-chat',
+					summaryModelName: 'ollama-summary',
+					completionsModelName: 'ollama-completions',
+				});
 				ModelClientFactory.createFromPlugin(plugin, useCase);
 
 				expect(MockOllamaClient).toHaveBeenCalledTimes(1);
 				expect(MockGeminiClient).not.toHaveBeenCalled();
 				const config = MockOllamaClient.mock.calls[0][0];
-				expect(config.model).toBe(expected);
+				expect(config.model).toBe('ollama-chat');
 			});
 
-			it('falls back to the Ollama default when the model name is empty', () => {
-				const plugin = createMockPlugin({ provider: 'ollama', chatModelName: '' });
-				ModelClientFactory.createFromPlugin(plugin, ModelUseCase.CHAT);
+			it('falls back to the Ollama default for every use case when chatModelName is empty', () => {
+				// Even with a summary model configured, an empty chatModelName under
+				// Ollama resolves SUMMARY to the Ollama chat default — never the
+				// summary setting.
+				const plugin = createMockPlugin({
+					provider: 'ollama',
+					chatModelName: '',
+					summaryModelName: 'ollama-summary',
+				});
+				ModelClientFactory.createFromPlugin(plugin, ModelUseCase.SUMMARY);
 
 				const config = MockOllamaClient.mock.calls[0][0];
 				// The default is resolved by the real getDefaultModelForRole (not mocked),
 				// so assert against it directly rather than a hard-coded string. In a unit
 				// context with no Ollama models loaded this is the empty-string sentinel,
-				// which is exactly the unconfigured-Ollama state the resolver is meant to pass through.
+				// which is exactly the unconfigured-Ollama state the resolver passes through.
 				expect(config.model).toBe(getDefaultModelForRole('chat', 'ollama'));
 			});
 		});

--- a/test/ui/settings-general.test.ts
+++ b/test/ui/settings-general.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Regression tests for provider-specific model-picker rendering in the General
+ * settings section (issue #1077).
+ *
+ * Under Ollama a single model applies to every use case, so only one model
+ * picker (bound to chatModelName) is shown; the summary / completions / image
+ * pickers are hidden. Gemini keeps all four independent pickers.
+ */
+const { mockSelectModelSetting } = vi.hoisted(() => ({
+	mockSelectModelSetting: vi.fn(),
+}));
+
+vi.mock('../../src/ui/settings-helpers', () => ({
+	selectModelSetting: mockSelectModelSetting,
+	// The General section is rendered directly into the element we pass in.
+	createAlwaysOpenSection: (containerEl: any) => containerEl,
+}));
+
+vi.mock('../../src/ui/folder-suggest', () => ({
+	FolderSuggest: vi.fn(),
+}));
+
+vi.mock('../../src/i18n', () => ({
+	t: (key: string) => key,
+}));
+
+vi.mock('../../src/utils/error-utils', () => ({
+	getErrorMessage: (e: unknown) => String(e),
+}));
+
+vi.mock('obsidian', () => {
+	class Setting {
+		constructor(public containerEl: any) {}
+		setName() {
+			return this;
+		}
+		setDesc() {
+			return this;
+		}
+		addButton(cb: (c: any) => void) {
+			cb({ setButtonText: () => ({ onClick: () => this }) });
+			return this;
+		}
+		addDropdown(cb: (c: any) => void) {
+			const c: any = {};
+			c.addOption = () => c;
+			c.setValue = () => c;
+			c.onChange = () => c;
+			cb(c);
+			return this;
+		}
+		addText(cb: (c: any) => void) {
+			const c: any = {};
+			c.setPlaceholder = () => c;
+			c.setValue = () => c;
+			c.onChange = () => c;
+			c.inputEl = {};
+			cb(c);
+			return this;
+		}
+		addComponent(cb: (el: any) => void) {
+			cb({});
+			return this;
+		}
+		addToggle(cb: (c: any) => void) {
+			const c: any = {};
+			c.setValue = () => c;
+			c.onChange = () => c;
+			cb(c);
+			return this;
+		}
+	}
+	class SecretComponent {
+		constructor(_app: any, _el: any) {}
+		setValue() {
+			return this;
+		}
+		onChange() {
+			return this;
+		}
+	}
+	return {
+		Setting,
+		SecretComponent,
+		Notice: vi.fn(),
+		debounce: (fn: any) => fn,
+		App: class {},
+	};
+});
+
+import { renderGeneralSettings } from '../../src/ui/settings-general';
+
+function createMockPlugin(provider: 'gemini' | 'ollama') {
+	return {
+		settings: {
+			provider,
+			chatModelName: 'chat-model',
+			summaryModelName: 'summary-model',
+			completionsModelName: 'completions-model',
+			imageModelName: 'image-model',
+			ollamaBaseUrl: 'http://localhost:11434',
+			apiKeySecretName: 'test-secret',
+			historyFolder: 'gemini-scribe',
+		},
+		saveSettings: vi.fn().mockResolvedValue(undefined),
+		logger: { log: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() },
+		getModelManager: vi.fn(),
+	} as any;
+}
+
+function createContext() {
+	return {
+		redisplay: vi.fn(),
+		showDeveloperSettings: false,
+		setShowDeveloperSettings: vi.fn(),
+	};
+}
+
+// The settingName is the 3rd positional arg to selectModelSetting.
+function renderedModelKeys(): string[] {
+	return mockSelectModelSetting.mock.calls.map((call) => call[2]);
+}
+
+describe('renderGeneralSettings — model pickers per provider', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('renders a single chatModelName picker under Ollama', async () => {
+		const plugin = createMockPlugin('ollama');
+		await renderGeneralSettings({} as any, plugin, {} as any, createContext());
+
+		expect(renderedModelKeys()).toEqual(['chatModelName']);
+	});
+
+	it('renders all four independent pickers under Gemini', async () => {
+		const plugin = createMockPlugin('gemini');
+		await renderGeneralSettings({} as any, plugin, {} as any, createContext());
+
+		expect(renderedModelKeys()).toEqual([
+			'chatModelName',
+			'summaryModelName',
+			'completionsModelName',
+			'imageModelName',
+		]);
+	});
+});

--- a/test/ui/settings-general.test.ts
+++ b/test/ui/settings-general.test.ts
@@ -116,9 +116,16 @@ function createContext() {
 	};
 }
 
-// The settingName is the 3rd positional arg to selectModelSetting.
-function renderedModelKeys(): string[] {
-	return mockSelectModelSetting.mock.calls.map((call) => call[2]);
+// selectModelSetting(containerEl, plugin, settingName, label, description, role?).
+// Capture the settingName (arg 2) plus the label/description i18n keys (args 3/4)
+// so a picker wired to the wrong i18n key is caught, not just the wrong setting.
+// `t()` is mocked to echo its key, so label/desc are the raw key strings.
+function renderedModelCalls(): Array<{ settingName: string; label: string; desc: string }> {
+	return mockSelectModelSetting.mock.calls.map((call) => ({
+		settingName: call[2],
+		label: call[3],
+		desc: call[4],
+	}));
 }
 
 describe('renderGeneralSettings — model pickers per provider', () => {
@@ -126,22 +133,44 @@ describe('renderGeneralSettings — model pickers per provider', () => {
 		vi.clearAllMocks();
 	});
 
-	it('renders a single chatModelName picker under Ollama', async () => {
+	it('renders a single chatModelName picker with the Ollama label/description under Ollama', async () => {
 		const plugin = createMockPlugin('ollama');
 		await renderGeneralSettings({} as any, plugin, {} as any, createContext());
 
-		expect(renderedModelKeys()).toEqual(['chatModelName']);
+		expect(renderedModelCalls()).toEqual([
+			{
+				settingName: 'chatModelName',
+				label: 'settings.general.ollamaModelName',
+				desc: 'settings.general.ollamaModelDesc',
+			},
+		]);
 	});
 
-	it('renders all four independent pickers under Gemini', async () => {
+	it('renders all four independent pickers with their own labels/descriptions under Gemini', async () => {
 		const plugin = createMockPlugin('gemini');
 		await renderGeneralSettings({} as any, plugin, {} as any, createContext());
 
-		expect(renderedModelKeys()).toEqual([
-			'chatModelName',
-			'summaryModelName',
-			'completionsModelName',
-			'imageModelName',
+		expect(renderedModelCalls()).toEqual([
+			{
+				settingName: 'chatModelName',
+				label: 'settings.general.chatModelName',
+				desc: 'settings.general.chatModelDesc',
+			},
+			{
+				settingName: 'summaryModelName',
+				label: 'settings.general.summaryModelName',
+				desc: 'settings.general.summaryModelDesc',
+			},
+			{
+				settingName: 'completionsModelName',
+				label: 'settings.general.completionModelName',
+				desc: 'settings.general.completionModelDesc',
+			},
+			{
+				settingName: 'imageModelName',
+				label: 'settings.general.imageModelName',
+				desc: 'settings.general.imageModelDesc',
+			},
 		]);
 	});
 });


### PR DESCRIPTION
<!-- auto-dev -->

## Summary

When `provider === 'ollama'`, resolve every `ModelUseCase` (chat, summary, completions, rewrite, search) to the single configured `chatModelName` instead of the three independent per-use-case settings. Ollama keeps one model resident at a time, so diverging models per use case only thrashes RAM/VRAM on each switch for no benefit. Gemini's per-use-case resolution is left exactly as today.

This PR was produced by the auto-dev pipeline from the approved plan on the issue.

Fixes #1077

## Changes

- **`src/api/factory.ts`** — `ModelClientFactory.resolveModelName` gains an early branch: under Ollama it returns `settings.chatModelName || getDefaultModelForRole('chat', 'ollama')` for all use cases. The existing `switch (useCase)` is untouched and still drives Gemini.
- **`src/ui/settings-general.ts`** — under Ollama the General section now renders a single **Ollama model** picker (bound to `chatModelName`) and hides the summary/completions/image pickers; Gemini keeps all four independent pickers.
- **`src/i18n/en.ts`** — new `settings.general.ollamaModelName` / `ollamaModelDesc` keys for the collapsed Ollama picker label/description. Per-locale files regenerate via the `Update UI translations` workflow on merge; missing keys fall back to English meanwhile.
- **`test/api/factory.test.ts`** — the existing `Ollama provider` block is rewritten to assert every use case resolves to the single `chatModelName` (divergent summary/completions values ignored), plus the empty-`chatModelName` fallback for a non-chat use case.
- **`test/ui/settings-general.test.ts`** (new) — asserts a single `chatModelName` picker renders under Ollama and all four independent pickers render under Gemini.
- **`docs/reference/settings.md`, `docs/guide/ollama-setup.md`** — document that under Ollama a single model applies to every use case and the per-use-case settings are ignored.

## Screenshots / Screencast

N/A — settings-UI wiring change (picker visibility); no new visual surface. Behavior is covered by the new `settings-general` UI test.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — plus `npm run lint` and `npm run typecheck:test`
- [ ] I have tested this change on Desktop
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards)
- [x] Documentation has been updated (if applicable)
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude (auto-dev pipeline)
- [x] I have reviewed and understand all AI-generated code in this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_015ULaaNtWJpeGVi741yZ9TY)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clearer Ollama settings behavior: a single “Ollama model” picker now drives chat, summaries, completions, and rewrites.
  * Updated the General settings screen to render provider-specific model pickers (Gemini vs Ollama).

* **Documentation**
  * Updated the Ollama setup guide and settings reference to reflect the unified Ollama model selection and model refresh guidance, plus Gemini-only notes.
  
* **Bug Fixes**
  * Fixed Ollama model routing so all request types consistently use the configured chat model.

* **Tests**
  * Added UI regression coverage for provider-specific picker rendering and updated model-resolution assertions for Ollama.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->