### PR TITLE
chore(daily): 2026-07-06 daily update

### DIFF
--- a/docs/guide/custom-prompts.md
+++ b/docs/guide/custom-prompts.md
@@ -316,9 +316,8 @@ Always maintain academic objectivity and cite sources appropriately.
    - Ensure proper YAML frontmatter formatting
    - Verify required fields (`name`, `description`) are present
 
-2. **Confirm settings**
-   - "Enable Custom Prompts" is ON
-   - Prompt file exists in the `[state-folder]/Prompts/` folder
+2. **Confirm the file location**
+   - Prompt file exists in the `[state-folder]/Prompts/` folder (there's no separate "enable custom prompts" toggle — any valid prompt file there is available)
 
 3. **Check session settings**
    - Open the session settings (gear icon) and verify the prompt is selected

--- a/planning/changelog/2026-07-06.md
+++ b/planning/changelog/2026-07-06.md
@@ -1,0 +1,24 @@
+# Daily changelog — July 06, 2026
+
+**Date:** 2026-07-06
+**PRs merged:** 3
+
+---
+
+## Summary
+
+A quiet day: the prior day's automated daily-update PR, a bot-curated model list refresh, and one small `auto-dev`-built compliance fix closing out a lingering security finding.
+
+## What shipped
+
+### [#1157 chore(daily): 2026-07-05 daily update](https://github.com/allenhutchison/obsidian-gemini/pull/1157)
+
+The prior day's automated daily-update run: changelog for 2026-07-05, a docs fix correcting the settings reference's stale description of the pre-#1152 provider-switch model bug, no unlabeled issues to triage, and a bundled-skill drift check that errored again on the same GitHub-scope limitation as recent runs.
+
+### [#1156 chore: Update available Gemini models](https://github.com/allenhutchison/obsidian-gemini/pull/1156)
+
+Automated model list update from Google's API, reviewed and merged by the maintainer. Contributed by @github-actions[bot].
+
+### [#1158 ci(security): document deliberate no-cache posture on release.yml setup-node](https://github.com/allenhutchison/obsidian-gemini/pull/1158)
+
+Closes the final acceptance item on #1096 (a `zizmor` `cache-poisoning` finding on `release.yml`'s `setup-node` steps). Both `setup-node` steps only ever set `node-version`, with no `cache:` key, so there was nothing to remove — this adds an explanatory comment to both so the no-cache posture can't be silently reversed without someone seeing the supply-chain rationale, mirroring the `persist-credentials: false` comments from #1127. Built by the auto-dev pipeline from the approved plan on #1096.


### PR DESCRIPTION
## Summary

Automated daily housekeeping run (`daily-update` meta-skill) bundling `daily-changelog`, `audit-docs`, `triage-issues`, and the bundled-skill drift check for 2026-07-06.

## Changes

- **daily-changelog**: wrote `planning/changelog/2026-07-06.md` — 3 PRs merged on 2026-07-06, a quiet day: the prior daily-update PR (#1157), a bot-curated Gemini model list refresh (#1156), and a small auto-dev-built fix documenting the deliberate no-cache posture on `release.yml`'s `setup-node` steps (#1158).
- **audit-docs**: one real drift fix — `docs/guide/custom-prompts.md`'s troubleshooting section told users to check that an "Enable Custom Prompts" setting is ON, but no such setting exists in the code (only `allowSystemPromptOverride` lives in the Custom Prompts settings section). Custom prompts have no master toggle; they're available as soon as a valid prompt file exists in `[state-folder]/Prompts/`. Changed the troubleshooting step to point at file location instead of a nonexistent setting. Everything else checked (settings names/defaults, command IDs, schedule formats, tool names, permission tiers, frontmatter fields, loop-detection thresholds, provider capability matrix, bundled-skills list, i18n language list) matched the code. No new docs warranted — recent `src/` history is almost entirely refactors/typing cleanups already reflected in existing docs.
- **triage-issues**: no-op — confirmed 0 unlabeled open issues.
- **bundled-skill drift check**: errored — this session's GitHub access is scoped to `allenhutchison/obsidian-gemini` only, so the `kepano/obsidian-skills` upstream comparison could not be run. Same limitation as the last several daily runs; still needs a human, or a session with broader GitHub scope, to check upstream drift for `obsidian-markdown`, `json-canvas`, and `obsidian-bases`.

## Screenshots / Screencast

N/A — changelog and docs-only changes, no UI change.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A; routine automated daily housekeeping run
- [x] All CI checks pass (`npm test` — 3359 passing, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop — N/A, changelog/docs-only change; verified via local pre-flight checks
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A, no code change
- [x] Documentation has been updated (if applicable) — this PR's own audit-docs pass is the documentation update
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_016ZAwperFvJhHMpye4UZ7uv)_