### PR TITLE
refactor: extract shared no-tool-call finalize from send paths (#1102)

### DIFF
--- a/src/ui/agent-view/agent-view-send.ts
+++ b/src/ui/agent-view/agent-view-send.ts
@@ -3,7 +3,7 @@ import type { Content } from '@google/genai';
 import { ChatSession } from '../../types/agent';
 import { GeminiConversationEntry } from '../../types/conversation';
 import { ToolExecutionContext } from '../../tools/types';
-import { ExtendedModelRequest, ModelApi, StreamChunk } from '../../api/interfaces/model-api';
+import { ExtendedModelRequest, ModelApi, ModelResponse, StreamChunk } from '../../api/interfaces/model-api';
 import { CustomPrompt } from '../../prompts/types';
 import { AgentFactory } from '../../agent/agent-factory';
 import { getErrorMessage } from '../../utils/error-utils';
@@ -620,61 +620,31 @@ To reference an attachment in your response, use the path shown above.`;
 								hadPartialText ? undefined : turnThoughts
 							);
 						} else {
-							// Normal response without tool calls
-							// Only finalize and save if response has content
-							if (response.markdown && response.markdown.trim()) {
-								const aiEntry: GeminiConversationEntry = {
-									role: 'model',
-									message: response.markdown,
-									notePath: '',
-									created_at: new Date(),
-									model: modelName,
-									...(turnThoughts ? { thoughts: turnThoughts } : {}),
-								};
-
-								// Finalize the streaming message with proper rendering
-								if (modelMessageContainer) {
-									await this.ctx.messages.finalizeStreamingMessage(
-										modelMessageContainer,
-										response.markdown,
-										aiEntry,
-										currentSession
-									);
+							// Normal response without tool calls — shared three-way finalize
+							// with a streaming-specific render step: finalize the live
+							// container for answer text (display the reasoning entry when
+							// there's no answer), then scroll to the bottom.
+							await this.finalizeNoToolCallResponse(
+								response,
+								turnThoughts,
+								modelName,
+								currentSession,
+								async (entry, reasoningOnly) => {
+									if (reasoningOnly) {
+										await this.ctx.messages.displayMessage(entry, currentSession);
+									} else if (modelMessageContainer) {
+										// Finalize the streaming message with proper rendering
+										await this.ctx.messages.finalizeStreamingMessage(
+											modelMessageContainer,
+											entry.message,
+											entry,
+											currentSession
+										);
+									}
+									// Ensure we're scrolled to bottom after streaming completes
+									this.ctx.messages.scrollToBottom();
 								}
-
-								// Save AI response to history (user message already saved early)
-								await this.ctx.plugin.sessionHistory.addEntryToSession(currentSession, aiEntry);
-
-								// Ensure we're scrolled to bottom after streaming completes
-								this.ctx.messages.scrollToBottom();
-
-								// Hide progress bar after successful response
-								this.ctx.progress.hide();
-							} else if (turnThoughts) {
-								// No answer text, but the model did reason — show and persist
-								// the reasoning instead of a bare "empty response" notice.
-								const reasoningEntry: GeminiConversationEntry = {
-									role: 'model',
-									message: '',
-									notePath: '',
-									created_at: new Date(),
-									model: modelName,
-									thoughts: turnThoughts,
-								};
-								await this.ctx.messages.displayMessage(reasoningEntry, currentSession);
-								await this.ctx.plugin.sessionHistory.addEntryToSession(currentSession, reasoningEntry);
-								this.ctx.messages.scrollToBottom();
-								this.ctx.progress.hide();
-							} else {
-								// Empty response - might be thinking tokens
-								this.ctx.plugin.logger.warn('Model returned empty response');
-								new Notice(t('agent.send.emptyResponse'));
-
-								// Hide progress bar
-								this.ctx.progress.hide();
-
-								// User message already saved early in sendMessage()
-							}
+							);
 						}
 					} catch (error) {
 						this.currentStreamingResponse = null;
@@ -717,48 +687,12 @@ To reference an attachment in your response, use the path shown above.`;
 							turnThoughts
 						);
 					} else {
-						// Normal response without tool calls
-						// Only display if response has content
-						if (response.markdown && response.markdown.trim()) {
-							// Display AI response
-							const aiEntry: GeminiConversationEntry = {
-								role: 'model',
-								message: response.markdown,
-								notePath: '',
-								created_at: new Date(),
-								model: modelName,
-								...(turnThoughts ? { thoughts: turnThoughts } : {}),
-							};
-							await this.ctx.displayMessage(aiEntry);
-
-							// Save AI response to history (user message already saved early)
-							await this.ctx.plugin.sessionHistory.addEntryToSession(currentSession, aiEntry);
-
-							// Hide progress bar after successful response
-							this.ctx.progress.hide();
-						} else if (turnThoughts) {
-							// No answer text, but the model reasoned — show and persist it.
-							const reasoningEntry: GeminiConversationEntry = {
-								role: 'model',
-								message: '',
-								notePath: '',
-								created_at: new Date(),
-								model: modelName,
-								thoughts: turnThoughts,
-							};
-							await this.ctx.displayMessage(reasoningEntry);
-							await this.ctx.plugin.sessionHistory.addEntryToSession(currentSession, reasoningEntry);
-							this.ctx.progress.hide();
-						} else {
-							// Empty response - might be thinking tokens
-							this.ctx.plugin.logger.warn('Model returned empty response');
-							new Notice(t('agent.send.emptyResponse'));
-
-							// User message already saved early in sendMessage()
-
-							// Hide progress bar
-							this.ctx.progress.hide();
-						}
+						// Normal response without tool calls — shared three-way finalize
+						// with the non-streaming render step (plain displayMessage, no
+						// scroll) for both the answer and reasoning-only cases.
+						await this.finalizeNoToolCallResponse(response, turnThoughts, modelName, currentSession, async (entry) => {
+							await this.ctx.displayMessage(entry);
+						});
 					}
 				}
 			} catch (error) {
@@ -791,6 +725,63 @@ To reference an attachment in your response, use the path shown above.`;
 
 			// Always update token usage display after any message completion
 			await this.ctx.updateTokenUsage();
+		}
+	}
+
+	/**
+	 * Finalize a normal (no-tool-call) model response. Shared by the streaming
+	 * and non-streaming send paths, which previously duplicated this three-way
+	 * branch. Owns the shared work — building the model entry, persisting it to
+	 * session history, and hiding the progress bar — while the caller-supplied
+	 * `renderEntry` step handles the one part that genuinely differs between the
+	 * two paths: how the entry is rendered (and, for streaming, the extra scroll).
+	 *
+	 * `renderEntry` is invoked with `reasoningOnly = false` for an answer entry
+	 * and `reasoningOnly = true` for a reasoning-only entry (no answer text).
+	 */
+	private async finalizeNoToolCallResponse(
+		response: Pick<ModelResponse, 'markdown'>,
+		turnThoughts: string | undefined,
+		modelName: string,
+		currentSession: ChatSession,
+		renderEntry: (entry: GeminiConversationEntry, reasoningOnly: boolean) => Promise<void>
+	): Promise<void> {
+		// Only finalize and save if response has content
+		if (response.markdown && response.markdown.trim()) {
+			const aiEntry: GeminiConversationEntry = {
+				role: 'model',
+				message: response.markdown,
+				notePath: '',
+				created_at: new Date(),
+				model: modelName,
+				...(turnThoughts ? { thoughts: turnThoughts } : {}),
+			};
+			await renderEntry(aiEntry, false);
+			// Save AI response to history (user message already saved early)
+			await this.ctx.plugin.sessionHistory.addEntryToSession(currentSession, aiEntry);
+			// Hide progress bar after successful response
+			this.ctx.progress.hide();
+		} else if (turnThoughts) {
+			// No answer text, but the model did reason — show and persist the
+			// reasoning instead of a bare "empty response" notice.
+			const reasoningEntry: GeminiConversationEntry = {
+				role: 'model',
+				message: '',
+				notePath: '',
+				created_at: new Date(),
+				model: modelName,
+				thoughts: turnThoughts,
+			};
+			await renderEntry(reasoningEntry, true);
+			await this.ctx.plugin.sessionHistory.addEntryToSession(currentSession, reasoningEntry);
+			this.ctx.progress.hide();
+		} else {
+			// Empty response - might be thinking tokens.
+			// User message already saved early in sendMessage().
+			this.ctx.plugin.logger.warn('Model returned empty response');
+			new Notice(t('agent.send.emptyResponse'));
+			// Hide progress bar
+			this.ctx.progress.hide();
 		}
 	}
 

--- a/test/ui/agent-view/agent-view-send.test.ts
+++ b/test/ui/agent-view/agent-view-send.test.ts
@@ -1,0 +1,114 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import { Notice } from 'obsidian';
+import { AgentViewSend } from '../../../src/ui/agent-view/agent-view-send';
+import type { GeminiConversationEntry } from '../../../src/types/conversation';
+
+// Unit coverage for the shared `finalizeNoToolCallResponse` helper extracted from
+// the streaming and non-streaming send paths (#1102). It owns the three-way
+// branch (answer / reasoning-only / empty); the per-path render step is supplied
+// by the caller, so these tests drive it with a stub render callback and assert
+// the shared work: entry construction, history persistence, and progress hiding.
+
+const NoticeMock = Notice as unknown as ReturnType<typeof vi.fn>;
+
+function makeCtx() {
+	const addEntryToSession = vi.fn().mockResolvedValue(undefined);
+	const hide = vi.fn();
+	const warn = vi.fn();
+	const ctx = {
+		plugin: {
+			sessionHistory: { addEntryToSession },
+			logger: { warn },
+		},
+		progress: { hide },
+	} as any;
+	return { ctx, addEntryToSession, hide, warn };
+}
+
+const session = { id: 's1' } as any;
+
+// Invoke the private helper under test without widening its visibility.
+function finalize(
+	send: AgentViewSend,
+	response: { markdown: string },
+	turnThoughts: string | undefined,
+	modelName: string,
+	renderEntry: (entry: GeminiConversationEntry, reasoningOnly: boolean) => Promise<void>
+): Promise<void> {
+	return (send as any).finalizeNoToolCallResponse(response, turnThoughts, modelName, session, renderEntry);
+}
+
+describe('AgentViewSend.finalizeNoToolCallResponse', () => {
+	beforeEach(() => {
+		NoticeMock.mockClear();
+	});
+
+	test('answer text: builds entry, renders with reasoningOnly=false, persists, hides progress', async () => {
+		const { ctx, addEntryToSession, hide } = makeCtx();
+		const send = new AgentViewSend(ctx);
+		const calls: Array<{ entry: GeminiConversationEntry; reasoningOnly: boolean }> = [];
+		const renderEntry = vi.fn(async (entry: GeminiConversationEntry, reasoningOnly: boolean) => {
+			calls.push({ entry, reasoningOnly });
+		});
+
+		await finalize(send, { markdown: 'hello world' }, 'my reasoning', 'gemini-3-flash', renderEntry);
+
+		expect(renderEntry).toHaveBeenCalledTimes(1);
+		expect(calls[0].reasoningOnly).toBe(false);
+		expect(calls[0].entry.role).toBe('model');
+		expect(calls[0].entry.message).toBe('hello world');
+		expect(calls[0].entry.model).toBe('gemini-3-flash');
+		expect(calls[0].entry.thoughts).toBe('my reasoning');
+		// The exact entry that was rendered is the one persisted to history.
+		expect(addEntryToSession).toHaveBeenCalledWith(session, calls[0].entry);
+		expect(hide).toHaveBeenCalledTimes(1);
+		expect(NoticeMock).not.toHaveBeenCalled();
+	});
+
+	test('answer text without thoughts omits the thoughts field', async () => {
+		const { ctx } = makeCtx();
+		const send = new AgentViewSend(ctx);
+		let captured: GeminiConversationEntry | undefined;
+
+		await finalize(send, { markdown: 'hi' }, undefined, 'm', async (entry) => {
+			captured = entry;
+		});
+
+		expect(captured).toBeDefined();
+		expect('thoughts' in (captured as object)).toBe(false);
+	});
+
+	test('reasoning only (whitespace answer): renders with reasoningOnly=true, persists, hides progress', async () => {
+		const { ctx, addEntryToSession, hide } = makeCtx();
+		const send = new AgentViewSend(ctx);
+		let captured: { entry: GeminiConversationEntry; reasoningOnly: boolean } | undefined;
+		const renderEntry = vi.fn(async (entry: GeminiConversationEntry, reasoningOnly: boolean) => {
+			captured = { entry, reasoningOnly };
+		});
+
+		// Whitespace-only markdown counts as "no answer" and falls to the reasoning branch.
+		await finalize(send, { markdown: '   ' }, 'deep thoughts', 'm', renderEntry);
+
+		expect(renderEntry).toHaveBeenCalledTimes(1);
+		expect(captured!.reasoningOnly).toBe(true);
+		expect(captured!.entry.message).toBe('');
+		expect(captured!.entry.thoughts).toBe('deep thoughts');
+		expect(addEntryToSession).toHaveBeenCalledWith(session, captured!.entry);
+		expect(hide).toHaveBeenCalledTimes(1);
+		expect(NoticeMock).not.toHaveBeenCalled();
+	});
+
+	test('empty response (no answer, no thoughts): warns, shows notice, hides progress, saves and renders nothing', async () => {
+		const { ctx, addEntryToSession, hide, warn } = makeCtx();
+		const send = new AgentViewSend(ctx);
+		const renderEntry = vi.fn();
+
+		await finalize(send, { markdown: '' }, undefined, 'm', renderEntry);
+
+		expect(renderEntry).not.toHaveBeenCalled();
+		expect(addEntryToSession).not.toHaveBeenCalled();
+		expect(warn).toHaveBeenCalledWith('Model returned empty response');
+		expect(NoticeMock).toHaveBeenCalledTimes(1);
+		expect(hide).toHaveBeenCalledTimes(1);
+	});
+});


### PR DESCRIPTION
<!-- auto-dev -->

## Summary

Both the streaming and non-streaming send paths in `AgentViewSend` duplicated the same three-way "normal response without tool calls" branch — answer text → build entry + save + hide progress; reasoning-only → build reasoning entry + save + hide; empty → warn + notice + hide. This extracts that branch into a single private `finalizeNoToolCallResponse` helper.

The helper owns the shared work (building the model entry, persisting it to session history, hiding the progress bar); the caller supplies a small `renderEntry(entry, reasoningOnly)` step for the one part that genuinely differs between the two paths — the streaming path finalizes the live streaming container (or displays the reasoning entry) and then scrolls, while the non-streaming path does a plain `displayMessage`. Pure code-motion: behavior for all three cases is preserved exactly, including the streaming path's extra `scrollToBottom()`, which is captured in the streaming render callback.

This PR was produced by the auto-dev pipeline from the approved plan on the issue.

Fixes #1102

## Changes

- **`src/ui/agent-view/agent-view-send.ts`** — added `private async finalizeNoToolCallResponse(response, turnThoughts, modelName, currentSession, renderEntry)` holding the shared answer/reasoning-only/empty branch. The streaming `else` branch (~L622–678) and the non-streaming `else` branch (~L719–762) now each call it, passing a path-specific render callback:
  - streaming: for answer text, `finalizeStreamingMessage(modelMessageContainer, entry.message, entry, session)` when a container exists; for reasoning-only, `messages.displayMessage(entry, session)`; then `scrollToBottom()` — matching prior behavior.
  - non-streaming: `ctx.displayMessage(entry)` for both cases, no scroll — matching prior behavior.
  - `ModelResponse` added to the existing model-api import (used to type the helper's `response` param via `Pick<ModelResponse, 'markdown'>`).
- **`test/ui/agent-view/agent-view-send.test.ts`** (new) — unit coverage for the extracted helper across all three cases (answer / answer-without-thoughts / reasoning-only / empty), driving it with a stub render callback and asserting entry construction, the `reasoningOnly` flag, the `addEntryToSession` persistence call, `progress.hide()`, and the empty-response `logger.warn` + `Notice`.

The tool-call branch (`handleToolCalls`) on each path is untouched — only the no-tool-calls `else` is unified.

## Screenshots / Screencast

N/A — internal refactor (pure code-motion) with no user-visible behavior change.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer — approved plan on #1102
- [x] All CI checks pass (`npm test` — 3276 passing, `npm run build`, `npm run format-check`) — plus `npm run typecheck:test` and `npm run lint` on the changed files
- [ ] I have tested this change on Desktop — automated pre-flight green; pure code-motion refactor with behavior preserved on both send paths
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — no platform-specific APIs touched
- [x] Documentation has been updated (if applicable) — N/A: internal refactor, no user-facing surface, settings, or commands changed
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude (auto-dev pipeline)
- [x] I have reviewed and understand all AI-generated code in this PR

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015KjL39V93kVUPzjM5dG1iG

---
_Generated by [Claude Code](https://claude.ai/code/session_015KjL39V93kVUPzjM5dG1iG)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how agent responses are finalized when no tool calls are made, keeping streaming and non-streaming behavior consistent.
  * Better handles reasoning-only and empty responses, including clearer empty-response notices and smoother progress cleanup.

* **Tests**
  * Added coverage for normal responses, responses without thoughts, reasoning-only output, and empty responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->