### PR TITLE
chore(daily): 2026-07-04 daily update

### DIFF
--- a/planning/changelog/2026-07-04.md
+++ b/planning/changelog/2026-07-04.md
@@ -1,0 +1,64 @@
+# Daily changelog — July 4, 2026
+
+**Date:** 2026-07-04
+**PRs merged:** 13
+
+---
+
+## Summary
+
+A strict-typing and lint-hygiene heavy day, driven almost entirely by the auto-dev pipeline working through the `#1032` dashboard sweep and `#1036` `no-explicit-any` tracker: four previously-softened ESLint rules (`no-misused-promises`, `no-deprecated`, `ui/sentence-case`, and the plugin-id-in-command-id check) were cleared of their remaining violations and re-enabled as errors, and the `no-explicit-any` migration extended into `src/tools/`. Alongside the lint work, three oversized-file refactors landed (hook matching, tool-section parsing, and the agent-view send path's no-tool-call finalize), Ollama's per-use-case model settings were collapsed to a single model, and CI checkouts were hardened against credential persistence. The day closed with the previous run's daily-update PR, an automated i18n translation refresh, and a dev-dependency bump.
+
+## What shipped
+
+### [#1130 chore(daily): 2026-07-04 daily update](https://github.com/allenhutchison/obsidian-gemini/pull/1130)
+
+Automated daily housekeeping run bundling `daily-changelog`, `audit-docs`, `triage-issues`, and the bundled-skill drift check for 2026-07-03 — wrote the changelog for a design-heavy, cleanup-heavy 27-PR day (design tokens, several strict-TS/architecture-audit passes, a scheduled-task-manager package split, CI SHA-pinning). No doc drift or unlabeled issues found; the bundled-skill drift check errored due to GitHub-scope limits in that session.
+
+### [#1127 ci(security): set persist-credentials: false on read-only checkouts (#1096)](https://github.com/allenhutchison/obsidian-gemini/pull/1127)
+
+Addresses a zizmor `artipacked` finding: `actions/checkout` was persisting the default `GITHUB_TOKEN` into the local git config for the rest of the job even on read-only checkouts. Adds `persist-credentials: false` to the read-only checkout steps in `ci.yml`, `lint.yml`, `knip.yml`, `model-update.yml`, and both jobs in `release.yml`. The `release.yml` `setup-node` cache-poisoning finding is left as a follow-up maintainer call.
+
+### [#1124 refactor: extract matcher/condition evaluation into hook-matcher.ts](https://github.com/allenhutchison/obsidian-gemini/pull/1124)
+
+Pure code-motion refactor splitting the glob/frontmatter matching helpers out of the 958-line `hook-manager.ts` into a dedicated `hook-matcher.ts`, leaving `HookManager` as registry + dispatch. No behavior or public-surface changes.
+
+### [#1129 refactor: extract shared no-tool-call finalize from send paths (#1102)](https://github.com/allenhutchison/obsidian-gemini/pull/1129)
+
+The streaming and non-streaming send paths in `AgentViewSend` duplicated the same three-way "answer / reasoning-only / empty response" branch. Extracts it into a single `finalizeNoToolCallResponse` helper, with each path supplying only the small render step that genuinely differs. Behavior preserved exactly for all three cases.
+
+### [#1128 refactor: clear/scope no-deprecated and enforce the rule (#1040)](https://github.com/allenhutchison/obsidian-gemini/pull/1128)
+
+Re-enables `@typescript-eslint/no-deprecated` as an error. One deprecated API (`Notice.noticeEl` → `messageEl`) was safely migrated; several others (`ButtonComponent.setWarning()`, `SliderComponent.setDynamicTooltip()`, and others) are retained behind scoped, justified disables because their replacements require Obsidian 1.13.0, above the plugin's current `minAppVersion` floor of 1.11.4.
+
+### [#1125 feat(ollama): collapse per-use-case model resolution to a single model](https://github.com/allenhutchison/obsidian-gemini/pull/1125)
+
+Under the Ollama provider, every use case (chat, summary, completions, rewrite, search) now resolves to the single configured `chatModelName` instead of three independent per-use-case settings, since Ollama only keeps one model resident at a time and diverging models just thrashed RAM/VRAM. The General settings screen now shows a single "Ollama model" picker under Ollama; Gemini keeps its four independent pickers unchanged.
+
+### [#1132 fix: drop plugin-id prefix from command IDs and enforce the rule](https://github.com/allenhutchison/obsidian-gemini/pull/1132)
+
+Obsidian already namespaces command IDs with the plugin's manifest id, so Gemini Scribe's commands were double-prefixed (`gemini-scribe:gemini-scribe-summarize-active-file`). Drops the redundant `gemini-scribe-` prefix from all 30 command IDs and re-enables the `no-plugin-id-in-command-id` lint rule. Per the maintainer's decision, this is a one-time break with no deprecated aliases — users with a custom hotkey bound to a Gemini Scribe command need to re-bind it once; command palette names are unchanged.
+
+### [#1134 refactor: extract tool-section parser from agent-view-messages.ts](https://github.com/allenhutchison/obsidian-gemini/pull/1134)
+
+Extracts the tool-execution message detection and `### `-section splitting out of the 931-line `agent-view-messages.ts` into a pure, dependency-free `tool-section-parser.ts`, making the string-parsing logic directly unit-testable. Sub-issue of the oversized-files tracker (#801); pure code-motion with no behavior change.
+
+### [#1133 refactor: enforce ui/sentence-case and scope literal-placeholder exceptions](https://github.com/allenhutchison/obsidian-gemini/pull/1133)
+
+Re-enables `obsidianmd/ui/sentence-case`. The rule was expected to need an acronym/brand allowlist for ~207 violations when the tracking issue was filed, but the i18n migration to `t()` since then eliminated nearly all of them — only 6 remained, all `setPlaceholder` hints showing literal values (command IDs, model names, a default frontmatter key) that must stay lowercase verbatim, so those are exempted at the call site instead.
+
+### [#1131 chore(i18n): Update UI translations](https://github.com/allenhutchison/obsidian-gemini/pull/1131)
+
+Automated regeneration of `src/i18n/` translation files from the current English source strings in `en.ts`, via the scheduled `Update UI translations` workflow.
+
+### [#1121 fix: resolve no-misused-promises violations and enforce the rule](https://github.com/allenhutchison/obsidian-gemini/pull/1121)
+
+Re-enables `@typescript-eslint/no-misused-promises` after clearing 53 violations — async functions passed where a `void` return was expected (DOM/Obsidian event handlers, lifecycle callbacks, modal callbacks) are made synchronous, running the async work fire-and-forget, with a few callback types widened to `() => void | Promise<void>` where genuinely-async handlers needed to stay awaitable.
+
+### [#1135 refactor(tools): replace `any` with precise types in src/tools](https://github.com/allenhutchison/obsidian-gemini/pull/1135)
+
+Continues the incremental `no-explicit-any` pass (tracked in #1036) into `src/tools/`, adding a shared `ToolParams` type alias and narrowing tool execution, registry, and individual tool implementations. `ToolResult.data` is deliberately kept as a documented `any` since it's a genuine per-tool dynamic payload consumed by ~40 sites outside `src/tools`. Type-only change, no runtime behavior difference. `src/api/` and `src/ui/` remain as the final slices.
+
+### [#1136 chore(deps-dev): bump the dev-dependencies group with 7 updates](https://github.com/allenhutchison/obsidian-gemini/pull/1136)
+
+Dependency bumps: `@eslint/json`, `@types/node`, `builtin-modules`, `eslint-plugin-obsidianmd`, `knip`, `prettier`, and `typescript-eslint`, all minor/patch updates.


### PR DESCRIPTION
## Summary

Automated daily housekeeping run (`daily-update` meta-skill) bundling `daily-changelog`, `audit-docs`, `triage-issues`, and the bundled-skill drift check for 2026-07-04. Changelog-only change; no plugin code changes.

## Changes

- **daily-changelog**: wrote `planning/changelog/2026-07-04.md` — 13 PRs merged on 2026-07-04. A strict-typing/lint-hygiene heavy day driven by the auto-dev pipeline: re-enabled `no-misused-promises`, `no-deprecated`, `ui/sentence-case`, and `no-plugin-id-in-command-id` after clearing their violations, extended `no-explicit-any` into `src/tools`, collapsed Ollama's per-use-case model settings to a single model, hardened CI checkout credential persistence, and landed three oversized-file refactors (hook-matcher, tool-section-parser, agent-view-send finalize).
- **audit-docs**: no drift found, no new docs warranted. Verified settings/defaults, command IDs (including the #1132 de-prefixing), Ollama model settings (#1125), schedule formats, tool names, permission tiers, loop-detection thresholds, MCP/RAG constants, and i18n locale lists all still match the code. Quiet day.
- **triage-issues**: no open issues without labels found — no-op.
- **bundled-skill drift check**: errored — this session's GitHub access is scoped to `allenhutchison/obsidian-gemini` only, so the `kepano/obsidian-skills` upstream comparison could not be run. Same limitation as the prior run (#1130); needs a human, or a session with broader GitHub scope, to check upstream drift for `obsidian-markdown`, `json-canvas`, and `obsidian-bases`.

## Screenshots / Screencast

N/A — internal changelog file only, no UI change.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A; routine automated daily housekeeping run
- [x] All CI checks pass (`npm test` — 3287 passing, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop — N/A, changelog-only change; verified via local pre-flight checks
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A, no code change
- [x] Documentation has been updated (if applicable) — audit-docs found nothing needing updates this run
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR


---
_Generated by [Claude Code](https://claude.ai/code/session_01X5QNk4LBA9jSpktYJAnEpd)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new daily changelog entry summarizing recent improvements, refinements, and maintenance updates.
  * Highlights include stricter code quality checks, behavior improvements for model selection, refreshed translations, and security hardening for CI workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->