### PR TITLE
refactor(ui): extract shared RAG-status panel presenter (#1141)

### DIFF
--- a/src/services/rag-types.ts
+++ b/src/services/rag-types.ts
@@ -68,6 +68,23 @@ export interface PendingChange {
 export type RagIndexStatus = 'disabled' | 'idle' | 'indexing' | 'error' | 'paused' | 'rate_limited';
 
 /**
+ * Detailed RAG status snapshot rendered by the status modal and the Background
+ * Tasks "RAG" tab. Lives here (next to `RagIndexStatus`/`FailedFileEntry`) rather
+ * than in a UI module so the shared presenter in `src/ui/components/rag-status-panel.ts`
+ * and both modal consumers depend on the domain type, not on each other.
+ */
+export interface RagDetailedStatus {
+	status: RagIndexStatus;
+	indexedCount: number;
+	failedCount: number;
+	pendingCount: number;
+	storeName: string | null;
+	lastSync: number | null;
+	indexedFiles: Array<{ path: string; lastIndexed: number }>;
+	failedFiles: FailedFileEntry[];
+}
+
+/**
  * Extended progress information for live UI updates
  */
 export interface RagProgressInfo {

--- a/src/ui/background-tasks-modal.ts
+++ b/src/ui/background-tasks-modal.ts
@@ -1,11 +1,11 @@
-import { App, Modal, Notice, Setting, setIcon } from 'obsidian';
+import { App, Modal, Notice, setIcon } from 'obsidian';
 import type ObsidianGemini from '../main';
 import type { BackgroundTask } from '../services/background-task-manager';
 import type { RagDetailedStatus } from './rag-status-modal';
 import type { ProgressListener } from '../services/rag-types';
 import type { RagIndexingService } from '../services/rag-indexing';
 import { getErrorMessage } from '../utils/error-utils';
-import { formatRelativeTime } from '../utils/format-relative-time';
+import { renderRagOverview, renderRagFileList, renderRagFailures } from './components/rag-status-panel';
 import { openPluginSettingsTab } from '../utils/obsidian-settings';
 import { t } from '../i18n';
 
@@ -381,118 +381,37 @@ export class BackgroundTasksModal extends Modal {
 	private renderRagInnerContent(container: HTMLElement, status: RagDetailedStatus, rag: RagIndexingService): void {
 		switch (this.ragInnerTab) {
 			case 'overview':
-				this.renderRagOverview(container, status, rag);
+				renderRagOverview(container, status, {
+					onSyncNow: () => rag.syncPendingChanges(),
+					onSyncSuccess: () => this.renderTabContent(),
+					formatSyncError: (error) => getErrorMessage(error),
+					onReindex: () => {
+						this.close();
+						// Fire-and-forget: user-initiated reindex; progress + errors surface via modal/notices.
+						void (async () => {
+							const { RagProgressModal } = await import('./rag-progress-modal');
+							const progressModal = new RagProgressModal(this.plugin.app, rag, (result) => {
+								new Notice(t('backgroundTasks.indexingComplete', { indexed: result.indexed, skipped: result.skipped }));
+							});
+							progressModal.open();
+							rag.indexVault().catch((error: unknown) => {
+								new Notice(t('backgroundTasks.indexingFailed', { message: getErrorMessage(error) }));
+							});
+						})();
+					},
+					onOpenSettings: () => {
+						this.close();
+						openPluginSettingsTab(this.plugin.app, this.plugin.manifest.id);
+					},
+				});
 				break;
 			case 'files':
 				this.renderRagFiles(container, status);
 				break;
 			case 'failures':
-				this.renderRagFailures(container, status);
+				renderRagFailures(container, status);
 				break;
 		}
-	}
-
-	private renderRagOverview(container: HTMLElement, status: RagDetailedStatus, rag: RagIndexingService): void {
-		const infoEl = container.createDiv({ cls: 'rag-status-info' });
-
-		// Status row
-		const statusRow = infoEl.createDiv({ cls: 'rag-status-row' });
-		statusRow.createSpan({ cls: 'rag-status-label', text: t('ragStatus.statusLabel') });
-		const statusValue = statusRow.createSpan({ cls: `rag-status-value ${this.ragStatusClass(status.status)}` });
-		statusValue.setText(this.ragStatusText(status.status));
-
-		// Files indexed
-		const filesRow = infoEl.createDiv({ cls: 'rag-status-row' });
-		filesRow.createSpan({ cls: 'rag-status-label', text: t('ragStatus.filesIndexedLabel') });
-		filesRow.createSpan({ cls: 'rag-status-value', text: status.indexedCount.toLocaleString() });
-
-		// Pending changes
-		const pendingRow = infoEl.createDiv({ cls: 'rag-status-row' });
-		pendingRow.createSpan({ cls: 'rag-status-label', text: t('ragStatus.pendingLabel') });
-		pendingRow.createSpan({
-			cls: 'rag-status-value',
-			text:
-				status.pendingCount === 1
-					? t('ragStatus.changeSingular', { count: status.pendingCount })
-					: t('ragStatus.changePlural', { count: status.pendingCount }),
-		});
-
-		// Failures (if any)
-		if (status.failedCount > 0) {
-			const failedRow = infoEl.createDiv({ cls: 'rag-status-row' });
-			failedRow.createSpan({ cls: 'rag-status-label', text: t('ragStatus.failedLabel') });
-			failedRow.createSpan({
-				cls: 'rag-status-value rag-status-error',
-				text:
-					status.failedCount === 1
-						? t('ragStatus.fileSingular', { count: status.failedCount })
-						: t('ragStatus.filePlural', { count: status.failedCount }),
-			});
-		}
-
-		// Last sync
-		if (status.lastSync) {
-			const syncRow = infoEl.createDiv({ cls: 'rag-status-row' });
-			syncRow.createSpan({ cls: 'rag-status-label', text: t('ragStatus.lastSyncLabel') });
-			syncRow.createSpan({ cls: 'rag-status-value', text: formatRelativeTime(status.lastSync) });
-		}
-
-		// Store name
-		if (status.storeName) {
-			const storeRow = infoEl.createDiv({ cls: 'rag-status-row' });
-			storeRow.createSpan({ cls: 'rag-status-label', text: t('ragStatus.storeLabel') });
-			storeRow.createSpan({ cls: 'rag-status-value rag-status-store', text: status.storeName });
-		}
-
-		// Action buttons
-		const isIndexing = status.status === 'indexing';
-		const hasPending = status.pendingCount > 0;
-
-		new Setting(container)
-			.addButton((btn) =>
-				btn
-					.setButtonText(t('ragStatus.syncNowButton'))
-					.setDisabled(isIndexing || !hasPending)
-					.setTooltip(hasPending ? t('ragStatus.syncTooltipPending') : t('ragStatus.syncTooltipNone'))
-					.onClick(async () => {
-						btn.setDisabled(true);
-						btn.setButtonText(t('ragStatus.syncing'));
-						try {
-							await rag.syncPendingChanges();
-							btn.setButtonText(t('ragStatus.syncNowButton'));
-							this.renderTabContent();
-						} catch (error) {
-							new Notice(t('ragStatus.syncFailed', { message: getErrorMessage(error) }));
-							btn.setButtonText(t('ragStatus.syncNowButton'));
-							btn.setDisabled(false);
-						}
-					})
-			)
-			.addButton((btn) =>
-				btn
-					.setButtonText(t('ragStatus.reindexButton'))
-					.setDisabled(isIndexing)
-					.onClick(async () => {
-						this.close();
-						const { RagProgressModal } = await import('./rag-progress-modal');
-						const progressModal = new RagProgressModal(this.plugin.app, rag, (result) => {
-							new Notice(t('backgroundTasks.indexingComplete', { indexed: result.indexed, skipped: result.skipped }));
-						});
-						progressModal.open();
-						rag.indexVault().catch((error: unknown) => {
-							new Notice(t('backgroundTasks.indexingFailed', { message: getErrorMessage(error) }));
-						});
-					})
-			)
-			.addButton((btn) =>
-				btn
-					.setButtonText(t('ragStatus.settingsButton'))
-					.setCta()
-					.onClick(() => {
-						this.close();
-						openPluginSettingsTab(this.plugin.app, this.plugin.manifest.id);
-					})
-			);
 	}
 
 	private renderRagFiles(container: HTMLElement, status: RagDetailedStatus): void {
@@ -503,7 +422,22 @@ export class BackgroundTasksModal extends Modal {
 		});
 
 		const listContainer = container.createDiv({ cls: 'rag-status-file-list' });
-		this.renderRagFileList(listContainer, status);
+		const renderList = () =>
+			renderRagFileList(listContainer, status, {
+				searchQuery: this.ragSearchQuery,
+				showAll: this.ragShowAllFiles,
+				maxInitial: this.RAG_MAX_FILES_INITIAL,
+				onShowAll: () => {
+					this.ragShowAllFiles = true;
+					renderList();
+				},
+				onOpenFile: (path) => {
+					this.close();
+					// Fire-and-forget: user-initiated navigation; errors surface via Obsidian.
+					void this.plugin.app.workspace.openLinkText(path, '', false);
+				},
+			});
+		renderList();
 
 		// Restore scroll position (lost on progress-tick re-render)
 		listContainer.scrollTop = this.ragFileScrollTop;
@@ -516,103 +450,8 @@ export class BackgroundTasksModal extends Modal {
 			this.ragDebounceTimer = window.setTimeout(() => {
 				this.ragSearchQuery = (e.target as HTMLInputElement).value;
 				this.ragFileScrollTop = 0;
-				this.renderRagFileList(listContainer, status);
+				renderList();
 			}, 150);
 		});
-	}
-
-	private renderRagFileList(container: HTMLElement, status: RagDetailedStatus): void {
-		container.empty();
-
-		if (status.indexedFiles.length === 0) {
-			container.createDiv({ cls: 'rag-status-empty', text: t('ragStatus.noFilesIndexed') });
-			return;
-		}
-
-		let filtered = status.indexedFiles;
-		if (this.ragSearchQuery) {
-			const q = this.ragSearchQuery.toLowerCase();
-			filtered = filtered.filter((f) => f.path.toLowerCase().includes(q));
-		}
-
-		if (filtered.length === 0) {
-			container.createDiv({ cls: 'rag-status-empty', text: t('ragStatus.noSearchMatches') });
-			return;
-		}
-
-		const total = filtered.length;
-		const display = this.ragShowAllFiles ? filtered : filtered.slice(0, this.RAG_MAX_FILES_INITIAL);
-
-		for (const file of display) {
-			const item = container.createEl('button', {
-				cls: 'rag-status-file-item rag-status-file-item--clickable',
-				attr: { type: 'button', 'aria-label': t('backgroundTasks.openFileAria', { path: file.path }) },
-			});
-			const pathEl = item.createSpan({ cls: 'rag-status-file-path' });
-			pathEl.setText(file.path);
-			pathEl.setAttribute('title', file.path);
-			item.createSpan({ cls: 'rag-status-file-time', text: formatRelativeTime(file.lastIndexed) });
-			item.addEventListener('click', () => {
-				this.close();
-				// Fire-and-forget: user-initiated navigation; errors surface via Obsidian.
-				void this.plugin.app.workspace.openLinkText(file.path, '', false);
-			});
-		}
-
-		if (!this.ragShowAllFiles && total > this.RAG_MAX_FILES_INITIAL) {
-			const more = container.createDiv({ cls: 'rag-status-show-more' });
-			more.setText(t('ragStatus.showAllFiles', { count: total.toLocaleString() }));
-			more.addEventListener('click', () => {
-				this.ragShowAllFiles = true;
-				this.renderRagFileList(container, status);
-			});
-		}
-	}
-
-	private renderRagFailures(container: HTMLElement, status: RagDetailedStatus): void {
-		if (status.failedFiles.length === 0) {
-			container.createDiv({ cls: 'rag-status-empty', text: t('ragStatus.noFailures') });
-			return;
-		}
-
-		const listContainer = container.createDiv({ cls: 'rag-status-failure-list' });
-		for (const failure of status.failedFiles) {
-			const item = listContainer.createDiv({ cls: 'rag-status-failure-item' });
-			const headerRow = item.createDiv({ cls: 'rag-status-failure-header' });
-			const iconEl = headerRow.createSpan({ cls: 'rag-status-failure-icon' });
-			setIcon(iconEl, 'x-circle');
-			const pathEl = headerRow.createSpan({ cls: 'rag-status-failure-path' });
-			pathEl.setText(failure.path);
-			pathEl.setAttribute('title', failure.path);
-			headerRow.createSpan({ cls: 'rag-status-failure-time', text: formatRelativeTime(failure.timestamp) });
-			item.createDiv({ cls: 'rag-status-failure-error', text: failure.error });
-		}
-	}
-
-	// ---------------------------------------------------------------------------
-	// RAG display helpers
-	// ---------------------------------------------------------------------------
-
-	private ragStatusText(status: string): string {
-		const map: Record<string, string> = {
-			idle: t('ragStatus.statusReady'),
-			indexing: t('ragStatus.statusIndexing'),
-			error: t('ragStatus.statusError'),
-			paused: t('ragStatus.statusPaused'),
-			disabled: t('ragStatus.statusDisabled'),
-			rate_limited: t('ragStatus.statusRateLimited'),
-		};
-		return map[status] ?? t('ragStatus.statusUnknown');
-	}
-
-	private ragStatusClass(status: string): string {
-		const map: Record<string, string> = {
-			idle: 'rag-status-ready',
-			indexing: 'rag-status-indexing',
-			error: 'rag-status-error',
-			paused: 'rag-status-paused',
-			rate_limited: 'rag-status-rate-limited',
-		};
-		return map[status] ?? '';
 	}
 }

--- a/src/ui/background-tasks-modal.ts
+++ b/src/ui/background-tasks-modal.ts
@@ -1,7 +1,7 @@
 import { App, Modal, Notice, setIcon } from 'obsidian';
 import type ObsidianGemini from '../main';
 import type { BackgroundTask } from '../services/background-task-manager';
-import type { RagDetailedStatus } from './rag-status-modal';
+import type { RagDetailedStatus } from '../services/rag-types';
 import type { ProgressListener } from '../services/rag-types';
 import type { RagIndexingService } from '../services/rag-indexing';
 import { getErrorMessage } from '../utils/error-utils';

--- a/src/ui/components/rag-status-panel.ts
+++ b/src/ui/components/rag-status-panel.ts
@@ -1,5 +1,5 @@
 import { Notice, Setting, setIcon } from 'obsidian';
-import type { RagDetailedStatus } from '../rag-status-modal';
+import type { RagDetailedStatus } from '../../services/rag-types';
 import { formatRelativeTime } from '../../utils/format-relative-time';
 import { t } from '../../i18n';
 

--- a/src/ui/components/rag-status-panel.ts
+++ b/src/ui/components/rag-status-panel.ts
@@ -1,0 +1,255 @@
+import { Notice, Setting, setIcon } from 'obsidian';
+import type { RagDetailedStatus } from '../rag-status-modal';
+import { formatRelativeTime } from '../../utils/format-relative-time';
+import { t } from '../../i18n';
+
+/**
+ * Shared, presenter-style rendering for the RAG-status panel.
+ *
+ * Both {@link RagStatusModal} (the standalone command-palette modal) and the "RAG"
+ * tab of `BackgroundTasksModal` render the same overview rows, Sync/Reindex button
+ * gating, indexed-file list, failures list, and status→label / status→css maps.
+ * Keeping two parallel copies meant every copy change or new status state had to be
+ * mirrored by hand. These helpers are the single source of truth; each modal keeps
+ * only its own tab shell, search-box wiring, and data acquisition and delegates the
+ * content rendering here.
+ *
+ * The behavioral differences between the two surfaces are parameterized through the
+ * options objects rather than branched inside the helpers:
+ *   - the post-sync follow-up (close the modal vs re-render the tab),
+ *   - the sync-failure error formatter,
+ *   - whether indexed-file rows are clickable (open the file) or plain.
+ */
+
+/** Map a RAG status value to its localized display label. */
+export function ragStatusText(status: string): string {
+	const map: Record<string, string> = {
+		idle: t('ragStatus.statusReady'),
+		indexing: t('ragStatus.statusIndexing'),
+		error: t('ragStatus.statusError'),
+		paused: t('ragStatus.statusPaused'),
+		disabled: t('ragStatus.statusDisabled'),
+		rate_limited: t('ragStatus.statusRateLimited'),
+	};
+	return map[status] ?? t('ragStatus.statusUnknown');
+}
+
+/** Map a RAG status value to its CSS state class (empty string for states with no color). */
+export function ragStatusClass(status: string): string {
+	const map: Record<string, string> = {
+		idle: 'rag-status-ready',
+		indexing: 'rag-status-indexing',
+		error: 'rag-status-error',
+		paused: 'rag-status-paused',
+		rate_limited: 'rag-status-rate-limited',
+	};
+	return map[status] ?? '';
+}
+
+/** Callbacks wiring the overview action buttons to a specific host modal. */
+export interface RagOverviewCallbacks {
+	/** Perform the "Sync now" action. The helper owns the button's disabled/label state. */
+	onSyncNow: () => Promise<unknown>;
+	/** Called after a successful sync — e.g. close the modal, or re-render the tab. */
+	onSyncSuccess: () => void;
+	/** Format the message shown in the sync-failure notice. */
+	formatSyncError: (error: unknown) => string;
+	/** Perform the "Reindex" action. Owns its own modal close + follow-up flow. */
+	onReindex: () => void;
+	/** Open plugin settings. Owns its own modal close. */
+	onOpenSettings: () => void;
+}
+
+/**
+ * Render the overview tab: status / files-indexed / pending / failures / last-sync /
+ * store rows, then the Sync-Now / Reindex / Settings action buttons with their gating
+ * (`isIndexing` disables Reindex and Sync; Sync also requires pending changes).
+ */
+export function renderRagOverview(container: HTMLElement, status: RagDetailedStatus, cb: RagOverviewCallbacks): void {
+	const infoEl = container.createDiv({ cls: 'rag-status-info' });
+
+	// Status row
+	const statusRow = infoEl.createDiv({ cls: 'rag-status-row' });
+	statusRow.createSpan({ cls: 'rag-status-label', text: t('ragStatus.statusLabel') });
+	statusRow.createSpan({
+		cls: `rag-status-value ${ragStatusClass(status.status)}`.trim(),
+		text: ragStatusText(status.status),
+	});
+
+	// Files indexed row
+	const filesRow = infoEl.createDiv({ cls: 'rag-status-row' });
+	filesRow.createSpan({ cls: 'rag-status-label', text: t('ragStatus.filesIndexedLabel') });
+	filesRow.createSpan({ cls: 'rag-status-value', text: status.indexedCount.toLocaleString() });
+
+	// Pending changes row
+	const pendingRow = infoEl.createDiv({ cls: 'rag-status-row' });
+	pendingRow.createSpan({ cls: 'rag-status-label', text: t('ragStatus.pendingLabel') });
+	pendingRow.createSpan({
+		cls: 'rag-status-value',
+		text:
+			status.pendingCount === 1
+				? t('ragStatus.changeSingular', { count: status.pendingCount })
+				: t('ragStatus.changePlural', { count: status.pendingCount }),
+	});
+
+	// Failures row (if any)
+	if (status.failedCount > 0) {
+		const failedRow = infoEl.createDiv({ cls: 'rag-status-row' });
+		failedRow.createSpan({ cls: 'rag-status-label', text: t('ragStatus.failedLabel') });
+		failedRow.createSpan({
+			cls: 'rag-status-value rag-status-error',
+			text:
+				status.failedCount === 1
+					? t('ragStatus.fileSingular', { count: status.failedCount })
+					: t('ragStatus.filePlural', { count: status.failedCount }),
+		});
+	}
+
+	// Last sync row
+	if (status.lastSync) {
+		const syncRow = infoEl.createDiv({ cls: 'rag-status-row' });
+		syncRow.createSpan({ cls: 'rag-status-label', text: t('ragStatus.lastSyncLabel') });
+		syncRow.createSpan({ cls: 'rag-status-value', text: formatRelativeTime(status.lastSync) });
+	}
+
+	// Store name row
+	if (status.storeName) {
+		const storeRow = infoEl.createDiv({ cls: 'rag-status-row' });
+		storeRow.createSpan({ cls: 'rag-status-label', text: t('ragStatus.storeLabel') });
+		storeRow.createSpan({ cls: 'rag-status-value rag-status-store', text: status.storeName });
+	}
+
+	// Action buttons
+	const isIndexing = status.status === 'indexing';
+	const hasPending = status.pendingCount > 0;
+
+	new Setting(container)
+		.addButton((btn) =>
+			btn
+				.setButtonText(t('ragStatus.syncNowButton'))
+				.setDisabled(isIndexing || !hasPending)
+				.setTooltip(hasPending ? t('ragStatus.syncTooltipPending') : t('ragStatus.syncTooltipNone'))
+				.onClick(async () => {
+					btn.setDisabled(true);
+					btn.setButtonText(t('ragStatus.syncing'));
+					try {
+						await cb.onSyncNow();
+						btn.setButtonText(t('ragStatus.syncNowButton'));
+						cb.onSyncSuccess();
+					} catch (error) {
+						new Notice(t('ragStatus.syncFailed', { message: cb.formatSyncError(error) }));
+						btn.setButtonText(t('ragStatus.syncNowButton'));
+						btn.setDisabled(false);
+					}
+				})
+		)
+		.addButton((btn) =>
+			btn
+				.setButtonText(t('ragStatus.reindexButton'))
+				.setDisabled(isIndexing)
+				.onClick(() => cb.onReindex())
+		)
+		.addButton((btn) =>
+			btn
+				.setButtonText(t('ragStatus.settingsButton'))
+				.setCta()
+				.onClick(() => cb.onOpenSettings())
+		);
+}
+
+/** Options controlling the indexed-file list rendering. */
+export interface RagFileListOptions {
+	/** Current search filter applied to file paths (case-insensitive substring). */
+	searchQuery: string;
+	/** Whether the full list is shown (vs capped at `maxInitial`). */
+	showAll: boolean;
+	/** How many files to show before the "show all" affordance. */
+	maxInitial: number;
+	/** Reveal the full list — the host flips its own `showAll` state and re-renders. */
+	onShowAll: () => void;
+	/**
+	 * When provided, each file row is a clickable button that invokes this with the
+	 * file's path (used by the Background Tasks modal to open the note). When omitted,
+	 * rows are plain, non-interactive divs (the standalone status modal).
+	 */
+	onOpenFile?: (path: string) => void;
+}
+
+/**
+ * Render the indexed-file list into `container` (which is emptied first): empty and
+ * no-search-match states, path/last-indexed rows, and the "show all N files" affordance.
+ */
+export function renderRagFileList(container: HTMLElement, status: RagDetailedStatus, opts: RagFileListOptions): void {
+	container.empty();
+
+	if (status.indexedFiles.length === 0) {
+		container.createDiv({ cls: 'rag-status-empty', text: t('ragStatus.noFilesIndexed') });
+		return;
+	}
+
+	let filtered = status.indexedFiles;
+	if (opts.searchQuery) {
+		const query = opts.searchQuery.toLowerCase();
+		filtered = filtered.filter((f) => f.path.toLowerCase().includes(query));
+	}
+
+	if (filtered.length === 0) {
+		container.createDiv({ cls: 'rag-status-empty', text: t('ragStatus.noSearchMatches') });
+		return;
+	}
+
+	const total = filtered.length;
+	const display = opts.showAll ? filtered : filtered.slice(0, opts.maxInitial);
+
+	for (const file of display) {
+		let item: HTMLElement;
+		const onOpenFile = opts.onOpenFile;
+		if (onOpenFile) {
+			item = container.createEl('button', {
+				cls: 'rag-status-file-item rag-status-file-item--clickable',
+				attr: { type: 'button', 'aria-label': t('backgroundTasks.openFileAria', { path: file.path }) },
+			});
+			item.addEventListener('click', () => onOpenFile(file.path));
+		} else {
+			item = container.createDiv({ cls: 'rag-status-file-item' });
+		}
+		const pathEl = item.createSpan({ cls: 'rag-status-file-path' });
+		pathEl.setText(file.path);
+		pathEl.setAttribute('title', file.path);
+		item.createSpan({ cls: 'rag-status-file-time', text: formatRelativeTime(file.lastIndexed) });
+	}
+
+	if (!opts.showAll && total > opts.maxInitial) {
+		const more = container.createDiv({ cls: 'rag-status-show-more' });
+		more.setText(t('ragStatus.showAllFiles', { count: total.toLocaleString() }));
+		more.addEventListener('click', () => opts.onShowAll());
+	}
+}
+
+/**
+ * Render the failures tab: an empty-state message, or one row per failed file with its
+ * path, timestamp, and error text.
+ */
+export function renderRagFailures(container: HTMLElement, status: RagDetailedStatus): void {
+	if (status.failedFiles.length === 0) {
+		container.createDiv({ cls: 'rag-status-empty', text: t('ragStatus.noFailures') });
+		return;
+	}
+
+	const listContainer = container.createDiv({ cls: 'rag-status-failure-list' });
+	for (const failure of status.failedFiles) {
+		const item = listContainer.createDiv({ cls: 'rag-status-failure-item' });
+
+		const headerRow = item.createDiv({ cls: 'rag-status-failure-header' });
+		const iconEl = headerRow.createSpan({ cls: 'rag-status-failure-icon' });
+		setIcon(iconEl, 'x-circle');
+
+		const pathEl = headerRow.createSpan({ cls: 'rag-status-failure-path' });
+		pathEl.setText(failure.path);
+		pathEl.setAttribute('title', failure.path);
+
+		headerRow.createSpan({ cls: 'rag-status-failure-time', text: formatRelativeTime(failure.timestamp) });
+
+		item.createDiv({ cls: 'rag-status-failure-error', text: failure.error });
+	}
+}

--- a/src/ui/rag-status-modal.ts
+++ b/src/ui/rag-status-modal.ts
@@ -1,22 +1,8 @@
 import { App, Modal, setIcon } from 'obsidian';
-import type { RagIndexStatus, FailedFileEntry } from '../services/rag-types';
+import type { RagDetailedStatus } from '../services/rag-types';
 import { getRawErrorMessage } from '../utils/error-utils';
 import { renderRagOverview, renderRagFileList, renderRagFailures } from './components/rag-status-panel';
 import { t } from '../i18n';
-
-/**
- * Detailed status information for the modal
- */
-export interface RagDetailedStatus {
-	status: RagIndexStatus;
-	indexedCount: number;
-	failedCount: number;
-	pendingCount: number;
-	storeName: string | null;
-	lastSync: number | null;
-	indexedFiles: Array<{ path: string; lastIndexed: number }>;
-	failedFiles: FailedFileEntry[];
-}
 
 type TabId = 'overview' | 'files' | 'failures';
 

--- a/src/ui/rag-status-modal.ts
+++ b/src/ui/rag-status-modal.ts
@@ -1,7 +1,7 @@
-import { App, Modal, Notice, Setting, setIcon } from 'obsidian';
+import { App, Modal, setIcon } from 'obsidian';
 import type { RagIndexStatus, FailedFileEntry } from '../services/rag-types';
 import { getRawErrorMessage } from '../utils/error-utils';
-import { formatRelativeTime } from '../utils/format-relative-time';
+import { renderRagOverview, renderRagFileList, renderRagFailures } from './components/rag-status-panel';
 import { t } from '../i18n';
 
 /**
@@ -122,103 +122,19 @@ export class RagStatusModal extends Modal {
 	}
 
 	private renderOverviewTab(container: HTMLElement): void {
-		const infoEl = container.createDiv({ cls: 'rag-status-info' });
-
-		// Status row
-		const statusRow = infoEl.createDiv({ cls: 'rag-status-row' });
-		statusRow.createSpan({ cls: 'rag-status-label', text: t('ragStatus.statusLabel') });
-		const statusValue = statusRow.createSpan({ cls: 'rag-status-value' });
-		statusValue.setText(this.getStatusText());
-		statusValue.addClass(this.getStatusClass());
-
-		// Files indexed row
-		const filesRow = infoEl.createDiv({ cls: 'rag-status-row' });
-		filesRow.createSpan({ cls: 'rag-status-label', text: t('ragStatus.filesIndexedLabel') });
-		filesRow.createSpan({ cls: 'rag-status-value', text: this.statusInfo.indexedCount.toLocaleString() });
-
-		// Pending changes row
-		const pendingRow = infoEl.createDiv({ cls: 'rag-status-row' });
-		pendingRow.createSpan({ cls: 'rag-status-label', text: t('ragStatus.pendingLabel') });
-		pendingRow.createSpan({
-			cls: 'rag-status-value',
-			text:
-				this.statusInfo.pendingCount === 1
-					? t('ragStatus.changeSingular', { count: this.statusInfo.pendingCount })
-					: t('ragStatus.changePlural', { count: this.statusInfo.pendingCount }),
+		renderRagOverview(container, this.statusInfo, {
+			onSyncNow: () => this.onSyncNow(),
+			onSyncSuccess: () => this.close(),
+			formatSyncError: (error) => getRawErrorMessage(error),
+			onReindex: () => {
+				this.close();
+				void this.onReindex();
+			},
+			onOpenSettings: () => {
+				this.close();
+				this.onOpenSettings();
+			},
 		});
-
-		// Failures row (if any)
-		if (this.statusInfo.failedCount > 0) {
-			const failedRow = infoEl.createDiv({ cls: 'rag-status-row' });
-			failedRow.createSpan({ cls: 'rag-status-label', text: t('ragStatus.failedLabel') });
-			const failedValue = failedRow.createSpan({ cls: 'rag-status-value rag-status-error' });
-			failedValue.setText(
-				this.statusInfo.failedCount === 1
-					? t('ragStatus.fileSingular', { count: this.statusInfo.failedCount })
-					: t('ragStatus.filePlural', { count: this.statusInfo.failedCount })
-			);
-		}
-
-		// Last sync row
-		if (this.statusInfo.lastSync) {
-			const syncRow = infoEl.createDiv({ cls: 'rag-status-row' });
-			syncRow.createSpan({ cls: 'rag-status-label', text: t('ragStatus.lastSyncLabel') });
-			syncRow.createSpan({
-				cls: 'rag-status-value',
-				text: formatRelativeTime(this.statusInfo.lastSync),
-			});
-		}
-
-		// Store name row
-		if (this.statusInfo.storeName) {
-			const storeRow = infoEl.createDiv({ cls: 'rag-status-row' });
-			storeRow.createSpan({ cls: 'rag-status-label', text: t('ragStatus.storeLabel') });
-			const storeValue = storeRow.createSpan({ cls: 'rag-status-value rag-status-store' });
-			storeValue.setText(this.statusInfo.storeName);
-		}
-
-		// Actions
-		const isIndexing = this.statusInfo.status === 'indexing';
-		const hasPending = this.statusInfo.pendingCount > 0;
-
-		new Setting(container)
-			.addButton((btn) =>
-				btn
-					.setButtonText(t('ragStatus.syncNowButton'))
-					.setDisabled(isIndexing || !hasPending)
-					.setTooltip(hasPending ? t('ragStatus.syncTooltipPending') : t('ragStatus.syncTooltipNone'))
-					.onClick(async () => {
-						btn.setDisabled(true);
-						btn.setButtonText(t('ragStatus.syncing'));
-						try {
-							await this.onSyncNow();
-							this.close();
-						} catch (error) {
-							const message = getRawErrorMessage(error);
-							new Notice(t('ragStatus.syncFailed', { message }));
-							btn.setButtonText(t('ragStatus.syncNowButton'));
-							btn.setDisabled(false);
-						}
-					})
-			)
-			.addButton((btn) =>
-				btn
-					.setButtonText(t('ragStatus.reindexButton'))
-					.setDisabled(isIndexing)
-					.onClick(() => {
-						this.close();
-						void this.onReindex();
-					})
-			)
-			.addButton((btn) =>
-				btn
-					.setButtonText(t('ragStatus.settingsButton'))
-					.setCta()
-					.onClick(() => {
-						this.close();
-						this.onOpenSettings();
-					})
-			);
 	}
 
 	private renderFilesTab(container: HTMLElement): void {
@@ -233,102 +149,33 @@ export class RagStatusModal extends Modal {
 			},
 		});
 
+		// File list container
+		const listContainer = container.createDiv({ cls: 'rag-status-file-list' });
+		const renderList = () =>
+			renderRagFileList(listContainer, this.statusInfo, {
+				searchQuery: this.searchQuery,
+				showAll: this.showAllFiles,
+				maxInitial: this.MAX_FILES_INITIAL,
+				onShowAll: () => {
+					this.showAllFiles = true;
+					renderList();
+				},
+			});
+		renderList();
+
 		searchInput.addEventListener('input', (e) => {
 			if (this.debounceTimer) {
 				window.clearTimeout(this.debounceTimer);
 			}
 			this.debounceTimer = window.setTimeout(() => {
 				this.searchQuery = (e.target as HTMLInputElement).value;
-				this.renderFileList(listContainer);
+				renderList();
 			}, 150);
 		});
-
-		// File list container
-		const listContainer = container.createDiv({ cls: 'rag-status-file-list' });
-		this.renderFileList(listContainer);
-	}
-
-	private renderFileList(container: HTMLElement): void {
-		container.empty();
-
-		if (this.statusInfo.indexedFiles.length === 0) {
-			container.createDiv({
-				cls: 'rag-status-empty',
-				text: t('ragStatus.noFilesIndexed'),
-			});
-			return;
-		}
-
-		// Filter files by search query
-		let filteredFiles = this.statusInfo.indexedFiles;
-		if (this.searchQuery) {
-			const query = this.searchQuery.toLowerCase();
-			filteredFiles = filteredFiles.filter((f) => f.path.toLowerCase().includes(query));
-		}
-
-		if (filteredFiles.length === 0) {
-			container.createDiv({
-				cls: 'rag-status-empty',
-				text: t('ragStatus.noSearchMatches'),
-			});
-			return;
-		}
-
-		// Limit display unless "show all" is enabled
-		const totalFiles = filteredFiles.length;
-		const displayFiles = this.showAllFiles ? filteredFiles : filteredFiles.slice(0, this.MAX_FILES_INITIAL);
-
-		// Render file items
-		for (const file of displayFiles) {
-			const item = container.createDiv({ cls: 'rag-status-file-item' });
-
-			const pathEl = item.createSpan({ cls: 'rag-status-file-path' });
-			pathEl.setText(file.path);
-			pathEl.setAttribute('title', file.path);
-
-			const timeEl = item.createSpan({ cls: 'rag-status-file-time' });
-			timeEl.setText(formatRelativeTime(file.lastIndexed));
-		}
-
-		// Show "load more" button if there are more files
-		if (!this.showAllFiles && totalFiles > this.MAX_FILES_INITIAL) {
-			const moreButton = container.createDiv({ cls: 'rag-status-show-more' });
-			moreButton.setText(t('ragStatus.showAllFiles', { count: totalFiles.toLocaleString() }));
-			moreButton.addEventListener('click', () => {
-				this.showAllFiles = true;
-				this.renderFileList(container);
-			});
-		}
 	}
 
 	private renderFailuresTab(container: HTMLElement): void {
-		if (this.statusInfo.failedFiles.length === 0) {
-			container.createDiv({
-				cls: 'rag-status-empty',
-				text: t('ragStatus.noFailures'),
-			});
-			return;
-		}
-
-		const listContainer = container.createDiv({ cls: 'rag-status-failure-list' });
-
-		for (const failure of this.statusInfo.failedFiles) {
-			const item = listContainer.createDiv({ cls: 'rag-status-failure-item' });
-
-			const headerRow = item.createDiv({ cls: 'rag-status-failure-header' });
-			const iconEl = headerRow.createSpan({ cls: 'rag-status-failure-icon' });
-			setIcon(iconEl, 'x-circle');
-
-			const pathEl = headerRow.createSpan({ cls: 'rag-status-failure-path' });
-			pathEl.setText(failure.path);
-			pathEl.setAttribute('title', failure.path);
-
-			const timeEl = headerRow.createSpan({ cls: 'rag-status-failure-time' });
-			timeEl.setText(formatRelativeTime(failure.timestamp));
-
-			const errorEl = item.createDiv({ cls: 'rag-status-failure-error' });
-			errorEl.setText(failure.error);
-		}
+		renderRagFailures(container, this.statusInfo);
 	}
 
 	private refresh(): void {
@@ -386,42 +233,6 @@ export class RagStatusModal extends Modal {
 				break;
 			default:
 				setIcon(el, 'database');
-		}
-	}
-
-	private getStatusText(): string {
-		switch (this.statusInfo.status) {
-			case 'idle':
-				return t('ragStatus.statusReady');
-			case 'indexing':
-				return t('ragStatus.statusIndexing');
-			case 'error':
-				return t('ragStatus.statusError');
-			case 'paused':
-				return t('ragStatus.statusPaused');
-			case 'disabled':
-				return t('ragStatus.statusDisabled');
-			case 'rate_limited':
-				return t('ragStatus.statusRateLimited');
-			default:
-				return t('ragStatus.statusUnknown');
-		}
-	}
-
-	private getStatusClass(): string {
-		switch (this.statusInfo.status) {
-			case 'idle':
-				return 'rag-status-ready';
-			case 'indexing':
-				return 'rag-status-indexing';
-			case 'error':
-				return 'rag-status-error';
-			case 'paused':
-				return 'rag-status-paused';
-			case 'rate_limited':
-				return 'rag-status-rate-limited';
-			default:
-				return '';
 		}
 	}
 }

--- a/test/ui/components/rag-status-panel.test.ts
+++ b/test/ui/components/rag-status-panel.test.ts
@@ -68,7 +68,7 @@ import {
 	type RagFileListOptions,
 	type RagOverviewCallbacks,
 } from '../../../src/ui/components/rag-status-panel';
-import type { RagDetailedStatus } from '../../../src/ui/rag-status-modal';
+import type { RagDetailedStatus } from '../../../src/services/rag-types';
 import { t } from '../../../src/i18n';
 
 /** Build a jsdom element carrying the Obsidian DOM-helper methods the panel uses. */

--- a/test/ui/components/rag-status-panel.test.ts
+++ b/test/ui/components/rag-status-panel.test.ts
@@ -1,0 +1,341 @@
+/**
+ * Tests for the shared RAG-status panel presenter used by both RagStatusModal
+ * and the "RAG" tab of BackgroundTasksModal.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Captures the button specs created via `new Setting(container).addButton(...)`
+// so the overview gating can be asserted without a real Obsidian Setting.
+const buttonSpecs: Array<{
+	text: string;
+	disabled: boolean;
+	tooltip: string;
+	cta: boolean;
+	click?: () => unknown;
+}> = [];
+
+vi.mock('obsidian', () => {
+	const setIcon = vi.fn();
+	const Notice = vi.fn();
+	class Setting {
+		constructor(public containerEl: unknown) {}
+		addButton(cb: (b: unknown) => void) {
+			const spec = {
+				text: '',
+				disabled: false,
+				tooltip: '',
+				cta: false,
+				click: undefined as undefined | (() => unknown),
+			};
+			const btn = {
+				setButtonText(t: string) {
+					spec.text = t;
+					return btn;
+				},
+				setDisabled(d: boolean) {
+					spec.disabled = d;
+					return btn;
+				},
+				setTooltip(tt: string) {
+					spec.tooltip = tt;
+					return btn;
+				},
+				setCta() {
+					spec.cta = true;
+					return btn;
+				},
+				onClick(fn: () => unknown) {
+					spec.click = fn;
+					return btn;
+				},
+			};
+			cb(btn);
+			buttonSpecs.push(spec);
+			return this;
+		}
+	}
+	return { setIcon, Notice, Setting, getLanguage: () => 'en' };
+});
+
+import { Notice } from 'obsidian';
+import {
+	ragStatusText,
+	ragStatusClass,
+	renderRagOverview,
+	renderRagFileList,
+	renderRagFailures,
+	type RagFileListOptions,
+	type RagOverviewCallbacks,
+} from '../../../src/ui/components/rag-status-panel';
+import type { RagDetailedStatus } from '../../../src/ui/rag-status-modal';
+import { t } from '../../../src/i18n';
+
+/** Build a jsdom element carrying the Obsidian DOM-helper methods the panel uses. */
+function makeEl(tag: string): HTMLElement {
+	const el = document.createElement(tag);
+	const anyEl = el as unknown as Record<string, unknown>;
+	anyEl.empty = function (this: HTMLElement) {
+		this.innerHTML = '';
+		return this;
+	};
+	anyEl.setText = function (this: HTMLElement, text: string) {
+		this.textContent = text;
+		return this;
+	};
+	anyEl.addClass = function (this: HTMLElement, ...cls: string[]) {
+		cls.forEach((c) => c && this.classList.add(c));
+		return this;
+	};
+	anyEl.createEl = function (
+		this: HTMLElement,
+		childTag: string,
+		opts?: { cls?: string; text?: string; attr?: Record<string, string> }
+	) {
+		const child = makeEl(childTag);
+		if (opts?.cls) child.className = opts.cls;
+		if (opts?.text) child.textContent = opts.text;
+		if (opts?.attr) Object.entries(opts.attr).forEach(([k, v]) => child.setAttribute(k, String(v)));
+		this.appendChild(child);
+		return child;
+	};
+	anyEl.createDiv = function (this: HTMLElement, opts?: unknown) {
+		return (this as unknown as { createEl: (t: string, o?: unknown) => HTMLElement }).createEl('div', opts);
+	};
+	anyEl.createSpan = function (this: HTMLElement, opts?: unknown) {
+		return (this as unknown as { createEl: (t: string, o?: unknown) => HTMLElement }).createEl('span', opts);
+	};
+	return el;
+}
+
+function statusFixture(overrides: Partial<RagDetailedStatus> = {}): RagDetailedStatus {
+	return {
+		status: 'idle',
+		indexedCount: 0,
+		failedCount: 0,
+		pendingCount: 0,
+		storeName: null,
+		lastSync: null,
+		indexedFiles: [],
+		failedFiles: [],
+		...overrides,
+	};
+}
+
+function baseFileListOptions(overrides: Partial<RagFileListOptions> = {}): RagFileListOptions {
+	return {
+		searchQuery: '',
+		showAll: false,
+		maxInitial: 200,
+		onShowAll: () => {},
+		...overrides,
+	};
+}
+
+describe('rag-status-panel maps', () => {
+	it('maps every known status to its localized label and falls back to unknown', () => {
+		expect(ragStatusText('idle')).toBe(t('ragStatus.statusReady'));
+		expect(ragStatusText('indexing')).toBe(t('ragStatus.statusIndexing'));
+		expect(ragStatusText('error')).toBe(t('ragStatus.statusError'));
+		expect(ragStatusText('paused')).toBe(t('ragStatus.statusPaused'));
+		expect(ragStatusText('disabled')).toBe(t('ragStatus.statusDisabled'));
+		expect(ragStatusText('rate_limited')).toBe(t('ragStatus.statusRateLimited'));
+		expect(ragStatusText('nonsense')).toBe(t('ragStatus.statusUnknown'));
+	});
+
+	it('maps status to its CSS class, with no class for disabled/unknown', () => {
+		expect(ragStatusClass('idle')).toBe('rag-status-ready');
+		expect(ragStatusClass('indexing')).toBe('rag-status-indexing');
+		expect(ragStatusClass('error')).toBe('rag-status-error');
+		expect(ragStatusClass('paused')).toBe('rag-status-paused');
+		expect(ragStatusClass('rate_limited')).toBe('rag-status-rate-limited');
+		// 'disabled' has a label but intentionally no color class
+		expect(ragStatusClass('disabled')).toBe('');
+		expect(ragStatusClass('nonsense')).toBe('');
+	});
+});
+
+describe('renderRagFileList', () => {
+	it('shows the empty state when no files are indexed', () => {
+		const container = makeEl('div');
+		renderRagFileList(container, statusFixture(), baseFileListOptions());
+		expect(container.querySelector('.rag-status-empty')?.textContent).toBe(t('ragStatus.noFilesIndexed'));
+	});
+
+	it('shows a no-matches state when the search filters everything out', () => {
+		const container = makeEl('div');
+		const status = statusFixture({ indexedFiles: [{ path: 'notes/a.md', lastIndexed: 1 }] });
+		renderRagFileList(container, status, baseFileListOptions({ searchQuery: 'zzz' }));
+		expect(container.querySelector('.rag-status-empty')?.textContent).toBe(t('ragStatus.noSearchMatches'));
+	});
+
+	it('caps the list at maxInitial and offers a show-all affordance', () => {
+		const container = makeEl('div');
+		const status = statusFixture({
+			indexedFiles: [
+				{ path: 'a.md', lastIndexed: 1 },
+				{ path: 'b.md', lastIndexed: 2 },
+				{ path: 'c.md', lastIndexed: 3 },
+			],
+		});
+		renderRagFileList(container, status, baseFileListOptions({ maxInitial: 2 }));
+		expect(container.querySelectorAll('.rag-status-file-item')).toHaveLength(2);
+		expect(container.querySelector('.rag-status-show-more')).toBeTruthy();
+	});
+
+	it('shows every file and no affordance when showAll is set', () => {
+		const container = makeEl('div');
+		const status = statusFixture({
+			indexedFiles: [
+				{ path: 'a.md', lastIndexed: 1 },
+				{ path: 'b.md', lastIndexed: 2 },
+				{ path: 'c.md', lastIndexed: 3 },
+			],
+		});
+		renderRagFileList(container, status, baseFileListOptions({ maxInitial: 2, showAll: true }));
+		expect(container.querySelectorAll('.rag-status-file-item')).toHaveLength(3);
+		expect(container.querySelector('.rag-status-show-more')).toBeNull();
+	});
+
+	it('invokes onShowAll when the affordance is clicked', () => {
+		const container = makeEl('div');
+		const status = statusFixture({
+			indexedFiles: [
+				{ path: 'a.md', lastIndexed: 1 },
+				{ path: 'b.md', lastIndexed: 2 },
+			],
+		});
+		const onShowAll = vi.fn();
+		renderRagFileList(container, status, baseFileListOptions({ maxInitial: 1, onShowAll }));
+		(container.querySelector('.rag-status-show-more') as HTMLElement).click();
+		expect(onShowAll).toHaveBeenCalledTimes(1);
+	});
+
+	it('renders plain, non-interactive rows when onOpenFile is omitted', () => {
+		const container = makeEl('div');
+		const status = statusFixture({ indexedFiles: [{ path: 'note.md', lastIndexed: 1 }] });
+		renderRagFileList(container, status, baseFileListOptions());
+		const item = container.querySelector('.rag-status-file-item') as HTMLElement;
+		expect(item.tagName).toBe('DIV');
+		expect(item.classList.contains('rag-status-file-item--clickable')).toBe(false);
+		expect(item.querySelector('.rag-status-file-path')?.textContent).toBe('note.md');
+	});
+
+	it('renders clickable button rows that open the file when onOpenFile is provided', () => {
+		const container = makeEl('div');
+		const status = statusFixture({ indexedFiles: [{ path: 'note.md', lastIndexed: 1 }] });
+		const opened: string[] = [];
+		renderRagFileList(container, status, baseFileListOptions({ onOpenFile: (p) => opened.push(p) }));
+		const item = container.querySelector('.rag-status-file-item') as HTMLElement;
+		expect(item.tagName).toBe('BUTTON');
+		expect(item.classList.contains('rag-status-file-item--clickable')).toBe(true);
+		item.click();
+		expect(opened).toEqual(['note.md']);
+	});
+});
+
+describe('renderRagFailures', () => {
+	it('shows the empty state when there are no failures', () => {
+		const container = makeEl('div');
+		renderRagFailures(container, statusFixture());
+		expect(container.querySelector('.rag-status-empty')?.textContent).toBe(t('ragStatus.noFailures'));
+	});
+
+	it('renders one row per failed file with its path and error', () => {
+		const container = makeEl('div');
+		const status = statusFixture({
+			failedCount: 1,
+			failedFiles: [{ path: 'bad.md', error: 'boom', timestamp: 1 }],
+		});
+		renderRagFailures(container, status);
+		expect(container.querySelectorAll('.rag-status-failure-item')).toHaveLength(1);
+		expect(container.querySelector('.rag-status-failure-path')?.textContent).toBe('bad.md');
+		expect(container.querySelector('.rag-status-failure-error')?.textContent).toBe('boom');
+	});
+});
+
+describe('renderRagOverview', () => {
+	beforeEach(() => {
+		buttonSpecs.length = 0;
+		vi.mocked(Notice).mockClear();
+	});
+
+	function callbacks(overrides: Partial<RagOverviewCallbacks> = {}): RagOverviewCallbacks {
+		return {
+			onSyncNow: vi.fn().mockResolvedValue(undefined),
+			onSyncSuccess: vi.fn(),
+			formatSyncError: (e) => String(e),
+			onReindex: vi.fn(),
+			onOpenSettings: vi.fn(),
+			...overrides,
+		};
+	}
+
+	it('renders the status row with its label and CSS class', () => {
+		const container = makeEl('div');
+		renderRagOverview(container, statusFixture({ status: 'idle' }), callbacks());
+		const statusValue = container.querySelector('.rag-status-value');
+		expect(statusValue?.textContent).toBe(t('ragStatus.statusReady'));
+		expect(statusValue?.classList.contains('rag-status-ready')).toBe(true);
+	});
+
+	it('disables Sync when there are no pending changes but keeps Reindex enabled', () => {
+		const container = makeEl('div');
+		renderRagOverview(container, statusFixture({ status: 'idle', pendingCount: 0 }), callbacks());
+		const [sync, reindex] = buttonSpecs;
+		expect(sync.disabled).toBe(true);
+		expect(reindex.disabled).toBe(false);
+	});
+
+	it('enables Sync when there are pending changes', () => {
+		const container = makeEl('div');
+		renderRagOverview(container, statusFixture({ status: 'idle', pendingCount: 3 }), callbacks());
+		const [sync, reindex] = buttonSpecs;
+		expect(sync.disabled).toBe(false);
+		expect(reindex.disabled).toBe(false);
+	});
+
+	it('disables both Sync and Reindex while indexing', () => {
+		const container = makeEl('div');
+		renderRagOverview(container, statusFixture({ status: 'indexing', pendingCount: 5 }), callbacks());
+		const [sync, reindex] = buttonSpecs;
+		expect(sync.disabled).toBe(true);
+		expect(reindex.disabled).toBe(true);
+	});
+
+	it('runs onSyncSuccess after a successful sync', async () => {
+		const container = makeEl('div');
+		const cb = callbacks();
+		renderRagOverview(container, statusFixture({ status: 'idle', pendingCount: 2 }), cb);
+		await buttonSpecs[0].click?.();
+		expect(cb.onSyncNow).toHaveBeenCalledTimes(1);
+		expect(cb.onSyncSuccess).toHaveBeenCalledTimes(1);
+		expect(Notice).not.toHaveBeenCalled();
+	});
+
+	it('shows a notice and skips onSyncSuccess when the sync fails', async () => {
+		const container = makeEl('div');
+		const formatSyncError = vi.fn().mockReturnValue('formatted');
+		const cb = callbacks({
+			onSyncNow: vi.fn().mockRejectedValue(new Error('nope')),
+			formatSyncError,
+		});
+		renderRagOverview(container, statusFixture({ status: 'idle', pendingCount: 2 }), cb);
+		await buttonSpecs[0].click?.();
+		expect(cb.onSyncSuccess).not.toHaveBeenCalled();
+		expect(formatSyncError).toHaveBeenCalledTimes(1);
+		expect(Notice).toHaveBeenCalledTimes(1);
+	});
+
+	it('wires Reindex and Settings buttons to their callbacks', () => {
+		const container = makeEl('div');
+		const cb = callbacks();
+		renderRagOverview(container, statusFixture({ status: 'idle', pendingCount: 1 }), cb);
+		const [, reindex, settings] = buttonSpecs;
+		reindex.click?.();
+		settings.click?.();
+		expect(cb.onReindex).toHaveBeenCalledTimes(1);
+		expect(cb.onOpenSettings).toHaveBeenCalledTimes(1);
+		expect(settings.cta).toBe(true);
+	});
+});


### PR DESCRIPTION
<!-- auto-dev -->

## Summary

`RagStatusModal` (`src/ui/rag-status-modal.ts`) and the "RAG" tab of `BackgroundTasksModal` (`src/ui/background-tasks-modal.ts`) rendered the same RAG-status panel through two parallel sets of near-identical private methods — overview rows, Sync/Reindex button gating, the indexed-file list, the failures list, and the status→label / status→css maps. Keeping two copies meant every copy change, gating tweak, or new status state had to be mirrored by hand or the views drifted.

This extracts a single presenter module that both surfaces delegate to, so the panel rendering lives in exactly one place. Pure de-duplication — the rendered output is unchanged and the production `main.js` bundle is **byte-identical**.

This PR was produced by the auto-dev pipeline from the approved plan on #1141.

Fixes #1141

## Changes

- `src/ui/components/rag-status-panel.ts` (new) — presenter helpers `renderRagOverview`, `renderRagFileList`, `renderRagFailures`, plus the two pure maps `ragStatusText` / `ragStatusClass` (keys `idle`/`indexing`/`error`/`paused`/`disabled`/`rate_limited`).
- `src/ui/rag-status-modal.ts` — deleted `renderOverviewTab` / `renderFileList` / `renderFailuresTab` / `getStatusText` / `getStatusClass`; delegates content rendering to the shared helper, keeping only its tab shell, `this.statusInfo` acquisition, and its `close()` follow-up callbacks.
- `src/ui/background-tasks-modal.ts` — deleted `renderRagOverview` / `renderRagFileList` / `renderRagFailures` / `ragStatusText` / `ragStatusClass`; delegates to the shared helper, keeping the RAG tab shell, the scroll-preserving search-box wiring, and its `renderTabContent()` / reindex-progress-modal follow-ups.
- `test/ui/components/rag-status-panel.test.ts` (new) — focused coverage: status-map correctness, empty/no-match/pending/failure states, file-list capping and the show-all affordance, clickable vs plain rows, and Sync/Reindex button gating.

**Deviations from the plan.** The approved plan named "two behavioral differences" (data source and post-action follow-up). Reality had two more, which are parameterized through the helper's options rather than branched inside it, and are documented here:

1. **Sync-failure error formatter** differs between the surfaces — the standalone modal uses `getRawErrorMessage`, the Background Tasks tab uses `getErrorMessage`. Exposed as a `formatSyncError` callback so each keeps its exact behavior.
2. **Indexed-file rows** differ — Background Tasks rows are clickable buttons that open the note (plus scroll-position preservation, which stays in that modal's search-box wiring), while the standalone modal's rows are plain, non-interactive divs. Exposed as an optional `onOpenFile` callback: present → clickable button rows; absent → plain divs.

The inner tab bars and search-box wiring stay per-modal, as the plan's out-of-scope note specified.

## Screenshots / Screencast

No visual change — this is a behavior-preserving de-duplication and the built `main.js` bundle is byte-identical to `master`, so the rendered output is unchanged in both surfaces.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards)
- [x] Documentation has been updated (if applicable) — n/a: internal refactor with no user-facing, settings, or behavioral change
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

If any part of this PR was generated or assisted by AI tools, you **must** complete this section:

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (auto-dev pipeline)
- [x] I have reviewed and understand all AI-generated code in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MNmeqnVSo5QFkkpYdY6RpG)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * RAG status screens now use shared, more consistent panels for overview, indexed files, and failures.
  * Added clearer actions for syncing, reindexing, opening settings, and opening files directly from the modal.
  * Search and “show more” behavior in file lists is now smoother and more responsive.

* **Bug Fixes**
  * Improved handling of sync errors and empty/no-match states.
  * Fixed button availability so actions are disabled when they can’t be used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->