### PR TITLE
refactor: dedup isCurrentSession into shared isSameSession helper

### DIFF
--- a/src/ui/agent-view/agent-view-messages.ts
+++ b/src/ui/agent-view/agent-view-messages.ts
@@ -1,5 +1,6 @@
 import { App, Component, MarkdownRenderer, Notice, setIcon } from 'obsidian';
 import { ChatSession } from '../../types/agent';
+import { isSameSession } from './session-identity';
 import { GeminiConversationEntry } from '../../types/conversation';
 import type { ObsidianGemini } from '../../types/plugin';
 import { formatModelMessage } from '../../utils/markdown-formatting';
@@ -619,9 +620,7 @@ export class AgentViewMessages {
 			// Try to get recent sessions (excluding the current session)
 			// Fetch 6 sessions since we might filter out the current one
 			const allRecentSessions = await this.plugin.sessionManager.getRecentAgentSessions(6);
-			const recentSessions = allRecentSessions
-				.filter((session) => !this.isCurrentSession(session, currentSession))
-				.slice(0, 5); // Limit to 5 after filtering
+			const recentSessions = allRecentSessions.filter((session) => !isSameSession(session, currentSession)).slice(0, 5); // Limit to 5 after filtering
 
 			if (recentSessions.length > 0) {
 				// Show recent sessions
@@ -689,15 +688,6 @@ export class AgentViewMessages {
 				});
 			}
 		}
-	}
-
-	/**
-	 * Check if a session is the current session
-	 * Compares both session ID and history path for robustness
-	 */
-	private isCurrentSession(session: ChatSession, currentSession: ChatSession | null): boolean {
-		if (!currentSession) return false;
-		return session.id === currentSession.id || session.historyPath === currentSession.historyPath;
 	}
 
 	/**

--- a/src/ui/agent-view/agent-view-session.ts
+++ b/src/ui/agent-view/agent-view-session.ts
@@ -1,6 +1,7 @@
 import { App, Notice } from 'obsidian';
 import { getActiveChatModel } from '../../models';
 import { ChatSession } from '../../types/agent';
+import { isSameSession } from './session-identity';
 import { GeminiConversationEntry } from '../../types/conversation';
 import type { ObsidianGemini } from '../../types/plugin';
 import { ModelClientFactory } from '../../api';
@@ -127,8 +128,7 @@ export class AgentViewSession {
 	 * Compares both session ID and history path for robustness
 	 */
 	isCurrentSession(session: ChatSession): boolean {
-		if (!this.currentSession) return false;
-		return session.id === this.currentSession.id || session.historyPath === this.currentSession.historyPath;
+		return isSameSession(session, this.currentSession);
 	}
 
 	/**

--- a/src/ui/agent-view/agent-view.ts
+++ b/src/ui/agent-view/agent-view.ts
@@ -1,6 +1,7 @@
 import { ItemView, MarkdownView, Platform, WorkspaceLeaf, TFile, Notice } from 'obsidian';
 import { getActiveChatModel } from '../../models';
 import { ChatSession, SessionModelConfig } from '../../types/agent';
+import { isSameSession } from './session-identity';
 import { GeminiConversationEntry } from '../../types/conversation';
 import type { ObsidianGemini } from '../../types/plugin';
 import type { Tool, ToolResult } from '../../tools/types';
@@ -635,8 +636,7 @@ export class AgentView extends ItemView {
 	 * Compares both session ID and history path for robustness
 	 */
 	private isCurrentSession(session: ChatSession): boolean {
-		if (!this.currentSession) return false;
-		return session.id === this.currentSession.id || session.historyPath === this.currentSession.historyPath;
+		return isSameSession(session, this.currentSession);
 	}
 
 	/**

--- a/src/ui/agent-view/session-identity.ts
+++ b/src/ui/agent-view/session-identity.ts
@@ -1,0 +1,14 @@
+import type { ChatSession } from '../../types/agent';
+
+/**
+ * Check whether `session` refers to the same session as `currentSession`.
+ *
+ * Compares both the session ID and the history path for robustness: a session
+ * can be re-loaded from disk with a fresh in-memory identity, so matching either
+ * field is treated as the same session. Returns `false` when there is no current
+ * session.
+ */
+export function isSameSession(session: ChatSession, currentSession: ChatSession | null): boolean {
+	if (!currentSession) return false;
+	return session.id === currentSession.id || session.historyPath === currentSession.historyPath;
+}

--- a/test/ui/agent-view/session-identity.test.ts
+++ b/test/ui/agent-view/session-identity.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { isSameSession } from '../../../src/ui/agent-view/session-identity';
+import { SessionType, type ChatSession } from '../../../src/types/agent';
+
+function makeSession(overrides: Partial<ChatSession>): ChatSession {
+	return {
+		id: 'id-1',
+		type: SessionType.AGENT_SESSION,
+		title: 'Session',
+		context: {} as ChatSession['context'],
+		created: new Date(0),
+		lastActive: new Date(0),
+		historyPath: 'History/session-1.md',
+		...overrides,
+	};
+}
+
+describe('isSameSession', () => {
+	it('returns false when there is no current session', () => {
+		expect(isSameSession(makeSession({}), null)).toBe(false);
+	});
+
+	it('matches on identical id', () => {
+		const a = makeSession({ id: 'same', historyPath: 'a.md' });
+		const b = makeSession({ id: 'same', historyPath: 'b.md' });
+		expect(isSameSession(a, b)).toBe(true);
+	});
+
+	it('matches on identical history path even when ids differ', () => {
+		const a = makeSession({ id: 'x', historyPath: 'shared.md' });
+		const b = makeSession({ id: 'y', historyPath: 'shared.md' });
+		expect(isSameSession(a, b)).toBe(true);
+	});
+
+	it('returns false when both id and history path differ', () => {
+		const a = makeSession({ id: 'x', historyPath: 'a.md' });
+		const b = makeSession({ id: 'y', historyPath: 'b.md' });
+		expect(isSameSession(a, b)).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary

Architecture-audit nightly sweep flagged: **DRY violation** in the agent-view layer.

The session-identity predicate — "is this session the current session?", matching on either `id` **or** `historyPath` — was copy-pasted verbatim (doc comment and all) into three separate classes: `AgentViewSession`, `AgentView`, and `AgentViewMessages`. This extracts the logic into a single pure leaf helper `isSameSession(session, currentSession)` and delegates all three call sites to it. Pure code-motion; no behavior change.

## Changes

- Add `src/ui/agent-view/session-identity.ts` exporting the pure predicate `isSameSession(session, currentSession)`.
- `agent-view-session.ts`: `isCurrentSession()` now delegates to `isSameSession`.
- `agent-view.ts`: `isCurrentSession()` now delegates to `isSameSession`.
- `agent-view-messages.ts`: remove the private `isCurrentSession` helper and call `isSameSession` directly at its single call site.
- Add `test/ui/agent-view/session-identity.test.ts` covering the id-match, history-path-match, no-match, and null-current-session cases.

## Screenshots / Screencast

N/A — internal refactor, no UI or behavior change.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: filed by the automated architecture-audit sweep as a mechanically-safe DRY fix.
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — pure logic refactor, no platform-specific code.
- [x] Documentation has been updated (if applicable) — N/A: internal refactor with no user-facing change.
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015Hqc7F4dA3YS5Dn8fa7U5U)_