### PR TITLE
refactor: migrate the remaining 68 static inline styles to CSS classes

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -62,11 +62,12 @@ const PERVASIVE_OBSIDIANMD_RULES_TODO = {
 	// live-view DOM operations use the target element's `ownerDocument`, and the few
 	// genuinely detached nodes (escape-only, rasterization, test stubs) carry scoped
 	// inline disables. The rule is enforced again (left at the preset default).
-	// ~69 violations remaining: direct `style.X = ...` assignments. Needs CSS class
-	// migration. Cleaned so far and enforced per-file below (see the scoped override
-	// block): src/ui/agent-view/agent-view-progress.ts, agent-view-shelf.ts. Flip to
-	// 'error' globally once the remaining sites are migrated.
-	'obsidianmd/no-static-styles-assignment': 'off',
+	// `obsidianmd/no-static-styles-assignment` was here (~69 violations) — now fixed:
+	// static inline styles migrated to CSS classes / Obsidian's show()/hide() helpers
+	// (#1167). The agent view's iOS layout fix keeps deliberate inline `!important`
+	// setProperty calls with scoped inline disables (a class can't beat theme
+	// !important rules or round-trip host-element inline styles). The rule is
+	// enforced again (left at the preset default).
 	// `obsidianmd/no-tfile-tfolder-cast` was here — now fixed: all `x as TFile`
 	// / `x as TFolder` casts replaced with `instanceof` narrowing (the sole
 	// remaining exception is a fabricated early-init folder stub in
@@ -154,13 +155,6 @@ export default defineConfig([
 			globals: NODE_GLOBALS,
 		},
 		rules: { ...SOFTENED_TS_RULES, ...PERVASIVE_OBSIDIANMD_RULES_TODO },
-	},
-	{
-		// Files fully migrated off direct `style.X = ...` assignments to CSS classes.
-		// Enforce `no-static-styles-assignment` here so they cannot regress while the
-		// rule stays globally disabled for the remaining unmigrated files (#1034).
-		files: ['src/ui/agent-view/agent-view-progress.ts', 'src/ui/agent-view/agent-view-shelf.ts'],
-		rules: { 'obsidianmd/no-static-styles-assignment': 'error' },
 	},
 	{
 		files: ['test/**/*.ts'],

--- a/src/prompts/prompt-manager.ts
+++ b/src/prompts/prompt-manager.ts
@@ -287,6 +287,7 @@ class PromptNameModal extends Modal {
 	onOpen() {
 		const { contentEl } = this;
 		contentEl.empty();
+		contentEl.addClass('gemini-prompt-name-modal');
 
 		contentEl.createEl('h2', { text: t('modal.promptName.title') });
 
@@ -297,12 +298,6 @@ class PromptNameModal extends Modal {
 			type: 'text',
 			placeholder: t('modal.promptName.placeholder'),
 		});
-
-		this.inputEl.style.width = '100%';
-		this.inputEl.style.marginTop = '8px';
-		this.inputEl.style.padding = '8px';
-		this.inputEl.style.border = '1px solid var(--background-modifier-border)';
-		this.inputEl.style.borderRadius = '4px';
 
 		// Handle Enter key
 		this.inputEl.addEventListener('keydown', (event) => {
@@ -315,21 +310,14 @@ class PromptNameModal extends Modal {
 		});
 
 		const buttonContainer = contentEl.createDiv({ cls: 'prompt-button-container' });
-		buttonContainer.style.marginTop = '16px';
-		buttonContainer.style.display = 'flex';
-		buttonContainer.style.gap = '8px';
-		buttonContainer.style.justifyContent = 'flex-end';
 
 		const cancelButton = buttonContainer.createEl('button', { text: t('modal.promptName.cancel') });
-		cancelButton.style.padding = '8px 16px';
 		cancelButton.addEventListener('click', () => this.close());
 
-		const createButton = buttonContainer.createEl('button', { text: t('modal.promptName.create') });
-		createButton.style.padding = '8px 16px';
-		createButton.style.backgroundColor = 'var(--interactive-accent)';
-		createButton.style.color = 'var(--text-on-accent)';
-		createButton.style.border = 'none';
-		createButton.style.borderRadius = '4px';
+		const createButton = buttonContainer.createEl('button', {
+			text: t('modal.promptName.create'),
+			cls: 'prompt-create-button',
+		});
 		createButton.addEventListener('click', () => this.submit());
 
 		// Focus the input

--- a/src/services/background-status-bar.ts
+++ b/src/services/background-status-bar.ts
@@ -94,11 +94,10 @@ export class BackgroundStatusBar {
 		if (badgeEl) {
 			if (this._pendingCatchUpCount > 0) {
 				badgeEl.setText('!');
-				badgeEl.style.display = 'inline-block';
 			} else {
 				badgeEl.setText('');
-				badgeEl.style.display = 'none';
 			}
+			badgeEl.toggleClass('is-visible', this._pendingCatchUpCount > 0);
 		}
 
 		const runningCount = this.taskManager.runningCount;
@@ -108,11 +107,11 @@ export class BackgroundStatusBar {
 		// AND there are no pending catch-up approvals (otherwise the ! badge would be
 		// unreachable). When RAG is idle, show the database icon + indexed-file count.
 		if (runningCount === 0 && ragStatus === 'disabled' && this._pendingCatchUpCount === 0) {
-			this.statusBarItem.style.display = 'none';
+			this.statusBarItem.hide();
 			return;
 		}
 
-		this.statusBarItem.style.display = '';
+		this.statusBarItem.show();
 		this.statusBarItem.removeClass('gemini-bg-active');
 
 		const tooltipParts: string[] = [];

--- a/src/services/rag-status-bar.ts
+++ b/src/services/rag-status-bar.ts
@@ -133,16 +133,16 @@ export class RagStatusBar {
 
 		switch (status) {
 			case 'disabled':
-				this.statusBarItem.style.display = 'none';
+				this.statusBarItem.hide();
 				break;
 			case 'idle':
-				this.statusBarItem.style.display = '';
+				this.statusBarItem.show();
 				setIcon(iconEl, 'database');
 				textEl.setText(`${indexedCount}`);
 				tooltip = t('statusbar.rag.indexed', { count: indexedCount });
 				break;
 			case 'indexing':
-				this.statusBarItem.style.display = '';
+				this.statusBarItem.show();
 				this.statusBarItem.addClass('rag-indexing');
 				setIcon(iconEl, 'upload-cloud');
 				if (indexingProgress.total > 0) {
@@ -155,19 +155,19 @@ export class RagStatusBar {
 				}
 				break;
 			case 'error':
-				this.statusBarItem.style.display = '';
+				this.statusBarItem.show();
 				setIcon(iconEl, 'alert-triangle');
 				textEl.setText('');
 				tooltip = t('statusbar.rag.error');
 				break;
 			case 'paused':
-				this.statusBarItem.style.display = '';
+				this.statusBarItem.show();
 				setIcon(iconEl, 'pause-circle');
 				textEl.setText('');
 				tooltip = t('statusbar.rag.paused');
 				break;
 			case 'rate_limited': {
-				this.statusBarItem.style.display = '';
+				this.statusBarItem.show();
 				setIcon(iconEl, 'clock');
 				const remaining = this.provider.getRateLimitRemainingSeconds();
 				textEl.setText(`${remaining}s`);

--- a/src/ui/agent-view/agent-view-messages.ts
+++ b/src/ui/agent-view/agent-view-messages.ts
@@ -303,7 +303,7 @@ export class AgentViewMessages {
 		setIcon(chevron, 'chevron-right');
 
 		const details = row.createDiv({ cls: 'gemini-tool-row-details gemini-reasoning-row-details' });
-		details.style.display = 'none';
+		details.hide();
 		await MarkdownRenderer.render(this.app, formatModelMessage(thoughts), details, sourcePath, this.viewContext);
 
 		const toggle = () => {

--- a/src/ui/agent-view/agent-view-tool-display.ts
+++ b/src/ui/agent-view/agent-view-tool-display.ts
@@ -132,7 +132,7 @@ export class AgentViewToolDisplay {
 
 		// Body (hidden by default)
 		const body = group.createDiv({ cls: 'gemini-tool-group-body' });
-		body.style.display = 'none';
+		body.hide();
 
 		// Store counts in dataset
 		group.dataset.totalCount = String(totalToolCount);
@@ -214,7 +214,7 @@ export class AgentViewToolDisplay {
 			const chevron = group.querySelector('.gemini-tool-group-chevron') as HTMLElement;
 			const summaryEl = group.querySelector('.gemini-tool-group-summary') as HTMLElement;
 			if (body && body.style.display === 'none') {
-				body.style.display = 'block';
+				body.show();
 				if (chevron) setIcon(chevron, 'chevron-down');
 				if (summaryEl) summaryEl.setAttribute('aria-expanded', 'true');
 				group.classList.add('gemini-tool-group-expanded');
@@ -306,7 +306,7 @@ export class AgentViewToolDisplay {
 
 		// Row details (hidden by default, contains parameters and later results)
 		const rowDetails = toolRow.createDiv({ cls: 'gemini-tool-row-details' });
-		rowDetails.style.display = 'none';
+		rowDetails.hide();
 
 		// Parameters section inside details
 		if (parameters && Object.keys(parameters).length > 0) {
@@ -526,7 +526,7 @@ export class AgentViewToolDisplay {
 							img.onloadstart = () => imgContainer.addClass('loading');
 							img.onload = () => imgContainer.removeClass('loading');
 							img.onerror = () => {
-								img.style.display = 'none';
+								img.hide();
 								imgContainer.removeClass('loading');
 								imgContainer.createEl('p', {
 									text: t('agent.tools.imagePreviewFailed'),
@@ -639,7 +639,7 @@ export class AgentViewToolDisplay {
 			const rowChevron = toolRow.querySelector('.gemini-tool-row-chevron') as HTMLElement;
 			const rowHeader = toolRow.querySelector('.gemini-tool-row-header') as HTMLElement;
 			if (rowDetails && rowDetails.style.display === 'none') {
-				rowDetails.style.display = 'block';
+				rowDetails.show();
 				if (rowChevron) setIcon(rowChevron, 'chevron-down');
 				if (rowHeader) rowHeader.setAttribute('aria-expanded', 'true');
 				toolRow.classList.add('gemini-tool-row-expanded');

--- a/src/ui/agent-view/agent-view-ui.ts
+++ b/src/ui/agent-view/agent-view-ui.ts
@@ -96,7 +96,7 @@ export class AgentViewUI {
 
 		// Token usage indicator (hidden by default, shown when setting enabled)
 		const tokenUsageContainer = inputArea.createDiv({ cls: 'gemini-agent-token-usage' });
-		tokenUsageContainer.style.display = 'none';
+		tokenUsageContainer.hide();
 
 		const { userInput, sendButton, planModeButton, imagePreviewContainer } = this.createInputArea(inputArea, callbacks);
 
@@ -144,7 +144,7 @@ export class AgentViewUI {
 				cls: 'gemini-agent-title-input-compact',
 			});
 
-			title.style.display = 'none';
+			title.hide();
 			input.focus();
 			input.select();
 
@@ -201,7 +201,7 @@ export class AgentViewUI {
 					// is never left with an orphaned input element.
 					if (input.isConnected) {
 						title.textContent = editingSession.title;
-						title.style.display = '';
+						title.show();
 						input.remove();
 					}
 				}
@@ -217,7 +217,7 @@ export class AgentViewUI {
 					void saveTitle();
 				} else if (e.key === 'Escape') {
 					finished = true; // prevent the upcoming blur from saving
-					title.style.display = '';
+					title.show();
 					input.remove();
 				}
 			});

--- a/src/ui/agent-view/agent-view.ts
+++ b/src/ui/agent-view/agent-view.ts
@@ -140,8 +140,11 @@ export class AgentView extends ItemView {
 			const ctrBottom = container.getBoundingClientRect().bottom;
 			const navbarTop = this.findMobileNavbar()?.getBoundingClientRect().top ?? Infinity;
 			const targetBottom = Math.min(ctrBottom, navbarTop);
+			// eslint-disable-next-line obsidianmd/no-static-styles-assignment -- inline !important is the point (see doc comment): it must beat theme !important flex rules, which a class cannot
 			chat.style.setProperty('flex-grow', '0', 'important');
+			// eslint-disable-next-line obsidianmd/no-static-styles-assignment -- see above
 			chat.style.setProperty('flex-shrink', '0', 'important');
+			// eslint-disable-next-line obsidianmd/no-static-styles-assignment -- see above
 			chat.style.setProperty('flex-basis', 'auto', 'important');
 			for (let i = 0; i < 3; i++) {
 				const delta = targetBottom - iarea.getBoundingClientRect().bottom;
@@ -175,7 +178,9 @@ export class AgentView extends ItemView {
 					priority: parent.style.getPropertyPriority('overflow'),
 				}
 			: null;
+		// eslint-disable-next-line obsidianmd/no-static-styles-assignment -- paired with the inline save/restore above on host elements Obsidian reuses; a class can't round-trip the pre-existing inline value
 		container.style.setProperty('overflow', 'hidden', 'important');
+		// eslint-disable-next-line obsidianmd/no-static-styles-assignment -- see above
 		parent?.style.setProperty('overflow', 'hidden', 'important');
 		const onScroll = () => {
 			if (container.scrollTop !== 0) container.scrollTop = 0;
@@ -819,7 +824,7 @@ export class AgentView extends ItemView {
 	private async updateTokenUsage(): Promise<void> {
 		if (!this.plugin.contextManager || !this.plugin.settings.showTokenUsage || !this.tokenUsageContainer) {
 			if (this.tokenUsageContainer) {
-				this.tokenUsageContainer.style.display = 'none';
+				this.tokenUsageContainer.hide();
 			}
 			return;
 		}
@@ -846,11 +851,11 @@ export class AgentView extends ItemView {
 
 			// Still no data (e.g., new session with no messages)
 			if (usage.estimatedTokens === 0) {
-				this.tokenUsageContainer.style.display = 'none';
+				this.tokenUsageContainer.hide();
 				return;
 			}
 
-			this.tokenUsageContainer.style.display = '';
+			this.tokenUsageContainer.show();
 			this.tokenUsageContainer.empty();
 
 			const tokenText = this.tokenUsageContainer.createSpan({ cls: 'gemini-agent-token-text' });

--- a/src/ui/agent-view/file-picker-modal.ts
+++ b/src/ui/agent-view/file-picker-modal.ts
@@ -83,7 +83,7 @@ export class FilePickerModal extends SuggestModal<TAbstractFile> {
 		// Always render the folder-icon span so paths align; hide it for plain files
 		const folderIconEl = titleEl.createSpan();
 		setIcon(folderIconEl, 'folder');
-		if (!isFolder) folderIconEl.style.visibility = 'hidden';
+		if (!isFolder) folderIconEl.addClass('gemini-invisible');
 		titleEl.createSpan({ text: ' ' + item.path + (isFolder ? '/' : '') });
 	}
 

--- a/src/ui/mcp-server-modal.ts
+++ b/src/ui/mcp-server-modal.ts
@@ -109,7 +109,7 @@ export class MCPServerModal extends Modal {
 				.setName(t('mcpServer.urlSetting'))
 				.setDesc(t('mcpServer.urlDesc'))
 				.addText((text) => {
-					text.inputEl.style.width = '30ch';
+					text.inputEl.addClass('gemini-input-wide');
 					text
 						.setPlaceholder(t('mcpServer.urlPlaceholder'))
 						.setValue(this.config.url || '')
@@ -145,7 +145,7 @@ export class MCPServerModal extends Modal {
 				.setName(t('mcpServer.commandSetting'))
 				.setDesc(t('mcpServer.commandDesc'))
 				.addText((text) => {
-					text.inputEl.style.width = '30ch';
+					text.inputEl.addClass('gemini-input-wide');
 					text
 						.setPlaceholder(t('mcpServer.commandPlaceholder'))
 						.setValue(this.config.command)
@@ -307,11 +307,10 @@ export class MCPServerModal extends Modal {
 		if (this.discoveredTools.length === 0) return;
 
 		this.discoveredToolsContainer.createEl('h3', { text: t('mcpServer.discoveredToolsTitle') });
-		const desc = this.discoveredToolsContainer.createEl('p', {
+		this.discoveredToolsContainer.createEl('p', {
 			text: t('mcpServer.discoveredToolsDesc'),
-			cls: 'setting-item-description',
+			cls: 'setting-item-description gemini-discovered-tools-desc',
 		});
-		desc.style.marginBottom = '0.5em';
 
 		const toolList = this.discoveredToolsContainer.createEl('ul');
 		for (const toolName of this.discoveredTools) {

--- a/src/ui/rag-cleanup-modal.ts
+++ b/src/ui/rag-cleanup-modal.ts
@@ -28,11 +28,10 @@ export class RagCleanupModal extends Modal {
 			cls: 'setting-item-description',
 		});
 
-		const warningEl = noteEl.createEl('p', {
+		noteEl.createEl('p', {
 			text: t('ragCleanup.deleteWarning'),
-			cls: 'setting-item-description',
+			cls: 'setting-item-description gemini-warning-text',
 		});
-		warningEl.style.color = 'var(--text-warning)';
 
 		new Setting(contentEl)
 			.addButton((btn) =>

--- a/src/ui/rag-progress-modal.ts
+++ b/src/ui/rag-progress-modal.ts
@@ -151,9 +151,7 @@ export class RagProgressModal extends Modal {
 		const percentage = Math.round((current / total) * 100);
 
 		// Update progress bar
-		if (this.progressBarFill) {
-			this.progressBarFill.style.width = `${percentage}%`;
-		}
+		this.setProgressBarWidth(percentage);
 		if (this.progressText) {
 			this.progressText.setText(`${percentage}% (${current} / ${total})`);
 		}
@@ -162,12 +160,12 @@ export class RagProgressModal extends Modal {
 		if (this.currentFileEl) {
 			if (progressInfo.currentFile) {
 				this.currentFileEl.setText(progressInfo.currentFile);
-				this.currentFileEl.style.display = '';
+				this.currentFileEl.show();
 			} else if (progressInfo.status === 'indexing') {
 				this.currentFileEl.setText(t('ragProgress.scanning'));
-				this.currentFileEl.style.display = '';
+				this.currentFileEl.show();
 			} else {
-				this.currentFileEl.style.display = 'none';
+				this.currentFileEl.hide();
 			}
 		}
 
@@ -189,6 +187,13 @@ export class RagProgressModal extends Modal {
 
 		// Update time display
 		this.updateTimeDisplay();
+	}
+
+	/** Single (dynamic) write site for the progress-bar fill width. */
+	private setProgressBarWidth(percent: number): void {
+		if (this.progressBarFill) {
+			this.progressBarFill.style.width = `${percent}%`;
+		}
 	}
 
 	private updateTimeDisplay(): void {
@@ -237,9 +242,7 @@ export class RagProgressModal extends Modal {
 		}
 
 		// Update progress bar to 100%
-		if (this.progressBarFill) {
-			this.progressBarFill.style.width = '100%';
-		}
+		this.setProgressBarWidth(100);
 		const total = this.progressInfo.indexedCount + this.progressInfo.skippedCount + this.progressInfo.failedCount;
 		if (this.progressText) {
 			this.progressText.setText(`100% (${total} / ${total})`);
@@ -260,12 +263,12 @@ export class RagProgressModal extends Modal {
 		// Hide current file section
 		const currentFileSection = this.contentEl.querySelector('.rag-progress-section');
 		if (currentFileSection) {
-			(currentFileSection as HTMLElement).style.display = 'none';
+			(currentFileSection as HTMLElement).hide();
 		}
 
 		// Update buttons
 		if (this.cancelBtn) {
-			this.cancelBtn.style.display = 'none';
+			this.cancelBtn.hide();
 		}
 		if (this.backgroundBtn) {
 			this.backgroundBtn.setText(t('ragProgress.closeButton'));

--- a/src/ui/selection-response-modal.ts
+++ b/src/ui/selection-response-modal.ts
@@ -129,11 +129,11 @@ export class SelectionResponseModal extends Modal {
 
 		// Response container (hidden initially)
 		this.responseContainer = contentEl.createDiv({ cls: 'gemini-scribe-response-container' });
-		this.responseContainer.style.display = 'none';
+		this.responseContainer.hide();
 
 		// Actions container (hidden initially)
 		this.actionsContainer = contentEl.createDiv({ cls: 'gemini-scribe-actions' });
-		this.actionsContainer.style.display = 'none';
+		this.actionsContainer.hide();
 
 		const insertBtn = this.actionsContainer.createEl('button', {
 			text: t('selectionResponse.insertButton'),
@@ -159,9 +159,9 @@ export class SelectionResponseModal extends Modal {
 		this.response = response;
 
 		// Hide loading, show response
-		this.loadingEl.style.display = 'none';
-		this.responseContainer.style.display = 'block';
-		this.actionsContainer.style.display = 'flex';
+		this.loadingEl.hide();
+		this.responseContainer.show();
+		this.actionsContainer.show();
 
 		// Normalize newlines for proper Markdown rendering
 		const normalizedResponse = normalizeNewlines(response);
@@ -176,9 +176,9 @@ export class SelectionResponseModal extends Modal {
 	 * Show an error in the modal
 	 */
 	showError(error: string) {
-		this.loadingEl.style.display = 'none';
-		this.responseContainer.style.display = 'block';
-		this.actionsContainer.style.display = 'flex';
+		this.loadingEl.hide();
+		this.responseContainer.show();
+		this.actionsContainer.show();
 
 		this.responseContainer.empty();
 		const errorEl = this.responseContainer.createDiv({ cls: 'gemini-scribe-error' });

--- a/src/ui/settings-rag.ts
+++ b/src/ui/settings-rag.ts
@@ -17,13 +17,11 @@ export async function renderRAGSettings(
 	const debouncedSave = createDebouncedSave(plugin, 'Failed to save RAG settings:');
 
 	// Privacy warning
-	const privacyWarning = containerEl.createDiv({ cls: 'setting-item' });
+	const privacyWarning = containerEl.createDiv({ cls: 'setting-item gemini-rag-privacy-notice' });
 	privacyWarning.createDiv({
 		cls: 'setting-item-description',
 		text: t('settings.rag.privacyNotice'),
 	});
-	privacyWarning.style.marginBottom = '1em';
-	privacyWarning.style.color = 'var(--text-warning)';
 
 	new Setting(containerEl)
 		.setName(t('settings.rag.enableName'))
@@ -167,7 +165,7 @@ export async function renderRAGSettings(
 		if (currentStoreName) {
 			storeNameSetting
 				.addText((text) => {
-					text.inputEl.style.width = '30ch';
+					text.inputEl.addClass('gemini-input-wide');
 					text.setValue(currentStoreName);
 					text.setDisabled(true);
 				})

--- a/src/ui/vault-analysis-modal.ts
+++ b/src/ui/vault-analysis-modal.ts
@@ -136,7 +136,7 @@ export class VaultAnalysisModal extends Modal {
 
 		// Hide spinner
 		if (this.spinnerEl) {
-			this.spinnerEl.style.display = 'none';
+			this.spinnerEl.hide();
 		}
 
 		// Add a close button

--- a/src/ui/yolo-confirmation-modal.ts
+++ b/src/ui/yolo-confirmation-modal.ts
@@ -30,11 +30,10 @@ export class YoloConfirmationModal extends Modal {
 			text: t('yolo.description'),
 		});
 
-		const warningEl = container.createEl('p', {
+		container.createEl('p', {
 			text: t('yolo.warning'),
+			cls: 'gemini-warning-text gemini-warning-text-bold',
 		});
-		warningEl.style.color = 'var(--text-warning)';
-		warningEl.style.fontWeight = 'bold';
 
 		container.createEl('p', {
 			text: t('yolo.trustNote'),

--- a/styles.css
+++ b/styles.css
@@ -5480,3 +5480,66 @@ body.theme-dark {
 	background-color: var(--gs-hover);
 	color: var(--gs-text);
 }
+
+/* ── #1167: classes replacing static inline style assignments ──────────────── */
+
+/* Shared utilities */
+.gemini-invisible {
+	visibility: hidden;
+}
+
+.gemini-input-wide {
+	width: 30ch;
+}
+
+.gemini-warning-text {
+	color: var(--text-warning);
+}
+
+.gemini-warning-text-bold {
+	font-weight: bold;
+}
+
+/* Prompt-name modal (PromptNameModal in prompt-manager.ts) */
+.gemini-prompt-name-modal .prompt-input-container input {
+	width: 100%;
+	margin-top: var(--gs-space-2);
+	padding: var(--gs-space-2);
+	border: 1px solid var(--background-modifier-border);
+	border-radius: 4px;
+}
+
+.gemini-prompt-name-modal .prompt-button-container {
+	margin-top: var(--gs-space-4);
+	display: flex;
+	gap: var(--gs-space-2);
+	justify-content: flex-end;
+}
+
+.gemini-prompt-name-modal .prompt-button-container button {
+	padding: var(--gs-space-2) var(--gs-space-4);
+}
+
+.gemini-prompt-name-modal .prompt-create-button {
+	background-color: var(--interactive-accent);
+	color: var(--text-on-accent);
+	border: none;
+	border-radius: 4px;
+}
+
+/* Background-tasks status bar: the ! badge is display:none at rest (see the
+   base .gemini-bg-status-badge rule) and shown via this modifier. */
+.gemini-bg-status-badge.is-visible {
+	display: inline-block;
+}
+
+/* MCP server modal: discovered-tools description spacing */
+.gemini-discovered-tools-desc {
+	margin-bottom: 0.5em;
+}
+
+/* RAG settings: privacy notice emphasis */
+.gemini-rag-privacy-notice {
+	margin-bottom: 1em;
+	color: var(--text-warning);
+}

--- a/test/ui/agent-view.test.ts
+++ b/test/ui/agent-view.test.ts
@@ -886,7 +886,7 @@ describe('AgentView UI Tests', () => {
 
 			// After failure, group should auto-expand
 			await agentView.showToolResult('read_file', { success: false, error: 'Error' }, 'exec-ae1');
-			expect(body.style.display).toBe('block');
+			expect(body.style.display).not.toBe('none');
 			expect(group.classList.contains('gemini-tool-group-expanded')).toBe(true);
 		});
 
@@ -899,7 +899,7 @@ describe('AgentView UI Tests', () => {
 
 			// After failure, row details should auto-expand
 			await agentView.showToolResult('read_file', { success: false, error: 'Error' }, 'exec-rd1');
-			expect(rowDetails.style.display).toBe('block');
+			expect(rowDetails.style.display).not.toBe('none');
 
 			// Row header aria-expanded should be updated
 			const rowHeader = chatContainer.querySelector('.gemini-tool-row-header') as HTMLElement;

--- a/test/vitest-setup.ts
+++ b/test/vitest-setup.ts
@@ -1,3 +1,35 @@
-// Reserved for future global test setup. Kept as a placeholder so
-// vitest.config.ts has a stable setup-file reference.
+// Global test setup.
+//
+// Obsidian extends HTMLElement.prototype with DOM helpers (show/hide/toggle,
+// toggleClass, ...) at runtime; the type declarations come from the obsidian
+// package's global augmentation. jsdom doesn't provide the runtime side, so
+// give unit tests minimal-faithful implementations of the helpers the plugin
+// uses. Kept intentionally small -- richer per-test mocks (createDiv/createEl
+// with cls/text options) stay in the tests that need them.
+
+if (typeof HTMLElement !== 'undefined') {
+	const proto = HTMLElement.prototype;
+	if (typeof proto.hide !== 'function') {
+		proto.hide = function (this: HTMLElement): void {
+			// eslint-disable-next-line obsidianmd/no-static-styles-assignment -- this IS the polyfill of Obsidian's hide(), which sets inline display
+			this.style.display = 'none';
+		};
+		proto.show = function (this: HTMLElement): void {
+			// eslint-disable-next-line obsidianmd/no-static-styles-assignment -- polyfill of Obsidian's show()
+			this.style.display = '';
+		};
+		proto.toggle = function (this: HTMLElement, show: boolean): void {
+			if (show) this.show();
+			else this.hide();
+		};
+	}
+	if (typeof proto.toggleClass !== 'function') {
+		proto.toggleClass = function (this: HTMLElement, classes: string | string[], value: boolean): void {
+			for (const cls of Array.isArray(classes) ? classes : [classes]) {
+				this.classList.toggle(cls, value);
+			}
+		};
+	}
+}
+
 export {};


### PR DESCRIPTION
## Summary

Closes #1167. Part of #1032 — with this, `obsidianmd/no-static-styles-assignment` moves out of the softened-rules TODO block to preset-default enforcement, and the per-file scoped override is deleted. `npx eslint src` with the rule forced reports **0 violations** (was 68 across 15 files).

## Changes

- **Display toggles (~50 sites)** → Obsidian's built-in `show()`/`hide()`/`toggleClass()` DOM helpers (status bars, tool activity rows, token-usage indicator, progress/selection/vault-analysis modals, session-title editing)
- **Static styling** → CSS classes in `styles.css`, consuming `--gs-*` spacing tokens where values match: the prompt-name modal (15 declarations, scoped under `.gemini-prompt-name-modal`), warning texts (`.gemini-warning-text[-bold]`), `30ch` inputs (`.gemini-input-wide`), RAG privacy notice, MCP discovered-tools description, folder-icon alignment (`.gemini-invisible`)
- **Status-bar badge**: the `!` badge (base class is `display:none` at rest) gains an `.is-visible` modifier instead of inline `inline-block`
- **`rag-progress-modal`**: progress-fill width writes collapse into one parameterized `setProgressBarWidth(percent)` — a single genuinely dynamic site
- **Kept inline, with scoped disables + justification**: the agent view's iOS layout fix — its `setProperty(..., 'important')` calls must beat theme `!important` flex rules (inline-important is the strongest precedence; a class isn't) and its overflow lock save/restores pre-existing inline styles on host elements Obsidian reuses across views, which a class can't round-trip
- **`test/vitest-setup.ts`** (was a reserved placeholder): minimal-faithful jsdom polyfills of Obsidian's `show`/`hide`/`toggle`/`toggleClass` prototype extensions; two tests now assert visibility as `display !== 'none'` instead of the old inline `'block'` mechanism

## Verification (live vault, per AGENTS.md — computed values, not eyeballing)

- **Twin-diff: 17/17 pass.** For every migrated site, two identical elements were built in the running app — one with the new class markup, one with the old inline styles — and *every* `getComputedStyle` property diffed. Zero differing properties across all 17 cases (including `show()`-restored display vs the old explicit `block`/`flex` values).
- **Real surfaces:** the settings tab's privacy notice (`margin-bottom: 15px`, warning color) and store-name input (`245.648px` = 30ch) are pixel-identical old-vs-new; the prompt-name modal renders correctly (screenshot verified: full-width bordered input, right-aligned flex button row, accent Create button — computed `8px/16px/1px/4px/flex/flex-end` all match the old literals).
- **One subtlety caught by the real-surface pass:** the status-bar badge computes `display: block`, not `inline-block` — because `.status-bar-item` is a flex container and flex items blockify inline-level display values. Verified the *old* inline style computed to the identical `block`, so old and new are the same on the real surface too.

## Testing

- `npm run lint`: 0 errors (34 pre-existing warnings); rule-forced scan of `src`: 0 violations
- `npm test`: 3360/3360 pass; `npm run typecheck:test` clean
- `npm run build`, `npm run lint:cycles` (0), `npm run format-check`: all clean
- Live vault: clean plugin load (`obsidian dev:errors` empty) + the computed-style verification above

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop (live-vault computed-style verification + modal render check, see above)
- [x] I have verified this change does not break Mobile (the mobile-specific iOS layout fix is deliberately untouched; all other changes are computed-value-identical)
- [x] Documentation has been updated (eslint.config.mjs rule ledger; no user-facing behavior changes)
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

https://claude.ai/code/session_01RZfXTNYfPsWjk32qrxV4dx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved the look and consistency of several modals and settings panels with updated spacing, wider inputs, and clearer warning text.
  - Status bars and progress dialogs now show and hide more smoothly during indexing, background tasks, and usage updates.

- **Bug Fixes**
  - Fixed visibility behavior across agent views, selection responses, vault analysis, and file pickers so collapsed sections and error states render reliably.
  - Restored enforcement of a previously exempted style rule to keep UI behavior consistent.

- **Tests**
  - Updated UI tests and test setup to better match the app’s visibility behavior in the browser environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->