### PR TITLE
chore(daily): 2026-07-05 daily update

### DIFF
--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -36,7 +36,7 @@ UI sections without a dedicated topic in this reference: _Vault search index_ (c
 - **Type**: `'gemini' | 'ollama'`
 - **Default**: `'gemini'`
 - **Description**: Selects the model backend. `gemini` calls the Google Cloud API; `ollama` calls a local Ollama daemon.
-- **Notes**: Switching providers re-initialises the plugin and resets stale model selections to the new provider's defaults. Provider-coupled features (Google Search, URL Context, Deep Research, image generation, RAG indexing) are hidden when `ollama` is active. See the [Ollama Setup Guide](/guide/ollama-setup) for details.
+- **Notes**: Switching providers re-initialises the plugin. Model selections persist across the switch — the Gemini fields (`chatModelName`, `summaryModelName`, `completionsModelName`, `imageModelName`) and `ollamaModelName` are stored separately, so returning to a provider restores the model you had there; a value is only reset if it's actually stale for its own provider (e.g. a deprecated Gemini model id), never merely because you switched providers. Provider-coupled features (Google Search, URL Context, Deep Research, image generation, RAG indexing) are hidden when `ollama` is active. See the [Ollama Setup Guide](/guide/ollama-setup) for details.
 
 ### Ollama base URL
 

--- a/planning/changelog/2026-07-05.md
+++ b/planning/changelog/2026-07-05.md
@@ -1,0 +1,64 @@
+# Daily changelog — July 05, 2026
+
+**Date:** 2026-07-05
+**PRs merged:** 13
+
+---
+
+## Summary
+
+A dedup-heavy day up front — four architecture-audit/auto-dev refactors collapsing copy-pasted UI and service code into shared helpers — followed by an evening cluster of three fixes from a pre-release manual test pass: a real regression where switching providers silently swapped the user's Gemini chat model, a completely broken Deep Research feature (dead since the `@google/genai` 2.x upgrade), and the network-error misclassification that had been hiding the Deep Research failure's real cause.
+
+## What shipped
+
+### [#1137 Add error handling to fire-and-forget UI handlers](https://github.com/allenhutchison/obsidian-gemini/pull/1137)
+
+Hardens eight fire-and-forget (`void`-dispatched) UI handlers across the scheduled-tasks, scheduler, hook, RAG-settings, and agent-view empty-state surfaces with `try/catch`, so a rejection no longer surfaces as an unhandled promise rejection or leaves a button stuck disabled. Two new i18n keys cover the previously-silent failure paths.
+
+### [#1138 test(scheduled-tasks): add execution.ts dispatch test mirror](https://github.com/allenhutchison/obsidian-gemini/pull/1138)
+
+Adds a direct test mirror for `execution.ts`, the one module in the `scheduled-tasks/` package split that lacked one — pinning the dispatch invariants (no double-firing, no bogus completions) that were previously only exercised indirectly.
+
+### [#1139 refactor(settings): extract shared createDebouncedSave helper](https://github.com/allenhutchison/obsidian-gemini/pull/1139)
+
+Architecture-audit sweep: collapses a byte-identical debounced-save factory that had been copy-pasted into four settings renderers into one `createDebouncedSave()` helper. Pure code motion, no behavior change.
+
+### [#1144 chore(daily): 2026-07-04 daily update](https://github.com/allenhutchison/obsidian-gemini/pull/1144)
+
+The prior day's automated daily-update run: changelog for 2026-07-04, a clean audit-docs pass, no unlabeled issues to triage, and a bundled-skill drift check that errored again on the same GitHub-scope limitation as before.
+
+### [#1140 refactor(tools): extract shared toFileEntry vault serializer](https://github.com/allenhutchison/obsidian-gemini/pull/1140)
+
+Architecture-audit sweep: extracts the identical file/folder entry object built inline in both `read_file`'s folder-listing branch and `list_files` into a shared `toFileEntry()` helper in `vault/utils.ts`.
+
+### [#1145 chore(i18n): Update UI translations](https://github.com/allenhutchison/obsidian-gemini/pull/1145)
+
+Automated regeneration of non-English UI strings from the current `en.ts` source. Contributed by @github-actions[bot].
+
+### [#1146 refactor(api): replace explicit any in src/api with precise types](https://github.com/allenhutchison/obsidian-gemini/pull/1146)
+
+Next slice of the incremental `no-explicit-any` cleanup (after `src/utils`+`src/mcp` and `src/tools`): clears explicit `any` from `src/api` and turns on the lint rule for that directory. Type-only — the built `main.js` is byte-identical. Only the final `src/ui` slice remains on the tracker (#1036).
+
+### [#1147 refactor(ui): extract shared RAG-status panel presenter (#1141)](https://github.com/allenhutchison/obsidian-gemini/pull/1147)
+
+`RagStatusModal` and the RAG tab of `BackgroundTasksModal` rendered the same status panel through two parallel sets of near-identical private methods. Extracts a single presenter module (`rag-status-panel.ts`) both surfaces now delegate to, parameterizing the two real behavioral differences (error formatter, file-row click behavior) rather than branching inside it. Byte-identical output.
+
+### [#1149 refactor(services): extract shared headless-run output helpers (#1142)](https://github.com/allenhutchison/obsidian-gemini/pull/1149)
+
+Slice 1 of #1142: `ScheduledTaskRunner` and `HookRunner` each carried near-identical output-path/write helpers for the headless "run an agent turn, write output to a vault file" pipeline. Extracts the shared mechanics (`resolveOutputPath`, unique-path suffixing, `writeHeadlessOutput`) into `headless-run-output.ts`, with the hook's concurrent-write retry now an optional parameter rather than a per-runner fork. The agent-turn body extraction is a separate follow-up slice.
+
+### [#1150 refactor(ui): pull up shared entity-row shell into ManagementModalBase (#1143)](https://github.com/allenhutchison/obsidian-gemini/pull/1150)
+
+`SchedulerManagementModal` and `HookManagementModal` each reimplemented the same entity-row shell (paused/disabled state classes, status icon). Pulls it into the shared `ManagementModalBase` both already extend, with the active-state icon (`clock` vs `webhook`) as the only per-modal parameter.
+
+### [#1152 fix: give Ollama its own model field so provider switches keep the Gemini chat model](https://github.com/allenhutchison/obsidian-gemini/pull/1152)
+
+Switching provider Gemini → Ollama → Gemini silently changed the user's chat model: the Ollama picker was bound to the shared `chatModelName` field, so switching back reconciled the now-invalid value to the first available Gemini model (often the pricier Pro tier) with no notice — contradicting the documented "settings persist across switches" guarantee. Fixes it by giving Ollama its own persisted `ollamaModelName` field and resolving the active chat model provider-aware via a new `getActiveChatModel()` helper, with a one-time migration for existing Ollama users. Found during a pre-release manual test run; regression from #1125.
+
+### [#1151 fix: restore Deep Research proxyFetch injection for @google/genai 2.x](https://github.com/allenhutchison/obsidian-gemini/pull/1151)
+
+Deep Research had been completely broken since at least the `4.10.2` tag: it threw on every run because its `proxyFetch` injection targeted `interactions._client.fetch`, a path that only existed in the old v0.14.x SDK. In the current 2.x SDK the interactions client is a Speakeasy-generated `ClientSDK` built lazily on first request; the fix traps the `sdk` assignment and injects `proxyFetch` into `sdk._httpClient.fetcher` the moment it's built. Verified end-to-end against the live API. Found during the same pre-release test pass as #1152.
+
+### [#1153 fix: narrow the network-error heuristic to real fetch failures](https://github.com/allenhutchison/obsidian-gemini/pull/1153)
+
+The user-facing error classifier flagged any error message containing the bare substring `fetch` as a network error — which meant the "proxyFetch injection failed" message from #1151's underlying bug was masked behind a generic "check your connection" notice instead of showing the actionable error. Narrows the check to the two real fetch-failure phrasings (`"failed to fetch"`, `"fetch failed"`). Finding 3 from the same pre-release acceptance test.


### PR DESCRIPTION
## Summary

Automated daily housekeeping run (`daily-update` meta-skill) bundling `daily-changelog`, `audit-docs`, `triage-issues`, and the bundled-skill drift check for 2026-07-05.

## Changes

- **daily-changelog**: wrote `planning/changelog/2026-07-05.md` — 13 PRs merged on 2026-07-05. A dedup-heavy morning (four architecture-audit/auto-dev refactors: `createDebouncedSave`, `toFileEntry` vault serializer, RAG-status panel presenter, headless-run-output helpers, `ManagementModalBase` entity-row shell) followed by an evening cluster of three pre-release-test fixes: Ollama got its own `ollamaModelName` field so provider switches no longer silently swap the Gemini chat model (#1152), Deep Research's `proxyFetch` injection was restored for `@google/genai` 2.x (#1151), and the network-error heuristic was narrowed to real fetch failures so it stops masking unrelated errors (#1153).
- **audit-docs**: fixed one conceptual drift item in `docs/reference/settings.md` — the "Provider" setting's Notes still described the pre-#1152 bug ("switching providers... resets stale model selections to the new provider's defaults") as if it were intended behavior. Corrected to describe the actual post-fix behavior: Gemini and Ollama model fields are stored separately and persist across provider switches; a value only resets if it's genuinely stale for its own provider. Everything else checked (settings names/defaults, all 22 agent tool names, command palette IDs, schedule formats, hook frontmatter defaults, loop-detection thresholds, settings-section IDs) matched the code. No new docs warranted — the only two feature commits in the last 3 months are already covered by existing docs.
- **triage-issues**: no-op — confirmed 0 unlabeled open issues (19 open issues total, all already labeled).
- **bundled-skill drift check**: errored — this session's GitHub access is scoped to `allenhutchison/obsidian-gemini` only, so the `kepano/obsidian-skills` upstream comparison could not be run. Same limitation as the prior daily run (#1144); still needs a human, or a session with broader GitHub scope, to check upstream drift for `obsidian-markdown`, `json-canvas`, and `obsidian-bases`.

## Screenshots / Screencast

N/A — changelog and docs-only changes, no UI change.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A; routine automated daily housekeeping run
- [x] All CI checks pass (`npm test` — 3359 passing, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop — N/A, changelog/docs-only change; verified via local pre-flight checks
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A, no code change
- [x] Documentation has been updated (if applicable) — this PR's own audit-docs pass is the documentation update
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR


---
_Generated by [Claude Code](https://claude.ai/code/session_016k94CVcTEcoSafoktcJwVj)_