### PR TITLE
chore(daily): 2026-07-04 daily update

### DIFF
--- a/planning/changelog/2026-07-03.md
+++ b/planning/changelog/2026-07-03.md
@@ -1,0 +1,120 @@
+# Daily changelog — July 03, 2026
+
+**Date:** 2026-07-03
+**PRs merged:** 27
+
+---
+
+## Summary
+
+A design-heavy, cleanup-heavy day. The design-token initiative that started the day before wrapped up: elevation, motion, icon sizing, and a signature brand accent (gradient send button, solid accent user bubbles) all landed, closing out the visible half of the styles.css migration. In parallel, the auto-dev pipeline chewed through a long backlog of strict-TS and architecture-audit findings — unnecessary type assertions, `TFile`/`TFolder` casts, floating promises, `no-explicit-any` in `src/utils`/`src/mcp`, and several DRY consolidations — each re-enabling its ESLint rule so the fix can't regress. The day closed with a large `scheduled-task-manager.ts` split into a proper package and a CI supply-chain hardening pass pinning every GitHub Action to a commit SHA.
+
+## What shipped
+
+### [#1093 refactor: use vault.configDir for system-folder exclusions](https://github.com/allenhutchison/obsidian-gemini/pull/1093)
+
+Threads the vault's real `configDir` through system-folder exclusion checks instead of hardcoding `.obsidian`, so a renamed config directory can no longer leak into agent/RAG operations or over-match a vault folder named `.obsidian`. Re-enables the ESLint rule guarding the anti-pattern.
+
+### [#1094 refactor(ui): move agent progress + shelf inline styles to CSS classes](https://github.com/allenhutchison/obsidian-gemini/pull/1094)
+
+First slice of the `no-static-styles-assignment` cleanup: `agent-view-progress.ts` and `agent-view-shelf.ts` move their direct `element.style.*` writes onto CSS modifier classes, establishing the naming convention for follow-up slices.
+
+### [#1095 ci(security): pin all GitHub Actions to commit SHAs + enforce](https://github.com/allenhutchison/obsidian-gemini/pull/1095)
+
+Pins all 25 `uses:` references across CI workflows to immutable commit SHAs (with version comments) instead of mutable tags, closing a supply-chain vector where a re-pointed tag could change what runs with repo secrets in scope. Adds a CI gate so new workflows can't reintroduce tag-based references.
+
+### [#1097 feat(agent): cancel streaming follow-up on mid-stream Stop](https://github.com/allenhutchison/obsidian-gemini/pull/1097)
+
+Pressing Stop during a streaming follow-up model call (the post-tool-batch response) now cancels the in-flight stream immediately via a new `AgentLoopHooks.onFollowUpStreamReady` hook, instead of waiting for the stream to finish before tearing down the UI.
+
+### [#1098 test(tools): add test mirror for vault-tools-extended](https://github.com/allenhutchison/obsidian-gemini/pull/1098)
+
+Adds the missing test file for `UpdateFrontmatterTool` and `AppendContentTool`, the last untested tools in `src/tools/`. Pure coverage fill, no production code changed.
+
+### [#1099 refactor(rag): extract shared openRagStatusModal helper](https://github.com/allenhutchison/obsidian-gemini/pull/1099)
+
+De-duplicates the RAG status modal construction that was previously copy-pasted between the "RAG status" command and the status-bar click handler into one `openRagStatusModal()` helper.
+
+### [#1100 refactor: remove dead createSessionHeader method](https://github.com/allenhutchison/obsidian-gemini/pull/1100)
+
+Architecture-audit sweep flagged `AgentViewUI.createSessionHeader()` as a zero-caller pass-through; deleted.
+
+### [#1101 refactor: dedupe conversation-history normalization in GeminiClient](https://github.com/allenhutchison/obsidian-gemini/pull/1101)
+
+Extracts a shared `normalizeHistoryEntry()` helper so the Interactions and classic `generateContent` code paths no longer duplicate the three-branch (canonical/legacy-text/legacy-message) history-entry dispatch.
+
+### [#1103 chore(daily): 2026-07-02 daily update](https://github.com/allenhutchison/obsidian-gemini/pull/1103)
+
+The previous day's automated housekeeping run — changelog, doc drift fixes, and issue triage for 2026-07-02.
+
+### [#1104 feat(design): unify elevation onto a 3-step shadow scale](https://github.com/allenhutchison/obsidian-gemini/pull/1104)
+
+Replaces ad-hoc `box-shadow` values scattered across surfaces with a coherent, theme-aware `--gs-shadow-sm/-md/-lg` scale (with a darker override for dark theme), and migrates 13 existing shadow usages onto it.
+
+### [#1105 refactor: clear small TS-strictness one-offs and enforce their rules](https://github.com/allenhutchison/obsidian-gemini/pull/1105)
+
+Clears a bundle of low-count strict-TS violations (unsafe enum comparisons, unused expressions, redundant type constituents) and flips each cleared ESLint rule from `off` to `error`.
+
+### [#1106 refactor: remove unnecessary type assertions, enforce no-unnecessary-type-assertion](https://github.com/allenhutchison/obsidian-gemini/pull/1106)
+
+Removes every `no-unnecessary-type-assertion` violation — 226 sites across 67 files, well above the plan's ~24 estimate — and enforces the rule going forward. Net -27 lines, all mechanical deletions via `eslint --fix` plus hand verification.
+
+### [#1107 feat(design): signature accent — bold user bubble, gradient send & brand mark](https://github.com/allenhutchison/obsidian-gemini/pull/1107)
+
+The plugin's identity layer: user message bubbles become solid accent-filled, the send button gets the Gemini brand gradient, and the empty-state sparkle becomes a gradient brand badge. The gradient is deliberately reserved for just these two spots.
+
+### [#1108 refactor(design): put remaining on-scale icons on the --gs-icon-* tokens](https://github.com/allenhutchison/obsidian-gemini/pull/1108)
+
+Migrates the remaining 18 hardcoded icon-size rules onto the `--gs-icon-*` scale, with zero visual change since the tokens resolve to the prior literals.
+
+### [#1109 feat(design): motion polish + fixed icon-size scale](https://github.com/allenhutchison/obsidian-gemini/pull/1109)
+
+Fixes the `--gs-icon-xl` token (was aliasing an Obsidian variable that didn't match the documented 20px value) and normalizes 37 transition timing/easing pairs plus 8 entrance animations onto the motion scale, leaving the 10 continuous loop animations (spinners, pulses) on their own durations.
+
+### [#1110 feat(design): progress bar uses the Gemini gradient across all states](https://github.com/allenhutchison/obsidian-gemini/pull/1110)
+
+Replaces the indeterminate progress bar's four per-state colors (accent/green/yellow/purple) with the Gemini brand gradient in all states, since the adjacent status text already conveys which state is active.
+
+### [#1111 refactor: extract command registration from main.ts into commands/](https://github.com/allenhutchison/obsidian-gemini/pull/1111)
+
+Moves the ~27 `addCommand()` registrations out of `main.ts` into a new `src/commands/register-commands.ts`, trimming `main.ts` toward pure plugin-lifecycle responsibilities. Command IDs, names, and behavior are unchanged.
+
+### [#1112 feat(design): accent-tinted elevation + tidier copy button on user bubbles](https://github.com/allenhutchison/obsidian-gemini/pull/1112)
+
+Follow-up polish on #1107: the user bubble's shadow becomes an accent-tinted glow instead of a barely-visible neutral shadow, and the copy button becomes circular with a translucent-white treatment so it doesn't fight the accent fill.
+
+### [#1113 feat(auto-dev): fallback self-review for PRs CodeRabbit can't reach](https://github.com/allenhutchison/obsidian-gemini/pull/1113)
+
+Teaches the auto-dev pipeline to post its own labeled fresh-eyes self-review (marker comment, `## Fallback review` heading) when a ready, CI-green automated PR has sat 60+ minutes with zero review activity, so CodeRabbit rate-limiting doesn't stall the queue.
+
+### [#1114 docs(design): capture migration/verification learnings from the design-system work](https://github.com/allenhutchison/obsidian-gemini/pull/1114)
+
+Records the day's process learnings in `AGENTS.md` and `docs/contributing/design-system.md`: verify value-preserving CSS/token changes by computed-style parity rather than eyeballing, and keep colored surfaces on colored (not neutral) elevation.
+
+### [#1115 refactor: replace TFile/TFolder casts with instanceof narrowing](https://github.com/allenhutchison/obsidian-gemini/pull/1115)
+
+Replaces every `x as TFile`/`x as TFolder` cast in production code with `instanceof` narrowing and re-enables `obsidianmd/no-tfile-tfolder-cast`, tightening null/wrong-kind checks the casts previously masked.
+
+### [#1116 refactor(ui): use activeDocument/ownerDocument for popout-window compatibility](https://github.com/allenhutchison/obsidian-gemini/pull/1116)
+
+Replaces cross-window-relevant bare `document` references with the target element's `ownerDocument` (23 sites across 7 files) so the plugin's views work correctly when opened in a popout window, and re-enables `obsidianmd/prefer-active-doc`.
+
+### [#1117 refactor: collapse 30 Unknown-error ternaries to getRawErrorMessageOr helper](https://github.com/allenhutchison/obsidian-gemini/pull/1117)
+
+Adds `getRawErrorMessageOr(error, fallback)` and replaces 30 duplicated `error instanceof Error ? error.message : '<literal>'` ternaries with it — the "with a fallback" sibling of the earlier `getRawErrorMessage` consolidation.
+
+### [#1118 refactor: replace no-explicit-any in src/utils and src/mcp](https://github.com/allenhutchison/obsidian-gemini/pull/1118)
+
+First slice of the `no-explicit-any` strict-typing pass: clears `any` from `src/utils/` and `src/mcp/` via a shared `asRecord` narrowing helper, and enforces the rule per-directory. `src/tools/`, `src/api/`, and `src/ui/` remain out of scope for later slices.
+
+### [#1119 test(gemini): cover Interactions API error path](https://github.com/allenhutchison/obsidian-gemini/pull/1119)
+
+Adds unit tests for the Interactions transport's error path (create-rejects and mid-stream throw), the one coverage gap identified on #1017. The eval-harness soak and the `useInteractionsApi` default-flip remain maintainer-owned follow-up, so #1017 stays open.
+
+### [#1120 refactor: handle floating promises, enforce no-floating-promises](https://github.com/allenhutchison/obsidian-gemini/pull/1120)
+
+Resolves all 29 `no-floating-promises` violations (plus 2 test-side probes) with the narrowest correct fix per site — genuine `await`s where ordering matters, `.catch(logger)` where a background failure should surface — and re-enables the rule.
+
+### [#1123 refactor: split scheduled-task-manager into a scheduled-tasks/ package](https://github.com/allenhutchison/obsidian-gemini/pull/1123)
+
+Splits the 919-line `scheduled-task-manager.ts` into a `src/services/scheduled-tasks/` package separating schedule math, missed-run detection, execution dispatch, and persistence. Pure code motion — the public `ScheduledTaskManager` API is unchanged.

--- a/planning/changelog/2026-07-03.md
+++ b/planning/changelog/2026-07-03.md
@@ -63,7 +63,7 @@ Removes every `no-unnecessary-type-assertion` violation — 226 sites across 67 
 
 The plugin's identity layer: user message bubbles become solid accent-filled, the send button gets the Gemini brand gradient, and the empty-state sparkle becomes a gradient brand badge. The gradient is deliberately reserved for just these two spots.
 
-### [#1108 refactor(design): put remaining on-scale icons on the --gs-icon-* tokens](https://github.com/allenhutchison/obsidian-gemini/pull/1108)
+### [#1108 refactor(design): put remaining on-scale icons on the --gs-icon-\* tokens](https://github.com/allenhutchison/obsidian-gemini/pull/1108)
 
 Migrates the remaining 18 hardcoded icon-size rules onto the `--gs-icon-*` scale, with zero visual change since the tokens resolve to the prior literals.
 


### PR DESCRIPTION
## Summary

Automated daily housekeeping run (`daily-update` meta-skill) bundling `daily-changelog`, `audit-docs`, `triage-issues`, and the bundled-skill drift check for 2026-07-04. Changelog-only change; no plugin code changes.

## Changes

- **daily-changelog**: wrote `planning/changelog/2026-07-03.md` — 27 PRs merged on 2026-07-03. A design-heavy, cleanup-heavy day: the design-token initiative wrapped up (elevation scale #1104, brand-accent identity layer #1107/#1112, icon tokens #1108/#1109, gradient progress bar #1110), a large batch of strict-TS/architecture-audit cleanups landed (unnecessary type assertions #1106, `TFile`/`TFolder` casts #1115, floating promises #1120, `no-explicit-any` in `src/utils`/`src/mcp` #1118, `activeDocument`/`ownerDocument` popout-window fixes #1116, several DRY consolidations), plus a `scheduled-task-manager.ts` package split (#1123), a `main.ts` command-registration extraction (#1111), a CI Actions SHA-pinning security hardening pass (#1095), and an auto-dev fallback self-review feature (#1113).
- **audit-docs**: no drift found, no new docs warranted — verified settings/defaults, command IDs, schedule formats, tool names, permission tiers, loop-detection thresholds, and design tokens all still match the code post-refactor. Quiet day.
- **triage-issues**: no open issues without labels found — no-op.
- **bundled-skill drift check**: errored — this session's GitHub access is scoped to `allenhutchison/obsidian-gemini` only, so the `kepano/obsidian-skills` upstream comparison could not be run. Needs a human, or a session with broader GitHub scope, to check upstream drift for `obsidian-markdown`, `json-canvas`, and `obsidian-bases`.

## Screenshots / Screencast

N/A — internal changelog file only, no UI change.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A; routine automated daily housekeeping run
- [x] All CI checks pass (`npm test` — 3272 passing, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop — N/A, changelog-only change; verified via local pre-flight checks
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A, no code change
- [x] Documentation has been updated (if applicable) — audit-docs found nothing needing updates this run
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR


---
_Generated by [Claude Code](https://claude.ai/code/session_013KnFkja5JLSwzW7wS3bAKk)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new daily changelog entry for 2026-07-03, covering 27 merged changes.
  * Highlights include design-system cleanup, improved code quality and type safety, a reworked scheduled-task area, and CI/security hardening.
  * The changelog now also lists the day’s shipped UI, test, and workflow updates in one place.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->