### PR TITLE
refactor: clear and enforce four more softened lint rules (#1032)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -25,16 +25,21 @@ const SOFTENED_TS_RULES = {
 	'@typescript-eslint/no-misused-promises': 'error',
 	// #1037: cleared — enforced.
 	'@typescript-eslint/no-floating-promises': 'error',
-	'@typescript-eslint/no-base-to-string': 'off',
-	'@typescript-eslint/restrict-template-expressions': 'off',
+	// #1032 sweep: cleared — enforced.
+	'@typescript-eslint/no-base-to-string': 'error',
+	'@typescript-eslint/restrict-template-expressions': 'error',
 	// #1041: cleared — enforced.
 	'@typescript-eslint/no-redundant-type-constituents': 'error',
-	'@typescript-eslint/no-require-imports': 'off',
+	// #1032 sweep: cleared — enforced. The one deliberate lazy require (AgentLoop's
+	// cycle-breaking agent-factory load, see AGENTS.md) carries an inline disable.
+	'@typescript-eslint/no-require-imports': 'error',
 	// #1041: cleared — enforced.
 	'@typescript-eslint/no-unused-expressions': 'error',
 	// #1040: cleared — enforced.
 	'@typescript-eslint/no-deprecated': 'error',
-	'@typescript-eslint/unbound-method': 'off',
+	// #1032 sweep: cleared — enforced (src was already clean; test/ overrides back to
+	// 'off' below for vitest's expect(mock.method) idiom, a known false positive).
+	'@typescript-eslint/unbound-method': 'error',
 	'@typescript-eslint/no-unused-vars': [
 		'warn',
 		{ argsIgnorePattern: '^_', varsIgnorePattern: '^_', caughtErrorsIgnorePattern: '^_' },
@@ -170,6 +175,9 @@ export default defineConfig([
 			// `any` is pervasive in test mocks/fixtures (~1.8k occurrences) and outside
 			// #1036's src-only scope — keep it off here.
 			'@typescript-eslint/no-explicit-any': 'off',
+			// vitest's expect(mock.method).toHaveBeenCalled() pattern trips this rule's
+			// method-reference check (~56 false positives) — keep it off for tests.
+			'@typescript-eslint/unbound-method': 'off',
 			// Tests legitimately use Node.js modules for fixtures and don't run in Obsidian.
 			'import/no-nodejs-modules': 'off',
 			// Tests run in jsdom, where Obsidian's createEl/createDiv/createSpan DOM

--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -315,6 +315,7 @@ export class AgentLoop {
 				// Deliberate lazy require to break the AgentFactory → tools → AgentLoop
 				// import cycle (see AGENTS.md). A top-level import here would be circular.
 
+				// eslint-disable-next-line @typescript-eslint/no-require-imports -- a top-level import here would recreate that cycle
 				const { AgentFactory } = require('./agent-factory');
 				return AgentFactory.createAgentModel(plugin, session) as ModelApi;
 			});

--- a/src/api/providers/gemini/interactions-mapper.ts
+++ b/src/api/providers/gemini/interactions-mapper.ts
@@ -239,7 +239,7 @@ export function extractModelResponseFromInteraction(interaction: Record<string, 
 			thoughts += textFromContentArray(step.summary);
 		} else if (type === 'function_call') {
 			toolCalls.push({
-				name: String(step.name ?? ''),
+				name: typeof step.name === 'string' ? step.name : '',
 				arguments: (step.arguments as Record<string, unknown>) ?? {},
 				id: typeof step.id === 'string' ? step.id : undefined,
 				thoughtSignature: typeof step.signature === 'string' ? step.signature : undefined,
@@ -324,7 +324,7 @@ export class InteractionStreamAccumulator {
 				const index = event.index as number;
 				this.pending.set(index, {
 					id: typeof step.id === 'string' ? step.id : undefined,
-					name: String(step.name ?? ''),
+					name: typeof step.name === 'string' ? step.name : '',
 					signature: typeof step.signature === 'string' ? step.signature : undefined,
 					argsBuffer: '',
 					seedArgs:
@@ -361,7 +361,7 @@ export class InteractionStreamAccumulator {
 
 		switch (delta.type) {
 			case 'text': {
-				const text = decodeHtmlEntities(String(delta.text ?? ''));
+				const text = decodeHtmlEntities(typeof delta.text === 'string' ? delta.text : '');
 				if (!text) return null;
 				this.text += text;
 				return { text };

--- a/src/api/utils/debug.ts
+++ b/src/api/utils/debug.ts
@@ -136,12 +136,9 @@ export function logDebugInfo(logger: Logger, title: string, data: unknown) {
 		logger.log(`[GeminiAPI Debug] ${title} (BaseModelRequest):\n${formatBaseModelRequest(data)}`);
 		return;
 	}
-	let sanitizedData: unknown;
 	if (typeof data === 'string' && data.includes('File Label:')) {
-		sanitizedData = redactLinkedFileSections(data);
-		logger.log(`[GeminiAPI Debug] ${title}:\n${sanitizedData}`);
+		logger.log(`[GeminiAPI Debug] ${title}:\n${redactLinkedFileSections(data)}`);
 	} else {
-		sanitizedData = stripLinkedFileContents(data);
-		logger.log(`[GeminiAPI Debug] ${title}:`, JSON.stringify(sanitizedData, null, 2));
+		logger.log(`[GeminiAPI Debug] ${title}:`, JSON.stringify(stripLinkedFileContents(data), null, 2));
 	}
 }

--- a/src/mcp/mcp-manager.ts
+++ b/src/mcp/mcp-manager.ts
@@ -528,7 +528,7 @@ export class MCPManager {
 					this.logger.debug(`MCP: OAuth callback server listening on port ${OAUTH_CALLBACK_PORT}`);
 				} catch (serverErr) {
 					// Non-fatal: if the port is busy, OAuth just won't work
-					this.logger.warn(`MCP: Could not start OAuth callback server: ${serverErr}`);
+					this.logger.warn(`MCP: Could not start OAuth callback server: ${getRawErrorMessage(serverErr)}`);
 				}
 			}
 		} else {

--- a/src/services/folder-initializer.ts
+++ b/src/services/folder-initializer.ts
@@ -1,6 +1,7 @@
 import { TFolder, normalizePath } from 'obsidian';
 import type { ObsidianGemini } from '../types/plugin';
 import { ensureFolderExists } from '../utils/file-utils';
+import { getRawErrorMessage } from '../utils/error-utils';
 
 /**
  * Centralizes creation of all plugin state folders.
@@ -55,7 +56,7 @@ export class FolderInitializer {
 				await this.plugin.app.fileManager.renameFile(oldFolder, newPath);
 				this.plugin.logger.log(`Migrated skills folder: ${oldPath} → ${newPath}`);
 			} catch (error) {
-				this.plugin.logger.warn(`Failed to migrate skills folder: ${error}`);
+				this.plugin.logger.warn(`Failed to migrate skills folder: ${getRawErrorMessage(error)}`);
 			}
 		}
 	}

--- a/src/services/hook-runner.ts
+++ b/src/services/hook-runner.ts
@@ -43,7 +43,7 @@ export class HookRunner {
 			case 'command':
 				return this.runCommand(isCancelled);
 			default:
-				throw new Error(`[HookRunner] Unknown action "${hook.action}" for hook "${hook.slug}"`);
+				throw new Error(`[HookRunner] Unknown action "${String(hook.action)}" for hook "${hook.slug}"`);
 		}
 	}
 

--- a/src/ui/agent-view/agent-view-tool-display.ts
+++ b/src/ui/agent-view/agent-view-tool-display.ts
@@ -615,7 +615,8 @@ export class AgentViewToolDisplay {
 
 							const item = resultList.createDiv({ cls: 'gemini-agent-tool-result-item' });
 							item.createSpan({ text: key + ':', cls: 'gemini-agent-tool-result-key' });
-							const valueStr = typeof value === 'string' ? value : JSON.stringify(value) || String(value);
+							const valueStr =
+								typeof value === 'string' ? value : JSON.stringify(value) || Object.prototype.toString.call(value);
 							item.createSpan({
 								text: valueStr.length > 100 ? valueStr.substring(0, 100) + '...' : valueStr,
 								cls: 'gemini-agent-tool-result-value',

--- a/src/utils/error-utils.ts
+++ b/src/utils/error-utils.ts
@@ -78,7 +78,9 @@ export function isQuotaExhausted(error: unknown): boolean {
 
 	// Fall back to message-based detection for SDK errors that flatten details
 	if (error && typeof error === 'object') {
-		const message: unknown = asRecord(error).message || String(error);
+		// No String(error) fallback: base Object stringification ('[object Object]')
+		// can never match the keyword checks below.
+		const message: unknown = asRecord(error).message;
 		const messageLower = typeof message === 'string' ? message.toLowerCase() : '';
 		if (
 			messageLower.includes('resource_exhausted') &&
@@ -106,7 +108,10 @@ export function isRateLimitError(error: unknown): boolean {
 
 	if (typeof error === 'object') {
 		const message: unknown = asRecord(error).message || '';
-		const messageLower = typeof message === 'string' ? message.toLowerCase() : String(error).toLowerCase();
+		// Numeric messages (e.g. `message: 429`) stringify to something matchable;
+		// any other non-string shape could only ever yield '[object Object]'.
+		const messageLower =
+			typeof message === 'string' ? message.toLowerCase() : typeof message === 'number' ? String(message) : '';
 		return (
 			messageLower.includes('429') ||
 			messageLower.includes('resource_exhausted') ||

--- a/src/utils/file-log-writer.ts
+++ b/src/utils/file-log-writer.ts
@@ -153,10 +153,14 @@ export class FileLogWriter {
 					try {
 						return JSON.stringify(arg);
 					} catch {
-						return String(arg);
+						// Circular structure — same output String(arg) would produce.
+						return Object.prototype.toString.call(arg);
 					}
 				}
-				return String(arg);
+				if (typeof arg === 'string') return arg;
+				if (typeof arg === 'number' || typeof arg === 'boolean' || typeof arg === 'bigint') return String(arg);
+				// symbol / function — never logged in practice; label rather than coerce
+				return Object.prototype.toString.call(arg);
 			})
 			.join(' ');
 	}

--- a/src/utils/proxy-fetch.ts
+++ b/src/utils/proxy-fetch.ts
@@ -173,6 +173,7 @@ export async function proxyFetch(input: RequestInfo | URL, init?: RequestInit): 
 			try {
 				body = JSON.stringify(init.body);
 			} catch {
+				// eslint-disable-next-line @typescript-eslint/no-base-to-string -- last-resort coercion of an exotic BodyInit after JSON.stringify threw; String() of e.g. URLSearchParams is meaningful
 				body = String(init.body);
 			}
 		}

--- a/test/agent/agent-loop.test.ts
+++ b/test/agent/agent-loop.test.ts
@@ -678,10 +678,10 @@ describe('AgentLoop', () => {
 					createModelApi: () => api,
 					hooks: {
 						onToolCallStart: (tcArg) => {
-							events.push(`start:${tcArg.name}:${tcArg.arguments?.path}`);
+							events.push(`start:${tcArg.name}:${tcArg.arguments?.path as string}`);
 						},
 						onToolCallComplete: (tcArg) => {
-							events.push(`complete:${tcArg.name}:${tcArg.arguments?.path}`);
+							events.push(`complete:${tcArg.name}:${tcArg.arguments?.path as string}`);
 						},
 					},
 				},

--- a/test/services/rag-rate-limiter.test.ts
+++ b/test/services/rag-rate-limiter.test.ts
@@ -1,7 +1,7 @@
 vi.mock('../../src/utils/error-utils', () => ({
 	isRateLimitError: (error: unknown) => {
 		if (!error) return false;
-		const msg = error instanceof Error ? error.message : String(error);
+		const msg = error instanceof Error ? error.message : typeof error === 'string' ? error : '';
 		return (
 			msg.includes('429') ||
 			msg.includes('RESOURCE_EXHAUSTED') ||

--- a/test/ui/settings-helpers.test.ts
+++ b/test/ui/settings-helpers.test.ts
@@ -9,7 +9,7 @@ import { Notice } from 'obsidian';
 import { createDebouncedSave } from '../../src/ui/settings-helpers';
 
 vi.mock('../../src/i18n', () => ({
-	t: (key: string, vars?: Record<string, unknown>) => `${key}:${vars?.error ?? ''}`,
+	t: (key: string, vars?: Record<string, unknown>) => `${key}:${(vars?.error as string) ?? ''}`,
 }));
 
 vi.mock('../../src/utils/error-utils', () => ({


### PR DESCRIPTION
## Summary

Part of #1032. With #1036 closed, four of the remaining softened `@typescript-eslint` rules were within a small sweep of being enforceable. This PR clears their 14 src violations (plus 5 in tests) and flips all four to `error`:

| Rule | Was | Now |
|---|---|---|
| `unbound-method` | off (0 src violations — free flip) | `error`; test/ overrides off (vitest `expect(mock.method)` idiom, ~56 known false positives) |
| `no-require-imports` | off (1) | `error`; the one deliberate lazy `require('./agent-factory')` (AgentLoop's documented cycle-breaker, see AGENTS.md) carries an inline disable |
| `no-base-to-string` | off (9) | `error` |
| `restrict-template-expressions` | off (4) | `error` |

After this, the only rules still softened for src are the `no-unsafe-*` family (~158) and `obsidianmd/no-static-styles-assignment` (68) — follow-up issues filed on the epic.

## Changes

- **interactions-mapper**: `String(step.name ?? '')` / `String(delta.text ?? '')` → `typeof x === 'string'` narrowing (an object here would have produced `[object Object]` in tool-call names/stream text)
- **debug.ts**: branch-local `redactLinkedFileSections(data)` keeps the template string-typed instead of interpolating an `unknown`
- **mcp-manager / folder-initializer**: error interpolations routed through `getRawErrorMessage`
- **hook-runner**: exhaustive-switch default wraps the `never`-typed action in `String()`
- **agent-view-tool-display / file-log-writer**: object fallbacks use explicit `JSON.stringify` + `Object.prototype.toString.call` instead of implicit coercion; log formatter's tail handles each primitive type explicitly
- **error-utils**: dropped `String(error)` fallbacks in the rate-limit/quota keyword heuristics — base stringification (`[object Object]`) could never match the keywords, so this is behavior-neutral in practice, and numeric `message: 429` shapes now match where they previously didn't (a small detection improvement)
- **proxy-fetch**: one documented inline disable — last-resort `String(init.body)` for exotic `BodyInit` after `JSON.stringify` threw (e.g. `URLSearchParams` stringifies meaningfully)
- **tests**: 5 violations fixed in 3 files (typed casts in mocks) so the rules hold for test/ too, except the `unbound-method` false-positive override
- **eslint.config.mjs**: the four flips annotated in the rule ledger

## Documentation

Internal lint-posture change; eslint.config.mjs ledger comments updated in place. No user-facing changes, no `docs/` updates needed.

## Testing

- `npm run lint`: 0 errors (34 pre-existing warnings, unchanged)
- `npm test`: 3360/3360 pass; `npm run typecheck:test` clean
- `npm run build`, `npm run lint:cycles` (0), `npm run knip`, `npm run format-check`: all clean

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop (full unit suite; error-utils heuristics covered by existing tests)
- [x] I have verified this change does not break Mobile (no platform-facing behavior change)
- [x] Documentation has been updated (eslint.config.mjs rule ledger; no user-facing changes)
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

https://claude.ai/code/session_01RZfXTNYfPsWjk32qrxV4dx