### PR TITLE
fix: narrow the network-error heuristic to real fetch failures

### DIFF
--- a/src/utils/error-utils.ts
+++ b/src/utils/error-utils.ts
@@ -231,9 +231,14 @@ export function getErrorMessage(error: unknown): string {
 			return 'The selected model is not available. Please check your model settings.';
 		}
 
-		// Network errors
+		// Network errors. Match the specific fetch-failure phrasings — "Failed to
+		// fetch" (Chromium/Electron) and "fetch failed" (Node/undici) — rather than
+		// a bare "fetch" substring, which would misclassify unrelated errors that
+		// merely mention fetch (e.g. "proxyFetch injection failed") as connectivity
+		// problems and send users to check their connection for the wrong reason.
 		if (
-			messageLower.includes('fetch') ||
+			messageLower.includes('failed to fetch') ||
+			messageLower.includes('fetch failed') ||
 			messageLower.includes('network') ||
 			messageLower.includes('econnrefused') ||
 			messageLower.includes('etimedout')

--- a/test/utils/error-utils.test.ts
+++ b/test/utils/error-utils.test.ts
@@ -250,6 +250,25 @@ describe('error-utils', () => {
 				);
 			});
 
+			test('Chromium/Electron "Failed to fetch" is a network error', () => {
+				const error = new Error('Unable to make request: TypeError: Failed to fetch');
+				expect(getErrorMessage(error)).toBe(
+					'Network error: Unable to reach the model API. Please check your connection.'
+				);
+			});
+
+			test('An error that merely mentions "fetch" is not misclassified as a network error', () => {
+				// The bare-"fetch" heuristic used to flag this as a connectivity problem
+				// because "proxyFetch" contains "fetch", sending users to check their
+				// connection instead of the real cause.
+				const error = new Error(
+					'Failed to initialize research client: SDK structure has changed and proxyFetch injection failed.'
+				);
+				expect(getErrorMessage(error)).not.toBe(
+					'Network error: Unable to reach the model API. Please check your connection.'
+				);
+			});
+
 			test('ECONNREFUSED to a non-Ollama localhost endpoint stays generic', () => {
 				// Mention a non-11434 localhost target so this would actually catch a
 				// regression of the old "any localhost ECONNREFUSED is Ollama" heuristic.


### PR DESCRIPTION
## Summary

`getUserFacingErrorMessage()` classified **any** error whose message contained the substring `fetch` as a network error, returning *"Network error: Unable to reach the model API. Please check your connection."* Because the match was a bare substring, unrelated failures that merely mention fetch — e.g. `"proxyFetch injection failed"` — were mislabeled as connectivity problems, sending users to debug their connection for the wrong reason.

This was **Finding 3** from the pre-release acceptance test: it's what masked the real Deep Research error before #1151 (the actionable "SDK structure changed / update the plugin" message was hidden behind the generic network copy). Hardening the classifier so a stray "fetch" in a message can't swallow the real error.

## Changes

- **`src/utils/error-utils.ts`**: replace the bare `messageLower.includes('fetch')` network-error check with the two specific fetch-failure phrasings — `"failed to fetch"` (Chromium/Electron `TypeError`) and `"fetch failed"` (Node/undici). The other signals (`network`, `econnrefused`, `etimedout`) are unchanged.
- **`test/utils/error-utils.test.ts`**: add tests for both directions — a real `"Failed to fetch"` still classifies as a network error, and a `"proxyFetch injection failed"`-style message no longer does.

Existing network-error tests (which use `"fetch failed"` / `ECONNREFUSED` / `ETIMEDOUT`) are unaffected.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer — Finding 3 from the maintainer-run pre-release acceptance test; follow-up to #1151
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop — unit-tested both classification directions
- [ ] I have verified this change does not break Mobile — N/A: pure string-classification logic, no platform-specific code
- [x] Documentation has been updated (if applicable) — N/A: internal error-message classification, no user-facing surface or setting changed
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

https://claude.ai/code/session_01U5znWezBVtCXRDdwn52Xu3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved network error detection so connection failures are more accurately shown as “Unable to reach the model API.”
  * Reduced false positives by avoiding misclassification of unrelated errors that only mention “fetch.”

* **Tests**
  * Added coverage for a Chromium/Electron-style failed request message.
  * Added a regression test to ensure unrelated messages are not treated as network errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->