### PR TITLE
refactor(tools): replace `any` with precise types in src/tools

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -132,8 +132,8 @@ export default defineConfig([
 	{
 		// #1036: `no-explicit-any` is cleared for these directories, so enforce it here
 		// to prevent regressions while the rule stays globally softened for the rest of
-		// `src/` (remaining areas — src/tools, src/api, src/ui — tracked in #1036).
-		files: ['src/utils/**/*.ts', 'src/mcp/**/*.ts'],
+		// `src/` (remaining areas — src/api, src/ui — tracked in #1036).
+		files: ['src/utils/**/*.ts', 'src/mcp/**/*.ts', 'src/tools/**/*.ts'],
 		rules: { '@typescript-eslint/no-explicit-any': 'error' },
 	},
 	{

--- a/src/tools/execution-engine.ts
+++ b/src/tools/execution-engine.ts
@@ -4,6 +4,7 @@ import {
 	ToolExecutionContext,
 	ToolCall,
 	ToolExecution,
+	ToolParams,
 	IConfirmationProvider,
 	DiffContext,
 	ConfirmationResult,
@@ -218,7 +219,7 @@ export class ToolExecutionEngine {
 	 */
 	private async requestUserConfirmation(
 		tool: Tool,
-		parameters: any,
+		parameters: ToolParams,
 		confirmationProvider: IConfirmationProvider
 	): Promise<ConfirmationResult> {
 		// Generate unique execution ID for tracking
@@ -240,34 +241,41 @@ export class ToolExecutionEngine {
 	 * - create_skill: originalContent = empty (new SKILL.md body), proposedContent = parameters.content
 	 * - edit_skill: originalContent = current SKILL.md body, proposedContent = parameters.content
 	 */
-	private async buildDiffContext(tool: Tool, parameters: any): Promise<DiffContext | undefined> {
+	private async buildDiffContext(tool: Tool, parameters: ToolParams): Promise<DiffContext | undefined> {
 		const plugin = this.plugin;
 
-		if (tool.name === 'write_file' && parameters.path && parameters.content !== undefined) {
-			const normalizedPath = normalizePath(parameters.path);
+		// Narrow the dynamic, model-supplied fields this method reads to their
+		// expected string types once, so each branch works with concrete values.
+		const path = typeof parameters.path === 'string' ? parameters.path : undefined;
+		const content = typeof parameters.content === 'string' ? parameters.content : undefined;
+		const name = typeof parameters.name === 'string' ? parameters.name : undefined;
+		const description = typeof parameters.description === 'string' ? parameters.description : undefined;
+
+		if (tool.name === 'write_file' && path && content !== undefined) {
+			const normalizedPath = normalizePath(path);
 			if (shouldExcludePath(normalizedPath, plugin.settings.historyFolder, plugin.app.vault.configDir))
 				return undefined;
 
 			const file = plugin.app.vault.getAbstractFileByPath(normalizedPath);
 			const originalContent = file instanceof TFile ? await this.safeReadFile(file) : '';
 			return {
-				filePath: parameters.path,
+				filePath: path,
 				originalContent,
-				proposedContent: parameters.content,
+				proposedContent: content,
 				isNewFile: !file,
 			};
 		}
 
-		if (tool.name === 'append_content' && parameters.path && parameters.content !== undefined) {
+		if (tool.name === 'append_content' && path && content !== undefined) {
 			// Use the canonical resolver, same as AppendContentTool — applies
 			// system-folder exclusion at every resolution strategy (including
 			// the wikilink path), so the diff matches what will actually be written.
-			const { file } = resolvePathToFile(parameters.path, plugin);
+			const { file } = resolvePathToFile(path, plugin);
 			if (!file) return undefined; // Tool will return its own error
 
 			const originalContent = await this.safeReadFile(file);
 			// Mirror the newline-insertion logic from AppendContentTool.execute()
-			let contentToAppend = parameters.content;
+			let contentToAppend = content;
 			if (originalContent.length > 0 && !originalContent.endsWith('\n') && !contentToAppend.startsWith('\n')) {
 				contentToAppend = '\n' + contentToAppend;
 			}
@@ -279,10 +287,10 @@ export class ToolExecutionEngine {
 			};
 		}
 
-		if (tool.name === 'create_skill' && parameters.name && parameters.content !== undefined) {
+		if (tool.name === 'create_skill' && name && content !== undefined) {
 			// Normalize name the same way CreateSkillTool.execute() does
-			const normalizedName = parameters.name.trim().toLowerCase();
-			const proposedBody = parameters.content.trim();
+			const normalizedName = name.trim().toLowerCase();
+			const proposedBody = content.trim();
 			return {
 				filePath: this.getSkillFilePath(normalizedName),
 				originalContent: '',
@@ -291,11 +299,11 @@ export class ToolExecutionEngine {
 			};
 		}
 
-		if (tool.name === 'edit_skill' && parameters.name) {
+		if (tool.name === 'edit_skill' && name) {
 			// Normalize name the same way EditSkillTool.execute() does
-			const normalizedName = parameters.name.trim().toLowerCase();
-			const proposedContent = parameters.content?.trim();
-			const proposedDescription = parameters.description?.trim();
+			const normalizedName = name.trim().toLowerCase();
+			const proposedContent = content?.trim();
+			const proposedDescription = description?.trim();
 
 			// Skip diff if neither content nor description is provided
 			if (!proposedContent && !proposedDescription) return undefined;

--- a/src/tools/image-tools.ts
+++ b/src/tools/image-tools.ts
@@ -1,4 +1,4 @@
-import { Tool, ToolResult, ToolExecutionContext } from './types';
+import { Tool, ToolResult, ToolExecutionContext, ToolParams } from './types';
 import { ToolCategory } from '../types/agent';
 import { ToolClassification } from '../types/tool-policy';
 import { getRawErrorMessage } from '../utils/error-utils';
@@ -40,10 +40,12 @@ export class GenerateImageTool implements Tool {
 
 	requiresConfirmation = true;
 
-	confirmationMessage = (params: any) => {
-		let message = t('tool.confirm.generateImage', { prompt: params.prompt });
-		if (params.output_path) {
-			message += `\n\n${t('tool.confirm.generateImageDestination', { path: params.output_path })}`;
+	confirmationMessage = (params: ToolParams) => {
+		const prompt = typeof params.prompt === 'string' ? params.prompt : '';
+		const outputPath = typeof params.output_path === 'string' ? params.output_path : undefined;
+		let message = t('tool.confirm.generateImage', { prompt });
+		if (outputPath) {
+			message += `\n\n${t('tool.confirm.generateImageDestination', { path: outputPath })}`;
 		}
 		return message;
 	};
@@ -56,8 +58,11 @@ export class GenerateImageTool implements Tool {
 		return 'Generating image';
 	}
 
-	async execute(params: any, context: ToolExecutionContext): Promise<ToolResult> {
+	async execute(params: ToolParams, context: ToolExecutionContext): Promise<ToolResult> {
 		const plugin = context.plugin;
+		const prompt = typeof params.prompt === 'string' ? params.prompt : undefined;
+		const outputPath = typeof params.output_path === 'string' ? params.output_path : undefined;
+		const background = !!params.background;
 
 		try {
 			// Get the image generation service
@@ -69,7 +74,7 @@ export class GenerateImageTool implements Tool {
 			}
 
 			// Validate prompt
-			if (!params.prompt || typeof params.prompt !== 'string' || params.prompt.trim().length === 0) {
+			if (!prompt || prompt.trim().length === 0) {
 				return {
 					success: false,
 					error: 'Prompt is required and must be a non-empty string',
@@ -77,7 +82,7 @@ export class GenerateImageTool implements Tool {
 			}
 
 			// ── Background mode ──────────────────────────────────────────────────
-			if (params.background) {
+			if (background) {
 				if (!plugin.backgroundTaskManager) {
 					return { success: false, error: 'Background task manager not available' };
 				}
@@ -89,7 +94,7 @@ export class GenerateImageTool implements Tool {
 				// matches where the task will actually write.
 				let resolvedOutputPath: string;
 				try {
-					resolvedOutputPath = await plugin.imageGeneration.resolveOutputPath(params.prompt, params.output_path);
+					resolvedOutputPath = await plugin.imageGeneration.resolveOutputPath(prompt, outputPath);
 				} catch (error) {
 					return {
 						success: false,
@@ -98,12 +103,12 @@ export class GenerateImageTool implements Tool {
 				}
 
 				const imageGeneration = plugin.imageGeneration;
-				const label = params.prompt.length > 40 ? params.prompt.slice(0, 37) + '…' : params.prompt;
+				const label = prompt.length > 40 ? prompt.slice(0, 37) + '…' : prompt;
 				const taskId = plugin.backgroundTaskManager.submit('image-generation', label, async (isCancelled) => {
 					if (isCancelled()) return undefined;
 					// Always pass the pre-resolved path as the explicit outputPath so the
 					// task writes exactly where we told the agent it would land.
-					return imageGeneration.generateImage(params.prompt, resolvedOutputPath);
+					return imageGeneration.generateImage(prompt, resolvedOutputPath);
 				});
 
 				return {
@@ -113,13 +118,13 @@ export class GenerateImageTool implements Tool {
 			}
 
 			// ── Foreground mode (default) ────────────────────────────────────────
-			const imagePath = await plugin.imageGeneration.generateImage(params.prompt, params.output_path);
+			const imagePath = await plugin.imageGeneration.generateImage(prompt, outputPath);
 
 			return {
 				success: true,
 				data: {
 					path: imagePath,
-					prompt: params.prompt,
+					prompt,
 					wikilink: `![[${imagePath}]]`,
 				},
 			};

--- a/src/tools/image-tools.ts
+++ b/src/tools/image-tools.ts
@@ -5,6 +5,17 @@ import { getRawErrorMessage } from '../utils/error-utils';
 import { t } from '../i18n';
 
 /**
+ * Narrow the model-supplied image params to their expected string types once, so
+ * `confirmationMessage` and `execute` share a single source of truth for the
+ * `prompt`/`output_path` fields instead of re-deriving them independently.
+ */
+function parseImageParams(params: ToolParams): { prompt?: string; outputPath?: string } {
+	const prompt = typeof params.prompt === 'string' ? params.prompt : undefined;
+	const outputPath = typeof params.output_path === 'string' ? params.output_path : undefined;
+	return { prompt, outputPath };
+}
+
+/**
  * Tool to generate images from text prompts using Gemini's image generation API
  */
 export class GenerateImageTool implements Tool {
@@ -41,8 +52,7 @@ export class GenerateImageTool implements Tool {
 	requiresConfirmation = true;
 
 	confirmationMessage = (params: ToolParams) => {
-		const prompt = typeof params.prompt === 'string' ? params.prompt : '';
-		const outputPath = typeof params.output_path === 'string' ? params.output_path : undefined;
+		const { prompt = '', outputPath } = parseImageParams(params);
 		let message = t('tool.confirm.generateImage', { prompt });
 		if (outputPath) {
 			message += `\n\n${t('tool.confirm.generateImageDestination', { path: outputPath })}`;
@@ -60,8 +70,7 @@ export class GenerateImageTool implements Tool {
 
 	async execute(params: ToolParams, context: ToolExecutionContext): Promise<ToolResult> {
 		const plugin = context.plugin;
-		const prompt = typeof params.prompt === 'string' ? params.prompt : undefined;
-		const outputPath = typeof params.output_path === 'string' ? params.output_path : undefined;
+		const { prompt, outputPath } = parseImageParams(params);
 		const background = !!params.background;
 
 		try {

--- a/src/tools/memory-tool.ts
+++ b/src/tools/memory-tool.ts
@@ -1,4 +1,4 @@
-import { Tool, ToolResult, ToolExecutionContext } from './types';
+import { Tool, ToolResult, ToolExecutionContext, ToolParams } from './types';
 import { ToolCategory } from '../types/agent';
 import { ToolClassification } from '../types/tool-policy';
 import { getRawErrorMessage } from '../utils/error-utils';
@@ -35,7 +35,7 @@ export class UpdateMemoryTool implements Tool {
 		return t('tool.confirm.addMemory', { preview });
 	};
 
-	getProgressDescription(_params: any): string {
+	getProgressDescription(_params: ToolParams): string {
 		return 'Updating vault memory';
 	}
 
@@ -97,11 +97,11 @@ export class ReadMemoryTool implements Tool {
 		required: [],
 	};
 
-	getProgressDescription(_params: any): string {
+	getProgressDescription(_params: ToolParams): string {
 		return 'Reading vault memory';
 	}
 
-	async execute(_params: any, context: ToolExecutionContext): Promise<ToolResult> {
+	async execute(_params: ToolParams, context: ToolExecutionContext): Promise<ToolResult> {
 		const plugin = context.plugin;
 
 		try {

--- a/src/tools/tool-registry.ts
+++ b/src/tools/tool-registry.ts
@@ -1,4 +1,4 @@
-import { Tool, ToolExecutionContext } from './types';
+import { Tool, ToolExecutionContext, ToolParameterSchema, ToolParams } from './types';
 import {
 	ToolPermission,
 	FeatureToolPolicy,
@@ -131,7 +131,7 @@ export class ToolRegistry {
 		function: {
 			name: string;
 			description: string;
-			parameters: any;
+			parameters: ToolParameterSchema;
 		};
 	}> {
 		const enabledTools = this.getEnabledTools(context);
@@ -149,7 +149,7 @@ export class ToolRegistry {
 	/**
 	 * Validate tool parameters against schema
 	 */
-	validateParameters(toolName: string, params: any): { valid: boolean; errors?: string[] } {
+	validateParameters(toolName: string, params: ToolParams): { valid: boolean; errors?: string[] } {
 		const tool = this.getTool(toolName);
 		if (!tool) {
 			return { valid: false, errors: [`Tool ${toolName} not found`] };

--- a/src/tools/types.ts
+++ b/src/tools/types.ts
@@ -7,10 +7,21 @@ import type { TFile } from 'obsidian';
 export type { ToolCall } from '../api/interfaces/model-api';
 
 /**
+ * Parameters passed to a tool, parsed from a model function call. The model
+ * supplies an arbitrary JSON object, so this is the honest static type; tools
+ * narrow individual fields at their execution boundary.
+ */
+export type ToolParams = Record<string, unknown>;
+
+/**
  * Result from a tool execution
  */
 export interface ToolResult {
 	success: boolean;
+	// Per-tool payload: each tool returns a differently-shaped object (and the ~40
+	// consumer sites narrow it by runtime shape), so this is a genuine dynamic
+	// boundary. Kept as `any` deliberately.
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	data?: any;
 	error?: string;
 	requiresConfirmation?: boolean;
@@ -75,7 +86,7 @@ export interface ToolParameterSchema {
 			type: 'string' | 'number' | 'boolean' | 'array';
 			description: string;
 			required?: boolean;
-			enum?: any[];
+			enum?: unknown[];
 			items?: { type: string };
 		}
 	>;
@@ -105,16 +116,16 @@ export interface Tool {
 	parameters: ToolParameterSchema;
 
 	/** Execute the tool with given parameters */
-	execute(params: any, context: ToolExecutionContext): Promise<ToolResult>;
+	execute(params: ToolParams, context: ToolExecutionContext): Promise<ToolResult>;
 
 	/** Whether this tool requires user confirmation before execution */
 	requiresConfirmation?: boolean;
 
 	/** Custom confirmation message (if requiresConfirmation is true) */
-	confirmationMessage?: (params: any) => string;
+	confirmationMessage?(params: ToolParams): string;
 
 	/** Get a human-friendly description of this tool execution for progress display */
-	getProgressDescription?: (params: any) => string;
+	getProgressDescription?(params: ToolParams): string;
 }
 
 /**
@@ -122,7 +133,7 @@ export interface Tool {
  */
 export interface ToolExecution {
 	toolName: string;
-	parameters: any;
+	parameters: ToolParams;
 	result: ToolResult;
 	timestamp: Date;
 	confirmed?: boolean;
@@ -163,7 +174,7 @@ export interface IConfirmationProvider {
 	/** Show a confirmation request in the chat UI */
 	showConfirmationInChat(
 		tool: Tool,
-		parameters: any,
+		parameters: ToolParams,
 		executionId: string,
 		diffContext?: DiffContext
 	): Promise<ConfirmationResult>;

--- a/src/tools/vault-tools-extended.ts
+++ b/src/tools/vault-tools-extended.ts
@@ -51,7 +51,7 @@ class UpdateFrontmatterTool implements Tool {
 		required: ['path', 'key', 'value'],
 	};
 
-	confirmationMessage = (params: { path: string; key: string; value: any }) => {
+	confirmationMessage = (params: { path: string; key: string; value: unknown }) => {
 		return t('tool.confirm.updateFrontmatter', { path: params.path, key: params.key, value: String(params.value) });
 	};
 
@@ -62,7 +62,10 @@ class UpdateFrontmatterTool implements Tool {
 		return 'Updating frontmatter';
 	}
 
-	async execute(params: { path: string; key: string; value: any }, context: ToolExecutionContext): Promise<ToolResult> {
+	async execute(
+		params: { path: string; key: string; value: unknown },
+		context: ToolExecutionContext
+	): Promise<ToolResult> {
 		const plugin = context.plugin;
 		const { path, key, value } = params;
 

--- a/src/tools/vault/get-workspace-state-tool.ts
+++ b/src/tools/vault/get-workspace-state-tool.ts
@@ -1,4 +1,4 @@
-import { Tool, ToolResult, ToolExecutionContext } from '../types';
+import { Tool, ToolResult, ToolExecutionContext, ToolParams } from '../types';
 import { ToolCategory } from '../../types/agent';
 import { ToolClassification } from '../../types/tool-policy';
 import { MarkdownView } from 'obsidian';
@@ -26,11 +26,11 @@ export class GetWorkspaceStateTool implements Tool {
 		required: [],
 	};
 
-	getProgressDescription(_params: any): string {
+	getProgressDescription(_params: ToolParams): string {
 		return 'Getting workspace state';
 	}
 
-	async execute(_params: any, context: ToolExecutionContext): Promise<ToolResult> {
+	async execute(_params: ToolParams, context: ToolExecutionContext): Promise<ToolResult> {
 		const plugin = context.plugin;
 
 		try {
@@ -53,7 +53,7 @@ export class GetWorkspaceStateTool implements Tool {
 				// Skip system/excluded files
 				if (shouldExcludePath(path, plugin)) return;
 
-				const isVisible = (leaf as any).containerEl?.isShown?.() ?? false;
+				const isVisible = (leaf as { containerEl?: { isShown?: () => boolean } }).containerEl?.isShown?.() ?? false;
 				const isActive = activeFile !== null && file.path === activeFile.path;
 				const isActiveLeaf = view === activeView;
 

--- a/src/tools/web-fetch-tool.ts
+++ b/src/tools/web-fetch-tool.ts
@@ -128,8 +128,10 @@ export class WebFetchTool implements Tool {
 			}
 
 			// Check if URL retrieval failed - the field is urlRetrievalStatus (camelCase)
-			const urlRetrievalFailed = urlMetadata?.urlMetadata?.some((meta: any) => {
-				const status = meta.urlRetrievalStatus;
+			const urlRetrievalFailed = urlMetadata?.urlMetadata?.some((meta) => {
+				// Widen the SDK enum to a plain string so the failure-status checks below
+				// stay a straight string comparison (avoiding no-unsafe-enum-comparison).
+				const status: string = meta.urlRetrievalStatus ?? '';
 				plugin.logger.log('Checking URL status:', status);
 				return (
 					status === 'URL_RETRIEVAL_STATUS_ERROR' ||
@@ -151,7 +153,7 @@ export class WebFetchTool implements Tool {
 					query: params.query,
 					content: text,
 					urlsRetrieved:
-						urlMetadata?.urlMetadata?.map((meta: any) => ({
+						urlMetadata?.urlMetadata?.map((meta) => ({
 							url: meta.retrievedUrl,
 							status: meta.urlRetrievalStatus,
 						})) || [],

--- a/test/tools/image-tools.test.ts
+++ b/test/tools/image-tools.test.ts
@@ -109,7 +109,7 @@ describe('ImageTools', () => {
 		});
 
 		it('should return error when prompt is not a string', async () => {
-			const result = await tool.execute({ prompt: 123 as any }, mockContext);
+			const result = await tool.execute({ prompt: 123 }, mockContext);
 
 			expect(result.success).toBe(false);
 			expect(result.error).toBe('Prompt is required and must be a non-empty string');

--- a/test/tools/memory-tool.test.ts
+++ b/test/tools/memory-tool.test.ts
@@ -258,7 +258,7 @@ describe('Memory Tools', () => {
 			mockAgentsMemory.getMemoryFilePath.mockReturnValue('test-folder/AGENTS.md');
 
 			// Should ignore extra params
-			const result = await tool.execute({ extraParam: 'ignored' } as any, mockContext);
+			const result = await tool.execute({ extraParam: 'ignored' }, mockContext);
 
 			expect(result.success).toBe(true);
 		});

--- a/test/tools/vault/vault-tools-extended.test.ts
+++ b/test/tools/vault/vault-tools-extended.test.ts
@@ -285,7 +285,7 @@ describe('UpdateFrontmatterTool', () => {
 		});
 
 		// When value is already a number (not a string), skip parsing
-		await tool.execute({ path: 'notes/foo.md', key: 'num', value: 99 as any }, makeContext(plugin));
+		await tool.execute({ path: 'notes/foo.md', key: 'num', value: 99 }, makeContext(plugin));
 		expect(captured['num']).toBe(99);
 	});
 


### PR DESCRIPTION
<!-- auto-dev -->

## Summary

Continues the incremental `@typescript-eslint/no-explicit-any` pass — the next directory slice after `src/utils/` + `src/mcp/` landed in #1118. This clears explicit `any` from `src/tools/` and flips `no-explicit-any` to `error` scoped to that directory, so the boundary can't regress. Per the maintainer's reopening note, this references the tracker with **Part of #1036** (not a closing keyword) so #1036 stays open until the final slices land.

Part of #1036

## Changes

- **`src/tools/types.ts`** — add a shared `ToolParams` (`Record<string, unknown>`) alias; type the `Tool` interface's `execute` / `confirmationMessage` / `getProgressDescription` params, `ToolExecution.parameters`, and `IConfirmationProvider.showConfirmationInChat` with it. The two optional callbacks use method-signature syntax so tools that declare narrower param shapes stay compatible. `ToolParameterSchema.enum` becomes `unknown[]`.
- **`src/tools/execution-engine.ts`** — `requestUserConfirmation` / `buildDiffContext` take `ToolParams`; the model-supplied `path` / `content` / `name` / `description` fields are narrowed once at the top of `buildDiffContext`.
- **`src/tools/image-tools.ts`** — narrow `prompt` / `output_path` / `background` at the execute boundary instead of trusting `any` (truthy semantics preserved).
- **`src/tools/tool-registry.ts`** — descriptor `parameters` typed as `ToolParameterSchema`; `validateParameters` takes `ToolParams`.
- **`src/tools/vault-tools-extended.ts`** — frontmatter `value` typed `unknown`.
- **`src/tools/vault/get-workspace-state-tool.ts`** — replace `leaf as any` with a structural cast; params typed `ToolParams`.
- **`src/tools/web-fetch-tool.ts`** — let the URL-metadata callbacks infer their SDK types; the retrieval status is widened to `string` so the existing failure-status comparison behaves identically.
- **`src/tools/memory-tool.ts`** — unused params typed `ToolParams`.
- **`eslint.config.mjs`** — add `src/tools/**/*.ts` to the scoped `no-explicit-any: 'error'` override.
- **tests** — drop three now-unnecessary `as any` casts that the tighter signatures made redundant.

`ToolResult.data` is deliberately kept as a documented `any` (with an inline disable): it's a genuine per-tool dynamic payload narrowed by ~40 consumer sites outside `src/tools`, and converting it would ripple casts across unrelated files.

**Out of scope:** `src/api/` and `src/ui/` — the final two directory slices, tracked in #1036.

Type-only change, no runtime behavior difference.

## Checklist

### Required

- [x] All CI checks pass locally: `npm run lint` (0 errors), `npm run build`, `npm run typecheck:test`, `npm test` (3287 passed), `npm run format-check`
- [x] Documentation reviewed — no user-facing surface changes (internal typing only), so no docs update applies
- [x] This PR is linked to an approved issue (#1036, plan approved via `auto:ready`)

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (auto-dev pipeline)
- [x] AI-generated code has been reviewed

---

Produced by the auto-dev pipeline from the approved plan on #1036.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ugp1ZSsM6UTxen3T4odm8f)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation and handling for tool inputs, making image generation, memory updates, vault edits, and workspace-state checks more reliable.
  - Better handling of invalid image prompts and safer parameter processing for confirmations and diffs.
  - Web fetch results now more consistently report URL retrieval failures and successful retrieved links.

- **Refactor**
  - Strengthened TypeScript typing across tool workflows with clearer parameter/result contracts to reduce input-related issues.

- **Tests**
  - Updated tool tests to remove unsafe casts while covering invalid input scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->