### PR TITLE
refactor(ui): pull up shared entity-row shell into ManagementModalBase (#1143)

### DIFF
--- a/src/ui/components/management-modal-base.ts
+++ b/src/ui/components/management-modal-base.ts
@@ -281,6 +281,38 @@ export abstract class ManagementModalBase<TEntity, TEntityState> extends Modal {
 		return msg.length > 80 ? `${msg.slice(0, 77)}…` : msg;
 	}
 
+	/**
+	 * Build the shared entity-row shell used by every management modal: the
+	 * `<li>` carrying the paused/disabled state classes and the leading
+	 * status-icon span. Subclasses call this, then append their entity-specific
+	 * badge/info/action content to the returned `li`. The icon reflects
+	 * paused → disabled → active state; the active-state icon is entity-specific
+	 * (e.g. `'clock'` for tasks, `'webhook'` for hooks) and is supplied by the
+	 * caller, while the paused (`alert-circle`) and disabled (`pause-circle`)
+	 * icons are shared.
+	 */
+	protected renderEntityRowShell(
+		container: HTMLElement,
+		opts: { isPaused: boolean; isDisabled: boolean; activeIcon: string }
+	): { li: HTMLElement; iconEl: HTMLElement } {
+		const { isPaused, isDisabled, activeIcon } = opts;
+
+		const li = container.createEl('li', {
+			cls: [
+				'gemini-scheduler-item',
+				isDisabled ? 'gemini-scheduler-item--disabled' : '',
+				isPaused ? 'gemini-scheduler-item--paused' : '',
+			]
+				.filter(Boolean)
+				.join(' '),
+		});
+
+		const iconEl = li.createSpan({ cls: 'gemini-scheduler-item-icon' });
+		setIcon(iconEl, isPaused ? 'alert-circle' : isDisabled ? 'pause-circle' : activeIcon);
+
+		return { li, iconEl };
+	}
+
 	/** Capitalize the entity label for use in UI strings. */
 	protected get capitalizedEntityLabel(): string {
 		return this.entityLabel.charAt(0).toUpperCase() + this.entityLabel.slice(1);

--- a/src/ui/hook-management-modal.ts
+++ b/src/ui/hook-management-modal.ts
@@ -96,18 +96,7 @@ export class HookManagementModal extends ManagementModalBase<Hook, HookState> {
 		const isPaused = hookState?.pausedDueToErrors === true;
 		const isDisabled = !hook.enabled;
 
-		const li = container.createEl('li', {
-			cls: [
-				'gemini-scheduler-item',
-				isDisabled ? 'gemini-scheduler-item--disabled' : '',
-				isPaused ? 'gemini-scheduler-item--paused' : '',
-			]
-				.filter(Boolean)
-				.join(' '),
-		});
-
-		const iconEl = li.createSpan({ cls: 'gemini-scheduler-item-icon' });
-		setIcon(iconEl, isPaused ? 'alert-circle' : isDisabled ? 'pause-circle' : 'webhook');
+		const { li } = this.renderEntityRowShell(container, { isPaused, isDisabled, activeIcon: 'webhook' });
 
 		const info = li.createDiv({ cls: 'gemini-scheduler-item-info' });
 		info.createDiv({ text: hook.slug, cls: 'gemini-scheduler-item-slug' });

--- a/src/ui/scheduler-management-modal.ts
+++ b/src/ui/scheduler-management-modal.ts
@@ -1,4 +1,4 @@
-import { Notice, Setting, setIcon } from 'obsidian';
+import { Notice, Setting } from 'obsidian';
 import type { ScheduledTask, TaskState, ScheduledTasksState } from '../services/scheduled-task-manager';
 import { DEFAULT_HEADLESS_MAX_ITERATIONS } from '../agent/agent-loop';
 import type { FeatureToolPolicy } from '../types/tool-policy';
@@ -80,19 +80,7 @@ export class SchedulerManagementModal extends ManagementModalBase<ScheduledTask,
 		const isPaused = taskState?.pausedDueToErrors === true;
 		const isDisabled = !task.enabled;
 
-		const li = container.createEl('li', {
-			cls: [
-				'gemini-scheduler-item',
-				isDisabled ? 'gemini-scheduler-item--disabled' : '',
-				isPaused ? 'gemini-scheduler-item--paused' : '',
-			]
-				.filter(Boolean)
-				.join(' '),
-		});
-
-		// Status icon
-		const iconEl = li.createSpan({ cls: 'gemini-scheduler-item-icon' });
-		setIcon(iconEl, isPaused ? 'alert-circle' : isDisabled ? 'pause-circle' : 'clock');
+		const { li } = this.renderEntityRowShell(container, { isPaused, isDisabled, activeIcon: 'clock' });
 
 		// Info block
 		const info = li.createDiv({ cls: 'gemini-scheduler-item-info' });

--- a/test/ui/management-modal-base.test.ts
+++ b/test/ui/management-modal-base.test.ts
@@ -1,3 +1,4 @@
+import { setIcon } from 'obsidian';
 import { ManagementModalBase } from '../../src/ui/components/management-modal-base';
 
 /**
@@ -178,6 +179,12 @@ class TestModal extends ManagementModalBase<StubEntity, StubState> {
 	callTruncateError(msg: string) {
 		return this.truncateError(msg);
 	}
+	callRenderEntityRowShell(
+		container: HTMLElement,
+		opts: { isPaused: boolean; isDisabled: boolean; activeIcon: string }
+	) {
+		return this.renderEntityRowShell(container, opts);
+	}
 
 	/** Disable the manager to test the "not available" path. */
 	setManagerNull() {
@@ -295,6 +302,62 @@ describe('ManagementModalBase', () => {
 		it('keeps exactly 80-char messages unchanged', () => {
 			const exact = 'B'.repeat(80);
 			expect(modal.callTruncateError(exact)).toBe(exact);
+		});
+	});
+
+	// ── renderEntityRowShell ─────────────────────────────────────────────
+
+	describe('renderEntityRowShell', () => {
+		beforeEach(() => {
+			(setIcon as any).mockClear();
+		});
+
+		it('builds a plain <li> with the base class and the active icon for an active entity', () => {
+			const container = createMockElement();
+			const { li, iconEl } = modal.callRenderEntityRowShell(container, {
+				isPaused: false,
+				isDisabled: false,
+				activeIcon: 'clock',
+			});
+			expect(container.createEl).toHaveBeenCalledWith('li', { cls: 'gemini-scheduler-item' });
+			expect((li as any).createSpan).toHaveBeenCalledWith({ cls: 'gemini-scheduler-item-icon' });
+			expect(setIcon).toHaveBeenCalledWith(iconEl, 'clock');
+		});
+
+		it('adds the disabled class and the pause-circle icon when disabled', () => {
+			const container = createMockElement();
+			const { iconEl } = modal.callRenderEntityRowShell(container, {
+				isPaused: false,
+				isDisabled: true,
+				activeIcon: 'clock',
+			});
+			expect(container.createEl).toHaveBeenCalledWith('li', {
+				cls: 'gemini-scheduler-item gemini-scheduler-item--disabled',
+			});
+			expect(setIcon).toHaveBeenCalledWith(iconEl, 'pause-circle');
+		});
+
+		it('adds the paused class and the alert-circle icon, with paused winning over disabled', () => {
+			const container = createMockElement();
+			const { iconEl } = modal.callRenderEntityRowShell(container, {
+				isPaused: true,
+				isDisabled: true,
+				activeIcon: 'webhook',
+			});
+			expect(container.createEl).toHaveBeenCalledWith('li', {
+				cls: 'gemini-scheduler-item gemini-scheduler-item--disabled gemini-scheduler-item--paused',
+			});
+			expect(setIcon).toHaveBeenCalledWith(iconEl, 'alert-circle');
+		});
+
+		it('uses the caller-supplied active icon (entity-specific)', () => {
+			const container = createMockElement();
+			const { iconEl } = modal.callRenderEntityRowShell(container, {
+				isPaused: false,
+				isDisabled: false,
+				activeIcon: 'webhook',
+			});
+			expect(setIcon).toHaveBeenCalledWith(iconEl, 'webhook');
 		});
 	});
 


### PR DESCRIPTION
<!-- auto-dev -->

## Summary

`SchedulerManagementModal` and `HookManagementModal` both extend the shared `ManagementModalBase` (`src/ui/components/management-modal-base.ts`), yet each reimplemented the same entity-row *shell*: the `isPaused`/`isDisabled` derivation, the `['gemini-scheduler-item', …'--disabled', …'--paused'].filter(Boolean).join(' ')` class array, and the status-icon span. Any change to the row shell had to be mirrored by hand in both modals.

This pulls the shell up into the base class both modals already extend, so it lives in exactly one place. Pure de-duplication — the rendered row (classes, icons, structure) is unchanged.

This PR was produced by the auto-dev pipeline from the approved plan on #1143.

Fixes #1143

## Changes

- `src/ui/components/management-modal-base.ts` — add `protected renderEntityRowShell(container, { isPaused, isDisabled, activeIcon }): { li, iconEl }`. It builds the `<li>` with the shared state-class array and the leading status-icon span, setting the icon from paused → disabled → active state. The paused (`alert-circle`) and disabled (`pause-circle`) icons are shared in the helper; the active-state icon is entity-specific and passed by the caller.
- `src/ui/scheduler-management-modal.ts` — `renderEntityRow` derives `isPaused`/`isDisabled` as before, then calls `renderEntityRowShell(..., { activeIcon: 'clock' })` and appends its `ScheduledTask` badge/info to the returned `li`. `setIcon` is no longer used directly here, so its import is dropped.
- `src/ui/hook-management-modal.ts` — same, calling `renderEntityRowShell(..., { activeIcon: 'webhook' })`. `setIcon` stays imported (still used by the "hooks disabled" banner in `renderListPreamble`).
- `test/ui/management-modal-base.test.ts` — extend the existing base-class coverage: assert the shell produces the correct class array and icon for active, disabled, and paused (paused-wins-over-disabled) states, and that it honors the caller-supplied active icon.

The active-state icon is the only per-modal divergence in the shell (`clock` for tasks vs `webhook` for hooks), so it's a parameter rather than branched inside the helper. Everything *inside* the row (entity-specific badges, meta, action buttons) stays in each subclass, exactly as the plan scoped.

## Screenshots / Screencast

No visual change — this is a behavior-preserving de-duplication. The row's classes, icons, and structure are identical to before, verified by the existing and new unit tests.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop
- [x] I have verified this change does not break Mobile (pure UI-logic de-duplication; no runtime or platform surface changed)
- [x] Documentation has been updated (if applicable) — n/a: internal refactor with no user-facing, settings, or behavioral change
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (auto-dev pipeline)
- [x] I have reviewed and understand all AI-generated code in this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01QQk1aZswEfkKEPuL3S4iPr)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved row state display in management modals so paused and disabled items now show the correct status icon and styling consistently.
  * Standardized how entity rows are rendered across hooks and schedulers, reducing visual inconsistencies.

* **Tests**
  * Added coverage for row state handling to verify the correct classes and icons appear for active, paused, and disabled items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->