### PR TITLE
ci(security): document deliberate no-cache posture on release.yml setup-node

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,11 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
+          # No npm cache on purpose. This is the release workflow that publishes
+          # the plugin build and its provenance attestation, so a poisoned or
+          # restored npm cache is a supply-chain risk that outweighs the
+          # install-time saving. Keep caching off on setup-node throughout
+          # release.yml — don't add a `cache:` key here without revisiting that.
           node-version: '24.x'
       - name: Install dependencies
         run: npm install
@@ -48,6 +53,11 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
+          # No npm cache on purpose. This job publishes the plugin build and its
+          # provenance attestation, so a poisoned or restored npm cache is a
+          # supply-chain risk that outweighs the install-time saving. Keep
+          # caching off on setup-node throughout release.yml — don't add a
+          # `cache:` key here without revisiting that.
           node-version: '24.x'
 
       - name: Build plugin


### PR DESCRIPTION
<!-- auto-dev -->

## Summary

Closes the final acceptance item on #1096 (the `zizmor` `cache-poisoning` finding on `release.yml`'s `setup-node` steps). As established in the issue thread, both `setup-node` steps in `release.yml` carry only `node-version: '24.x'` with no `cache:` key — and never have — so there is nothing to remove. Per the maintainer's decision (option 2), this documents the deliberate no-cache posture inline so npm caching can't be silently reintroduced into the artifact- and provenance-publishing workflow without someone seeing the rationale, mirroring the `persist-credentials: false` explanatory comments added in #1127.

Fixes #1096

## Changes

- `.github/workflows/release.yml` — add an explanatory comment to the `with:` block of **both** `actions/setup-node` steps (the `test` job and the artifact/provenance-publishing `build` job) noting that the npm cache is intentionally omitted, because a poisoned or restored cache in the release workflow is a supply-chain risk that outweighs the install-time saving.

Comment-only change to the workflow; `actions/setup-node`'s runtime behavior is unchanged.

## Screenshots / Screencast

<!-- Not applicable — CI/workflow-only change, no UI. -->

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards)
- [x] Documentation has been updated (if applicable)
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude (auto-dev pipeline)
- [x] I have reviewed and understand all AI-generated code in this PR

---

Produced by the auto-dev pipeline from the approved plan on #1096. Pre-flight green locally: `npm run format-check`, `npm run build`, `npm test` (3359 passing), `npm run typecheck:test`, `npm run lint:actions`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CpiCpSWYKXKa25m1exbYhN)_