### PR TITLE
refactor(settings): extract shared createDebouncedSave helper

### DIFF
--- a/src/ui/settings-agent-config.ts
+++ b/src/ui/settings-agent-config.ts
@@ -1,7 +1,6 @@
 import type ObsidianGemini from '../main';
-import { Setting, Notice, debounce } from 'obsidian';
-import { createCollapsibleSection } from './settings-helpers';
-import { getErrorMessage } from '../utils/error-utils';
+import { Setting, Notice } from 'obsidian';
+import { createCollapsibleSection, createDebouncedSave } from './settings-helpers';
 import { t } from '../i18n';
 import type { SettingsSectionContext } from './settings';
 
@@ -31,20 +30,7 @@ export async function renderAgentConfigSettings(
 		}
 	);
 
-	// Debounce saveSettings() for text inputs so typing doesn't trigger the plugin
-	// lifecycle on every keystroke. Settings are mutated immediately; only the save is delayed.
-	const debouncedSave = debounce(
-		async () => {
-			try {
-				await plugin.saveSettings();
-			} catch (error) {
-				plugin.logger.error('Failed to save settings:', error);
-				new Notice(t('settings.common.saveFailedNotice', { error: getErrorMessage(error) }));
-			}
-		},
-		300,
-		true
-	);
+	const debouncedSave = createDebouncedSave(plugin);
 
 	// --- Custom Prompts ---
 	new Setting(sectionEl).setName(t('settings.agentConfig.customPromptsHeading')).setHeading();

--- a/src/ui/settings-general.ts
+++ b/src/ui/settings-general.ts
@@ -1,6 +1,6 @@
 import type ObsidianGemini from '../main';
-import { App, Notice, Setting, SecretComponent, debounce } from 'obsidian';
-import { createAlwaysOpenSection, selectModelSetting } from './settings-helpers';
+import { App, Notice, Setting, SecretComponent } from 'obsidian';
+import { createAlwaysOpenSection, createDebouncedSave, selectModelSetting } from './settings-helpers';
 import { FolderSuggest } from './folder-suggest';
 import { getErrorMessage } from '../utils/error-utils';
 import { t } from '../i18n';
@@ -12,22 +12,7 @@ export async function renderGeneralSettings(
 	app: App,
 	context: SettingsSectionContext
 ): Promise<void> {
-	// Debounce saveSettings() to avoid re-running the plugin lifecycle on every keystroke
-	// in text inputs. In-memory settings are mutated immediately so the UI stays responsive.
-	// The callback is async + wrapped in try/catch so rejections from saveSettings() don't
-	// become unhandled promise rejections.
-	const debouncedSave = debounce(
-		async () => {
-			try {
-				await plugin.saveSettings();
-			} catch (error) {
-				plugin.logger.error('Failed to save settings:', error);
-				new Notice(t('settings.common.saveFailedNotice', { error: getErrorMessage(error) }));
-			}
-		},
-		300,
-		true
-	);
+	const debouncedSave = createDebouncedSave(plugin);
 
 	const generalEl = createAlwaysOpenSection(
 		containerEl,

--- a/src/ui/settings-helpers.ts
+++ b/src/ui/settings-helpers.ts
@@ -1,8 +1,36 @@
-import { Setting } from 'obsidian';
+import { Setting, Notice, debounce } from 'obsidian';
 import type ObsidianGemini from '../main';
 import type { ObsidianGeminiSettings } from '../main';
 import { GEMINI_MODELS } from '../models';
+import { getErrorMessage } from '../utils/error-utils';
 import { t } from '../i18n';
+
+/**
+ * Create a debounced `saveSettings()` callback shared by the settings renderers.
+ *
+ * Text inputs invoke this on every keystroke; debouncing avoids re-running the
+ * plugin lifecycle (and its reload) until typing settles. The callback is async
+ * and wrapped in try/catch so a rejected save surfaces a Notice instead of an
+ * unhandled promise rejection.
+ *
+ * @param plugin - The plugin instance whose settings are saved.
+ * @param logLabel - Debug-log prefix used when a save fails; pass a
+ *   section-specific label to keep failure logs greppable.
+ */
+export function createDebouncedSave(plugin: ObsidianGemini, logLabel: string = 'Failed to save settings:'): () => void {
+	return debounce(
+		async () => {
+			try {
+				await plugin.saveSettings();
+			} catch (error) {
+				plugin.logger.error(logLabel, error);
+				new Notice(t('settings.common.saveFailedNotice', { error: getErrorMessage(error) }));
+			}
+		},
+		300,
+		true
+	);
+}
 
 export interface CollapsibleSectionOptions {
 	/** Description shown under the title; visible whether the section is open or closed. */

--- a/src/ui/settings-rag.ts
+++ b/src/ui/settings-rag.ts
@@ -1,7 +1,7 @@
 import type ObsidianGemini from '../main';
-import { App, Setting, Notice, debounce } from 'obsidian';
+import { App, Setting, Notice } from 'obsidian';
 import { getErrorMessage } from '../utils/error-utils';
-import { createCollapsibleSection } from './settings-helpers';
+import { createCollapsibleSection, createDebouncedSave } from './settings-helpers';
 import { t } from '../i18n';
 import type { SettingsSectionContext } from './settings';
 
@@ -14,20 +14,7 @@ export async function renderRAGSettings(
 	const containerEl = createCollapsibleSection(plugin, outerContainerEl, t('settings.rag.sectionTitle'), 'rag', {
 		description: t('settings.rag.sectionDesc'),
 	});
-	// Debounce saveSettings() for text inputs so typing doesn't trigger the plugin
-	// lifecycle on every keystroke. Settings are mutated immediately; only the save is delayed.
-	const debouncedSave = debounce(
-		async () => {
-			try {
-				await plugin.saveSettings();
-			} catch (error) {
-				plugin.logger.error('Failed to save RAG settings:', error);
-				new Notice(t('settings.common.saveFailedNotice', { error: getErrorMessage(error) }));
-			}
-		},
-		300,
-		true
-	);
+	const debouncedSave = createDebouncedSave(plugin, 'Failed to save RAG settings:');
 
 	// Privacy warning
 	const privacyWarning = containerEl.createDiv({ cls: 'setting-item' });

--- a/src/ui/settings-ui.ts
+++ b/src/ui/settings-ui.ts
@@ -1,7 +1,6 @@
 import type ObsidianGemini from '../main';
-import { Setting, ToggleComponent, debounce, Notice } from 'obsidian';
-import { createCollapsibleSection } from './settings-helpers';
-import { getErrorMessage } from '../utils/error-utils';
+import { Setting, ToggleComponent } from 'obsidian';
+import { createCollapsibleSection, createDebouncedSave } from './settings-helpers';
 import { t } from '../i18n';
 
 export function renderUISettings(containerEl: HTMLElement, plugin: ObsidianGemini): void {
@@ -9,18 +8,7 @@ export function renderUISettings(containerEl: HTMLElement, plugin: ObsidianGemin
 		description: t('settings.ui.sectionDesc'),
 	});
 
-	const debouncedSave = debounce(
-		async () => {
-			try {
-				await plugin.saveSettings();
-			} catch (error) {
-				plugin.logger.error('Failed to save settings:', error);
-				new Notice(t('settings.common.saveFailedNotice', { error: getErrorMessage(error) }));
-			}
-		},
-		300,
-		true
-	);
+	const debouncedSave = createDebouncedSave(plugin);
 
 	new Setting(sectionEl)
 		.setName(t('settings.ui.userNameName'))

--- a/test/ui/settings-general.test.ts
+++ b/test/ui/settings-general.test.ts
@@ -14,6 +14,7 @@ vi.mock('../../src/ui/settings-helpers', () => ({
 	selectModelSetting: mockSelectModelSetting,
 	// The General section is rendered directly into the element we pass in.
 	createAlwaysOpenSection: (containerEl: any) => containerEl,
+	createDebouncedSave: () => () => {},
 }));
 
 vi.mock('../../src/ui/folder-suggest', () => ({

--- a/test/ui/settings-helpers.test.ts
+++ b/test/ui/settings-helpers.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Unit tests for `createDebouncedSave` — the shared debounced-`saveSettings()`
+ * helper consumed by the settings renderers (settings-ui / -general /
+ * -agent-config / -rag). Covers the success path, the error path (logs +
+ * Notice), and the optional `logLabel` passthrough.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Notice } from 'obsidian';
+import { createDebouncedSave } from '../../src/ui/settings-helpers';
+
+vi.mock('../../src/i18n', () => ({
+	t: (key: string, vars?: Record<string, unknown>) => `${key}:${vars?.error ?? ''}`,
+}));
+
+vi.mock('../../src/utils/error-utils', () => ({
+	getErrorMessage: (e: unknown) => (e instanceof Error ? e.message : String(e)),
+}));
+
+// The obsidian `debounce` mock defers firing until `.run()` is called, so tests
+// drive it explicitly. `createDebouncedSave` returns that debouncer typed as
+// `() => void`; cast to reach `.run()`.
+type Debounced = (() => void) & { run: () => void };
+
+function makePlugin() {
+	return {
+		saveSettings: vi.fn().mockResolvedValue(undefined),
+		logger: { error: vi.fn() },
+	};
+}
+
+// Flush the async callback that `.run()` invokes but does not await.
+const flush = () => new Promise((resolve) => window.setTimeout(resolve, 0));
+
+describe('createDebouncedSave', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('calls saveSettings on the success path without logging or a Notice', async () => {
+		const plugin = makePlugin();
+		const save = createDebouncedSave(plugin as any) as Debounced;
+
+		save();
+		save.run();
+		await flush();
+
+		expect(plugin.saveSettings).toHaveBeenCalledTimes(1);
+		expect(plugin.logger.error).not.toHaveBeenCalled();
+		expect(Notice).not.toHaveBeenCalled();
+	});
+
+	it('logs and shows a Notice when saveSettings rejects', async () => {
+		const plugin = makePlugin();
+		const error = new Error('disk full');
+		plugin.saveSettings.mockRejectedValueOnce(error);
+		const save = createDebouncedSave(plugin as any) as Debounced;
+
+		save();
+		save.run();
+		await flush();
+
+		expect(plugin.logger.error).toHaveBeenCalledWith('Failed to save settings:', error);
+		expect(Notice).toHaveBeenCalledWith('settings.common.saveFailedNotice:disk full');
+	});
+
+	it('uses the custom logLabel on failure', async () => {
+		const plugin = makePlugin();
+		const error = new Error('nope');
+		plugin.saveSettings.mockRejectedValueOnce(error);
+		const save = createDebouncedSave(plugin as any, 'Failed to save RAG settings:') as Debounced;
+
+		save();
+		save.run();
+		await flush();
+
+		expect(plugin.logger.error).toHaveBeenCalledWith('Failed to save RAG settings:', error);
+	});
+});


### PR DESCRIPTION
## Summary

Architecture-audit nightly sweep flagged: **DRY violation** across the settings renderers.

A byte-identical debounced-`saveSettings()` factory — the same `debounce(async () => { try { await plugin.saveSettings() } catch … logger.error … new Notice(saveFailedNotice) }, 300, true)` block — was copy-pasted into four settings renderers. This extracts it into `settings-helpers.ts` as `createDebouncedSave(plugin, logLabel?)`, collapsing ~12 duplicated lines in each renderer to a single call. The optional `logLabel` preserves `settings-rag.ts`'s section-specific failure-log prefix. Pure code-motion — behavior is unchanged.

## Changes

- `src/ui/settings-helpers.ts` — new `createDebouncedSave(plugin, logLabel = 'Failed to save settings:')` helper.
- `src/ui/settings-ui.ts` — use the helper; drop now-unused `debounce`, `Notice`, `getErrorMessage` imports.
- `src/ui/settings-general.ts` — use the helper; drop now-unused `debounce` import.
- `src/ui/settings-agent-config.ts` — use the helper; drop now-unused `debounce`, `getErrorMessage` imports.
- `src/ui/settings-rag.ts` — use the helper with the `'Failed to save RAG settings:'` label; drop now-unused `debounce` import.
- `test/ui/settings-general.test.ts` — add `createDebouncedSave` to the `settings-helpers` mock.

## Screenshots / Screencast

N/A — no user-facing or visual change; this is an internal refactor.

## Checklist

### Required

- [x] I have read and agree to the Contributing Guidelines
- [x] I have read and agree to the AI Policy
- [x] All CI checks pass (`npm test` — 3287 passed; `npm run build`; `npm run format-check`; `npm run typecheck:test`)
- [x] I have tested this change on Desktop
- [x] I have verified this change does not break Mobile (no platform-specific APIs; pure refactor)
- [x] Documentation has been updated (N/A — no user-facing feature/setting/command change)

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude (architecture-audit skill)
- [x] I have reviewed and understand all AI-generated code in this PR

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0153krLr5eRpsKSo1JPhKxkS

---
_Generated by [Claude Code](https://claude.ai/code/session_0153krLr5eRpsKSo1JPhKxkS)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized how settings changes are saved across multiple settings screens.
  * Improved consistency in save delay handling and failure messages.
  * Simplified shared settings behavior to reduce duplicate logic.

* **Tests**
  * Updated test coverage to match the new shared save-handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->