### PR TITLE
fix: drop plugin-id prefix from command IDs and enforce the rule

### DIFF
--- a/docs/guide/lifecycle-hooks.md
+++ b/docs/guide/lifecycle-hooks.md
@@ -143,7 +143,7 @@ Run a full-file rewrite using the prompt body as the rewrite instruction. The tr
 
 ### `command`
 
-Execute a registered command palette command by id. The hook frontmatter must include `commandId:` (e.g. `editor:save-file`, `gemini-scribe-summarize-active-file`); the prompt body is ignored. If the command id is unknown, the hook records a failure rather than silently no-op.
+Execute a registered command palette command by id. The hook frontmatter must include `commandId:` (e.g. `editor:save-file`, `gemini-scribe:summarize-active-file`); the prompt body is ignored. If the command id is unknown, the hook records a failure rather than silently no-op.
 
 **Active file vs. trigger file.** Obsidian's command API (`app.commands.executeCommandById`) always runs the command against whatever workspace state is currently active — there's no way to scope a single dispatch to a specific file. By default a hook just dispatches; if your trigger file is already focused (typical for `file-modified`), an editor-scoped command like `editor:save-file` will act on it. If you can't rely on that, opt in to `focusFile: true`:
 
@@ -274,7 +274,7 @@ Tighten the prose in {{fileName}}: remove filler words, hedging, and passive voi
 trigger: file-created
 pathGlob: 'Inbox/**/*.md'
 action: command
-commandId: gemini-scribe-summarize-active-file
+commandId: gemini-scribe:summarize-active-file
 focusFile: true
 ---
 ```

--- a/docs/reference/advanced-settings.md
+++ b/docs/reference/advanced-settings.md
@@ -108,7 +108,7 @@ Model discovery is automatic — no configuration is required. On startup, the p
 
 Both providers expose a **Refresh model list** button in Settings → General:
 
-- **Gemini** — bypasses the 24-hour cache and re-fetches the remote model list immediately. You can also trigger this from the command palette with **Gemini Scribe: Refresh model list** (`gemini-scribe-refresh-model-list`). Useful when a newly-published model doesn't appear yet.
+- **Gemini** — bypasses the 24-hour cache and re-fetches the remote model list immediately. You can also trigger this from the command palette with **Gemini Scribe: Refresh model list** (`gemini-scribe:refresh-model-list`). Useful when a newly-published model doesn't appear yet.
 - **Ollama** — re-queries the Ollama daemon for any models you've pulled since the plugin loaded (`ollama pull <name>`). Use this instead of restarting Obsidian.
 
 ## Performance Optimization

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -359,7 +359,7 @@ Advanced settings for developers and power users. Access by clicking "Show advan
 
 Model discovery is automatic — no user-configurable settings are required. On startup, the plugin fetches the latest available Gemini models from GitHub and falls back to the bundled list if the fetch fails. The remote list is cached in `data.json` under `remoteModelCache` for 24 hours; subsequent reloads within that window are no-ops.
 
-To pick up a newly-published model without waiting for the cache to expire, click **Refresh model list** in Settings → General, or run the **Gemini Scribe: Refresh model list** command (`gemini-scribe-refresh-model-list`). Both honor the same skip conditions as the auto-fetch — they no-op when the provider is Ollama or the host reports offline, and surface the outcome via a `Notice`. When the Ollama provider is active, the same row appears but re-queries the Ollama daemon for newly pulled models instead.
+To pick up a newly-published model without waiting for the cache to expire, click **Refresh model list** in Settings → General, or run the **Gemini Scribe: Refresh model list** command (`gemini-scribe:refresh-model-list`). Both honor the same skip conditions as the auto-fetch — they no-op when the provider is Ollama or the host reports offline, and surface the outcome via a `Notice`. When the Ollama provider is active, the same row appears but re-queries the Ollama daemon for newly pulled models instead.
 
 ### Tool Execution
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -58,9 +58,10 @@ const PERVASIVE_OBSIDIANMD_RULES_TODO = {
 	// remaining exception is a fabricated early-init folder stub in
 	// file-utils.ts with a scoped inline disable), so the rule is enforced
 	// again (left at the preset default).
-	// 28 violations: command IDs include the plugin ID (e.g. `gemini-scribe-foo`).
-	// Removing the prefix would break user hotkey bindings — needs a migration.
-	'obsidianmd/commands/no-plugin-id-in-command-id': 'off',
+	// `obsidianmd/commands/no-plugin-id-in-command-id` was here (28 violations) —
+	// now fixed: the `gemini-scribe-` prefix was dropped from every command ID
+	// (#1042), so Obsidian's automatic `gemini-scribe:` namespacing is no longer
+	// duplicated and the rule is enforced again (left at the preset default).
 	// `obsidianmd/prefer-file-manager-trash-file` was here (6 violations) — now
 	// fixed: all deletions go through `fileManager.trashFile`, so the rule is
 	// enforced again (left at the preset default).

--- a/src/commands/register-commands.ts
+++ b/src/commands/register-commands.ts
@@ -19,7 +19,7 @@ import type ObsidianGemini from '../main';
 export function registerCommands(plugin: ObsidianGemini): void {
 	// Add command
 	plugin.addCommand({
-		id: 'gemini-scribe-open-agent-view',
+		id: 'open-agent-view',
 		name: t('command.openAgentView'),
 		callback: () => {
 			if (!plugin.checkInitialized()) return;
@@ -30,7 +30,7 @@ export function registerCommands(plugin: ObsidianGemini): void {
 
 	// Refresh remote Gemini model list (bypass 24h cache)
 	plugin.addCommand({
-		id: 'gemini-scribe-refresh-model-list',
+		id: 'refresh-model-list',
 		name: t('command.refreshModelList'),
 		callback: async () => {
 			if (!plugin.checkInitialized()) return;
@@ -40,7 +40,7 @@ export function registerCommands(plugin: ObsidianGemini): void {
 
 	// View background tasks
 	plugin.addCommand({
-		id: 'gemini-scribe-view-background-tasks',
+		id: 'view-background-tasks',
 		name: t('command.viewBackgroundTasks'),
 		callback: async () => {
 			const { BackgroundTasksModal } = await import('../ui/background-tasks-modal');
@@ -52,7 +52,7 @@ export function registerCommands(plugin: ObsidianGemini): void {
 
 	// Open scheduler management modal
 	plugin.addCommand({
-		id: 'gemini-scribe-open-scheduler',
+		id: 'open-scheduler',
 		name: t('command.openScheduler'),
 		callback: async () => {
 			const { SchedulerManagementModal } = await import('../ui/scheduler-management-modal');
@@ -62,7 +62,7 @@ export function registerCommands(plugin: ObsidianGemini): void {
 
 	// New scheduled task — jump straight to create form
 	plugin.addCommand({
-		id: 'gemini-scribe-new-scheduled-task',
+		id: 'new-scheduled-task',
 		name: t('command.newScheduledTask'),
 		callback: async () => {
 			const { SchedulerManagementModal } = await import('../ui/scheduler-management-modal');
@@ -72,7 +72,7 @@ export function registerCommands(plugin: ObsidianGemini): void {
 
 	// Open lifecycle hook management modal
 	plugin.addCommand({
-		id: 'gemini-scribe-open-hook-manager',
+		id: 'open-hook-manager',
 		name: t('command.openHookManager'),
 		callback: async () => {
 			const { HookManagementModal } = await import('../ui/hook-management-modal');
@@ -82,7 +82,7 @@ export function registerCommands(plugin: ObsidianGemini): void {
 
 	// New lifecycle hook — jump straight to create form
 	plugin.addCommand({
-		id: 'gemini-scribe-new-hook',
+		id: 'new-hook',
 		name: t('command.newHook'),
 		callback: async () => {
 			const { HookManagementModal } = await import('../ui/hook-management-modal');
@@ -92,7 +92,7 @@ export function registerCommands(plugin: ObsidianGemini): void {
 
 	// View scheduled tasks (read-only legacy — kept for backwards compatibility)
 	plugin.addCommand({
-		id: 'gemini-scribe-view-scheduled-tasks',
+		id: 'view-scheduled-tasks',
 		name: t('command.viewScheduledTasks'),
 		callback: async () => {
 			const { ScheduledTasksModal } = await import('../ui/scheduled-tasks-modal');
@@ -102,7 +102,7 @@ export function registerCommands(plugin: ObsidianGemini): void {
 
 	// Switch project for the current agent session
 	plugin.addCommand({
-		id: 'gemini-scribe-switch-project',
+		id: 'switch-project',
 		name: t('command.switchProject'),
 		callback: () => {
 			if (!plugin.checkInitialized()) return;
@@ -115,7 +115,7 @@ export function registerCommands(plugin: ObsidianGemini): void {
 
 	// Create a new project
 	plugin.addCommand({
-		id: 'gemini-scribe-create-project',
+		id: 'create-project',
 		name: t('command.createProject'),
 		callback: async () => {
 			if (!plugin.checkInitialized()) return;
@@ -134,7 +134,7 @@ export function registerCommands(plugin: ObsidianGemini): void {
 
 	// Convert current note to a project
 	plugin.addCommand({
-		id: 'gemini-scribe-convert-to-project',
+		id: 'convert-to-project',
 		name: t('command.convertToProject'),
 		editorCallback: async (_editor: Editor, view: MarkdownView | MarkdownFileInfo) => {
 			if (!plugin.checkInitialized()) return;
@@ -151,7 +151,7 @@ export function registerCommands(plugin: ObsidianGemini): void {
 
 	// Open project settings (the project file itself)
 	plugin.addCommand({
-		id: 'gemini-scribe-open-project-settings',
+		id: 'open-project-settings',
 		name: t('command.openProjectSettings'),
 		callback: async () => {
 			if (!plugin.checkInitialized()) return;
@@ -180,7 +180,7 @@ export function registerCommands(plugin: ObsidianGemini): void {
 
 	// Resume the most recent session for a project
 	plugin.addCommand({
-		id: 'gemini-scribe-resume-project-session',
+		id: 'resume-project-session',
 		name: t('command.resumeProjectSession'),
 		callback: async () => {
 			if (!plugin.checkInitialized()) return;
@@ -213,7 +213,7 @@ export function registerCommands(plugin: ObsidianGemini): void {
 
 	// Remove project status from a file
 	plugin.addCommand({
-		id: 'gemini-scribe-remove-project',
+		id: 'remove-project',
 		name: t('command.removeProject'),
 		editorCallback: async (_editor: Editor, view: MarkdownView | MarkdownFileInfo) => {
 			if (!plugin.checkInitialized()) return;
@@ -230,7 +230,7 @@ export function registerCommands(plugin: ObsidianGemini): void {
 
 	// Add rewrite command (works with selection or full file)
 	plugin.addCommand({
-		id: 'gemini-scribe-rewrite-selection',
+		id: 'rewrite-selection',
 		name: t('command.rewriteSelection'),
 		editorCallback: (editor: Editor, _view: MarkdownView | MarkdownFileInfo) => {
 			if (!plugin.checkInitialized()) return;
@@ -264,7 +264,7 @@ export function registerCommands(plugin: ObsidianGemini): void {
 
 	// Add explain selection command
 	plugin.addCommand({
-		id: 'gemini-scribe-explain-selection',
+		id: 'explain-selection',
 		name: t('command.explainSelection'),
 		editorCallback: async (editor: Editor, view: MarkdownView | MarkdownFileInfo) => {
 			if (!plugin.checkInitialized()) return;
@@ -274,7 +274,7 @@ export function registerCommands(plugin: ObsidianGemini): void {
 
 	// Add ask about selection command
 	plugin.addCommand({
-		id: 'gemini-scribe-ask-selection',
+		id: 'ask-selection',
 		name: t('command.askSelection'),
 		editorCallback: async (editor: Editor, view: MarkdownView | MarkdownFileInfo) => {
 			if (!plugin.checkInitialized()) return;
@@ -284,7 +284,7 @@ export function registerCommands(plugin: ObsidianGemini): void {
 
 	// Add command to view release notes
 	plugin.addCommand({
-		id: 'gemini-scribe-view-release-notes',
+		id: 'view-release-notes',
 		name: t('command.viewReleaseNotes'),
 		callback: () => {
 			const modal = new UpdateNotificationModal(plugin.app, plugin.manifest.version);
@@ -297,7 +297,7 @@ export function registerCommands(plugin: ObsidianGemini): void {
 	// callback gates on provider before touching the (potentially null)
 	// `imageGeneration` service.
 	plugin.addCommand({
-		id: 'gemini-scribe-generate-image',
+		id: 'generate-image',
 		name: t('command.generateImage'),
 		callback: async () => {
 			if (!plugin.checkInitialized()) return;
@@ -321,7 +321,7 @@ export function registerCommands(plugin: ObsidianGemini): void {
 	// consistent and the user gets a clear "not available" notice on the
 	// Ollama path (RAG depends on Gemini's File Search Store in Phase 1).
 	plugin.addCommand({
-		id: 'gemini-scribe-rag-pause',
+		id: 'rag-pause',
 		name: t('command.ragPause'),
 		callback: () => {
 			if (plugin.settings.provider === 'ollama') {
@@ -346,7 +346,7 @@ export function registerCommands(plugin: ObsidianGemini): void {
 	});
 
 	plugin.addCommand({
-		id: 'gemini-scribe-rag-resume',
+		id: 'rag-resume',
 		name: t('command.ragResume'),
 		callback: () => {
 			if (plugin.settings.provider === 'ollama') {
@@ -367,7 +367,7 @@ export function registerCommands(plugin: ObsidianGemini): void {
 	});
 
 	plugin.addCommand({
-		id: 'gemini-scribe-rag-status',
+		id: 'rag-status',
 		name: t('command.ragStatus'),
 		callback: async () => {
 			if (plugin.settings.provider === 'ollama') {
@@ -391,7 +391,7 @@ export function registerCommands(plugin: ObsidianGemini): void {
 
 	// Agent session management commands
 	plugin.addCommand({
-		id: 'gemini-scribe-new-session',
+		id: 'new-session',
 		name: t('command.newSession'),
 		callback: async () => {
 			if (!plugin.checkInitialized()) return;
@@ -408,7 +408,7 @@ export function registerCommands(plugin: ObsidianGemini): void {
 	});
 
 	plugin.addCommand({
-		id: 'gemini-scribe-browse-sessions',
+		id: 'browse-sessions',
 		name: t('command.browseSessions'),
 		callback: async () => {
 			if (!plugin.checkInitialized()) return;
@@ -420,7 +420,7 @@ export function registerCommands(plugin: ObsidianGemini): void {
 	});
 
 	plugin.addCommand({
-		id: 'gemini-scribe-link-project',
+		id: 'link-project',
 		name: t('command.linkProject'),
 		callback: async () => {
 			if (!plugin.checkInitialized()) return;
@@ -432,7 +432,7 @@ export function registerCommands(plugin: ObsidianGemini): void {
 	});
 
 	plugin.addCommand({
-		id: 'gemini-scribe-session-settings',
+		id: 'session-settings',
 		name: t('command.sessionSettings'),
 		callback: async () => {
 			if (!plugin.checkInitialized()) return;
@@ -444,7 +444,7 @@ export function registerCommands(plugin: ObsidianGemini): void {
 	});
 
 	plugin.addCommand({
-		id: 'gemini-scribe-toggle-plan-mode',
+		id: 'toggle-plan-mode',
 		name: t('command.togglePlanMode'),
 		callback: async () => {
 			if (!plugin.checkInitialized()) return;

--- a/src/completions.ts
+++ b/src/completions.ts
@@ -73,7 +73,7 @@ export class GeminiCompletions {
 	async setupCompletionsCommands() {
 		try {
 			this.plugin.addCommand({
-				id: 'gemini-scribe-toggle-completions', // Add plugin prefix
+				id: 'toggle-completions',
 				name: t('command.toggleCompletions'),
 				callback: () => {
 					// Use callback instead of editorCallback

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -1812,7 +1812,7 @@ export const en = {
 	},
 	'hooks.commandIdDesc': {
 		message:
-			'Command palette id to fire. Examples: editor:save-file, gemini-scribe-summarize-active-file. View command IDs via Settings → Hotkeys (open the developer console with Ctrl+Shift+I to inspect ids).',
+			'Command palette id to fire. Examples: editor:save-file, gemini-scribe:summarize-active-file. View command IDs via Settings → Hotkeys (open the developer console with Ctrl+Shift+I to inspect ids).',
 		context: 'Description of the command id field. The example ids and Ctrl+Shift+I are literal; keep them.',
 	},
 	'hooks.focusFileSetting': {

--- a/src/prompts/prompt-manager.ts
+++ b/src/prompts/prompt-manager.ts
@@ -188,7 +188,7 @@ Focus on being helpful while maintaining intellectual honesty.`;
 	// Setup commands for prompt management
 	setupPromptCommands(): void {
 		this.plugin.addCommand({
-			id: 'gemini-scribe-create-custom-prompt',
+			id: 'create-custom-prompt',
 			name: t('command.createCustomPrompt'),
 			callback: () => this.createNewCustomPrompt(),
 		});

--- a/src/summary.ts
+++ b/src/summary.ts
@@ -70,7 +70,7 @@ export class GeminiSummary {
 
 	async setupSummarizationCommand() {
 		this.plugin.addCommand({
-			id: 'gemini-scribe-summarize-active-file',
+			id: 'summarize-active-file',
 			name: t('command.summarizeActiveFile'),
 			callback: () => this.summarizeActiveFile(),
 		});

--- a/test/completions.test.ts
+++ b/test/completions.test.ts
@@ -156,7 +156,7 @@ describe('GeminiCompletions', () => {
 			await completions.setupCompletionsCommands();
 			expect(mockPlugin.addCommand).toHaveBeenCalledWith(
 				expect.objectContaining({
-					id: 'gemini-scribe-toggle-completions',
+					id: 'toggle-completions',
 					name: 'Toggle completions',
 					callback: expect.any(Function),
 				})

--- a/test/prompts/prompt-manager.test.ts
+++ b/test/prompts/prompt-manager.test.ts
@@ -597,7 +597,7 @@ Content`;
 			expect(mockPlugin.addCommand).toHaveBeenCalledTimes(1);
 			expect(mockPlugin.addCommand).toHaveBeenCalledWith(
 				expect.objectContaining({
-					id: 'gemini-scribe-create-custom-prompt',
+					id: 'create-custom-prompt',
 					name: 'Create new custom prompt',
 				})
 			);

--- a/test/summary.test.ts
+++ b/test/summary.test.ts
@@ -150,7 +150,7 @@ describe('GeminiSummary', () => {
 			await summaryService.setupSummarizationCommand();
 			expect(mockPlugin.addCommand).toHaveBeenCalledWith(
 				expect.objectContaining({
-					id: 'gemini-scribe-summarize-active-file',
+					id: 'summarize-active-file',
 					name: 'Summarize active file',
 					callback: expect.any(Function),
 				})


### PR DESCRIPTION
<!-- auto-dev -->

## Summary

Obsidian automatically namespaces command IDs with the plugin's manifest id (`gemini-scribe`), so an id like `gemini-scribe-summarize-active-file` was being surfaced as `gemini-scribe:gemini-scribe-summarize-active-file` — the plugin id appeared twice. This drops the `gemini-scribe-` prefix from all 30 command IDs so they resolve cleanly as `gemini-scribe:<id>`, and re-enables the `obsidianmd/commands/no-plugin-id-in-command-id` lint rule (previously softened off, 28 violations) now that the IDs are clean.

Per the maintainer's decision on the issue: a one-time break with a release-note warning — **no deprecated aliases** and **no reliance on Obsidian's internal hotkey manager**. Only the small subset of users who bound a *custom hotkey* to a Gemini Scribe command is affected, and it is a one-time re-bind (command palette *names* are unchanged).

This PR was produced by the auto-dev pipeline from the approved plan on the issue.

Fixes #1042

## Changes

- **Command IDs** — dropped the `gemini-scribe-` prefix from the `id:` field of all 30 `addCommand` registrations: 27 in `src/commands/register-commands.ts`, plus one each in `src/completions.ts`, `src/prompts/prompt-manager.ts`, and `src/summary.ts`.
- **`eslint.config.mjs`** — removed the rule's `off` override and its stale "would break user hotkey bindings" comment, replacing it with the sibling "now fixed — enforced again" note. `npm run lint` is clean (0 errors).
- **Docs** — updated the full command IDs shown to users to the new namespaced form: `docs/reference/advanced-settings.md`, `docs/reference/settings.md`, and `docs/guide/lifecycle-hooks.md` (including the copy-paste `commandId:` hook example, which would otherwise no longer resolve).
- **i18n** — updated the hook command-id example in `src/i18n/en.ts` to `gemini-scribe:summarize-active-file`. The 20 translation files regenerate automatically via the *Update UI translations* workflow when `en.ts` lands on master.
- **Tests** — updated the asserted command IDs in `test/completions.test.ts`, `test/prompts/prompt-manager.test.ts`, and `test/summary.test.ts`.

### Deviations from the posted plan

- The plan referenced `src/main.ts` for the bulk of the registrations; command registration has since been refactored into `src/commands/register-commands.ts`. Same rename, different file.
- The plan called for a `src/release-notes.json` entry. That file is composed **per released version at release time** (there is no unreleased bucket), and adding an entry would require choosing the next version number — the release process's job. The user-facing note is provided below instead for the release process to fold into the next version's notes.

### 📣 Release note (for the next version)

> **Command IDs changed.** Gemini Scribe command IDs no longer carry a redundant `gemini-scribe-` prefix (Obsidian already namespaces them). If you bound a *custom hotkey* to a Gemini Scribe command, that binding was cleared and needs to be re-set once under Settings → Hotkeys. Command palette names are unchanged.

## Screenshots / Screencast

N/A — internal command-ID rename + lint enablement, no UI/visual change.

## Checklist

### Required

- [x] I have read and agree to the Contributing Guidelines
- [x] I have read and agree to the AI Policy
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — plus `npm run lint` (rule now enforced) and `npm run typecheck:test`
- [ ] I have tested this change on Desktop
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards)
- [x] Documentation has been updated (if applicable)
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude (auto-dev pipeline)
- [x] I have reviewed and understand all AI-generated code in this PR

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017qNovAQC1Fi71P9qcGux8Q)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated several command palette entries to use cleaner, stable command names.
  * Fixed model refresh documentation to match the current command name.
  * Clarified command-palette behavior in the lifecycle hooks guide.

* **Documentation**
  * Refreshed setup and reference docs for command IDs and command-palette usage.

* **Tests**
  * Aligned command registration tests with the updated command names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->