### PR TITLE
fix(rag): make RAG "show all files" affordance keyboard-accessible

### DIFF
--- a/src/ui/components/rag-status-panel.ts
+++ b/src/ui/components/rag-status-panel.ts
@@ -220,9 +220,18 @@ export function renderRagFileList(container: HTMLElement, status: RagDetailedSta
 	}
 
 	if (!opts.showAll && total > opts.maxInitial) {
-		const more = container.createDiv({ cls: 'rag-status-show-more' });
+		const more = container.createDiv({
+			cls: 'rag-status-show-more',
+			attr: { role: 'button', tabindex: '0' },
+		});
 		more.setText(t('ragStatus.showAllFiles', { count: total.toLocaleString() }));
 		more.addEventListener('click', () => opts.onShowAll());
+		more.addEventListener('keydown', (e) => {
+			if (e.key === 'Enter' || e.key === ' ') {
+				e.preventDefault();
+				opts.onShowAll();
+			}
+		});
 	}
 }
 

--- a/test/ui/components/rag-status-panel.test.ts
+++ b/test/ui/components/rag-status-panel.test.ts
@@ -211,6 +211,32 @@ describe('renderRagFileList', () => {
 		expect(onShowAll).toHaveBeenCalledTimes(1);
 	});
 
+	it('exposes button semantics and invokes onShowAll on Enter/Space (keyboard access)', () => {
+		const container = makeEl('div');
+		const status = statusFixture({
+			indexedFiles: [
+				{ path: 'a.md', lastIndexed: 1 },
+				{ path: 'b.md', lastIndexed: 2 },
+			],
+		});
+		const onShowAll = vi.fn();
+		renderRagFileList(container, status, baseFileListOptions({ maxInitial: 1, onShowAll }));
+		const more = container.querySelector('.rag-status-show-more') as HTMLElement;
+
+		expect(more.getAttribute('role')).toBe('button');
+		expect(more.getAttribute('tabindex')).toBe('0');
+
+		more.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true }));
+		expect(onShowAll).toHaveBeenCalledTimes(1);
+
+		more.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true, cancelable: true }));
+		expect(onShowAll).toHaveBeenCalledTimes(2);
+
+		// An unrelated key does not activate the control.
+		more.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', bubbles: true, cancelable: true }));
+		expect(onShowAll).toHaveBeenCalledTimes(2);
+	});
+
 	it('renders plain, non-interactive rows when onOpenFile is omitted', () => {
 		const container = makeEl('div');
 		const status = statusFixture({ indexedFiles: [{ path: 'note.md', lastIndexed: 1 }] });


### PR DESCRIPTION
<!-- auto-dev -->

## Summary

The "show all N files" control in the shared RAG-status panel was a plain `div` with only a `click` listener — no `role`, no `tabindex`, and no keyboard handling — so it could not be reached or activated by keyboard. This gives it button semantics and Enter/Space activation.

Because both the standalone `RagStatusModal` and the Background Tasks "RAG" tab now render through `renderRagFileList` (after #1147), this single fix restores keyboard access on both surfaces at once.

Fixes #1148

This PR was produced by the auto-dev pipeline from the approved plan on the issue.

## Changes

- `src/ui/components/rag-status-panel.ts` — in `renderRagFileList`, the `rag-status-show-more` element now sets `role="button"` and `tabindex="0"`, and gains a `keydown` handler that calls `opts.onShowAll()` on `Enter`/`Space` (with `preventDefault()`), alongside the existing `click` listener.
- `test/ui/components/rag-status-panel.test.ts` — added a test asserting the affordance exposes `role="button"`/`tabindex="0"`, activates `onShowAll` on Enter and Space, and ignores unrelated keys (the click path was already covered).

## Screenshots / Screencast

Not applicable — this is a non-visual accessibility change (keyboard activation and ARIA semantics on an existing control; no visual appearance change).

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards)
- [x] Documentation has been updated (if applicable) — no user-facing docs change; internal a11y fix to existing UI
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (auto-dev pipeline)
- [x] I have reviewed and understand all AI-generated code in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FekVoriPRorP4RUYXDqurU)_