### PR TITLE
ci(security): set persist-credentials: false on read-only checkouts (#1096)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # Read-only test job — nothing here pushes with the git-config
+          # credential, so don't persist the checkout token for the rest of
+          # the job. (The coverage deploy runs in a separate job that manages
+          # its own token.)
+          persist-credentials: false
 
       - name: Use Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/workflows/knip.yml
+++ b/.github/workflows/knip.yml
@@ -16,6 +16,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # Read-only report job — nothing here pushes with the git-config
+          # credential, so don't persist the checkout token for the rest of the job.
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,6 +15,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # Read-only lint job — nothing here pushes with the git-config
+          # credential, so don't persist the checkout token for the rest of the job.
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/workflows/model-update.yml
+++ b/.github/workflows/model-update.yml
@@ -15,6 +15,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # create-pull-request authenticates with its own token, so the checkout
+          # token does not need to persist in git config where npm ci / the model
+          # script could read it (mirrors i18n-translate.yml).
+          persist-credentials: false
 
       - name: Use Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,10 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # Read-only test job — nothing here pushes with the git-config
+          # credential, so don't persist the checkout token for the rest of the job.
+          persist-credentials: false
       - name: Use Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -34,6 +38,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # The release step authenticates `gh release create` with its own
+          # GITHUB_TOKEN env, and attest-build-provenance uses the OIDC id-token —
+          # neither relies on the git-config credential, and nothing here runs
+          # `git push`, so don't persist the checkout token.
+          persist-credentials: false
 
       - name: Use Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0


### PR DESCRIPTION
<!-- auto-dev -->

## Summary

Addresses the zizmor `artipacked` findings from #1096. `actions/checkout` persists the default `GITHUB_TOKEN` into the local git config for the remainder of the job unless `persist-credentials: false` is set — an unnecessary credential-exposure surface for jobs that only read the repo or manage their own auth. This adds `persist-credentials: false` to those checkout steps, mirroring the existing precedent in `.github/workflows/i18n-translate.yml`.

This is the **first slice only** of the approved plan. The `release.yml` `setup-node` cache-poisoning finding is a real caching-vs-security tradeoff flagged as the maintainer's call and is left out of scope for a follow-up.

This PR was produced by the auto-dev pipeline from the approved plan on the issue.

Fixes #1096

## Changes

- **`.github/workflows/ci.yml`** — `test` job checkout (read-only; the coverage deploy runs in a separate job with no checkout that manages its own token).
- **`.github/workflows/lint.yml`** — read-only lint job checkout.
- **`.github/workflows/knip.yml`** — read-only report job checkout.
- **`.github/workflows/model-update.yml`** — checkout; `peter-evans/create-pull-request` authenticates with its own token (same as i18n-translate).
- **`.github/workflows/release.yml`** — both the `test` job (read-only) and `build` job checkouts. Verified before applying: `gh release create` authenticates via its own `GITHUB_TOKEN` env, `attest-build-provenance` uses the OIDC id-token, and no step runs `git push`, so neither relies on the persisted git-config credential.

Each addition carries a short comment explaining why persistence is safe to drop, consistent with the i18n-translate.yml precedent.

**Out of scope (per the approved plan):** `docs.yml`'s gh-pages deploy (a push job); the `release.yml` `setup-node` cache-poisoning finding; wiring zizmor's full audit suite into CI.

## Screenshots / Screencast

N/A — CI/security configuration change only, no user-facing surface.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer — approved plan on #1096
- [x] All CI checks pass (`npm test` — 3272 passing, `npm run build`, `npm run format-check`) — plus `npm run typecheck:test` and `npm run lint:actions`
- [ ] I have tested this change on Desktop — N/A (CI config); workflows are exercised by CI on this PR
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A; no plugin code touched
- [x] Documentation has been updated (if applicable) — N/A; internal CI/security change with no user-facing surface
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude (auto-dev pipeline)
- [x] I have reviewed and understand all AI-generated code in this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01LnMek9KFXpMooVhmxzW8WZ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated workflows to avoid persisting checkout credentials during jobs.
  * Improved the security posture of CI, linting, reporting, model update, and release pipelines.
  * Kept all workflow behavior unchanged aside from the credential handling update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->