### PR TITLE
Add error handling to fire-and-forget UI handlers

### DIFF
--- a/__mocks__/obsidian.js
+++ b/__mocks__/obsidian.js
@@ -248,6 +248,9 @@ export class SuggestModal extends Modal {
 		};
 	}
 
+	setPlaceholder() {
+		return this;
+	}
 	getSuggestions() {
 		return [];
 	}

--- a/src/commands/register-commands.ts
+++ b/src/commands/register-commands.ts
@@ -193,18 +193,24 @@ export function registerCommands(plugin: ObsidianGemini): void {
 			const modal = new ProjectPickerModal(plugin.app, plugin, {
 				onSelect: (project) => {
 					void (async () => {
-						if (!project) return;
-						// Find most recent session linked to this project
-						const sessions = await plugin.sessionManager.getRecentAgentSessions(50);
-						const projectSession = sessions.find((s) => s.projectPath === project.filePath);
-						if (projectSession) {
-							await plugin.activateAgentView();
-							// The agent view will load the session
-							if (plugin.agentView) {
-								await plugin.agentView.loadSession(projectSession);
+						try {
+							if (!project) return;
+							// Find most recent session linked to this project
+							const sessions = await plugin.sessionManager.getRecentAgentSessions(50);
+							const projectSession = sessions.find((s) => s.projectPath === project.filePath);
+							if (projectSession) {
+								await plugin.activateAgentView();
+								// The agent view will load the session
+								if (plugin.agentView) {
+									await plugin.agentView.loadSession(projectSession);
+								}
+							} else {
+								new Notice(t('notice.main.noSessionsForProject', { name: project.name }));
 							}
-						} else {
-							new Notice(t('notice.main.noSessionsForProject', { name: project.name }));
+						} catch (error) {
+							// Mirror the try/catch the sibling project commands already have.
+							plugin.logger.error('Failed to resume project session:', error);
+							new Notice(t('notice.main.resumeProjectSessionFailed'));
 						}
 					})();
 				},

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -72,6 +72,11 @@ export const en = {
 		context:
 			'Button description under "Initialize Vault Context". Phrased as the AI agent asking the user to let it analyze the vault.',
 	},
+	'agent.empty.initContextFailed': {
+		message: 'Failed to initialize vault context',
+		context:
+			'Error notice shown when the "Initialize vault context" empty-state button fails to analyze the vault (e.g. an API error).',
+	},
 	'agent.empty.recentSessions': {
 		message: 'Recent sessions:',
 		context: 'List header above recently used chat sessions. Keep the trailing colon.',
@@ -2854,6 +2859,10 @@ export const en = {
 		message: 'No sessions found for project: {name}',
 		context:
 			'Notice when resuming a project session but no agent sessions are linked to that project; {name} is the project name.',
+	},
+	'notice.main.resumeProjectSessionFailed': {
+		message: 'Failed to resume project session',
+		context: 'Error notice shown when resuming the most recent session for a project fails.',
 	},
 	'notice.main.projectRemoved': {
 		message: 'Removed project status from: {name}',

--- a/src/services/background-status-bar.ts
+++ b/src/services/background-status-bar.ts
@@ -55,20 +55,26 @@ export class BackgroundStatusBar {
 
 		this.statusBarItem.addEventListener('click', () => {
 			void (async () => {
-				// Pending catch-up approvals take priority — open the approval modal first
-				if (this._pendingCatchUpCount > 0 && this.plugin.scheduledTaskManager) {
-					const pending = this.plugin.scheduledTaskManager.detectMissedRuns();
-					if (pending.length > 0) {
-						const { CatchUpModal } = await import('../ui/catch-up-modal');
-						new CatchUpModal(this.plugin.app, this.plugin, pending).open();
-						return;
+				try {
+					// Pending catch-up approvals take priority — open the approval modal first
+					if (this._pendingCatchUpCount > 0 && this.plugin.scheduledTaskManager) {
+						const pending = this.plugin.scheduledTaskManager.detectMissedRuns();
+						if (pending.length > 0) {
+							const { CatchUpModal } = await import('../ui/catch-up-modal');
+							new CatchUpModal(this.plugin.app, this.plugin, pending).open();
+							return;
+						}
+						// detectMissedRuns returned empty — stale badge; self-correct
+						this.setPendingCatchUpCount(0);
 					}
-					// detectMissedRuns returned empty — stale badge; self-correct
-					this.setPendingCatchUpCount(0);
+					const { BackgroundTasksModal } = await import('../ui/background-tasks-modal');
+					const defaultTab = this.taskManager.runningCount > 0 ? 'tasks' : 'rag';
+					new BackgroundTasksModal(this.plugin.app, this.plugin, defaultTab).open();
+				} catch (error) {
+					// Mirror the RagStatusBar click handler's guard so a dynamic import or
+					// modal-open failure can't become an unhandled promise rejection.
+					this.plugin.logger.error('BackgroundStatusBar: failed to open status UI', error);
 				}
-				const { BackgroundTasksModal } = await import('../ui/background-tasks-modal');
-				const defaultTab = this.taskManager.runningCount > 0 ? 'tasks' : 'rag';
-				new BackgroundTasksModal(this.plugin.app, this.plugin, defaultTab).open();
 			})();
 		});
 

--- a/src/ui/agent-view/agent-view-messages.ts
+++ b/src/ui/agent-view/agent-view-messages.ts
@@ -603,9 +603,16 @@ export class AgentViewMessages {
 				void (async () => {
 					// Run the vault analyzer
 					if (this.plugin.vaultAnalyzer) {
-						await this.plugin.vaultAnalyzer.initializeAgentsMemory();
-						// Refresh the empty state to update the button
-						await this.showEmptyState(currentSession, onLoadSession, onSendMessage);
+						try {
+							await this.plugin.vaultAnalyzer.initializeAgentsMemory();
+							// Refresh the empty state to update the button
+							await this.showEmptyState(currentSession, onLoadSession, onSendMessage);
+						} catch (error) {
+							// Without this, a failing analyzer run is an unhandled rejection
+							// with no feedback to the user.
+							this.plugin.logger.error('Failed to initialize vault context (AGENTS.md):', error);
+							new Notice(t('agent.empty.initContextFailed'));
+						}
 					}
 				})();
 			});

--- a/src/ui/agent-view/agent-view-messages.ts
+++ b/src/ui/agent-view/agent-view-messages.ts
@@ -605,13 +605,20 @@ export class AgentViewMessages {
 					if (this.plugin.vaultAnalyzer) {
 						try {
 							await this.plugin.vaultAnalyzer.initializeAgentsMemory();
-							// Refresh the empty state to update the button
-							await this.showEmptyState(currentSession, onLoadSession, onSendMessage);
 						} catch (error) {
 							// Without this, a failing analyzer run is an unhandled rejection
 							// with no feedback to the user.
 							this.plugin.logger.error('Failed to initialize vault context (AGENTS.md):', error);
 							new Notice(t('agent.empty.initContextFailed'));
+							return;
+						}
+						try {
+							// Refresh the empty state to update the button
+							await this.showEmptyState(currentSession, onLoadSession, onSendMessage);
+						} catch (error) {
+							// Init already succeeded; only the UI refresh failed, so don't mislabel it
+							// as an init failure — log it without alarming the user.
+							this.plugin.logger.error('Vault context initialized, but failed to refresh empty state:', error);
 						}
 					}
 				})();

--- a/src/ui/explain-prompt-modal.ts
+++ b/src/ui/explain-prompt-modal.ts
@@ -53,12 +53,18 @@ export class ExplainPromptSelectionModal extends SuggestModal<PromptInfo> {
 	}
 
 	private async chooseSuggestion(promptInfo: PromptInfo): Promise<void> {
-		// Load the full prompt content
-		const prompt = await this.plugin.promptManager.loadPrompt(promptInfo.path);
-		if (prompt) {
-			await this.onSelect(prompt);
-		} else {
-			this.plugin.logger.error('Failed to load prompt:', promptInfo.path);
+		// Invoked via `void this.chooseSuggestion(...)`, so a rejection here would be
+		// an unhandled promise rejection — guard loadPrompt/onSelect with try/catch.
+		try {
+			// Load the full prompt content
+			const prompt = await this.plugin.promptManager.loadPrompt(promptInfo.path);
+			if (prompt) {
+				await this.onSelect(prompt);
+			} else {
+				this.plugin.logger.error('Failed to load prompt:', promptInfo.path);
+			}
+		} catch (error) {
+			this.plugin.logger.error('Failed to load or apply prompt:', promptInfo.path, error);
 		}
 	}
 }

--- a/src/ui/hook-management-modal.ts
+++ b/src/ui/hook-management-modal.ts
@@ -178,8 +178,15 @@ export class HookManagementModal extends ManagementModalBase<Hook, HookState> {
 			resetBtn.addEventListener('click', () => {
 				void (async () => {
 					resetBtn.disabled = true;
-					await this.plugin.hookManager?.resetHook(hook.slug);
-					this.render();
+					try {
+						await this.plugin.hookManager?.resetHook(hook.slug);
+						this.render();
+					} catch (err) {
+						// On success render() rebuilds the row; on failure restore the
+						// button so it can't stay stuck disabled (mirrors the toggle handler above).
+						this.plugin.logger.error(`[HookManagementModal] resetHook failed for "${hook.slug}":`, err);
+						resetBtn.disabled = false;
+					}
 				})();
 			});
 		}

--- a/src/ui/scheduled-tasks-modal.ts
+++ b/src/ui/scheduled-tasks-modal.ts
@@ -111,8 +111,16 @@ export class ScheduledTasksModal extends Modal {
 				void (async () => {
 					resetBtn.disabled = true;
 					resetBtn.setText(t('scheduledTasks.resetting'));
-					await this.plugin.scheduledTaskManager?.resetTask(task.slug);
-					this.onOpen(); // re-render
+					try {
+						await this.plugin.scheduledTaskManager?.resetTask(task.slug);
+						this.onOpen(); // re-render
+					} catch (error) {
+						// resetTask failed before the re-render, so restore the button
+						// instead of leaving it stuck disabled/"…"-ing.
+						this.plugin.logger.error(`[ScheduledTasksModal] resetTask failed for "${task.slug}":`, error);
+						resetBtn.disabled = false;
+						resetBtn.setText(t('scheduledTasks.resetButton'));
+					}
 				})();
 			});
 		}
@@ -133,6 +141,9 @@ export class ScheduledTasksModal extends Modal {
 					runBtn.setText(t('scheduledTasks.submitted'));
 				} catch (error) {
 					runBtn.setText(t('scheduledTasks.runError'));
+					// Restore the disabled state so the user can retry, matching the
+					// scheduler-management run-button sibling.
+					runBtn.disabled = false;
 					this.plugin.logger.error(`[ScheduledTasksModal] runNow failed for "${task.slug}":`, error);
 				}
 			})();

--- a/src/ui/scheduler-management-modal.ts
+++ b/src/ui/scheduler-management-modal.ts
@@ -159,8 +159,15 @@ export class SchedulerManagementModal extends ManagementModalBase<ScheduledTask,
 			resetBtn.addEventListener('click', () => {
 				void (async () => {
 					resetBtn.disabled = true;
-					await this.plugin.scheduledTaskManager?.resetTask(task.slug);
-					this.render();
+					try {
+						await this.plugin.scheduledTaskManager?.resetTask(task.slug);
+						this.render();
+					} catch (err) {
+						// On success render() rebuilds the row; on failure restore the
+						// button so it can't stay stuck disabled.
+						this.plugin.logger.error(`[SchedulerManagementModal] resetTask failed for "${task.slug}":`, err);
+						resetBtn.disabled = false;
+					}
 				})();
 			});
 		}

--- a/src/ui/settings-rag.ts
+++ b/src/ui/settings-rag.ts
@@ -52,12 +52,21 @@ export async function renderRAGSettings(
 						const { RagCleanupModal } = await import('./rag-cleanup-modal');
 						const modal = new RagCleanupModal(app, (deleteData) => {
 							void (async () => {
-								if (deleteData && plugin.ragIndexing) {
-									await plugin.ragIndexing.deleteFileSearchStore();
+								try {
+									if (deleteData && plugin.ragIndexing) {
+										await plugin.ragIndexing.deleteFileSearchStore();
+									}
+									plugin.settings.ragIndexing.enabled = false;
+									await plugin.saveSettings();
+									context.redisplay();
+								} catch (error) {
+									// If cleanup/save throws, surface it and redisplay so the toggle
+									// reflects the actual settings.ragIndexing.enabled rather than
+									// drifting silently (mirrors the delete-index flow).
+									plugin.logger.error('Failed to disable RAG indexing:', error);
+									new Notice(t('settings.rag.deleteIndexFailed', { error: getErrorMessage(error) }));
+									context.redisplay();
 								}
-								plugin.settings.ragIndexing.enabled = false;
-								await plugin.saveSettings();
-								context.redisplay();
 							})();
 						});
 						modal.open();

--- a/src/ui/settings-rag.ts
+++ b/src/ui/settings-rag.ts
@@ -52,6 +52,7 @@ export async function renderRAGSettings(
 						const { RagCleanupModal } = await import('./rag-cleanup-modal');
 						const modal = new RagCleanupModal(app, (deleteData) => {
 							void (async () => {
+								const previousEnabled = plugin.settings.ragIndexing.enabled;
 								try {
 									if (deleteData && plugin.ragIndexing) {
 										await plugin.ragIndexing.deleteFileSearchStore();
@@ -60,9 +61,10 @@ export async function renderRAGSettings(
 									await plugin.saveSettings();
 									context.redisplay();
 								} catch (error) {
-									// If cleanup/save throws, surface it and redisplay so the toggle
-									// reflects the actual settings.ragIndexing.enabled rather than
-									// drifting silently (mirrors the delete-index flow).
+									// Revert the in-memory flag so it can't drift from the persisted
+									// value when saveSettings()/deleteFileSearchStore() throws after it
+									// was flipped, then surface it and redisplay (mirrors delete-index).
+									plugin.settings.ragIndexing.enabled = previousEnabled;
 									plugin.logger.error('Failed to disable RAG indexing:', error);
 									new Notice(t('settings.rag.deleteIndexFailed', { error: getErrorMessage(error) }));
 									context.redisplay();

--- a/test/ui/explain-prompt-modal.test.ts
+++ b/test/ui/explain-prompt-modal.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ExplainPromptSelectionModal } from '../../src/ui/explain-prompt-modal';
+import type { PromptInfo, CustomPrompt } from '../../src/prompts/types';
+
+// Flush enough microtask turns for the fire-and-forget `chooseSuggestion`
+// (loadPrompt await + onSelect await) to settle.
+async function flushMicrotasks(): Promise<void> {
+	for (let i = 0; i < 5; i++) {
+		await Promise.resolve();
+	}
+}
+
+function makePromptInfo(overrides: Partial<PromptInfo> = {}): PromptInfo {
+	return {
+		name: 'Explain',
+		description: '',
+		tags: [],
+		path: 'Prompts/explain.md',
+		...overrides,
+	};
+}
+
+describe('ExplainPromptSelectionModal error handling', () => {
+	let logger: { error: ReturnType<typeof vi.fn> };
+	let loadPrompt: ReturnType<typeof vi.fn>;
+	let plugin: any;
+
+	beforeEach(() => {
+		logger = { error: vi.fn() };
+		loadPrompt = vi.fn();
+		plugin = { promptManager: { loadPrompt }, logger };
+	});
+
+	it('logs and does not throw when loadPrompt rejects (was an unhandled rejection)', async () => {
+		loadPrompt.mockRejectedValue(new Error('boom'));
+		const onSelect = vi.fn();
+		const modal = new ExplainPromptSelectionModal({} as any, plugin, [], onSelect);
+
+		// SuggestModal dispatches selection via a void fire-and-forget call.
+		expect(() => modal.onChooseSuggestion(makePromptInfo())).not.toThrow();
+		await flushMicrotasks();
+
+		expect(logger.error).toHaveBeenCalled();
+		expect(onSelect).not.toHaveBeenCalled();
+	});
+
+	it('logs when onSelect rejects instead of leaking an unhandled rejection', async () => {
+		loadPrompt.mockResolvedValue({ name: 'Explain' });
+		const onSelect = vi.fn().mockRejectedValue(new Error('apply failed'));
+		const modal = new ExplainPromptSelectionModal({} as any, plugin, [], onSelect);
+
+		modal.onChooseSuggestion(makePromptInfo());
+		await flushMicrotasks();
+
+		expect(onSelect).toHaveBeenCalledTimes(1);
+		expect(logger.error).toHaveBeenCalled();
+	});
+
+	it('applies the prompt normally on the success path', async () => {
+		const prompt = { name: 'Explain' } as CustomPrompt;
+		loadPrompt.mockResolvedValue(prompt);
+		const onSelect = vi.fn().mockResolvedValue(undefined);
+		const modal = new ExplainPromptSelectionModal({} as any, plugin, [], onSelect);
+
+		modal.onChooseSuggestion(makePromptInfo());
+		await flushMicrotasks();
+
+		expect(onSelect).toHaveBeenCalledWith(prompt);
+		expect(logger.error).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
<!-- auto-dev -->

## Summary

Several UI click/callback handlers ran their async work as fire-and-forget (`void (async () => {…})()` or `void someAsync()`) **without a surrounding `try/catch`**. On rejection they produced an unhandled promise rejection with no user-facing notice, and some left a button stuck in a disabled/"…"-ing state. This hardens the eight handlers enumerated in #1122 by adding a consistent `try/catch` (or state-restoring `catch`) around each async body, each mirroring the error handling already present in the corresponding sibling handler. It is a targeted robustness change — the fire-and-forget (`void`-dispatch) pattern is retained; only error handling is added.

Fixes #1122

## Changes

- `src/ui/scheduled-tasks-modal.ts` — reset-button handler now catches failures and restores its label/`disabled` instead of staying stuck; run-button `catch` now also restores `disabled` so the run can be retried (matching the scheduler-management sibling).
- `src/ui/scheduler-management-modal.ts` — reset-button handler catches failures and restores `disabled`.
- `src/ui/hook-management-modal.ts` — reset-button handler catches failures and restores `disabled` (mirrors the toggle handler above it).
- `src/ui/settings-rag.ts` — the disable-RAG `RagCleanupModal` callback now logs, shows a `Notice`, and `redisplay()`s on failure so the toggle can't drift out of sync with `settings.ragIndexing.enabled` (mirrors the delete-index flow, reusing `settings.rag.deleteIndexFailed`).
- `src/ui/agent-view/agent-view-messages.ts` — the "Initialize vault context" empty-state button surfaces a `Notice` on failure instead of an unhandled rejection (**new i18n key** `agent.empty.initContextFailed`).
- `src/commands/register-commands.ts` — the resume-project-session picker `onSelect` IIFE gains the `try/catch` its sibling project commands already have (**new i18n key** `notice.main.resumeProjectSessionFailed`).
- `src/ui/explain-prompt-modal.ts` — `chooseSuggestion` (invoked via `void`) now guards `loadPrompt`/`onSelect`.
- `src/services/background-status-bar.ts` — the status-bar click handler guards its dynamic imports/modal open (mirrors the `RagStatusBar` sibling's guard).
- `src/i18n/en.ts` — adds the two new keys above; other locales fall back to English until the `Update UI translations` workflow regenerates them.
- `test/ui/explain-prompt-modal.test.ts` (+ a `setPlaceholder` stub on the shared `SuggestModal` mock) — focused tests asserting the `chooseSuggestion` rejection paths log instead of throwing, plus the success path.

### Deviation from the approved plan

`background-status-bar.ts`'s `RagStatusBar` sibling surfaces a `Notice` using the RAG-specific `notice.rag.uiError` ("RAG indexing UI error"). Reusing that string on the shared background status bar (which also opens the catch-up / background-tasks modals) would be misleading, and the approved plan scoped new i18n strings to exactly two sites. So this handler mirrors the sibling's protective `try/catch` structure but logs via `logger.error` only, rather than showing a mismatched RAG notice. The unhandled-rejection bug is fixed either way.

## Screenshots / Screencast

No visual change — these are error-path handlers. Behavior is only observable on failure (a logged error, a `Notice`, and buttons no longer stuck disabled).

## Testing

- `npm run format-check` ✅
- `npm run build` ✅
- `npm test` ✅ (3290 passed, incl. the new `explain-prompt-modal` tests)
- `npm run typecheck:test` ✅
- `npm run lint` ✅ (0 errors; the 94 remaining warnings are pre-existing in untouched test files)

## Documentation

No user-facing docs required updating — this adds error handling to existing UI actions with no new/changed features, settings, or commands. The two new strings are error-toast copy.

## Checklist

### Required

- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have verified this change does not break Mobile (no platform-specific APIs; pure error handling)
- [x] Documentation has been updated (if applicable — N/A here)

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude (auto-dev pipeline)
- [x] I have reviewed and understand all AI-generated code in this PR

---

This PR was produced by the auto-dev pipeline from the approved plan on #1122.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q4ztTt9hiVdz49tVcQeZKe)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling across several dialogs and settings actions so failed operations now show clear messages and logs instead of silently breaking.
  * Retry controls and buttons are now properly re-enabled after errors, preventing actions from getting stuck.
  * Better handling when loading prompts, resuming sessions, initializing context, or updating indexing settings fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->