### PR TITLE
refactor: enforce ui/sentence-case and scope literal-placeholder exceptions

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -41,9 +41,15 @@ const SOFTENED_TS_RULES = {
 // Obsidian-specific rules that flag pervasive patterns we can't realistically
 // migrate in this PR. Tracked as follow-up issues — flip to 'error' once cleaned up.
 const PERVASIVE_OBSIDIANMD_RULES_TODO = {
-	// 207 violations: many false positives on acronyms (e.g. URL, HTTP) and brand
-	// names. Needs a brand allowlist + audit pass.
-	'obsidianmd/ui/sentence-case': 'off',
+	// `obsidianmd/ui/sentence-case` was here (originally ~207 violations) — now
+	// fixed: the i18n migration routed almost all UI text through `t()` (which the
+	// rule can't statically evaluate), leaving only a handful of `setPlaceholder`
+	// hints that intentionally show a literal value the user types verbatim (a URL,
+	// example model IDs, a command-id format, skill names, a frontmatter key). Those
+	// carry scoped inline disables at their call sites, so the rule is enforced again
+	// (left at the preset default). The anticipated brand/acronym allowlist proved
+	// unnecessary — the plugin's built-in allowlist already covers the acronyms and
+	// brands in use (#1043).
 	// `obsidianmd/prefer-active-doc` was here (bare `document` usage) — now fixed:
 	// live-view DOM operations use the target element's `ownerDocument`, and the few
 	// genuinely detached nodes (escape-only, rasterization, test stubs) carry scoped
@@ -159,6 +165,10 @@ export default defineConfig([
 			// narrow with `instanceof`. The rule guards production vault lookups in
 			// `src/`, not fabricated fixture objects.
 			'obsidianmd/no-tfile-tfolder-cast': 'off',
+			// Tests build DOM elements with arbitrary placeholder fixture text
+			// (`'some text'`, `'file1'`, `'inside'`); sentence-case enforcement targets
+			// real user-facing UI strings in `src/`, not fixture data.
+			'obsidianmd/ui/sentence-case': 'off',
 		},
 	},
 ]);

--- a/src/ui/hook-management-modal.ts
+++ b/src/ui/hook-management-modal.ts
@@ -242,6 +242,7 @@ export class HookManagementModal extends ManagementModalBase<Hook, HookState> {
 			.setDesc(t('hooks.commandIdDesc'))
 			.addText((text) =>
 				text
+					// eslint-disable-next-line obsidianmd/ui/sentence-case -- literal command-id format hint, shown verbatim
 					.setPlaceholder('plugin-id:command-name')
 					.setValue(this.form.commandId)
 					.onChange((v) => {
@@ -354,6 +355,7 @@ export class HookManagementModal extends ManagementModalBase<Hook, HookState> {
 			.setDesc(t('hooks.skillsDesc'))
 			.addText((text) =>
 				text
+					// eslint-disable-next-line obsidianmd/ui/sentence-case -- example skill names (lowercase), shown verbatim
 					.setPlaceholder('summarize, index-files')
 					.setValue(this.form.enabledSkills.join(', '))
 					.onChange((v) => {
@@ -369,6 +371,7 @@ export class HookManagementModal extends ManagementModalBase<Hook, HookState> {
 			.setDesc(t('hooks.modelOverrideDesc'))
 			.addText((text) =>
 				text
+					// eslint-disable-next-line obsidianmd/ui/sentence-case -- example model id, shown verbatim
 					.setPlaceholder('gemini-2.5-flash-lite')
 					.setValue(this.form.model)
 					.onChange((v) => {

--- a/src/ui/scheduler-management-modal.ts
+++ b/src/ui/scheduler-management-modal.ts
@@ -302,6 +302,7 @@ export class SchedulerManagementModal extends ManagementModalBase<ScheduledTask,
 			.setDesc(t('scheduler.modelOverrideDesc'))
 			.addText((text) =>
 				text
+					// eslint-disable-next-line obsidianmd/ui/sentence-case -- example model id, shown verbatim
 					.setPlaceholder('gemini-2.0-flash')
 					.setValue(this.form.model)
 					.onChange((v) => {

--- a/src/ui/settings-general.ts
+++ b/src/ui/settings-general.ts
@@ -82,6 +82,7 @@ async function renderGeneralSection(
 			.setDesc(t('settings.general.ollamaBaseUrlDesc'))
 			.addText((text) =>
 				text
+					// eslint-disable-next-line obsidianmd/ui/sentence-case -- default endpoint URL, shown verbatim
 					.setPlaceholder('http://localhost:11434')
 					.setValue(plugin.settings.ollamaBaseUrl)
 					.onChange((value) => {

--- a/src/ui/settings-ui.ts
+++ b/src/ui/settings-ui.ts
@@ -40,6 +40,7 @@ export function renderUISettings(containerEl: HTMLElement, plugin: ObsidianGemin
 		.setDesc(t('settings.ui.summaryFrontmatterKeyDesc'))
 		.addText((text) =>
 			text
+				// eslint-disable-next-line obsidianmd/ui/sentence-case -- default frontmatter key (lowercase), shown verbatim
 				.setPlaceholder('summary')
 				.setValue(plugin.settings.summaryFrontmatterKey)
 				.onChange((value) => {


### PR DESCRIPTION
<!-- auto-dev -->

## Summary

Re-enables `obsidianmd/ui/sentence-case` (previously softened off) after the audit tracked in #1032. When the issue was filed the rule reported **~207 violations**, mostly assumed to be acronym/brand false positives needing an allowlist. Reality has since drifted: the i18n migration routed almost all UI text through `t()` — which the rule can't statically evaluate — so today only **6 violations remain**, and every one is a `setPlaceholder` hint that intentionally shows a **literal value the user types verbatim**. None is an acronym/brand false positive, so the anticipated allowlist proved unnecessary — the plugin's built-in brand/acronym list already covers the tokens in use.

This PR was produced by the auto-dev pipeline from the approved plan on the issue.

Fixes #1043

## Changes

- **`eslint.config.mjs`** — removed `obsidianmd/ui/sentence-case` from `PERVASIVE_OBSIDIANMD_RULES_TODO`, so it reverts to the preset default (`error`), matching how the other cleared rules in that block are handled. Also disabled it for the `test/**` tree (alongside the existing production-only exemptions there), since test fixtures build DOM elements with arbitrary placeholder text (`'some text'`, `'file1'`, `'inside'`) that isn't real UI.
- **Scoped inline disables** on the 6 residual `setPlaceholder` sites, each with a one-line justification (the repo's established pattern for genuine rule exceptions):
  - `src/ui/hook-management-modal.ts` — `plugin-id:command-name` (command-id format), `summarize, index-files` (skill names), `gemini-2.5-flash-lite` (model id)
  - `src/ui/scheduler-management-modal.ts` — `gemini-2.0-flash` (model id)
  - `src/ui/settings-general.ts` — `http://localhost:11434` (Ollama endpoint URL)
  - `src/ui/settings-ui.ts` — `summary` (default frontmatter key)

### Deviation from the approved plan

The plan called for configuring a brand/acronym allowlist plus fixing genuine violations and running `npm run translate`. In practice the `t()` migration had already eliminated the acronym/brand false positives the allowlist was meant to suppress (verified: enabling the rule at the preset default yields the same 6 placeholder-only hits), so no allowlist and no `en.ts`/translation changes were needed. The residual placeholders must stay lowercase verbatim (a sentence-cased `Gemini-2.5-flash-lite` or `Summary` would misrepresent a real model id / frontmatter key), so they're exempted at the call site rather than by broadening the rule.

## Screenshots / Screencast

N/A — internal lint-rule enablement. No user-visible change: every placeholder string is unchanged; only lint enforcement and scoped disables were added.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — plus `npm run lint` (rule now enforced) and `npm run typecheck:test`
- [ ] I have tested this change on Desktop
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards)
- [x] Documentation has been updated (if applicable) — N/A, no user-facing change
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude (auto-dev pipeline)
- [x] I have reviewed and understand all AI-generated code in this PR

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PAa2fthpFg9XEsKA1gXwKm)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of literal example text in settings and management screens so it no longer triggers unnecessary lint issues.
  * Reduced test-only lint noise for placeholder content, making development and validation smoother.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->