### PR TITLE
refactor: clear/scope no-deprecated and enforce the rule (#1040)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -29,7 +29,8 @@ const SOFTENED_TS_RULES = {
 	'@typescript-eslint/no-require-imports': 'off',
 	// #1041: cleared — enforced.
 	'@typescript-eslint/no-unused-expressions': 'error',
-	'@typescript-eslint/no-deprecated': 'off',
+	// #1040: cleared — enforced.
+	'@typescript-eslint/no-deprecated': 'error',
 	'@typescript-eslint/unbound-method': 'off',
 	'@typescript-eslint/no-unused-vars': [
 		'warn',

--- a/src/api/providers/gemini/client.ts
+++ b/src/api/providers/gemini/client.ts
@@ -301,6 +301,10 @@ export class GeminiClient implements ModelApi {
 			if (content) steps.push(...contentToSteps(content));
 		}
 
+		// `imageAttachments` is the deprecated alias for `inlineAttachments`; still read here so
+		// callers passing the legacy field keep working (backward-compat merge). Remove once no
+		// caller populates it. See ExtendedModelRequest.imageAttachments (#1040).
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		const attachments = [...(request.inlineAttachments || []), ...(request.imageAttachments || [])];
 		const userStep = buildUserInputStep(request.userMessage, request.perTurnContext, attachments);
 		if (userStep) steps.push(userStep);
@@ -553,6 +557,9 @@ export class GeminiClient implements ModelApi {
 		}
 
 		// Add inline data attachments (images, audio, video, PDF)
+		// `imageAttachments` is the deprecated alias for `inlineAttachments`; still merged here for
+		// backward-compat with callers passing the legacy field (#1040).
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		const allAttachments = [...(extReq.inlineAttachments || []), ...(extReq.imageAttachments || [])];
 		for (const attachment of allAttachments) {
 			userParts.push({

--- a/src/api/providers/ollama/client.ts
+++ b/src/api/providers/ollama/client.ts
@@ -253,6 +253,9 @@ export class OllamaClient implements ModelApi {
 		}
 		const allAttachments: InlineDataPart[] = [
 			...(request.inlineAttachments || []),
+			// `imageAttachments` is the deprecated alias for `inlineAttachments`; still merged here for
+			// backward-compat with callers passing the legacy field (#1040).
+			// eslint-disable-next-line @typescript-eslint/no-deprecated
 			...(request.imageAttachments || []),
 		];
 		for (const att of allAttachments) {

--- a/src/services/background-task-manager.ts
+++ b/src/services/background-task-manager.ts
@@ -215,7 +215,7 @@ export class BackgroundTaskManager {
 	private showCompletionNotice(task: BackgroundTask): void {
 		if (task.outputPath) {
 			const notice = new Notice(``, 8000);
-			const fragment = notice.noticeEl;
+			const fragment = notice.messageEl;
 			fragment.createSpan({ text: `${t('notice.backgroundTask.complete', { label: task.label })} ` });
 			const link = fragment.createEl('a', { text: t('notice.backgroundTask.openResult'), href: '#' });
 			link.addEventListener('click', (e) => {

--- a/src/ui/agent-view/session-settings-modal.ts
+++ b/src/ui/agent-view/session-settings-modal.ts
@@ -91,6 +91,8 @@ export class SessionSettingsModal extends Modal {
 				slider
 					.setLimits(0, 2, 0.1)
 					.setValue(currentTemp)
+					// Dropping setDynamicTooltip() is only safe on Obsidian >= 1.13.0 (where the value shows inline); minAppVersion is 1.11.4, so keep it to preserve the slider value tooltip (#1040).
+					// eslint-disable-next-line @typescript-eslint/no-deprecated
 					.setDynamicTooltip()
 					.onChange(async (value) => {
 						// Only save if different from default
@@ -139,6 +141,8 @@ export class SessionSettingsModal extends Modal {
 				slider
 					.setLimits(0, 1, 0.05)
 					.setValue(currentTopP)
+					// Dropping setDynamicTooltip() is only safe on Obsidian >= 1.13.0 (where the value shows inline); minAppVersion is 1.11.4, so keep it to preserve the slider value tooltip (#1040).
+					// eslint-disable-next-line @typescript-eslint/no-deprecated
 					.setDynamicTooltip()
 					.onChange(async (value) => {
 						// Only save if different from default

--- a/src/ui/mcp-server-modal.ts
+++ b/src/ui/mcp-server-modal.ts
@@ -127,6 +127,8 @@ export class MCPServerModal extends Modal {
 					.addButton((btn) =>
 						btn
 							.setButtonText(t('mcpServer.oauthClearButton'))
+							// setDestructive() (the recommended replacement) requires Obsidian 1.13.0, above the current minAppVersion 1.11.4; keep setWarning until the floor is raised (#1040).
+							// eslint-disable-next-line @typescript-eslint/no-deprecated
 							.setWarning()
 							.onClick(() => {
 								oauthProvider.clearAll();

--- a/src/ui/rag-cleanup-modal.ts
+++ b/src/ui/rag-cleanup-modal.ts
@@ -44,6 +44,8 @@ export class RagCleanupModal extends Modal {
 			.addButton((btn) =>
 				btn
 					.setButtonText(t('ragCleanup.deleteButton'))
+					// setDestructive() (the recommended replacement) requires Obsidian 1.13.0, above the current minAppVersion 1.11.4; keep setWarning until the floor is raised (#1040).
+					// eslint-disable-next-line @typescript-eslint/no-deprecated
 					.setWarning()
 					.onClick(() => {
 						this.close();

--- a/src/ui/rag-progress-modal.ts
+++ b/src/ui/rag-progress-modal.ts
@@ -114,6 +114,8 @@ export class RagProgressModal extends Modal {
 			this.cancelBtn = btn.buttonEl;
 			btn
 				.setButtonText(t('ragProgress.cancelButton'))
+				// setDestructive() (the recommended replacement) requires Obsidian 1.13.0, above the current minAppVersion 1.11.4; keep setWarning until the floor is raised (#1040).
+				// eslint-disable-next-line @typescript-eslint/no-deprecated
 				.setWarning()
 				.onClick(() => {
 					this.ragService.cancelIndexing();

--- a/src/ui/rag-resume-modal.ts
+++ b/src/ui/rag-resume-modal.ts
@@ -70,6 +70,8 @@ export class RagResumeModal extends Modal {
 			.addButton((btn) =>
 				btn
 					.setButtonText(t('ragResume.startFreshButton'))
+					// setDestructive() (the recommended replacement) requires Obsidian 1.13.0, above the current minAppVersion 1.11.4; keep setWarning until the floor is raised (#1040).
+					// eslint-disable-next-line @typescript-eslint/no-deprecated
 					.setWarning()
 					.onClick(() => {
 						this.close();

--- a/src/ui/settings-agent-config.ts
+++ b/src/ui/settings-agent-config.ts
@@ -165,6 +165,8 @@ export async function renderAgentConfigSettings(
 		slider
 			.setLimits(5, 50, 5)
 			.setValue(plugin.settings.contextCompactionThreshold)
+			// Dropping setDynamicTooltip() is only safe on Obsidian >= 1.13.0 (where the value shows inline); minAppVersion is 1.11.4, so keep it to preserve the slider value tooltip (#1040).
+			// eslint-disable-next-line @typescript-eslint/no-deprecated
 			.setDynamicTooltip()
 			.onChange(async (value) => {
 				plugin.settings.contextCompactionThreshold = value;
@@ -195,6 +197,8 @@ export async function renderAgentConfigSettings(
 				slider
 					.setLimits(2, 10, 1)
 					.setValue(plugin.settings.loopDetectionThreshold)
+					// Dropping setDynamicTooltip() is only safe on Obsidian >= 1.13.0 (where the value shows inline); minAppVersion is 1.11.4, so keep it to preserve the slider value tooltip (#1040).
+					// eslint-disable-next-line @typescript-eslint/no-deprecated
 					.setDynamicTooltip()
 					.onChange(async (value) => {
 						plugin.settings.loopDetectionThreshold = value;
@@ -209,6 +213,8 @@ export async function renderAgentConfigSettings(
 				slider
 					.setLimits(10, 120, 5)
 					.setValue(plugin.settings.loopDetectionTimeWindowSeconds)
+					// Dropping setDynamicTooltip() is only safe on Obsidian >= 1.13.0 (where the value shows inline); minAppVersion is 1.11.4, so keep it to preserve the slider value tooltip (#1040).
+					// eslint-disable-next-line @typescript-eslint/no-deprecated
 					.setDynamicTooltip()
 					.onChange(async (value) => {
 						plugin.settings.loopDetectionTimeWindowSeconds = value;
@@ -234,6 +240,8 @@ async function createTemperatureSetting(containerEl: HTMLElement, plugin: Obsidi
 			slider
 				.setLimits(ranges.temperature.min, ranges.temperature.max, ranges.temperature.step)
 				.setValue(plugin.settings.temperature)
+				// Dropping setDynamicTooltip() is only safe on Obsidian >= 1.13.0 (where the value shows inline); minAppVersion is 1.11.4, so keep it to preserve the slider value tooltip (#1040).
+				// eslint-disable-next-line @typescript-eslint/no-deprecated
 				.setDynamicTooltip()
 				.onChange(async (value) => {
 					if (temperatureDebounceTimer) {
@@ -299,6 +307,8 @@ async function createTopPSetting(containerEl: HTMLElement, plugin: ObsidianGemin
 			slider
 				.setLimits(ranges.topP.min, ranges.topP.max, ranges.topP.step)
 				.setValue(plugin.settings.topP)
+				// Dropping setDynamicTooltip() is only safe on Obsidian >= 1.13.0 (where the value shows inline); minAppVersion is 1.11.4, so keep it to preserve the slider value tooltip (#1040).
+				// eslint-disable-next-line @typescript-eslint/no-deprecated
 				.setDynamicTooltip()
 				.onChange(async (value) => {
 					if (topPDebounceTimer) {

--- a/src/ui/settings-mcp.ts
+++ b/src/ui/settings-mcp.ts
@@ -152,6 +152,8 @@ async function createMCPSettings(
 				.addButton((btn) =>
 					btn
 						.setButtonText(t('settings.mcp.deleteButton'))
+						// setDestructive() (the recommended replacement) requires Obsidian 1.13.0, above the current minAppVersion 1.11.4; keep setWarning until the floor is raised (#1040).
+						// eslint-disable-next-line @typescript-eslint/no-deprecated
 						.setWarning()
 						.onClick(async () => {
 							// Disconnect first if connected

--- a/src/ui/settings-rag.ts
+++ b/src/ui/settings-rag.ts
@@ -117,6 +117,8 @@ export async function renderRAGSettings(
 			.addButton((button) =>
 				button
 					.setButtonText(t('settings.rag.deleteIndexButton'))
+					// setDestructive() (the recommended replacement) requires Obsidian 1.13.0, above the current minAppVersion 1.11.4; keep setWarning until the floor is raised (#1040).
+					// eslint-disable-next-line @typescript-eslint/no-deprecated
 					.setWarning()
 					.onClick(async () => {
 						if (!plugin.ragIndexing) {

--- a/src/ui/settings.ts
+++ b/src/ui/settings.ts
@@ -38,6 +38,11 @@ export default class ObsidianGeminiSettingTab extends PluginSettingTab {
 		containerEl.empty();
 
 		const context: SettingsSectionContext = {
+			// `PluginSettingTab.display()` is deprecated in favor of the declarative
+			// `getSettingDefinitions()` (Obsidian 1.13.0). Migrating this settings tree to the
+			// new API is a large rework tracked separately and out of scope for #1040; the
+			// imperative `display()` override remains the supported pattern meanwhile.
+			// eslint-disable-next-line @typescript-eslint/no-deprecated
 			redisplay: () => this.display(),
 			showDeveloperSettings: this.showDeveloperSettings,
 			setShowDeveloperSettings: (value: boolean) => {

--- a/src/ui/yolo-confirmation-modal.ts
+++ b/src/ui/yolo-confirmation-modal.ts
@@ -51,6 +51,8 @@ export class YoloConfirmationModal extends Modal {
 			.addButton((btn) =>
 				btn
 					.setButtonText(t('yolo.enableButton'))
+					// setDestructive() (the recommended replacement) requires Obsidian 1.13.0, above the current minAppVersion 1.11.4; keep setWarning until the floor is raised (#1040).
+					// eslint-disable-next-line @typescript-eslint/no-deprecated
 					.setWarning()
 					.onClick(() => {
 						this.resolved = true;

--- a/src/utils/dom-context.ts
+++ b/src/utils/dom-context.ts
@@ -108,8 +108,15 @@ export function moveCursorToEnd(element: HTMLElement): void {
 /**
  * Execute a command in the correct document context.
  * Useful for commands like 'paste', 'copy', etc.
+ *
+ * This is a last-resort fallback: the sole caller (the agent input paste handler)
+ * tries the async Clipboard API (`navigator.clipboard.readText`) first and only
+ * falls back here when it is unavailable or throws (e.g. some popout-window
+ * contexts). `document.execCommand` is deprecated but remains the only synchronous
+ * fallback for those environments, so the deprecation is intentionally suppressed.
  */
 export function execContextCommand(element: HTMLElement, command: string, value?: string): boolean {
 	const { doc } = getDOMContext(element);
+	// eslint-disable-next-line @typescript-eslint/no-deprecated
 	return doc.execCommand(command, false, value);
 }

--- a/test/services/background-task-manager.test.ts
+++ b/test/services/background-task-manager.test.ts
@@ -26,12 +26,12 @@ function createMockPlugin(overrides: Record<string, any> = {}): any {
 	};
 }
 
-// Mock Obsidian's Notice — provide a noticeEl so showCompletionNotice doesn't throw.
-// Track instances via noticeInstances so tests can assert on noticeEl method calls.
+// Mock Obsidian's Notice — provide a messageEl so showCompletionNotice doesn't throw.
+// Track instances via noticeInstances so tests can assert on messageEl method calls.
 const { noticeInstances, NoticeMock } = vi.hoisted(() => {
 	const instances: any[] = [];
 	const Mock = vi.fn().mockImplementation(function (this: any) {
-		this.noticeEl = {
+		this.messageEl = {
 			createSpan: vi.fn().mockReturnValue({ setText: vi.fn() }),
 			createEl: vi.fn().mockReturnValue({
 				addEventListener: vi.fn(),
@@ -377,12 +377,12 @@ describe('BackgroundTaskManager', () => {
 
 			// showCompletionNotice should have created a Notice with a clickable link
 			expect(NoticeMock).toHaveBeenCalled();
-			const notice = noticeInstances.find((n) => n.noticeEl.createEl.mock.calls.length > 0);
+			const notice = noticeInstances.find((n) => n.messageEl.createEl.mock.calls.length > 0);
 			expect(notice).toBeDefined();
-			expect(notice.noticeEl.createSpan).toHaveBeenCalledWith(
+			expect(notice.messageEl.createSpan).toHaveBeenCalledWith(
 				expect.objectContaining({ text: expect.stringContaining('Deep research') })
 			);
-			expect(notice.noticeEl.createEl).toHaveBeenCalledWith('a', expect.objectContaining({ text: 'Open result' }));
+			expect(notice.messageEl.createEl).toHaveBeenCalledWith('a', expect.objectContaining({ text: 'Open result' }));
 		});
 
 		it('completes without error when task has no outputPath', async () => {

--- a/test/ui/settings-display-race.test.ts
+++ b/test/ui/settings-display-race.test.ts
@@ -1,3 +1,7 @@
+// This suite exists specifically to exercise the race behavior of the settings tab's
+// `display()` override, so it calls the deprecated `PluginSettingTab.display()` directly.
+// Migrating off `display()` to `getSettingDefinitions()` is out of scope for #1040.
+/* eslint-disable @typescript-eslint/no-deprecated */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // Counters that the section-render mocks bump so the test can assert on


### PR DESCRIPTION
<!-- auto-dev -->

## Summary

Re-enables `@typescript-eslint/no-deprecated` as `error` (softened `off` in #1032's dashboard sweep) after resolving every violation, so new deprecated-API usage can't regress. Part of #1032.

The key constraint the approved plan didn't anticipate: the plugin's `minAppVersion` is **1.11.4**, but the recommended replacements for two of the deprecated APIs only exist in Obsidian **1.13.0** (`obsidianmd/no-unsupported-api` rejects them). Those are therefore retained behind scoped, documented `no-deprecated` disables rather than swapped — bumping the min-version floor is a user-facing maintainer decision, out of scope for this quick-win. Everything safe-to-migrate is migrated; every retained deprecation carries an inline justification pointing at its blocker.

This PR was produced by the auto-dev pipeline from the approved plan on the issue.

Fixes #1040

## Changes

**Migrated (replacement available at minAppVersion 1.11.4):**

- `src/services/background-task-manager.ts` — `Notice.noticeEl` → `messageEl` (available since Obsidian 1.8.7).
- `test/services/background-task-manager.test.ts` — the `Notice` mock now exposes `messageEl` (matching the real API) so `showCompletionNotice` resolves; assertions updated.

**Retained behind scoped, documented `no-deprecated` disables (not safe to clear yet):**

- `ButtonComponent.setWarning()` (7 sites: `rag-progress-modal`, `settings-mcp`, `settings-rag`, `mcp-server-modal`, `rag-resume-modal`, `yolo-confirmation-modal`, `rag-cleanup-modal`) — the replacement `setDestructive()` requires Obsidian 1.13.0 and fails `obsidianmd/no-unsupported-api` at the current floor.
- `SliderComponent.setDynamicTooltip()` (7 sites: `settings-agent-config` ×5, `session-settings-modal` ×2) — its "value always shown inline" behavior only lands in 1.13.0; dropping it would remove the slider value tooltip on 1.11.4–1.12.x.
- `ExtendedModelRequest.imageAttachments` reads (3 sites in the Gemini/Ollama clients) — the deprecated alias is still merged for backward-compat with callers passing the legacy field. It's a runtime request field, never persisted to session history, so no deserialization shim is needed (the backward-compat merge test in `client.test.ts` is unaffected — object-literal keys aren't flagged by the rule).
- `document.execCommand` in `src/utils/dom-context.ts` — last-resort synchronous paste fallback used only after the async Clipboard API (`navigator.clipboard.readText`) is unavailable/throws.
- `PluginSettingTab.display()` (`src/ui/settings.ts` + `test/ui/settings-display-race.test.ts`) — migrating to the declarative `getSettingDefinitions()` (1.13.0) is a large rework, explicitly out of scope per the approved plan.

**Rule enforcement:**

- `eslint.config.mjs` — `@typescript-eslint/no-deprecated` flipped from `off` to `error` (applies to both `src/` and `test/`).

**Plan deviations (documented):** the plan proposed `setWarning → setDestructive` and dropping `setDynamicTooltip`; both are blocked by `minAppVersion 1.11.4 < 1.13.0`, so they are scoped rather than migrated (per the issue's "re-enabled *or scoped*" done-criteria). The plan's `imageAttachments` deserialization shim was unnecessary since the field is request-time only, never serialized.

## Screenshots / Screencast

N/A — internal lint/deprecation-hygiene change. The one runtime touch (`noticeEl` → `messageEl`) targets the same notice element and is visually identical; `setWarning`/`setDynamicTooltip` behavior is unchanged (retained).

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer — approved plan on #1040
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — plus `npm run lint` (0 errors, `no-deprecated` now enforced) and `npm run typecheck:test`; locally 3272 tests pass
- [ ] I have tested this change on Desktop — automated pre-flight green; changes are deprecation-hygiene with one visually-identical notice-element rename
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — no platform-specific APIs; `messageEl` is available at minAppVersion 1.11.4
- [x] Documentation has been updated (if applicable) — N/A: internal lint change with no user-facing surface, settings, or commands changed
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude (auto-dev pipeline)
- [x] I have reviewed and understand all AI-generated code in this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01TUH5Yu1f3JDMqT7jqCFwVH)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed task completion notices so the message and “Open result” link appear in the correct place when a result file is available.
  * Preserved existing app behavior for attachment handling and settings actions while improving compatibility with older app versions.

* **Tests**
  * Updated tests to match the revised completion notice rendering.
  * Added coverage notes for deprecated settings-screen behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->