### PR TITLE
fix: give Ollama its own model field so provider switches keep the Gemini chat model

### DIFF
--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -102,7 +102,7 @@ UI sections without a dedicated topic in this reference: _Vault search index_ (c
 The active model list depends on the [`provider`](#provider) setting:
 
 - **Gemini (default)** — models are loaded from the bundled list and auto-refreshed from GitHub on startup (cached for 24h). `imageModelName` is only available on this provider. Click **Refresh model list** in Settings → General — or run the **Gemini Scribe: Refresh model list** command — to fetch the latest list immediately (bypasses the cache).
-- **Ollama** — a single **Ollama model** picker is shown (bound to `chatModelName`); that one model serves every use case — chat, summary, completions, and rewrite. Ollama keeps only one model resident at a time, so diverging models per use case would just thrash RAM/VRAM on each switch; the separate `summaryModelName` / `completionsModelName` values are ignored while Ollama is active. The dropdown is populated from `GET <ollamaBaseUrl>/api/tags`, listing whatever you have pulled. Click "Refresh model list" in settings if a freshly pulled model doesn't appear. Image generation is unavailable in this mode.
+- **Ollama** — a single **Ollama model** picker is shown (bound to its own `ollamaModelName` setting); that one model serves every use case — chat, summary, completions, and rewrite. Ollama keeps only one model resident at a time, so diverging models per use case would just thrash RAM/VRAM on each switch; the Gemini `chatModelName` / `summaryModelName` / `completionsModelName` values are ignored while Ollama is active. Because Ollama uses its own field, switching Gemini ↔ Ollama preserves each provider's model choice — returning to Gemini restores the exact chat model you had. The dropdown is populated from `GET <ollamaBaseUrl>/api/tags`, listing whatever you have pulled. Click "Refresh model list" in settings if a freshly pulled model doesn't appear. Image generation is unavailable in this mode.
 
 ### Chat model
 
@@ -127,7 +127,7 @@ The active model list depends on the [`provider`](#provider) setting:
 - **Default**: `gemini-flash-latest`
 - **Description**: Model used for document summarization
 - **Used by**: Summarize active file command
-- **Note**: Gemini only. Under Ollama every use case resolves to `chatModelName`, so this value is ignored and its picker is hidden.
+- **Note**: Gemini only. Under Ollama every use case resolves to `ollamaModelName`, so this value is ignored and its picker is hidden.
 
 ### Completions Model
 
@@ -136,7 +136,7 @@ The active model list depends on the [`provider`](#provider) setting:
 - **Default**: `gemini-flash-lite-latest`
 - **Description**: Model used for IDE-style auto-completions
 - **Note**: Completions must be enabled via command palette
-- **Note**: Gemini only. Under Ollama every use case resolves to `chatModelName`, so this value is ignored and its picker is hidden.
+- **Note**: Gemini only. Under Ollama every use case resolves to `ollamaModelName`, so this value is ignored and its picker is hidden.
 
 ### Image model
 
@@ -145,6 +145,14 @@ The active model list depends on the [`provider`](#provider) setting:
 - **Default**: `gemini-2.5-flash-image`
 - **Only available when**: Provider is `gemini`
 - **Description**: Model used for image generation via the `generate_image` tool and the **Generate image** command. Only models with image-generation capability appear in this dropdown.
+
+### Ollama model
+
+- **Setting**: `ollamaModelName`
+- **Type**: String
+- **Default**: `''` (backfilled to the first pulled model once the daemon's list loads)
+- **Only shown when**: Provider is `ollama`
+- **Description**: The single local model that serves every use case (chat, summary, completions, rewrite) while Ollama is the active provider. Stored separately from the Gemini `chatModelName` so switching Gemini ↔ Ollama preserves each provider's model choice. Populated from `GET <ollamaBaseUrl>/api/tags`.
 
 ## Custom Prompts
 

--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -1,4 +1,5 @@
 import type { Content } from '@google/genai';
+import { getActiveChatModel } from '../models';
 import type ObsidianGemini from '../main';
 import type { ChatSession, PerTurnContext } from '../types/agent';
 import type { FeatureToolPolicy } from '../types/tool-policy';
@@ -284,7 +285,7 @@ export class AgentLoop {
 		// entries strictly before it (prior, already-completed turns) are
 		// eligible. See #662.
 		let loopStartIndex = initialHistory.length;
-		const modelName = session?.modelConfig?.model || plugin.settings.chatModelName;
+		const modelName = session?.modelConfig?.model || getActiveChatModel(plugin.settings);
 		// `perTurnContext` is a first-iteration input, like `userMessage`:
 		// `buildToolHistoryTurns` splices it into the user turn once, after which
 		// it lives in `conversationHistory`. Re-passing it on later iterations

--- a/src/api/factory.ts
+++ b/src/api/factory.ts
@@ -85,7 +85,7 @@ export class ModelClientFactory {
 		// Collapse every use case to the one configured chat model; the
 		// per-use-case summary/completions settings are ignored under Ollama. (#1077)
 		if (provider === 'ollama') {
-			return settings.chatModelName || getDefaultModelForRole('chat', 'ollama');
+			return settings.ollamaModelName || getDefaultModelForRole('chat', 'ollama');
 		}
 		switch (useCase) {
 			case ModelUseCase.CHAT:

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,7 +8,7 @@ import { ScribeFile } from './files';
 import { GeminiHistory } from './history/history';
 import { GeminiCompletions } from './completions';
 import { Notice } from 'obsidian';
-import { getDefaultModelForRole, GeminiModel, ModelProvider } from './models';
+import { getDefaultModelForRole, GeminiModel, migrateOllamaModelSetting, ModelProvider } from './models';
 import { ModelManager } from './services/model-manager';
 import { PromptManager, GeminiPrompts } from './prompts';
 import { SelectionRewriter } from './rewrite-selection';
@@ -461,14 +461,9 @@ export default class ObsidianGemini extends Plugin {
 		this.settings = Object.assign({}, DEFAULT_SETTINGS, data);
 
 		// One-time migration: split the Ollama model out of the shared chatModelName
-		// field. Before ollamaModelName existed, the Ollama single-model picker wrote
-		// to chatModelName, so an Ollama user's chatModelName holds an Ollama model
-		// (and any prior Gemini choice was already overwritten). Move it into its own
-		// field and reset chatModelName to a Gemini default so switching providers no
-		// longer clobbers either choice.
-		if (data && data.ollamaModelName === undefined && this.settings.provider === 'ollama') {
-			this.settings.ollamaModelName = this.settings.chatModelName || '';
-			this.settings.chatModelName = getDefaultModelForRole('chat', 'gemini');
+		// field so switching providers no longer clobbers either choice. See
+		// migrateOllamaModelSetting for the full rationale.
+		if (migrateOllamaModelSetting(this.settings, data)) {
 			await this.saveData(this.settings);
 			this.logger?.log('Migrated Ollama model into its own setting (ollamaModelName)');
 		}

--- a/src/main.ts
+++ b/src/main.ts
@@ -65,6 +65,12 @@ export interface ObsidianGeminiSettings {
 	summaryModelName: string;
 	completionsModelName: string;
 	imageModelName: string;
+	/**
+	 * Single model used for every use case under the Ollama provider (Ollama keeps
+	 * one model resident at a time). Stored separately from the Gemini fields above
+	 * so switching Gemini ↔ Ollama preserves each provider's model choice.
+	 */
+	ollamaModelName: string;
 	summaryFrontmatterKey: string;
 	userName: string;
 	chatHistory: boolean;
@@ -126,6 +132,7 @@ const DEFAULT_SETTINGS: ObsidianGeminiSettings = {
 	summaryModelName: getDefaultModelForRole('summary'),
 	completionsModelName: getDefaultModelForRole('completions'),
 	imageModelName: getDefaultModelForRole('image'),
+	ollamaModelName: getDefaultModelForRole('chat', 'ollama'),
 	summaryFrontmatterKey: 'summary',
 	userName: 'User',
 	chatHistory: false,
@@ -452,6 +459,19 @@ export default class ObsidianGemini extends Plugin {
 	async loadSettings() {
 		const data = await this.loadData();
 		this.settings = Object.assign({}, DEFAULT_SETTINGS, data);
+
+		// One-time migration: split the Ollama model out of the shared chatModelName
+		// field. Before ollamaModelName existed, the Ollama single-model picker wrote
+		// to chatModelName, so an Ollama user's chatModelName holds an Ollama model
+		// (and any prior Gemini choice was already overwritten). Move it into its own
+		// field and reset chatModelName to a Gemini default so switching providers no
+		// longer clobbers either choice.
+		if (data && data.ollamaModelName === undefined && this.settings.provider === 'ollama') {
+			this.settings.ollamaModelName = this.settings.chatModelName || '';
+			this.settings.chatModelName = getDefaultModelForRole('chat', 'gemini');
+			await this.saveData(this.settings);
+			this.logger?.log('Migrated Ollama model into its own setting (ollamaModelName)');
+		}
 
 		// One-time migration: move API key from data.json to secret storage
 		if (!this.settings.apiKeySecretName && data?.apiKey) {

--- a/src/models.ts
+++ b/src/models.ts
@@ -97,6 +97,36 @@ export interface ModelUpdateResult {
 	changedSettingsInfo: string[];
 }
 
+/**
+ * One-time migration: split an existing Ollama user's model out of the shared
+ * `chatModelName` field into the dedicated `ollamaModelName` field.
+ *
+ * Before `ollamaModelName` existed, the Ollama single-model picker wrote to
+ * `chatModelName`, so an Ollama user's `chatModelName` holds an Ollama model (and
+ * any prior Gemini choice was already overwritten). This moves it into its own
+ * field and resets `chatModelName` to a Gemini default so switching providers no
+ * longer clobbers either choice.
+ *
+ * Mutates `settings` in place and returns `true` when a migration was applied, so
+ * the caller can persist and log. The pre-migration shape is detected from the
+ * raw persisted data (`ollamaModelName === undefined`) rather than the merged
+ * settings, whose default already backfills the field.
+ *
+ * @param settings - freshly merged settings (mutated in place)
+ * @param rawData - raw persisted data as loaded from disk, pre-merge
+ */
+export function migrateOllamaModelSetting(
+	settings: { provider?: ModelProvider; chatModelName?: string; ollamaModelName?: string },
+	rawData: Record<string, unknown> | null | undefined
+): boolean {
+	if (rawData && rawData.ollamaModelName === undefined && settings.provider === 'ollama') {
+		settings.ollamaModelName = settings.chatModelName || '';
+		settings.chatModelName = getDefaultModelForRole('chat', 'gemini');
+		return true;
+	}
+	return false;
+}
+
 export function getUpdatedModelSettings(currentSettings: any): ModelUpdateResult {
 	const geminiModelValues = new Set(GEMINI_MODELS.filter((m) => getModelProvider(m) === 'gemini').map((m) => m.value));
 	const ollamaModelValues = new Set(GEMINI_MODELS.filter((m) => getModelProvider(m) === 'ollama').map((m) => m.value));

--- a/src/models.ts
+++ b/src/models.ts
@@ -72,6 +72,25 @@ export function getDefaultModelForRole(role: ModelRole, provider: ModelProvider 
 	throw new Error('CRITICAL: GEMINI_MODELS array is empty. Please configure available models.');
 }
 
+/**
+ * Resolve the chat model for the *active* provider. Gemini and Ollama each keep
+ * their own persisted model (`chatModelName` vs `ollamaModelName`), so switching
+ * providers back and forth never clobbers the other's choice. Use this anywhere
+ * the "current chat model" is needed for a request or for history metadata; the
+ * Gemini-cloud tools (search grounding, URL context, RAG) intentionally keep
+ * reading `chatModelName` directly since they always call Google's API.
+ */
+export function getActiveChatModel(settings: {
+	provider?: ModelProvider;
+	chatModelName?: string;
+	ollamaModelName?: string;
+}): string {
+	if ((settings.provider ?? 'gemini') === 'ollama') {
+		return settings.ollamaModelName || getDefaultModelForRole('chat', 'ollama');
+	}
+	return settings.chatModelName || getDefaultModelForRole('chat', 'gemini');
+}
+
 export interface ModelUpdateResult {
 	updatedSettings: any; // Ideally, this would be ObsidianGeminiSettings, but that would create a circular dependency
 	settingsChanged: boolean;
@@ -79,61 +98,52 @@ export interface ModelUpdateResult {
 }
 
 export function getUpdatedModelSettings(currentSettings: any): ModelUpdateResult {
-	const provider: ModelProvider = currentSettings?.provider === 'ollama' ? 'ollama' : 'gemini';
-	const availableModelValues = new Set(
-		GEMINI_MODELS.filter((m) => getModelProvider(m) === provider).map((m) => m.value)
-	);
+	const geminiModelValues = new Set(GEMINI_MODELS.filter((m) => getModelProvider(m) === 'gemini').map((m) => m.value));
+	const ollamaModelValues = new Set(GEMINI_MODELS.filter((m) => getModelProvider(m) === 'ollama').map((m) => m.value));
 	let settingsChanged = false;
 	const changedSettingsInfo: string[] = [];
 	const newSettings = { ...currentSettings };
 
-	// Helper function to check if a model needs updating.
-	// For Ollama we tolerate empty *only* while the model list hasn't loaded
-	// yet — once /api/tags has resolved, an empty value should be backfilled
-	// to a real default (otherwise a Gemini → Ollama switch made before the
-	// daemon was reachable would leave chat/summary/completions blank
-	// indefinitely, since the empty value never re-triggers reconciliation).
-	const needsUpdate = (modelName: string) => {
-		if (!modelName) {
-			return provider !== 'ollama' || availableModelValues.size > 0;
-		}
-		return !availableModelValues.has(modelName);
-	};
-
-	const reconcile = (
-		key: 'chatModelName' | 'summaryModelName' | 'completionsModelName',
+	// The Gemini per-use-case fields are always reconciled against the (always
+	// bundled) Gemini list, regardless of the active provider. This migrates
+	// renamed/legacy Gemini model IDs and, critically, keeps a Gemini → Ollama →
+	// Gemini round trip from clobbering the user's Gemini chat model: the Ollama
+	// model lives in its own `ollamaModelName` field, so the Gemini fields are
+	// never reconciled against the Ollama list.
+	const reconcileGemini = (
+		key: 'chatModelName' | 'summaryModelName' | 'completionsModelName' | 'imageModelName',
 		role: ModelRole,
 		label: string
 	) => {
-		if (!needsUpdate(newSettings[key])) return;
-		const next = getDefaultModelForRole(role, provider);
-		// When the active provider has no default available (e.g. Ollama before
-		// /api/tags has resolved), clear the stale value so the factory falls
-		// through to its "no model selected" path instead of sending a
-		// cross-provider model name (e.g. `gemini-flash-latest` to Ollama).
 		const previous = newSettings[key];
+		if (previous && geminiModelValues.has(previous)) return;
+		const next = getDefaultModelForRole(role, 'gemini');
+		// Image generation has no dedicated default in some model lists; leave a
+		// stale image model untouched rather than blanking it.
+		if (!next) return;
 		newSettings[key] = next;
-		changedSettingsInfo.push(
-			next
-				? `${label}: '${previous}' -> '${next}' (legacy model update)`
-				: `${label}: cleared stale '${previous}' (no default for provider '${provider}')`
-		);
+		changedSettingsInfo.push(`${label}: '${previous}' -> '${next}' (legacy model update)`);
 		settingsChanged = true;
 	};
 
-	reconcile('chatModelName', 'chat', 'Chat model');
-	reconcile('summaryModelName', 'summary', 'Summary model');
-	reconcile('completionsModelName', 'completions', 'Completions model');
+	reconcileGemini('chatModelName', 'chat', 'Chat model');
+	reconcileGemini('summaryModelName', 'summary', 'Summary model');
+	reconcileGemini('completionsModelName', 'completions', 'Completions model');
+	reconcileGemini('imageModelName', 'image', 'Image model');
 
-	// Image generation is Gemini-only in Phase 1 — only reconcile when on Gemini.
-	if (provider === 'gemini' && needsUpdate(newSettings.imageModelName)) {
-		const newDefaultImage = getDefaultModelForRole('image', 'gemini');
-		if (newDefaultImage) {
-			changedSettingsInfo.push(
-				`Image model: '${newSettings.imageModelName}' -> '${newDefaultImage}' (legacy model update)`
-			);
-			newSettings.imageModelName = newDefaultImage;
-			settingsChanged = true;
+	// The single Ollama model is only backfilled/validated once the daemon's
+	// models are known (they load lazily via /api/tags). Until then, tolerate an
+	// empty or stale value so a switch made while the daemon was unreachable
+	// doesn't blank it, and a Gemini model name is never sent to Ollama.
+	if (ollamaModelValues.size > 0) {
+		const previous = newSettings.ollamaModelName;
+		if (!previous || !ollamaModelValues.has(previous)) {
+			const next = getDefaultModelForRole('chat', 'ollama');
+			if (next && next !== previous) {
+				newSettings.ollamaModelName = next;
+				changedSettingsInfo.push(`Ollama model: '${previous ?? ''}' -> '${next}' (legacy model update)`);
+				settingsChanged = true;
+			}
 		}
 	}
 

--- a/src/services/hook-runner.ts
+++ b/src/services/hook-runner.ts
@@ -1,4 +1,5 @@
 import { App, TFile } from 'obsidian';
+import { getActiveChatModel } from '../models';
 import type ObsidianGemini from '../main';
 import { DestructiveAction } from '../types/agent';
 import { ToolExecutionContext } from '../tools/types';
@@ -78,7 +79,7 @@ export class HookRunner {
 		const renderedPrompt = renderPrompt(hook.prompt, this.promptVars());
 		const startedAt = formatLocalTimestamp(session.created);
 		const userMessage = buildTurnPreamble(formatLocalTimestamp(new Date())) + renderedPrompt;
-		const model = hook.model ?? this.plugin.settings.chatModelName;
+		const model = hook.model ?? getActiveChatModel(this.plugin.settings);
 
 		const initialRequest: ExtendedModelRequest = {
 			kind: 'extended',

--- a/src/services/scheduled-task-runner.ts
+++ b/src/services/scheduled-task-runner.ts
@@ -1,3 +1,4 @@
+import { getActiveChatModel } from '../models';
 import type ObsidianGemini from '../main';
 import type { ScheduledTask } from './scheduled-task-manager';
 import { DestructiveAction } from '../types/agent';
@@ -61,7 +62,7 @@ export class ScheduledTaskRunner {
 		// Prepend a turn preamble so the model has accurate "now" awareness.
 		const startedAt = formatLocalTimestamp(session.created);
 		const userMessage = buildTurnPreamble(formatLocalTimestamp(new Date())) + this.task.prompt;
-		const model = this.task.model ?? this.plugin.settings.chatModelName;
+		const model = this.task.model ?? getActiveChatModel(this.plugin.settings);
 
 		const initialRequest: ExtendedModelRequest = {
 			kind: 'extended',

--- a/src/services/selection-action-service.ts
+++ b/src/services/selection-action-service.ts
@@ -1,4 +1,5 @@
 import { Editor, TFile, Notice } from 'obsidian';
+import { getActiveChatModel } from '../models';
 import type ObsidianGemini from '../main';
 import { ExplainPromptSelectionModal } from '../ui/explain-prompt-modal';
 import { SelectionResponseModal, AskQuestionModal } from '../ui/selection-response-modal';
@@ -141,7 +142,7 @@ export class SelectionActionService {
 				kind: 'extended',
 				userMessage: userMessage,
 				conversationHistory: [],
-				model: this.plugin.settings.chatModelName,
+				model: getActiveChatModel(this.plugin.settings),
 				prompt: contextInfo,
 				temperature: this.plugin.settings.temperature,
 				topP: this.plugin.settings.topP,

--- a/src/services/vault-analyzer.ts
+++ b/src/services/vault-analyzer.ts
@@ -1,4 +1,5 @@
 import { TFolder, TFile, Notice } from 'obsidian';
+import { getActiveChatModel } from '../models';
 import type ObsidianGemini from '../main';
 import { ModelClientFactory } from '../api';
 import { AgentsMemoryData } from './agents-memory';
@@ -47,7 +48,7 @@ export class VaultAnalyzer {
 		modal.open();
 
 		// Get the model name for display
-		const modelName = this.plugin.settings.chatModelName;
+		const modelName = getActiveChatModel(this.plugin.settings);
 
 		// Define steps
 		modal.addStep('collect', t('modal.vaultAnalysis.stepCollect'));
@@ -81,7 +82,7 @@ export class VaultAnalyzer {
 			const response = await modelApi.generateModelResponse({
 				kind: 'base',
 				prompt: analysisPrompt,
-				model: this.plugin.settings.chatModelName,
+				model: getActiveChatModel(this.plugin.settings),
 			});
 			await this.ensureMinimumDelay(stepStart);
 			modal.setStepComplete('analyze');
@@ -135,7 +136,7 @@ export class VaultAnalyzer {
 			const examplePromptsResponse = await modelApi.generateModelResponse({
 				kind: 'base',
 				prompt: examplePromptsPrompt,
-				model: this.plugin.settings.chatModelName,
+				model: getActiveChatModel(this.plugin.settings),
 			});
 			await this.ensureMinimumDelay(stepStart);
 			modal.setStepComplete('examples');

--- a/src/ui/agent-view/agent-view-send.ts
+++ b/src/ui/agent-view/agent-view-send.ts
@@ -1,4 +1,5 @@
 import { Notice, setIcon, App } from 'obsidian';
+import { getActiveChatModel } from '../../models';
 import type { Content } from '@google/genai';
 import { ChatSession } from '../../types/agent';
 import { GeminiConversationEntry } from '../../types/conversation';
@@ -425,7 +426,7 @@ To reference an attachment in your response, use the path shown above.`;
 			try {
 				// Get model config from session or use defaults
 				const modelConfig = currentSession?.modelConfig || {};
-				const modelName = modelConfig.model || this.ctx.plugin.settings.chatModelName;
+				const modelName = modelConfig.model || getActiveChatModel(this.ctx.plugin.settings);
 
 				// beginTurn() is now handled by the turnStart event bus subscriber
 

--- a/src/ui/agent-view/agent-view-session.ts
+++ b/src/ui/agent-view/agent-view-session.ts
@@ -1,4 +1,5 @@
 import { App, Notice } from 'obsidian';
+import { getActiveChatModel } from '../../models';
 import { ChatSession } from '../../types/agent';
 import { GeminiConversationEntry } from '../../types/conversation';
 import type ObsidianGemini from '../../main';
@@ -237,7 +238,7 @@ Assistant: ${modelSummary}`;
 				kind: 'extended',
 				userMessage: titlePrompt,
 				conversationHistory: [],
-				model: this.plugin.settings.chatModelName,
+				model: getActiveChatModel(this.plugin.settings),
 				prompt: titlePrompt,
 				renderContent: false,
 			});

--- a/src/ui/agent-view/agent-view-tool-followup.ts
+++ b/src/ui/agent-view/agent-view-tool-followup.ts
@@ -1,4 +1,5 @@
 import type { Content } from '@google/genai';
+import { getActiveChatModel } from '../../models';
 import type ObsidianGemini from '../../main';
 import { ChatSession, type PerTurnContext } from '../../types/agent';
 import { ToolExecutionContext } from '../../tools/types';
@@ -75,7 +76,7 @@ export function buildFollowUpRequest(params: FollowUpRequestParams): ExtendedMod
 		kind: 'extended',
 		userMessage: '', // Empty since tool results are already in conversation history
 		conversationHistory: updatedHistory,
-		model: modelConfig.model || plugin.settings.chatModelName,
+		model: modelConfig.model || getActiveChatModel(plugin.settings),
 		temperature: modelConfig.temperature ?? plugin.settings.temperature,
 		topP: modelConfig.topP ?? plugin.settings.topP,
 		prompt: '', // Unused in agent pipeline — context lives in conversationHistory
@@ -103,7 +104,7 @@ export function buildRetryRequest(params: RetryRequestParams): ExtendedModelRequ
 		kind: 'extended',
 		userMessage: 'Please summarize what you just did with the tools.',
 		conversationHistory: updatedHistory,
-		model: modelConfig.model || plugin.settings.chatModelName,
+		model: modelConfig.model || getActiveChatModel(plugin.settings),
 		temperature: modelConfig.temperature ?? plugin.settings.temperature,
 		topP: modelConfig.topP ?? plugin.settings.topP,
 		prompt: '', // Unused in agent pipeline — context lives in conversationHistory

--- a/src/ui/agent-view/agent-view-tools.ts
+++ b/src/ui/agent-view/agent-view-tools.ts
@@ -1,4 +1,5 @@
 import type { Content } from '@google/genai';
+import { getActiveChatModel } from '../../models';
 import type ObsidianGemini from '../../main';
 import { ChatSession } from '../../types/agent';
 import { GeminiConversationEntry } from '../../types/conversation';
@@ -112,7 +113,7 @@ export class AgentViewTools {
 				message: '',
 				notePath: '',
 				created_at: new Date(),
-				model: currentSession.modelConfig?.model || this.plugin.settings.chatModelName,
+				model: currentSession.modelConfig?.model || getActiveChatModel(this.plugin.settings),
 				thoughts: this.pendingReasoning,
 			});
 		}
@@ -207,7 +208,7 @@ export class AgentViewTools {
 								message: '',
 								notePath: '',
 								created_at: new Date(),
-								model: currentSession.modelConfig?.model || this.plugin.settings.chatModelName,
+								model: currentSession.modelConfig?.model || getActiveChatModel(this.plugin.settings),
 								thoughts,
 							});
 						},
@@ -224,7 +225,7 @@ export class AgentViewTools {
 								message: `> [!info] Context Compacted\n> Older conversation turns have been summarized to maintain performance.\n\n${summaryText}`,
 								notePath: '',
 								created_at: new Date(),
-								model: currentSession.modelConfig?.model || this.plugin.settings.chatModelName,
+								model: currentSession.modelConfig?.model || getActiveChatModel(this.plugin.settings),
 							};
 							await this.context.displayMessage(compactionEntry);
 							await this.plugin.sessionHistory.addEntryToSession(currentSession, compactionEntry);
@@ -257,7 +258,7 @@ export class AgentViewTools {
 				message: result.markdown,
 				notePath: '',
 				created_at: new Date(),
-				model: currentSession.modelConfig?.model || this.plugin.settings.chatModelName,
+				model: currentSession.modelConfig?.model || getActiveChatModel(this.plugin.settings),
 				...(result.thoughts ? { thoughts: result.thoughts } : {}),
 			};
 

--- a/src/ui/agent-view/agent-view.ts
+++ b/src/ui/agent-view/agent-view.ts
@@ -1,4 +1,5 @@
 import { ItemView, MarkdownView, Platform, WorkspaceLeaf, TFile, Notice } from 'obsidian';
+import { getActiveChatModel } from '../../models';
 import { ChatSession, SessionModelConfig } from '../../types/agent';
 import { GeminiConversationEntry } from '../../types/conversation';
 import type ObsidianGemini from '../../main';
@@ -824,7 +825,7 @@ export class AgentView extends ItemView {
 		}
 
 		try {
-			const modelName = this.currentSession?.modelConfig?.model || this.plugin.settings.chatModelName;
+			const modelName = this.currentSession?.modelConfig?.model || getActiveChatModel(this.plugin.settings);
 			let usage = await this.plugin.contextManager.getTokenUsage(modelName);
 
 			// If no cached data, try counting from conversation history as fallback
@@ -896,7 +897,7 @@ export class AgentView extends ItemView {
 		}
 
 		try {
-			const modelName = this.currentSession?.modelConfig?.model || this.plugin.settings.chatModelName;
+			const modelName = this.currentSession?.modelConfig?.model || getActiveChatModel(this.plugin.settings);
 			const conversationHistory = await this.plugin.sessionHistory.getHistoryForSession(this.currentSession);
 			if (conversationHistory && conversationHistory.length > 0) {
 				const tokenCount = await this.plugin.contextManager.countTokens(modelName, conversationHistory);

--- a/src/ui/settings-general.ts
+++ b/src/ui/settings-general.ts
@@ -128,11 +128,12 @@ async function renderGeneralSection(
 	if (plugin.settings.provider === 'ollama') {
 		// Ollama keeps a single model resident at a time, so one model applies to
 		// every use case (chat / summary / completions / rewrite). Show just the
-		// one picker, bound to chatModelName. (#1077)
+		// one picker, bound to the dedicated `ollamaModelName` field so switching
+		// providers doesn't overwrite the user's Gemini chat model. (#1077)
 		await selectModelSetting(
 			sectionEl,
 			plugin,
-			'chatModelName',
+			'ollamaModelName',
 			t('settings.general.ollamaModelName'),
 			t('settings.general.ollamaModelDesc')
 		);

--- a/test/api/factory.test.ts
+++ b/test/api/factory.test.ts
@@ -210,8 +210,9 @@ describe('ModelClientFactory', () => {
 
 		describe('Ollama provider', () => {
 			// Ollama keeps a single model resident at a time, so every use case
-			// resolves to the one configured chatModelName — the per-use-case
-			// summary/completions settings are ignored under Ollama. (#1077)
+			// resolves to the one configured ollamaModelName — the Gemini
+			// chat/summary/completions settings are ignored under Ollama, and kept
+			// separate so switching providers preserves each choice. (#1077, #1125)
 			const useCases: ModelUseCase[] = [
 				ModelUseCase.CHAT,
 				ModelUseCase.SUMMARY,
@@ -220,13 +221,14 @@ describe('ModelClientFactory', () => {
 				ModelUseCase.SEARCH,
 			];
 
-			it.each(useCases)('resolves %s to the single chatModelName', (useCase) => {
-				// Divergent summary/completions values are set but must be ignored.
+			it.each(useCases)('resolves %s to the single ollamaModelName', (useCase) => {
+				// The Gemini fields are set to divergent values but must be ignored.
 				const plugin = createMockPlugin({
 					provider: 'ollama',
-					chatModelName: 'ollama-chat',
-					summaryModelName: 'ollama-summary',
-					completionsModelName: 'ollama-completions',
+					ollamaModelName: 'ollama-chat',
+					chatModelName: 'gemini-chat',
+					summaryModelName: 'gemini-summary',
+					completionsModelName: 'gemini-completions',
 				});
 				ModelClientFactory.createFromPlugin(plugin, useCase);
 
@@ -236,14 +238,14 @@ describe('ModelClientFactory', () => {
 				expect(config.model).toBe('ollama-chat');
 			});
 
-			it('falls back to the Ollama default for every use case when chatModelName is empty', () => {
-				// Even with a summary model configured, an empty chatModelName under
-				// Ollama resolves SUMMARY to the Ollama chat default — never the
-				// summary setting.
+			it('falls back to the Ollama default for every use case when ollamaModelName is empty', () => {
+				// Even with a Gemini chat model configured, an empty ollamaModelName
+				// under Ollama resolves to the Ollama chat default — never a Gemini field.
 				const plugin = createMockPlugin({
 					provider: 'ollama',
-					chatModelName: '',
-					summaryModelName: 'ollama-summary',
+					ollamaModelName: '',
+					chatModelName: 'gemini-chat',
+					summaryModelName: 'gemini-summary',
 				});
 				ModelClientFactory.createFromPlugin(plugin, ModelUseCase.SUMMARY);
 

--- a/test/models.test.ts
+++ b/test/models.test.ts
@@ -4,6 +4,7 @@ import {
 	getDefaultModelForRole,
 	GeminiModel,
 	getUpdatedModelSettings,
+	migrateOllamaModelSetting,
 	setGeminiModels,
 } from '../src/models';
 
@@ -359,5 +360,72 @@ describe('getActiveChatModel', () => {
 		expect(getActiveChatModel({ provider: 'ollama', chatModelName: 'gemini-flash-lite', ollamaModelName: '' })).toBe(
 			'llama3.2'
 		);
+	});
+});
+
+describe('migrateOllamaModelSetting', () => {
+	let originalModels: GeminiModel[];
+
+	beforeEach(() => {
+		originalModels = [...GEMINI_MODELS];
+		setTestModels([{ value: 'gemini-chat-default', label: 'Chat Default', defaultForRoles: ['chat'] }]);
+	});
+
+	afterEach(() => {
+		setTestModels(originalModels);
+	});
+
+	it('moves the legacy Ollama chatModelName into ollamaModelName and resets chatModelName', () => {
+		// The pre-migration shape: an Ollama user whose data.json predates
+		// ollamaModelName (so rawData.ollamaModelName is undefined) and whose
+		// chatModelName holds the Ollama model.
+		const rawData = { provider: 'ollama', chatModelName: 'gemma4:31b-mlx' };
+		const settings = { provider: 'ollama' as const, chatModelName: 'gemma4:31b-mlx', ollamaModelName: '' };
+
+		const migrated = migrateOllamaModelSetting(settings, rawData);
+
+		expect(migrated).toBe(true);
+		expect(settings.ollamaModelName).toBe('gemma4:31b-mlx');
+		expect(settings.chatModelName).toBe('gemini-chat-default');
+	});
+
+	it('does not migrate a Gemini user (leaves chatModelName intact)', () => {
+		const rawData = { provider: 'gemini', chatModelName: 'gemini-chat-default' };
+		const settings = { provider: 'gemini' as const, chatModelName: 'gemini-chat-default', ollamaModelName: '' };
+
+		const migrated = migrateOllamaModelSetting(settings, rawData);
+
+		expect(migrated).toBe(false);
+		expect(settings.chatModelName).toBe('gemini-chat-default');
+		expect(settings.ollamaModelName).toBe('');
+	});
+
+	it('does not migrate when the data already has ollamaModelName (already migrated)', () => {
+		const rawData = { provider: 'ollama', chatModelName: 'gemini-chat-default', ollamaModelName: 'llama3.2' };
+		const settings = { provider: 'ollama' as const, chatModelName: 'gemini-chat-default', ollamaModelName: 'llama3.2' };
+
+		const migrated = migrateOllamaModelSetting(settings, rawData);
+
+		expect(migrated).toBe(false);
+		expect(settings.chatModelName).toBe('gemini-chat-default');
+		expect(settings.ollamaModelName).toBe('llama3.2');
+	});
+
+	it('does not migrate a first-run install (no persisted data)', () => {
+		const settings = { provider: 'ollama' as const, chatModelName: 'gemini-chat-default', ollamaModelName: '' };
+
+		expect(migrateOllamaModelSetting(settings, null)).toBe(false);
+		expect(migrateOllamaModelSetting(settings, undefined)).toBe(false);
+	});
+
+	it('tolerates an empty legacy chatModelName', () => {
+		const rawData = { provider: 'ollama', chatModelName: '' };
+		const settings = { provider: 'ollama' as const, chatModelName: '', ollamaModelName: '' };
+
+		const migrated = migrateOllamaModelSetting(settings, rawData);
+
+		expect(migrated).toBe(true);
+		expect(settings.ollamaModelName).toBe('');
+		expect(settings.chatModelName).toBe('gemini-chat-default');
 	});
 });

--- a/test/models.test.ts
+++ b/test/models.test.ts
@@ -1,5 +1,6 @@
 import {
 	GEMINI_MODELS,
+	getActiveChatModel,
 	getDefaultModelForRole,
 	GeminiModel,
 	getUpdatedModelSettings,
@@ -235,42 +236,72 @@ describe('getUpdatedModelSettings', () => {
 		]);
 	});
 
-	it('tolerates empty Ollama model names while the model list has not loaded yet', () => {
-		setTestModels([]); // Simulates Ollama before /api/tags responds — no models registered
+	it('tolerates an empty Ollama model while the daemon list has not loaded yet', () => {
+		// Only Gemini models are registered here — the Ollama list loads later via
+		// /api/tags. The Gemini fields stay valid and the empty ollamaModelName is
+		// left untouched (rather than throwing or blanking a Gemini field).
 		const currentSettings = {
 			provider: 'ollama',
-			chatModelName: '', // Empty after a previous reconcile cleared a stale Gemini value
-			summaryModelName: '',
-			completionsModelName: '',
+			chatModelName: 'gemini-chat-default',
+			summaryModelName: 'gemini-summary-default',
+			completionsModelName: 'gemini-completions-default',
+			imageModelName: 'gemini-image-default',
+			ollamaModelName: '',
 		};
-		// Should NOT throw; empty values are allowed when the daemon hasn't reported
-		// any models yet (the throw only fires when an empty needs replacing AND no
-		// models are available, but for Ollama the "we'll backfill later" path wins).
 		const result = getUpdatedModelSettings(currentSettings);
 		expect(result.settingsChanged).toBe(false);
-		expect(result.updatedSettings.chatModelName).toBe('');
-		expect(result.updatedSettings.summaryModelName).toBe('');
-		expect(result.updatedSettings.completionsModelName).toBe('');
+		expect(result.updatedSettings.ollamaModelName).toBe('');
 		expect(result.changedSettingsInfo).toEqual([]);
 	});
 
-	it('backfills empty Ollama model names once the model list has loaded', () => {
+	it('backfills an empty Ollama model once the daemon list has loaded', () => {
 		setTestModels([
+			{ value: 'gemini-chat-default', label: 'Chat Default', defaultForRoles: ['chat'] },
+			{ value: 'gemini-summary-default', label: 'Summary Default', defaultForRoles: ['summary'] },
+			{ value: 'gemini-completions-default', label: 'Completions Default', defaultForRoles: ['completions'] },
+			{ value: 'gemini-image-default', label: 'Image Default', defaultForRoles: ['image'] },
 			{ value: 'llama3.2', label: 'Llama 3.2', provider: 'ollama' as const, defaultForRoles: ['chat'] },
-			{ value: 'mistral', label: 'Mistral', provider: 'ollama' as const, defaultForRoles: ['summary'] },
-			{ value: 'qwen2.5', label: 'Qwen 2.5', provider: 'ollama' as const, defaultForRoles: ['completions'] },
+			{ value: 'mistral', label: 'Mistral', provider: 'ollama' as const },
 		]);
 		const currentSettings = {
 			provider: 'ollama',
-			chatModelName: '', // Cleared on an earlier reconcile when daemon was unreachable
-			summaryModelName: '',
-			completionsModelName: '',
+			chatModelName: 'gemini-chat-default',
+			summaryModelName: 'gemini-summary-default',
+			completionsModelName: 'gemini-completions-default',
+			imageModelName: 'gemini-image-default',
+			ollamaModelName: '',
 		};
 		const result = getUpdatedModelSettings(currentSettings);
 		expect(result.settingsChanged).toBe(true);
-		expect(result.updatedSettings.chatModelName).toBe('llama3.2');
-		expect(result.updatedSettings.summaryModelName).toBe('mistral');
-		expect(result.updatedSettings.completionsModelName).toBe('qwen2.5');
+		expect(result.updatedSettings.ollamaModelName).toBe('llama3.2');
+		// Gemini fields are preserved across an Ollama-active reconcile.
+		expect(result.updatedSettings.chatModelName).toBe('gemini-chat-default');
+	});
+
+	it('preserves the Gemini model fields when the active provider is Ollama (#1125 regression)', () => {
+		// The core of the fix: reconciling while Ollama is active must never touch
+		// the Gemini per-use-case fields, so a Gemini → Ollama → Gemini round trip
+		// keeps the user's Gemini chat model instead of resetting it to the default.
+		setTestModels([
+			{ value: 'gemini-chat-default', label: 'Chat Default', defaultForRoles: ['chat'] },
+			{ value: 'gemini-flash-lite', label: 'Flash Lite' },
+			{ value: 'gemini-summary-default', label: 'Summary Default', defaultForRoles: ['summary'] },
+			{ value: 'gemini-completions-default', label: 'Completions Default', defaultForRoles: ['completions'] },
+			{ value: 'gemini-image-default', label: 'Image Default', defaultForRoles: ['image'] },
+			{ value: 'llama3.2', label: 'Llama 3.2', provider: 'ollama' as const, defaultForRoles: ['chat'] },
+		]);
+		const currentSettings = {
+			provider: 'ollama',
+			chatModelName: 'gemini-flash-lite', // a non-default Gemini choice
+			summaryModelName: 'gemini-summary-default',
+			completionsModelName: 'gemini-completions-default',
+			imageModelName: 'gemini-image-default',
+			ollamaModelName: 'llama3.2',
+		};
+		const result = getUpdatedModelSettings(currentSettings);
+		expect(result.settingsChanged).toBe(false);
+		expect(result.updatedSettings.chatModelName).toBe('gemini-flash-lite');
+		expect(result.updatedSettings.ollamaModelName).toBe('llama3.2');
 	});
 
 	it('should propagate error if GEMINI_MODELS is empty and a model update is attempted', () => {
@@ -284,6 +315,49 @@ describe('getUpdatedModelSettings', () => {
 		// Expect getUpdatedModelSettings to throw the error from getDefaultModelForRole
 		expect(() => getUpdatedModelSettings(currentSettings)).toThrow(
 			'CRITICAL: GEMINI_MODELS array is empty. Please configure available models.'
+		);
+	});
+});
+
+describe('getActiveChatModel', () => {
+	let originalModels: GeminiModel[];
+
+	beforeEach(() => {
+		originalModels = [...GEMINI_MODELS];
+		setTestModels([
+			{ value: 'gemini-chat-default', label: 'Chat Default', defaultForRoles: ['chat'] },
+			{ value: 'gemini-flash-lite', label: 'Flash Lite' },
+			{ value: 'llama3.2', label: 'Llama 3.2', provider: 'ollama' as const, defaultForRoles: ['chat'] },
+		]);
+	});
+
+	afterEach(() => {
+		setTestModels(originalModels);
+	});
+
+	it('returns chatModelName under the Gemini provider', () => {
+		expect(
+			getActiveChatModel({ provider: 'gemini', chatModelName: 'gemini-flash-lite', ollamaModelName: 'llama3.2' })
+		).toBe('gemini-flash-lite');
+	});
+
+	it('defaults to the provider when no explicit provider is set', () => {
+		expect(getActiveChatModel({ chatModelName: 'gemini-flash-lite' })).toBe('gemini-flash-lite');
+	});
+
+	it('returns ollamaModelName under the Ollama provider', () => {
+		expect(
+			getActiveChatModel({ provider: 'ollama', chatModelName: 'gemini-flash-lite', ollamaModelName: 'llama3.2' })
+		).toBe('llama3.2');
+	});
+
+	it('falls back to the Gemini chat default when chatModelName is empty', () => {
+		expect(getActiveChatModel({ provider: 'gemini', chatModelName: '' })).toBe('gemini-chat-default');
+	});
+
+	it('falls back to the Ollama chat default when ollamaModelName is empty', () => {
+		expect(getActiveChatModel({ provider: 'ollama', chatModelName: 'gemini-flash-lite', ollamaModelName: '' })).toBe(
+			'llama3.2'
 		);
 	});
 });

--- a/test/ui/settings-general.test.ts
+++ b/test/ui/settings-general.test.ts
@@ -134,13 +134,13 @@ describe('renderGeneralSettings — model pickers per provider', () => {
 		vi.clearAllMocks();
 	});
 
-	it('renders a single chatModelName picker with the Ollama label/description under Ollama', async () => {
+	it('renders a single ollamaModelName picker with the Ollama label/description under Ollama', async () => {
 		const plugin = createMockPlugin('ollama');
 		await renderGeneralSettings({} as any, plugin, {} as any, createContext());
 
 		expect(renderedModelCalls()).toEqual([
 			{
-				settingName: 'chatModelName',
+				settingName: 'ollamaModelName',
 				label: 'settings.general.ollamaModelName',
 				desc: 'settings.general.ollamaModelDesc',
 			},


### PR DESCRIPTION
## Summary

Switching provider **Gemini → Ollama → Gemini** silently changed the user's chat model. The Ollama single-model picker (#1077/#1125) was bound to the **shared `chatModelName`** field, so:

1. Switching to Ollama overwrote `chatModelName` with an Ollama model (and any prior Gemini choice was lost).
2. Switching back reconciled the now-invalid value to `availableModels[0]` = `gemini-pro-latest`, silently moving the user from their chosen model (e.g. the cheap `gemini-3.1-flash-lite` default) to the pricier **Pro** model — with no notice.

This contradicted the documented "no data is lost… settings persist across switches" guarantee (`provider-capabilities.md`) and has a real cost implication. Found during a pre-release manual test run.

**Fix:** give Ollama its own persisted `ollamaModelName` field and resolve the active chat model provider-aware via a new `getActiveChatModel()` helper. Gemini's per-use-case fields (`chatModelName` / `summaryModelName` / `completionsModelName` / `imageModelName`) are now always reconciled against the Gemini list — never the active provider's — so a round trip preserves both providers' choices. The Gemini-cloud tools (search grounding, URL context, RAG) intentionally keep reading `chatModelName` since they always call Google's API.

Verified live: with the fix, `chatModelName` stays `gemini-3.1-flash-lite` across a full Gemini → Ollama → Gemini round trip while `ollamaModelName` independently holds the Ollama model.

Fixes the #1125 regression.

## Changes

- **`src/models.ts`**: add `getActiveChatModel(settings)` (provider-aware chat-model resolver); restructure `getUpdatedModelSettings` so Gemini fields reconcile against the Gemini list always, and the new `ollamaModelName` reconciles against the Ollama list only once the daemon's models load.
- **`src/main.ts`**: add the `ollamaModelName` setting + default; one-time migration that moves an existing Ollama user's model out of `chatModelName` into `ollamaModelName` and restores a Gemini default for `chatModelName`.
- **`src/api/factory.ts`**: the Ollama branch of `resolveModelName` now returns `ollamaModelName`.
- **`src/ui/settings-general.ts`**: the Ollama model picker binds `ollamaModelName` instead of `chatModelName`.
- Agent/session/task/selection/hook/vault-analyzer paths now resolve the chat model via `getActiveChatModel()` (routing + history metadata correct under either provider).
- **`docs/reference/settings.md`**: document `ollamaModelName`, correct the "bound to `chatModelName`" / "resolves to `chatModelName`" notes, and state that provider switches preserve each model choice.
- **Tests**: `getActiveChatModel` resolver; reconcile preserves Gemini fields under Ollama and backfills `ollamaModelName`; a #1125 round-trip regression test; factory resolves Ollama → `ollamaModelName`; settings picker binds `ollamaModelName`.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer — fixes the #1125 regression; discovered and approved by the maintainer during a pre-release test run
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop — verified the Gemini → Ollama → Gemini round trip preserves the chat model, and the one-time migration
- [ ] I have verified this change does not break Mobile — N/A: settings/model-resolution logic only, no platform-specific code
- [x] Documentation has been updated (if applicable) — `docs/reference/settings.md`
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

https://claude.ai/code/session_01U5znWezBVtCXRDdwn52Xu3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dedicated Ollama model selection, with provider switching now preserving each provider’s last chosen model.

* **Bug Fixes**
  * Ollama settings no longer overwrite Gemini model choices.
  * Model selection now stays consistent across chat, summaries, completions, agent actions, scheduled runs, and token tracking.
  * Improved handling when Ollama model lists are not yet available.

* **Documentation**
  * Updated settings docs to clarify Ollama model behavior and limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->