### PR TITLE
refactor: clear the last no-explicit-any violations, enforce across src

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -9,7 +9,9 @@ import obsidianmd from 'eslint-plugin-obsidianmd';
 // remaining violations are cleared (the `'error'` entries below are already
 // enforced; the `'off'` entries are tracked in sibling #1032 issues).
 const SOFTENED_TS_RULES = {
-	'@typescript-eslint/no-explicit-any': 'off',
+	// #1036: cleared — enforced across src/ (test/ overrides back to 'off' below;
+	// mock plumbing there is tracked separately, not part of #1036's src scope).
+	'@typescript-eslint/no-explicit-any': 'error',
 	'@typescript-eslint/no-unsafe-argument': 'off',
 	'@typescript-eslint/no-unsafe-assignment': 'off',
 	'@typescript-eslint/no-unsafe-call': 'off',
@@ -149,14 +151,6 @@ export default defineConfig([
 		rules: { ...SOFTENED_TS_RULES, ...PERVASIVE_OBSIDIANMD_RULES_TODO },
 	},
 	{
-		// #1036: `no-explicit-any` is cleared for these directories, so enforce it here
-		// to prevent regressions while the rule stays globally softened for the rest of
-		// `src/` (remaining areas — src/agent, src/services, src/types, src/subscribers,
-		// src/main.ts, src/models.ts — still tracked in #1036).
-		files: ['src/utils/**/*.ts', 'src/mcp/**/*.ts', 'src/tools/**/*.ts', 'src/api/**/*.ts', 'src/ui/**/*.ts'],
-		rules: { '@typescript-eslint/no-explicit-any': 'error' },
-	},
-	{
 		// Files fully migrated off direct `style.X = ...` assignments to CSS classes.
 		// Enforce `no-static-styles-assignment` here so they cannot regress while the
 		// rule stays globally disabled for the remaining unmigrated files (#1034).
@@ -173,6 +167,9 @@ export default defineConfig([
 		rules: {
 			...SOFTENED_TS_RULES,
 			...PERVASIVE_OBSIDIANMD_RULES_TODO,
+			// `any` is pervasive in test mocks/fixtures (~1.8k occurrences) and outside
+			// #1036's src-only scope — keep it off here.
+			'@typescript-eslint/no-explicit-any': 'off',
 			// Tests legitimately use Node.js modules for fixtures and don't run in Obsidian.
 			'import/no-nodejs-modules': 'off',
 			// Tests run in jsdom, where Obsidian's createEl/createDiv/createSpan DOM

--- a/src/agent/agent-event-bus.ts
+++ b/src/agent/agent-event-bus.ts
@@ -14,7 +14,14 @@ import { getRawErrorMessage } from '../utils/error-utils';
  * Errors in handlers are logged but never propagate.
  */
 export class AgentEventBus {
-	private handlers = new Map<string, HandlerRegistration<any>[]>();
+	/**
+	 * Heterogeneous per-event storage: each key's array only ever holds
+	 * registrations for that event (enforced by the generic signatures of
+	 * on/off/emit), but a Map value type can't express that per-key link.
+	 * `never` makes the arrays accept any registration contravariantly; emit
+	 * re-asserts the concrete handler type at the single dispatch site.
+	 */
+	private handlers = new Map<AgentEventName, HandlerRegistration<never>[]>();
 	private logger: Logger;
 
 	constructor(logger: Logger) {
@@ -58,11 +65,13 @@ export class AgentEventBus {
 		if (!registrations || registrations.length === 0) return;
 
 		const sorted = [...registrations].sort((a, b) => a.priority - b.priority);
-		const frozenPayload = Object.freeze(payload);
+		// Safe: every AgentEventMap payload is declared Readonly<…>, so freezing
+		// doesn't change the type handlers were declared against.
+		const frozenPayload = Object.freeze(payload) as AgentEventMap[E];
 
 		for (const { handler } of sorted) {
 			try {
-				await handler(frozenPayload);
+				await (handler as AgentEventHandler<E>)(frozenPayload);
 			} catch (error) {
 				this.logger.error(`Handler error for event "${event}":`, getRawErrorMessage(error));
 			}

--- a/src/agent/agent-loop-helpers.ts
+++ b/src/agent/agent-loop-helpers.ts
@@ -17,7 +17,7 @@ import type { ToolResult } from '../tools/types';
  */
 export interface ToolCallResultPair {
 	toolName: string;
-	toolArguments: Record<string, any>;
+	toolArguments: Record<string, unknown>;
 	result: ToolResult;
 }
 

--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -2,6 +2,7 @@ import type { Content } from '@google/genai';
 import { getActiveChatModel } from '../models';
 import type { ObsidianGemini } from '../types/plugin';
 import type { ChatSession, PerTurnContext } from '../types/agent';
+import type { AgentEventMap, AgentEventName } from '../types/agent-events';
 import type { FeatureToolPolicy } from '../types/tool-policy';
 import type { ToolCall, ModelResponse, ModelApi, StreamChunk } from '../api/interfaces/model-api';
 import type { CustomPrompt } from '../prompts/types';
@@ -647,9 +648,13 @@ export class AgentLoop {
 	 * hooks. A subscriber's failure is observability noise, not a reason to
 	 * abort an in-flight agent turn.
 	 */
-	private async safeEmit(plugin: ObsidianGemini, event: string, payload: any): Promise<void> {
+	private async safeEmit<E extends AgentEventName>(
+		plugin: ObsidianGemini,
+		event: E,
+		payload: AgentEventMap[E]
+	): Promise<void> {
 		try {
-			await plugin.agentEventBus?.emit(event as any, payload);
+			await plugin.agentEventBus?.emit(event, payload);
 		} catch (error) {
 			plugin.logger.error(`[AgentLoop] Event bus emit "${event}" threw — continuing:`, error);
 		}

--- a/src/agent/session-history.ts
+++ b/src/agent/session-history.ts
@@ -1,6 +1,6 @@
 import { TFile, TFolder, normalizePath } from 'obsidian';
 import { ChatSession } from '../types/agent';
-import { GeminiConversationEntry } from '../types/conversation';
+import { ConversationEntryMetadata, GeminiConversationEntry } from '../types/conversation';
 import type { ObsidianGemini } from '../types/plugin';
 import { pathToWikilink } from '../utils/accessed-files';
 import { formatLocalTimestamp } from '../utils/format-utils';
@@ -125,7 +125,7 @@ export class SessionHistory {
 			topP: entry.metadata?.topP,
 			customPrompt: entry.metadata?.customPrompt,
 			toolsUsed: [], // TODO: Add tool support later
-			isDefined: (value: any) => value !== undefined,
+			isDefined: (value: unknown) => value !== undefined,
 		});
 
 		const newContent = existingContent + '\n' + entryContent;
@@ -247,7 +247,7 @@ export class SessionHistory {
 					const message = this.extractCalloutBody(lines, i).join('\n').trim();
 					if (!message) continue;
 
-					const metadata: Record<string, any> = {};
+					const metadata: ConversationEntryMetadata = {};
 					const isPlanCallout = calloutType === 'plan';
 					if (!isPlanCallout && toolNameMatch) {
 						metadata.toolName = toolNameMatch[1];
@@ -341,7 +341,7 @@ export class SessionHistory {
 	 * Apply session metadata to file frontmatter using Obsidian API
 	 */
 	private async applySessionFrontmatter(file: TFile, session: ChatSession): Promise<void> {
-		await this.plugin.app.fileManager.processFrontMatter(file, (frontmatter: any) => {
+		await this.plugin.app.fileManager.processFrontMatter(file, (frontmatter: Record<string, unknown>) => {
 			// Required fields - always set
 			frontmatter.session_id = session.id;
 			frontmatter.type = session.type;

--- a/src/main.ts
+++ b/src/main.ts
@@ -405,7 +405,7 @@ export default class ObsidianGemini extends Plugin implements ObsidianGeminiApi 
 			const stored = this.app.secretStorage.getSecret(MIGRATION_SECRET_NAME);
 			if (stored === data.apiKey) {
 				this.settings.apiKeySecretName = MIGRATION_SECRET_NAME;
-				delete (this.settings as any).apiKey;
+				delete (this.settings as { apiKey?: unknown }).apiKey;
 				await this.saveData(this.settings);
 				this.logger?.log('Migrated API key from settings to secure storage');
 			} else {
@@ -427,8 +427,8 @@ export default class ObsidianGemini extends Plugin implements ObsidianGeminiApi 
 
 		// Migrate: remove deprecated modelDiscovery and modelDiscoveryCache
 		if (data?.modelDiscovery !== undefined || data?.modelDiscoveryCache !== undefined) {
-			delete (this.settings as any).modelDiscovery;
-			delete (this.settings as any).modelDiscoveryCache;
+			delete (this.settings as { modelDiscovery?: unknown }).modelDiscovery;
+			delete (this.settings as { modelDiscoveryCache?: unknown }).modelDiscoveryCache;
 			await this.saveData(this.settings);
 			this.logger?.log('Removed deprecated model discovery settings');
 		}
@@ -444,7 +444,7 @@ export default class ObsidianGemini extends Plugin implements ObsidianGeminiApi 
 				toolPermissions: {},
 			};
 			// Clear the legacy setting
-			delete (this.settings as any).alwaysAllowReadWrite;
+			delete (this.settings as { alwaysAllowReadWrite?: unknown }).alwaysAllowReadWrite;
 			await this.saveData(this.settings);
 			this.logger?.log(
 				`Migrated alwaysAllowReadWrite=${data.alwaysAllowReadWrite} → toolPolicy.activePreset=${this.settings.toolPolicy.activePreset}`

--- a/src/models.ts
+++ b/src/models.ts
@@ -91,8 +91,27 @@ export function getActiveChatModel(settings: {
 	return settings.chatModelName || getDefaultModelForRole('chat', 'gemini');
 }
 
-export interface ModelUpdateResult {
-	updatedSettings: any; // Ideally, this would be ObsidianGeminiSettings, but that would create a circular dependency
+/**
+ * The slice of plugin settings that model reconciliation reads and rewrites.
+ * Structural on purpose: importing ObsidianGeminiSettings here would create a
+ * models.ts ↔ types/settings.ts import cycle (types/settings.ts imports
+ * GeminiModel/ModelProvider from this module), which the lint:cycles gate
+ * forbids. ObsidianGeminiSettings satisfies this shape structurally.
+ */
+export interface ModelSettingsSlice {
+	chatModelName: string;
+	summaryModelName: string;
+	completionsModelName: string;
+	imageModelName: string;
+	/**
+	 * Optional: the Ollama model is only reconciled once the daemon's models are
+	 * known, and callers (tests, partial fixtures) may omit the field entirely.
+	 */
+	ollamaModelName?: string;
+}
+
+export interface ModelUpdateResult<T extends ModelSettingsSlice = ModelSettingsSlice> {
+	updatedSettings: T;
 	settingsChanged: boolean;
 	changedSettingsInfo: string[];
 }
@@ -127,12 +146,15 @@ export function migrateOllamaModelSetting(
 	return false;
 }
 
-export function getUpdatedModelSettings(currentSettings: any): ModelUpdateResult {
+export function getUpdatedModelSettings<T extends ModelSettingsSlice>(currentSettings: T): ModelUpdateResult<T> {
 	const geminiModelValues = new Set(GEMINI_MODELS.filter((m) => getModelProvider(m) === 'gemini').map((m) => m.value));
 	const ollamaModelValues = new Set(GEMINI_MODELS.filter((m) => getModelProvider(m) === 'ollama').map((m) => m.value));
 	let settingsChanged = false;
 	const changedSettingsInfo: string[] = [];
 	const newSettings = { ...currentSettings };
+	// Mutations go through a ModelSettingsSlice-typed view of the same object so
+	// the writes below don't have to assign into generic indexed-access types.
+	const modelFields: ModelSettingsSlice = newSettings;
 
 	// The Gemini per-use-case fields are always reconciled against the (always
 	// bundled) Gemini list, regardless of the active provider. This migrates
@@ -145,13 +167,13 @@ export function getUpdatedModelSettings(currentSettings: any): ModelUpdateResult
 		role: ModelRole,
 		label: string
 	) => {
-		const previous = newSettings[key];
+		const previous = modelFields[key];
 		if (previous && geminiModelValues.has(previous)) return;
 		const next = getDefaultModelForRole(role, 'gemini');
 		// Image generation has no dedicated default in some model lists; leave a
 		// stale image model untouched rather than blanking it.
 		if (!next) return;
-		newSettings[key] = next;
+		modelFields[key] = next;
 		changedSettingsInfo.push(`${label}: '${previous}' -> '${next}' (legacy model update)`);
 		settingsChanged = true;
 	};
@@ -166,11 +188,11 @@ export function getUpdatedModelSettings(currentSettings: any): ModelUpdateResult
 	// empty or stale value so a switch made while the daemon was unreachable
 	// doesn't blank it, and a Gemini model name is never sent to Ollama.
 	if (ollamaModelValues.size > 0) {
-		const previous = newSettings.ollamaModelName;
+		const previous = modelFields.ollamaModelName;
 		if (!previous || !ollamaModelValues.has(previous)) {
 			const next = getDefaultModelForRole('chat', 'ollama');
 			if (next && next !== previous) {
-				newSettings.ollamaModelName = next;
+				modelFields.ollamaModelName = next;
 				changedSettingsInfo.push(`Ollama model: '${previous ?? ''}' -> '${next}' (legacy model update)`);
 				settingsChanged = true;
 			}

--- a/src/services/context-manager.ts
+++ b/src/services/context-manager.ts
@@ -323,13 +323,11 @@ export class ContextManager {
 		}
 
 		try {
-			const config: any = {};
 			const response = await executeWithRetry(
 				() =>
 					this.ai!.models.countTokens({
 						model: modelName,
 						contents: sanitizedContents,
-						config: Object.keys(config).length > 0 ? config : undefined,
 					}),
 				undefined,
 				{ operationName: 'ContextManager.countTokens', logger: this.logger }

--- a/src/services/deep-research.ts
+++ b/src/services/deep-research.ts
@@ -197,7 +197,7 @@ export class DeepResearchService {
 
 		// Check status
 		if (completed.status === 'failed') {
-			const errorMessage = (completed as any).error?.message || 'Unknown error';
+			const errorMessage = (completed as { error?: { message?: string } }).error?.message || 'Unknown error';
 			// Clear interaction ID on terminal failure state
 			this.currentInteractionId = null;
 			throw new Error(`Research failed: ${errorMessage}`);

--- a/src/services/model-manager.ts
+++ b/src/services/model-manager.ts
@@ -1,6 +1,7 @@
 import type { ObsidianGemini } from '../types/plugin';
 import * as modelsModule from '../models';
 import { GeminiModel, ModelUpdateResult, getUpdatedModelSettings, DEFAULT_GEMINI_MODELS } from '../models';
+import type { ObsidianGeminiSettings } from '../types/settings';
 import { ModelListProvider, RefreshResult } from './model-list-provider';
 import { OllamaModelsService } from './ollama-models-service';
 import { ParameterValidationService, ParameterRanges } from './parameter-validation';
@@ -52,7 +53,7 @@ export class ModelManager {
 	/**
 	 * Update the global GEMINI_MODELS list from the active provider and fix any stale settings.
 	 */
-	async updateModels(options: ModelUpdateOptions = {}): Promise<ModelUpdateResult> {
+	async updateModels(options: ModelUpdateOptions = {}): Promise<ModelUpdateResult<ObsidianGeminiSettings>> {
 		const allModels =
 			this.plugin.settings.provider === 'ollama'
 				? await this.ollamaModelsService.getModels(options.forceRefresh)

--- a/src/services/project-manager.ts
+++ b/src/services/project-manager.ts
@@ -116,7 +116,7 @@ export class ProjectManager {
 		const file = this.plugin.app.vault.getAbstractFileByPath(filePath);
 		if (!(file instanceof TFile)) return;
 
-		await this.plugin.app.fileManager.processFrontMatter(file, (frontmatter: any) => {
+		await this.plugin.app.fileManager.processFrontMatter(file, (frontmatter: Record<string, unknown>) => {
 			if (updates.name !== undefined) frontmatter.name = updates.name;
 			if (updates.skills !== undefined) frontmatter.skills = updates.skills;
 			if ('toolPolicy' in updates) {
@@ -161,7 +161,7 @@ Add your project instructions here. This text will be injected into the agent's 
 	 * Add the project tag to an existing note, converting it into a project.
 	 */
 	async convertNoteToProject(file: TFile): Promise<void> {
-		await this.plugin.app.fileManager.processFrontMatter(file, (frontmatter: any) => {
+		await this.plugin.app.fileManager.processFrontMatter(file, (frontmatter: Record<string, unknown>) => {
 			// Normalize tags to array (handle string, array, or missing)
 			let tags: string[] = [];
 			if (Array.isArray(frontmatter.tags)) {
@@ -184,7 +184,7 @@ Add your project instructions here. This text will be injected into the agent's 
 	 * Remove the project tag from a file, stripping its project status.
 	 */
 	async removeProject(file: TFile): Promise<void> {
-		await this.plugin.app.fileManager.processFrontMatter(file, (frontmatter: any) => {
+		await this.plugin.app.fileManager.processFrontMatter(file, (frontmatter: Record<string, unknown>) => {
 			// Normalize tags to array (handle string or array)
 			let tags: string[] = [];
 			if (Array.isArray(frontmatter.tags)) {
@@ -278,7 +278,7 @@ Add your project instructions here. This text will be injected into the agent's 
 		// Failures here are non-fatal — the in-memory shape is correct either way.
 		if (frontmatter.permissions !== undefined && frontmatter.toolPolicy === undefined) {
 			try {
-				await this.plugin.app.fileManager.processFrontMatter(file, (fm: any) => {
+				await this.plugin.app.fileManager.processFrontMatter(file, (fm: Record<string, unknown>) => {
 					const serialized = serializeToolPolicy(config.toolPolicy);
 					if (serialized) {
 						fm.toolPolicy = serialized;

--- a/src/services/rag-status-bar.ts
+++ b/src/services/rag-status-bar.ts
@@ -1,6 +1,6 @@
 import { App, Notice, setIcon, setTooltip } from 'obsidian';
 import type { ObsidianGemini } from '../types/plugin';
-import type { RagIndexStatus, RagProgressInfo, IndexResult, ProgressListener } from './rag-types';
+import type { RagIndexStatus, RagProgressInfo, IndexResult, ProgressListener, RagDetailedStatus } from './rag-types';
 import { getErrorMessage } from '../utils/error-utils';
 import { openPluginSettingsTab } from '../utils/obsidian-settings';
 import { t } from '../i18n';
@@ -15,7 +15,7 @@ export interface RagStatusProvider {
 	getProgressInfo(): RagProgressInfo;
 	isPaused(): boolean;
 	getRateLimitRemainingSeconds(): number;
-	getDetailedStatus(): any;
+	getDetailedStatus(): RagDetailedStatus;
 	indexVault(): Promise<IndexResult>;
 	syncPendingChanges(): Promise<boolean>;
 	addProgressListener(listener: ProgressListener): void;

--- a/src/services/rag-vault-scanner.ts
+++ b/src/services/rag-vault-scanner.ts
@@ -1,6 +1,6 @@
 import { TFile, Notice } from 'obsidian';
 import type { GoogleGenAI } from '@google/genai';
-import type { FileUploader } from '@allenhutchison/gemini-utils';
+import type { FileUploader, UploadProgressEvent } from '@allenhutchison/gemini-utils';
 import type { ObsidianGemini } from '../types/plugin';
 import type { ObsidianVaultAdapter } from './obsidian-file-adapter';
 import type { RagCache } from './rag-cache';
@@ -420,11 +420,11 @@ export class RagVaultScanner {
 				smartSync: true,
 				parallel: { maxConcurrent: 5 },
 				logger: {
-					debug: (msg: string, ...args: any[]) => this.plugin.logger.debug(msg, ...args),
+					debug: (msg: string, ...args: unknown[]) => this.plugin.logger.debug(msg, ...args),
 					// Per-file upload failures are already tracked via the file_error progress
 					// event and surfaced in the RAG Failures tab — downgrade to warn to avoid
 					// alarming console noise for routine skips (empty files, inaccessible notes).
-					error: (msg: string, ...args: any[]) => this.plugin.logger.warn(msg, ...args),
+					error: (msg: string, ...args: unknown[]) => this.plugin.logger.warn(msg, ...args),
 				},
 				// ProgressCallback is typed `(event) => void`, but this handler must be async:
 				// it awaits per-file hashing / incremental cache saves, and it *throws* to signal
@@ -432,7 +432,7 @@ export class RagVaultScanner {
 				// in tests) await and rely on propagating. Wrapping the body to void the promise
 				// would swallow those throws, so the async signature is intentional here.
 				// eslint-disable-next-line @typescript-eslint/no-misused-promises -- async handler must propagate cancellation/rate-limit throws
-				onProgress: async (event: any) => {
+				onProgress: async (event: UploadProgressEvent) => {
 					// Check for cancellation
 					if (this.cancelRequested) {
 						throw new Error('Indexing cancelled by user');

--- a/src/subscribers/accessed-files-subscriber.ts
+++ b/src/subscribers/accessed-files-subscriber.ts
@@ -1,7 +1,6 @@
 import type { ObsidianGemini } from '../types/plugin';
 import { HandlerPriority } from '../types/agent-events';
 import { extractAccessedPaths } from '../utils/accessed-files';
-import { ToolResult } from '../tools/types';
 
 /**
  * Subscribes to toolChainComplete to track which files the agent
@@ -17,13 +16,7 @@ export class AccessedFilesSubscriber {
 				'toolChainComplete',
 				async (payload) => {
 					const session = payload.session;
-					const accessedPaths = extractAccessedPaths(
-						payload.toolResults as Array<{
-							toolName: string;
-							toolArguments: any;
-							result: ToolResult;
-						}>
-					);
+					const accessedPaths = extractAccessedPaths(payload.toolResults);
 					if (accessedPaths.length === 0) return;
 
 					if (!session.accessedFiles) {

--- a/src/types/agent.ts
+++ b/src/types/agent.ts
@@ -112,7 +112,7 @@ export interface ChatSession {
 	/** Additional metadata for the session */
 	metadata?: {
 		autoLabeled?: boolean;
-		[key: string]: any;
+		[key: string]: unknown;
 	};
 
 	/** In-memory set of file paths accessed during this session. Converted to wikilinks and persisted to frontmatter as accessed_files. */

--- a/src/types/conversation.ts
+++ b/src/types/conversation.ts
@@ -1,16 +1,31 @@
+/**
+ * Optional per-entry metadata persisted with conversation history. Known keys
+ * are typed; the index signature keeps room for forward-compatible extras
+ * parsed back from older/newer history files.
+ */
+export interface ConversationEntryMetadata {
+	temperature?: number;
+	topP?: number;
+	customPrompt?: string;
+	/** Set on tool-activity entries parsed from session history. */
+	toolName?: string;
+	toolStatus?: string;
+	[key: string]: unknown;
+}
+
 export interface BasicGeminiConversationEntry {
 	role: 'user' | 'model' | 'system';
 	message: string;
 	userMessage?: string;
 	model?: string;
-	metadata?: Record<string, any>;
+	metadata?: ConversationEntryMetadata;
 }
 
 export interface GeminiConversationEntry extends BasicGeminiConversationEntry {
 	id?: number;
 	notePath: string;
 	created_at: Date;
-	metadata?: Record<string, any>;
+	metadata?: ConversationEntryMetadata;
 	/**
 	 * Model reasoning ("thinking") captured for this turn, when the model is a
 	 * thinking model and emitted thought summaries. Persisted to session history

--- a/src/utils/accessed-files.ts
+++ b/src/utils/accessed-files.ts
@@ -23,7 +23,7 @@ interface ToolResultEntry {
  * occurs in agent-view-tools.ts when paths are added to the session Set.
  * Search/list tools are excluded to avoid noise.
  */
-export function extractAccessedPaths(toolResults: ToolResultEntry[]): string[] {
+export function extractAccessedPaths(toolResults: readonly ToolResultEntry[]): string[] {
 	const paths: string[] = [];
 
 	for (const tr of toolResults) {


### PR DESCRIPTION
## Summary

Fixes #1036.

Finishes the strict-typing pass: the previous slices (#1118 utils/mcp, #1146 api, #1163 ui, plus tools) cleared their directories with per-directory enforcement; this PR fixes the **27 remaining occurrences** (src/agent, src/services, src/types, src/subscribers, main.ts, models.ts) and flips `@typescript-eslint/no-explicit-any` to **`error` for all of `src/`**, removing the per-directory scaffolding. `npx eslint src` with the rule forced now reports **0 violations**.

Per the issue's guidance, fixes prefer precise types or `unknown` + narrowing. Two spots use targeted, commented casts at genuine variance boundaries (the event bus's heterogeneous handler map and its frozen-payload dispatch) — no `any`, no eslint disables.

## Changes

- **Typed conversation metadata** (`src/types/conversation.ts`): new `ConversationEntryMetadata` (known keys + `unknown` index signature) replaces `Record<string, any>` on both entry interfaces; session metadata's index signature (`src/types/agent.ts`) tightens to `unknown`
- **Event bus** (`src/agent/agent-event-bus.ts`): handler map stores registrations contravariantly (`HandlerRegistration<never>`) with one commented cast at the single dispatch site; `AgentLoop.safeEmit` becomes generic over `AgentEventMap`, so every emitted payload now type-checks against the event map (`src/agent/agent-loop.ts`)
- **models.ts**: new structural `ModelSettingsSlice` documents why it can't import `ObsidianGeminiSettings` (would create a `models ↔ types/settings` cycle the `lint:cycles` gate forbids); `getUpdatedModelSettings`/`ModelUpdateResult` become generic; `ModelManager.updateModels` returns `ModelUpdateResult<ObsidianGeminiSettings>` so `LifecycleService`'s `plugin.settings = result.updatedSettings` stays sound
- **Frontmatter callbacks** (`session-history.ts`, `project-manager.ts` ×4): `(frontmatter: any)` → `Record<string, unknown>`
- **Legacy settings migrations** (`main.ts` ×4): `delete (this.settings as any).X` → single-field optional casts (`as { apiKey?: unknown }` etc.)
- **RAG** : `RagStatusProvider.getDetailedStatus()` returns the existing `RagDetailedStatus` type (called out in the issue body); scanner logger args → `unknown[]`; `onProgress` event typed with gemini-utils' exported `UploadProgressEvent`
- **`ContextManager.countTokens`**: removed a dead, always-empty `config: any` object (it unconditionally resolved to `config: undefined` — behavior unchanged)
- **`extractAccessedPaths`** accepts `readonly` arrays, which deletes the subscriber's shape-cast entirely
- **eslint.config.mjs**: `no-explicit-any: 'error'` in `SOFTENED_TS_RULES` (annotated `#1036: cleared`), per-directory enforcement block removed, `test/**` explicitly keeps the rule off (~1.8k occurrences in mock plumbing, outside this issue's src-only scope)

## Documentation

Internal typing/lint change with no user-facing behavior; eslint.config.mjs comments updated in place (they are the living documentation of the rule-tightening ledger). No `docs/` changes needed.

## Testing

- `npx eslint src` with `no-explicit-any` forced: **0 violations** (was 27); `npm run lint`: 0 errors
- `npm test`: 3360/3360 pass (155 files)
- `npm run typecheck:test`: clean (caught and drove the `ModelSettingsSlice.ollamaModelName?` design — test fixtures legitimately omit it, matching the function's lazy-Ollama tolerance)
- `npm run build`, `npm run lint:cycles` (0 cycles), `npm run knip`, `npm run format-check`: all clean

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop (full unit suite; type-level change — the only runtime delta is the dead empty `config` object removal, covered by countTokens tests)
- [x] I have verified this change does not break Mobile (no platform-facing behavior change)
- [x] Documentation has been updated (eslint.config.mjs rule-ledger comments; no user-facing changes)
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

https://claude.ai/code/session_01RZfXTNYfPsWjk32qrxV4dx