### PR TITLE
refactor: extract tool-section parser from agent-view-messages.ts

### DIFF
--- a/src/ui/agent-view/agent-view-messages.ts
+++ b/src/ui/agent-view/agent-view-messages.ts
@@ -6,6 +6,7 @@ import { formatModelMessage } from '../../utils/markdown-formatting';
 import { stripTurnPreamble } from '../../utils/turn-preamble';
 import { Tool, DiffContext, ConfirmationResult } from '../../tools/types';
 import { t, getResolvedLocale } from '../../i18n';
+import { isToolExecutionMessage, parseToolSections } from './tool-section-parser';
 
 // Documentation and help content
 const DOCS_BASE_URL = 'https://allenhutchison.github.io/obsidian-gemini';
@@ -130,7 +131,7 @@ export class AgentViewMessages {
 		const renderMessage = entry.role === 'user' ? stripTurnPreamble(entry.message) : entry.message;
 
 		// Check if this is a tool execution message from history
-		const isToolExecution = entry.metadata?.toolName || renderMessage.includes('Tool Execution Results:');
+		const isToolExecution = isToolExecutionMessage(renderMessage, Boolean(entry.metadata?.toolName));
 
 		// Convert single newlines to double newlines for proper markdown rendering
 		// while preserving table formatting
@@ -152,69 +153,63 @@ export class AgentViewMessages {
 		// Special handling for tool execution messages
 		if (isToolExecution && renderMessage.includes('Tool Execution Results:')) {
 			// Extract tool execution sections and make them collapsible
-			const toolSections = formattedMessage.split(/### ([^\n]+)/);
+			const { hasSections, intro, sections } = parseToolSections(formattedMessage);
 
-			if (toolSections.length > 1) {
+			if (hasSections) {
 				// First part before any tool sections
-				const intro = toolSections[0].trim();
 				if (intro) {
 					const introDiv = content.createDiv();
 					await MarkdownRenderer.render(this.app, intro, introDiv, sourcePath, this.viewContext);
 				}
 
 				// Process each tool section
-				for (let i = 1; i < toolSections.length; i += 2) {
-					const toolName = toolSections[i];
-					const toolContent = toolSections[i + 1]?.trim() || '';
+				for (const { toolName, content: toolContent } of sections) {
+					// Create collapsible tool execution block
+					const toolDiv = content.createDiv({ cls: 'gemini-agent-tool-execution' });
+					const toolHeader = toolDiv.createDiv({ cls: 'gemini-agent-tool-header' });
 
-					if (toolName && toolContent) {
-						// Create collapsible tool execution block
-						const toolDiv = content.createDiv({ cls: 'gemini-agent-tool-execution' });
-						const toolHeader = toolDiv.createDiv({ cls: 'gemini-agent-tool-header' });
+					// Add expand/collapse icon
+					const icon = toolHeader.createEl('span', { cls: 'gemini-agent-tool-icon' });
+					setIcon(icon, 'chevron-right');
 
-						// Add expand/collapse icon
-						const icon = toolHeader.createEl('span', { cls: 'gemini-agent-tool-icon' });
-						setIcon(icon, 'chevron-right');
+					// Tool name
+					toolHeader.createEl('span', {
+						text: t('agent.message.toolPrefix', { name: toolName }),
+						cls: 'gemini-agent-tool-name',
+					});
 
-						// Tool name
+					// Tool status (if available)
+					if (toolContent.includes('✅')) {
 						toolHeader.createEl('span', {
-							text: t('agent.message.toolPrefix', { name: toolName }),
-							cls: 'gemini-agent-tool-name',
+							text: t('agent.message.toolSuccess'),
+							cls: 'gemini-agent-tool-status gemini-agent-tool-status-success',
 						});
-
-						// Tool status (if available)
-						if (toolContent.includes('✅')) {
-							toolHeader.createEl('span', {
-								text: t('agent.message.toolSuccess'),
-								cls: 'gemini-agent-tool-status gemini-agent-tool-status-success',
-							});
-						} else if (toolContent.includes('❌')) {
-							toolHeader.createEl('span', {
-								text: t('agent.message.toolFailed'),
-								cls: 'gemini-agent-tool-status gemini-agent-tool-status-error',
-							});
-						}
-
-						// Tool content (initially hidden)
-						const toolContentDiv = toolDiv.createDiv({
-							cls: 'gemini-agent-tool-content gemini-agent-tool-content-collapsed',
-						});
-
-						// Render the tool content
-						await MarkdownRenderer.render(this.app, toolContent, toolContentDiv, sourcePath, this.viewContext);
-
-						// Toggle handler
-						toolHeader.addEventListener('click', () => {
-							const isCollapsed = toolContentDiv.hasClass('gemini-agent-tool-content-collapsed');
-							if (isCollapsed) {
-								toolContentDiv.removeClass('gemini-agent-tool-content-collapsed');
-								setIcon(icon, 'chevron-down');
-							} else {
-								toolContentDiv.addClass('gemini-agent-tool-content-collapsed');
-								setIcon(icon, 'chevron-right');
-							}
+					} else if (toolContent.includes('❌')) {
+						toolHeader.createEl('span', {
+							text: t('agent.message.toolFailed'),
+							cls: 'gemini-agent-tool-status gemini-agent-tool-status-error',
 						});
 					}
+
+					// Tool content (initially hidden)
+					const toolContentDiv = toolDiv.createDiv({
+						cls: 'gemini-agent-tool-content gemini-agent-tool-content-collapsed',
+					});
+
+					// Render the tool content
+					await MarkdownRenderer.render(this.app, toolContent, toolContentDiv, sourcePath, this.viewContext);
+
+					// Toggle handler
+					toolHeader.addEventListener('click', () => {
+						const isCollapsed = toolContentDiv.hasClass('gemini-agent-tool-content-collapsed');
+						if (isCollapsed) {
+							toolContentDiv.removeClass('gemini-agent-tool-content-collapsed');
+							setIcon(icon, 'chevron-down');
+						} else {
+							toolContentDiv.addClass('gemini-agent-tool-content-collapsed');
+							setIcon(icon, 'chevron-right');
+						}
+					});
 				}
 			} else {
 				// No tool sections found, render normally

--- a/src/ui/agent-view/tool-section-parser.ts
+++ b/src/ui/agent-view/tool-section-parser.ts
@@ -1,0 +1,67 @@
+/**
+ * Pure parsing helpers for tool-execution messages rendered in the agent view.
+ *
+ * Extracted from `agent-view-messages.ts` (issue #1072) so the string-only
+ * detection/splitting logic is directly unit-testable, separate from the
+ * DOM-building that consumes it. No Obsidian API dependency.
+ */
+
+/** Marker embedded in persisted tool-execution messages. */
+const TOOL_EXECUTION_MARKER = 'Tool Execution Results:';
+
+/** A single `### <name>` delimited tool section with its trimmed content. */
+export interface ToolSection {
+	toolName: string;
+	content: string;
+}
+
+/** Result of splitting a formatted tool-execution message into sections. */
+export interface ParsedToolSections {
+	/**
+	 * Whether the message split into `### `-delimited sections at all. This is
+	 * distinct from `sections` being empty: a `### name` heading with empty
+	 * content produces `hasSections === true` but contributes no section, and
+	 * the caller must still render only the intro (never the whole message) in
+	 * that case — preserving the original `toolSections.length > 1` behavior.
+	 */
+	hasSections: boolean;
+	/** Trimmed text preceding the first `### ` section. */
+	intro: string;
+	/** Sections with a non-empty name and non-empty (trimmed) content. */
+	sections: ToolSection[];
+}
+
+/**
+ * Whether a message should be treated as a tool-execution message.
+ *
+ * Mirrors the original inline check: a history entry carrying `toolName`
+ * metadata, or a message body containing the `Tool Execution Results:` marker.
+ */
+export function isToolExecutionMessage(message: string, hasToolNameMetadata: boolean): boolean {
+	return hasToolNameMetadata || message.includes(TOOL_EXECUTION_MARKER);
+}
+
+/**
+ * Split a formatted tool-execution message into an intro plus per-tool sections.
+ *
+ * The message is split on `### <name>` headings. Content for each section is
+ * trimmed; sections whose name or trimmed content is empty are dropped (matching
+ * the original `if (toolName && toolContent)` guard). When no headings are found
+ * (`hasSections === false`), the caller renders the message normally.
+ */
+export function parseToolSections(formattedMessage: string): ParsedToolSections {
+	const parts = formattedMessage.split(/### ([^\n]+)/);
+	const hasSections = parts.length > 1;
+	const intro = parts[0].trim();
+	const sections: ToolSection[] = [];
+
+	for (let i = 1; i < parts.length; i += 2) {
+		const toolName = parts[i];
+		const content = parts[i + 1]?.trim() || '';
+		if (toolName && content) {
+			sections.push({ toolName, content });
+		}
+	}
+
+	return { hasSections, intro, sections };
+}

--- a/test/ui/agent-view/tool-section-parser.test.ts
+++ b/test/ui/agent-view/tool-section-parser.test.ts
@@ -1,0 +1,63 @@
+import { isToolExecutionMessage, parseToolSections } from '../../../src/ui/agent-view/tool-section-parser';
+
+describe('isToolExecutionMessage', () => {
+	it('returns true when the entry carries toolName metadata', () => {
+		expect(isToolExecutionMessage('just some text', true)).toBe(true);
+	});
+
+	it('returns true when the message contains the marker, even without metadata', () => {
+		expect(isToolExecutionMessage('Tool Execution Results:\n\n### read_file', false)).toBe(true);
+	});
+
+	it('returns false when there is no metadata and no marker', () => {
+		expect(isToolExecutionMessage('a normal assistant reply', false)).toBe(false);
+	});
+});
+
+describe('parseToolSections', () => {
+	it('reports no sections for a message without any ### headings', () => {
+		const result = parseToolSections('Tool Execution Results:\n\nno headings here');
+		expect(result.hasSections).toBe(false);
+		expect(result.sections).toEqual([]);
+		// intro still holds the trimmed message, but the caller renders the
+		// whole message directly when hasSections is false.
+		expect(result.intro).toBe('Tool Execution Results:\n\nno headings here');
+	});
+
+	it('parses a single section with intro text', () => {
+		const message = 'Tool Execution Results:\n\n### read_file\n✅ contents of the file';
+		const result = parseToolSections(message);
+		expect(result.hasSections).toBe(true);
+		expect(result.intro).toBe('Tool Execution Results:');
+		expect(result.sections).toEqual([{ toolName: 'read_file', content: '✅ contents of the file' }]);
+	});
+
+	it('parses multiple sections and pairs each name with its content', () => {
+		const message = 'Intro line\n\n### read_file\n✅ file body\n\n### list_files\n❌ permission denied';
+		const result = parseToolSections(message);
+		expect(result.hasSections).toBe(true);
+		expect(result.intro).toBe('Intro line');
+		expect(result.sections).toEqual([
+			{ toolName: 'read_file', content: '✅ file body' },
+			{ toolName: 'list_files', content: '❌ permission denied' },
+		]);
+	});
+
+	it('drops a section whose content is empty but still reports hasSections', () => {
+		// A ### heading with no following content must not fall back to rendering
+		// the whole message — hasSections stays true so the caller renders only
+		// the intro, matching the original toolSections.length > 1 behavior.
+		const message = 'Tool Execution Results:\n\n### read_file\n';
+		const result = parseToolSections(message);
+		expect(result.hasSections).toBe(true);
+		expect(result.intro).toBe('Tool Execution Results:');
+		expect(result.sections).toEqual([]);
+	});
+
+	it('keeps intro-only text before the first section separate from the sections', () => {
+		const message = 'Here is what I did\n\n### write_file\n✅ saved';
+		const result = parseToolSections(message);
+		expect(result.intro).toBe('Here is what I did');
+		expect(result.sections).toEqual([{ toolName: 'write_file', content: '✅ saved' }]);
+	});
+});


### PR DESCRIPTION
<!-- auto-dev -->

## Summary

Extracts the tool-execution message detection and `### `-section splitting out of `AgentViewMessages.displayMessage` (`src/ui/agent-view/agent-view-messages.ts`, previously 931 lines) into a pure, dependency-free `tool-section-parser.ts`, so the string-parsing logic becomes directly unit-testable while the collapsible DOM building stays in place. Pure code-motion refactor — no behavior change, no public-surface renames.

This PR was produced by the auto-dev pipeline from the approved plan on the issue.

Sub-issue of #801 (oversized files).

Fixes #1072

## Changes

- **`src/ui/agent-view/tool-section-parser.ts`** (new) — `isToolExecutionMessage(message, hasToolNameMetadata)` wraps the `metadata?.toolName || includes('Tool Execution Results:')` check, and `parseToolSections(formattedMessage)` wraps the `split(/### ([^\n]+)/)` logic, pairing each tool name with its trimmed content and applying the original `toolName && content` skip guard. No Obsidian API dependency.
- **`src/ui/agent-view/agent-view-messages.ts`** — `displayMessage` now calls `isToolExecutionMessage()` and `parseToolSections()`; the collapsible DOM (icon / header / status / content / toggle handler) is built from the parsed `{ toolName, content }` pairs exactly as before.
- **`test/ui/agent-view/tool-section-parser.test.ts`** (new) — covers no-section, single-section, multiple-section, empty-content, and intro-only cases (8 assertions).

### Deviation from the approved plan

The plan's parser return shape was `{ intro, sections }`. To preserve behavior exactly I added a `hasSections` flag to the return value: the original outer decision was `toolSections.length > 1` (did the split find `### ` delimiters), which is **distinct** from the filtered `sections` being empty. A `### name` heading with empty content produces `hasSections === true` but no section, and the original still renders only the intro in that case rather than falling back to rendering the whole message — `hasSections` lets the caller reproduce that exactly. This edge case is covered by a dedicated test.

## Screenshots / Screencast

N/A — internal code-motion refactor with no user-visible change. Tool-execution message rendering (collapsible sections, icons, expand/collapse) is byte-for-byte the same.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — plus `npm run typecheck:test` and `npm run lint`
- [ ] I have tested this change on Desktop
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards)
- [x] Documentation has been updated (if applicable) — N/A, no user-facing change
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude (auto-dev pipeline)
- [x] I have reviewed and understand all AI-generated code in this PR

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UAJLmeD91PdqqpwrBxrUFe)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tool execution messages are now parsed and displayed with a more reliable structure, including intro text and individual tool sections.
  * Tool blocks continue to support collapsible sections and status indicators for success or failure.

* **Bug Fixes**
  * Improved detection of tool execution messages, reducing false positives and missed tool-result displays.
  * Better handling of messages with multiple tool sections, missing content, or text before the first section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->