### PR TITLE
fix: restore Deep Research proxyFetch injection for @google/genai 2.x

### DIFF
--- a/src/services/deep-research.ts
+++ b/src/services/deep-research.ts
@@ -56,27 +56,66 @@ export class DeepResearchService {
 
 		if (!this.researchManager) {
 			const genAI = createGoogleGenAI(this.plugin);
-			// WORKAROUND (as of @google/genai v0.14.x): The GoogleGenAI interactions getter creates
-			// a new client that ignores the fetch option passed to the constructor. We must manually
-			// inject our proxyFetch into the generated interactions client to ensure CORS requests
-			// are handled correctly in Obsidian's browser environment.
-			// This may break if the SDK internal structure changes - monitor on SDK updates.
-			const interactions = genAI.interactions as any;
-			if (interactions && interactions._client) {
-				this.plugin.logger.log('[DeepResearch] Injecting proxyFetch into interactions client');
-				interactions._client.fetch = proxyFetch;
-			} else {
-				// Fail fast - without proxyFetch injection, all research requests will fail with CORS errors
-				throw new Error(
-					'Failed to initialize research client: SDK structure has changed and proxyFetch injection failed. ' +
-						'Please update the plugin or report this issue at https://github.com/allenhutchison/obsidian-gemini/issues'
-				);
-			}
-
+			this.injectProxyFetch(genAI);
 			this.researchManager = new ResearchManager(genAI);
 		}
 
 		return this.researchManager;
+	}
+
+	/**
+	 * Route the Deep Research (`interactions`) API through Obsidian's requestUrl-based
+	 * {@link proxyFetch}. Unlike `models.*` (which reach Google's endpoint directly
+	 * from the renderer), the interactions endpoint is not CORS-accessible with the
+	 * default `fetch`, so its requests must go through the proxy or they fail with
+	 * "Failed to fetch".
+	 *
+	 * In `@google/genai` 2.x the interactions client is a Speakeasy-generated
+	 * `ClientSDK` created **lazily on the first request** and assigned to
+	 * `interactions.sdk`; its fetch lives at `sdk._httpClient.fetcher` (this was
+	 * `interactions._client.fetch` in the 0.14.x SDK the old workaround targeted).
+	 * Because the client doesn't exist until the first call, we trap the `sdk`
+	 * assignment on the (stable) interactions instance and swap in `proxyFetch` the
+	 * moment the client is built — and patch it immediately if it already exists.
+	 */
+	private injectProxyFetch(genAI: unknown): void {
+		type SpeakeasyClient = { _httpClient?: { fetcher?: unknown } };
+		const interactions = (genAI as { interactions?: { sdk?: SpeakeasyClient } }).interactions;
+		if (!interactions) {
+			this.plugin.logger.warn('[DeepResearch] GoogleGenAI has no interactions client; proxyFetch not injected');
+			return;
+		}
+
+		const patch = (sdk: SpeakeasyClient | undefined) => {
+			const httpClient = sdk?._httpClient;
+			if (httpClient && typeof httpClient.fetcher === 'function' && httpClient.fetcher !== proxyFetch) {
+				httpClient.fetcher = proxyFetch;
+				this.plugin.logger.log('[DeepResearch] Injected proxyFetch into interactions HTTP client');
+			}
+		};
+
+		// Patch an already-built client (e.g. a warm getter) up front...
+		patch(interactions.sdk);
+
+		// ...and trap future lazy assignment so the client built on the first request
+		// gets proxyFetch before it makes any call.
+		let current = interactions.sdk;
+		try {
+			Object.defineProperty(interactions, 'sdk', {
+				configurable: true,
+				enumerable: true,
+				get: () => current,
+				set: (value: SpeakeasyClient | undefined) => {
+					patch(value);
+					current = value;
+				},
+			});
+		} catch (error) {
+			this.plugin.logger.warn(
+				'[DeepResearch] Could not install interactions fetch trap; Deep Research may fail with CORS errors',
+				error
+			);
+		}
 	}
 
 	/**

--- a/test/services/deep-research.test.ts
+++ b/test/services/deep-research.test.ts
@@ -1,4 +1,6 @@
 import { DeepResearchService, DeepResearchParams } from '../../src/services/deep-research';
+import { proxyFetch } from '../../src/utils/proxy-fetch';
+import { GoogleGenAI } from '@google/genai';
 import { TFile } from 'obsidian';
 
 // Mock obsidian
@@ -31,16 +33,16 @@ vi.mock('@allenhutchison/gemini-utils', () => ({
 	}),
 }));
 
-// Mock Google GenAI with interactions structure for proxyFetch injection
+// Mock Google GenAI. In @google/genai 2.x, `interactions` is a stable object whose
+// Speakeasy `sdk` (holding the HTTP client / fetcher) is created lazily on the first
+// request and assigned to `interactions.sdk` — there is no `sdk` up front, only
+// `parentClient`. `genAiMock.interactions` is refreshed on each client construction so
+// tests can inspect and drive the lazy assignment.
+const genAiMock = vi.hoisted(() => ({ interactions: undefined as any }));
 vi.mock('@google/genai', () => ({
 	GoogleGenAI: vi.fn().mockImplementation(function () {
-		return {
-			interactions: {
-				_client: {
-					fetch: undefined,
-				},
-			},
-		};
+		genAiMock.interactions = { parentClient: {} };
+		return { interactions: genAiMock.interactions };
 	}),
 }));
 
@@ -515,6 +517,45 @@ describe('DeepResearchService', () => {
 
 		it('allows arbitrary paths outside the state folder', () => {
 			expect(validate('Notes/foo.md')).toBe('Notes/foo.md');
+		});
+	});
+
+	describe('proxyFetch injection into the interactions client', () => {
+		// The Deep Research (interactions) endpoint is not CORS-accessible from
+		// Obsidian's renderer with the default fetch, so its Speakeasy HTTP client's
+		// fetcher must be swapped for proxyFetch. The client is created lazily on the
+		// first request and assigned to `interactions.sdk`, so the service traps that
+		// assignment. These tests guard that wiring against future SDK-shape drift.
+		const buildManager = () => (service as any).ensureResearchManager();
+
+		it('swaps in proxyFetch when the SDK lazily creates its HTTP client', () => {
+			buildManager();
+
+			// Simulate @google/genai building the Speakeasy client on the first request.
+			const originalFetcher = vi.fn();
+			genAiMock.interactions.sdk = { _httpClient: { fetcher: originalFetcher } };
+
+			expect(genAiMock.interactions.sdk._httpClient.fetcher).toBe(proxyFetch);
+			expect(genAiMock.interactions.sdk._httpClient.fetcher).not.toBe(originalFetcher);
+		});
+
+		it('still exposes the assigned sdk through the trap getter', () => {
+			buildManager();
+
+			const sdk = { _httpClient: { fetcher: vi.fn() } };
+			genAiMock.interactions.sdk = sdk;
+
+			// Reading back returns the same client the SDK assigned (now patched).
+			expect(genAiMock.interactions.sdk).toBe(sdk);
+		});
+
+		it('does not throw when the interactions client is missing', () => {
+			// A future SDK without an interactions client must degrade gracefully.
+			(GoogleGenAI as unknown as ReturnType<typeof vi.fn>).mockImplementationOnce(function () {
+				return { interactions: undefined };
+			});
+			expect(() => buildManager()).not.toThrow();
+			expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining('no interactions client'));
 		});
 	});
 });


### PR DESCRIPTION
## Summary

Deep Research was completely broken: every run threw *"Failed to initialize research client: SDK structure has changed and proxyFetch injection failed"* before making a single request. The service injected `proxyFetch` into `interactions._client.fetch`, but that path only existed in the **v0.14.x** `@google/genai` SDK the workaround was written for — the plugin has been on **2.10.0** (already the latest published; a version bump can't fix it), where `interactions._client` no longer exists. The failure was also surfaced to users as a misleading *"Network error: Unable to reach the model API. Please check your connection."* (the `error-utils` network heuristic matches the substring `fetch` in "proxy**Fetch**").

This was found during a pre-release manual test run. `@google/genai` was already `^2.10.0` at the `4.10.2` tag, so Deep Research has been non-functional since at least that release.

In `@google/genai` 2.x the interactions client is a **Speakeasy-generated `ClientSDK` created lazily on the first request** and assigned to `interactions.sdk` (its fetch lives at `sdk._httpClient.fetcher`). Since it doesn't exist until the first call — and no constructor option exposes the fetcher — this PR traps the `sdk` assignment on the (stable) interactions instance and swaps in `proxyFetch` the moment the client is built. The Deep Research (`interactions`) endpoint is **not** CORS-accessible from Obsidian's renderer with the default fetch (unlike `models.*`), so it must route through Obsidian's `requestUrl` — verified: with the default fetch the request fails `TypeError: Failed to fetch`; with the trap it succeeds.

Verified end-to-end against the live API in a test vault: `[DeepResearch] Injected proxyFetch into interactions HTTP client` → research started → report returned with sources.

Related to #1023.

## Changes

- `src/services/deep-research.ts`: replace the obsolete `interactions._client.fetch` injection (and its fail-fast throw) with `injectProxyFetch()`, which patches an already-built client and traps the lazy `interactions.sdk` assignment to inject `proxyFetch` into `sdk._httpClient.fetcher`. Degrades gracefully (warn) if the interactions client is absent instead of throwing.
- `test/services/deep-research.test.ts`: update the `@google/genai` mock to the realistic 2.x shape (lazy `sdk`), and add regression tests for (a) proxyFetch injection on lazy `sdk` assignment, (b) the trap getter returning the assigned client, and (c) graceful degradation when the interactions client is missing.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer — related to #1023; fix discovered and approved by the maintainer during a pre-release test run
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop — verified Deep Research completes end-to-end against the live API
- [ ] I have verified this change does not break Mobile — N/A: no platform-specific code; Deep Research is a Gemini-only cloud feature already gated to desktop-capable networking, and the change only swaps the fetch implementation
- [x] Documentation has been updated (if applicable) — N/A: restores behavior already documented in `docs/guide/deep-research.md`; no user-facing surface changed
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

https://claude.ai/code/session_01U5znWezBVtCXRDdwn52Xu3