### PR TITLE
refactor(ui): de-duplicate external image/SVG attachment loop (#1170)

### DIFF
--- a/src/ui/agent-view/agent-view-ui.ts
+++ b/src/ui/agent-view/agent-view-ui.ts
@@ -751,45 +751,7 @@ export class AgentViewUI {
 				e.stopPropagation();
 
 				// Process all supported images from non-vault sources
-				let imagesProcessed = 0;
-				let unsupportedCount = 0;
-				let cumulativeSize = this.getCurrentAttachmentSize(callbacks);
-				for (const file of fileArray) {
-					if (isSupportedImageType(file.type)) {
-						if (cumulativeSize + file.size > GEMINI_INLINE_DATA_LIMIT) {
-							new Notice(t('agent.attachments.sizeLimitReached'));
-							break;
-						}
-						try {
-							const base64 = await fileToBase64(file);
-							const attachment: InlineAttachment = {
-								base64,
-								mimeType: getMimeType(file),
-								id: generateAttachmentId(),
-							};
-							callbacks.addAttachment(attachment);
-							cumulativeSize += file.size;
-							imagesProcessed++;
-						} catch (err) {
-							this.plugin.logger.error('Failed to process dropped image:', err);
-							new Notice(t('agent.attachments.imageAttachFailed'));
-						}
-					} else if (this.isSvgFile(file)) {
-						// External SVG/SVGZ — rasterize to PNG before inlining.
-						if (cumulativeSize + file.size > GEMINI_INLINE_DATA_LIMIT) {
-							new Notice(t('agent.attachments.sizeLimitReached'));
-							break;
-						}
-						if (await this.attachExternalSvgFile(file, callbacks)) {
-							cumulativeSize += file.size;
-							imagesProcessed++;
-						} else {
-							unsupportedCount++;
-						}
-					} else if (file.type.startsWith('image/')) {
-						unsupportedCount++;
-					}
-				}
+				const { imagesProcessed, unsupportedCount } = await this.processAttachmentFiles(fileArray, callbacks);
 
 				if (imagesProcessed > 0) {
 					new Notice(
@@ -811,50 +773,12 @@ export class AgentViewUI {
 				let imagesProcessed = 0;
 				let unsupportedCount = 0;
 				if (e.clipboardData?.files?.length) {
-					let cumulativeSize = this.getCurrentAttachmentSize(callbacks);
-					for (const file of Array.from(e.clipboardData.files)) {
-						if (isSupportedImageType(file.type)) {
-							if (cumulativeSize + file.size > GEMINI_INLINE_DATA_LIMIT) {
-								new Notice(t('agent.attachments.sizeLimitReached'));
-								break;
-							}
-							// Prevent default once when we find the first image
-							if (imagesProcessed === 0) {
-								e.preventDefault();
-							}
-							try {
-								const base64 = await fileToBase64(file);
-								const attachment: InlineAttachment = {
-									base64,
-									mimeType: getMimeType(file),
-									id: generateAttachmentId(),
-								};
-								callbacks.addAttachment(attachment);
-								cumulativeSize += file.size;
-								imagesProcessed++;
-							} catch (err) {
-								this.plugin.logger.error('Failed to process pasted image:', err);
-								new Notice(t('agent.attachments.imageAttachFailed'));
-							}
-						} else if (this.isSvgFile(file)) {
-							// External SVG/SVGZ paste — rasterize to PNG before inlining.
-							if (cumulativeSize + file.size > GEMINI_INLINE_DATA_LIMIT) {
-								new Notice(t('agent.attachments.sizeLimitReached'));
-								break;
-							}
-							if (imagesProcessed === 0) {
-								e.preventDefault();
-							}
-							if (await this.attachExternalSvgFile(file, callbacks)) {
-								cumulativeSize += file.size;
-								imagesProcessed++;
-							} else {
-								unsupportedCount++;
-							}
-						} else if (file.type.startsWith('image/')) {
-							unsupportedCount++;
-						}
-					}
+					// Prevent default once when the first image/SVG is accepted.
+					({ imagesProcessed, unsupportedCount } = await this.processAttachmentFiles(
+						Array.from(e.clipboardData.files),
+						callbacks,
+						{ onFirstImage: () => e.preventDefault() }
+					));
 				}
 
 				// Notify about unsupported formats
@@ -990,6 +914,75 @@ export class AgentViewUI {
 			this.plugin.logger.error('Failed to rasterize external SVG:', err);
 			return false;
 		}
+	}
+
+	/**
+	 * Process a list of external (non-vault) files as image/SVG inline attachments.
+	 *
+	 * Shared by the external-drop and clipboard-paste handlers, which ran a
+	 * near-identical per-file loop. Per file it runs: `isSupportedImageType` →
+	 * cumulative-size check against `GEMINI_INLINE_DATA_LIMIT` (breaks on
+	 * overflow) → `fileToBase64` → build `InlineAttachment` → `addAttachment` →
+	 * bump counters, with an `isSvgFile` branch delegating to
+	 * `attachExternalSvgFile` (rasterization) and a trailing
+	 * `else if (image/*) unsupportedCount++`. The distinct post-loop notice
+	 * logic stays in each caller.
+	 *
+	 * The paste-only `e.preventDefault()` is parameterized via
+	 * `opts.onFirstImage`, invoked the first time an image or SVG is accepted
+	 * (before the accepted item is processed); drop passes no callback.
+	 */
+	private async processAttachmentFiles(
+		files: File[],
+		callbacks: UICallbacks,
+		opts?: { onFirstImage?: () => void }
+	): Promise<{ imagesProcessed: number; unsupportedCount: number }> {
+		let imagesProcessed = 0;
+		let unsupportedCount = 0;
+		let cumulativeSize = this.getCurrentAttachmentSize(callbacks);
+		for (const file of files) {
+			if (isSupportedImageType(file.type)) {
+				if (cumulativeSize + file.size > GEMINI_INLINE_DATA_LIMIT) {
+					new Notice(t('agent.attachments.sizeLimitReached'));
+					break;
+				}
+				if (imagesProcessed === 0) {
+					opts?.onFirstImage?.();
+				}
+				try {
+					const base64 = await fileToBase64(file);
+					const attachment: InlineAttachment = {
+						base64,
+						mimeType: getMimeType(file),
+						id: generateAttachmentId(),
+					};
+					callbacks.addAttachment(attachment);
+					cumulativeSize += file.size;
+					imagesProcessed++;
+				} catch (err) {
+					this.plugin.logger.error('Failed to process attachment image:', err);
+					new Notice(t('agent.attachments.imageAttachFailed'));
+				}
+			} else if (this.isSvgFile(file)) {
+				// External SVG/SVGZ — rasterize to PNG before inlining.
+				if (cumulativeSize + file.size > GEMINI_INLINE_DATA_LIMIT) {
+					new Notice(t('agent.attachments.sizeLimitReached'));
+					break;
+				}
+				if (imagesProcessed === 0) {
+					opts?.onFirstImage?.();
+				}
+				if (await this.attachExternalSvgFile(file, callbacks)) {
+					cumulativeSize += file.size;
+					imagesProcessed++;
+				} else {
+					unsupportedCount++;
+				}
+			} else if (file.type.startsWith('image/')) {
+				unsupportedCount++;
+			}
+		}
+		return { imagesProcessed, unsupportedCount };
 	}
 
 	/**

--- a/src/ui/agent-view/agent-view-ui.ts
+++ b/src/ui/agent-view/agent-view-ui.ts
@@ -939,16 +939,26 @@ export class AgentViewUI {
 	): Promise<{ imagesProcessed: number; unsupportedCount: number }> {
 		let imagesProcessed = 0;
 		let unsupportedCount = 0;
+		// Gate onFirstImage on its own flag rather than `imagesProcessed === 0`,
+		// so it still fires exactly once if an earlier accepted item fails to
+		// process (a rejected `fileToBase64` or a failed SVG rasterization leaves
+		// `imagesProcessed` at 0). It fires the first time an item passes the
+		// size check and enters processing.
+		let firstImageNotified = false;
 		let cumulativeSize = this.getCurrentAttachmentSize(callbacks);
+		const notifyFirstImage = () => {
+			if (!firstImageNotified) {
+				firstImageNotified = true;
+				opts?.onFirstImage?.();
+			}
+		};
 		for (const file of files) {
 			if (isSupportedImageType(file.type)) {
 				if (cumulativeSize + file.size > GEMINI_INLINE_DATA_LIMIT) {
 					new Notice(t('agent.attachments.sizeLimitReached'));
 					break;
 				}
-				if (imagesProcessed === 0) {
-					opts?.onFirstImage?.();
-				}
+				notifyFirstImage();
 				try {
 					const base64 = await fileToBase64(file);
 					const attachment: InlineAttachment = {
@@ -969,9 +979,7 @@ export class AgentViewUI {
 					new Notice(t('agent.attachments.sizeLimitReached'));
 					break;
 				}
-				if (imagesProcessed === 0) {
-					opts?.onFirstImage?.();
-				}
+				notifyFirstImage();
 				if (await this.attachExternalSvgFile(file, callbacks)) {
 					cumulativeSize += file.size;
 					imagesProcessed++;

--- a/test/ui/agent-view-ui.test.ts
+++ b/test/ui/agent-view-ui.test.ts
@@ -1,5 +1,6 @@
 import type { Mock } from 'vitest';
 import { AgentViewUI, UICallbacks } from '../../src/ui/agent-view/agent-view-ui';
+import { GEMINI_INLINE_DATA_LIMIT } from '../../src/utils/file-classification';
 import { App, TFile, TFolder, Notice } from 'obsidian';
 import ObsidianGemini from '../../src/main';
 import { shouldExcludePathForPlugin } from '../../src/utils/file-utils';
@@ -562,6 +563,80 @@ describe('AgentViewUI', () => {
 			expect(callbacks.addAttachment).toHaveBeenCalledTimes(1);
 			// Big file should be skipped, notice shown
 			expect(Notice).toHaveBeenCalledWith(expect.stringContaining('20MB'), expect.any(Number));
+		});
+	});
+
+	// The external-drop and clipboard-paste handlers share this per-file
+	// image/SVG loop (extracted from the two near-verbatim copies). Exercise it
+	// directly so the shared unit is covered independently of the DOM events.
+	describe('processAttachmentFiles', () => {
+		const run = (files: File[], opts?: { onFirstImage?: () => void }) =>
+			(agentViewUI as any).processAttachmentFiles(files, callbacks, opts) as Promise<{
+				imagesProcessed: number;
+				unsupportedCount: number;
+			}>;
+
+		const imageFile = (name: string, type: string, size?: number): File => {
+			const file = new File([new Uint8Array([1, 2, 3])], name, { type });
+			if (size !== undefined) {
+				Object.defineProperty(file, 'size', { value: size });
+			}
+			return file;
+		};
+
+		it('accepts a supported image and increments imagesProcessed', async () => {
+			const result = await run([imageFile('a.png', 'image/png')]);
+			expect(result).toEqual({ imagesProcessed: 1, unsupportedCount: 0 });
+			expect(callbacks.addAttachment).toHaveBeenCalledTimes(1);
+			expect(callbacks.addAttachment).toHaveBeenCalledWith(expect.objectContaining({ mimeType: 'image/png' }));
+		});
+
+		it('breaks on the cumulative size limit without attaching', async () => {
+			const result = await run([imageFile('big.png', 'image/png', GEMINI_INLINE_DATA_LIMIT + 1)]);
+			expect(result).toEqual({ imagesProcessed: 0, unsupportedCount: 0 });
+			expect(callbacks.addAttachment).not.toHaveBeenCalled();
+			expect(Notice).toHaveBeenCalledWith(expect.stringContaining('20 MB'));
+		});
+
+		it('delegates SVG files to attachExternalSvgFile (success counts as processed)', async () => {
+			const svgSpy = vi.spyOn(agentViewUI as any, 'attachExternalSvgFile').mockResolvedValue(true);
+			const result = await run([imageFile('icon.svg', 'image/svg+xml')]);
+			expect(svgSpy).toHaveBeenCalledTimes(1);
+			expect(result).toEqual({ imagesProcessed: 1, unsupportedCount: 0 });
+		});
+
+		it('counts an SVG that fails rasterization as unsupported', async () => {
+			vi.spyOn(agentViewUI as any, 'attachExternalSvgFile').mockResolvedValue(false);
+			const result = await run([imageFile('icon.svg', 'image/svg+xml')]);
+			expect(result).toEqual({ imagesProcessed: 0, unsupportedCount: 1 });
+			expect(callbacks.addAttachment).not.toHaveBeenCalled();
+		});
+
+		it('ignores non-image files', async () => {
+			const result = await run([imageFile('note.txt', 'text/plain')]);
+			expect(result).toEqual({ imagesProcessed: 0, unsupportedCount: 0 });
+			expect(callbacks.addAttachment).not.toHaveBeenCalled();
+		});
+
+		it('counts an unsupported image MIME type as unsupported', async () => {
+			const result = await run([imageFile('old.bmp', 'image/bmp')]);
+			expect(result).toEqual({ imagesProcessed: 0, unsupportedCount: 1 });
+			expect(callbacks.addAttachment).not.toHaveBeenCalled();
+		});
+
+		it('invokes onFirstImage exactly once for the first accepted image', async () => {
+			const onFirstImage = vi.fn();
+			const result = await run([imageFile('a.png', 'image/png'), imageFile('b.png', 'image/png')], {
+				onFirstImage,
+			});
+			expect(result).toEqual({ imagesProcessed: 2, unsupportedCount: 0 });
+			expect(onFirstImage).toHaveBeenCalledTimes(1);
+		});
+
+		it('does not invoke onFirstImage when nothing is accepted', async () => {
+			const onFirstImage = vi.fn();
+			await run([imageFile('note.txt', 'text/plain')], { onFirstImage });
+			expect(onFirstImage).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/test/ui/agent-view-ui.test.ts
+++ b/test/ui/agent-view-ui.test.ts
@@ -633,6 +633,18 @@ describe('AgentViewUI', () => {
 			expect(onFirstImage).toHaveBeenCalledTimes(1);
 		});
 
+		it('invokes onFirstImage only once even when an earlier accepted item fails to process', async () => {
+			// First item is an SVG that fails rasterization (imagesProcessed stays 0),
+			// second is an image that succeeds. onFirstImage must still fire exactly once.
+			vi.spyOn(agentViewUI as any, 'attachExternalSvgFile').mockResolvedValue(false);
+			const onFirstImage = vi.fn();
+			const result = await run([imageFile('icon.svg', 'image/svg+xml'), imageFile('ok.png', 'image/png')], {
+				onFirstImage,
+			});
+			expect(result).toEqual({ imagesProcessed: 1, unsupportedCount: 1 });
+			expect(onFirstImage).toHaveBeenCalledTimes(1);
+		});
+
 		it('does not invoke onFirstImage when nothing is accepted', async () => {
 			const onFirstImage = vi.fn();
 			await run([imageFile('note.txt', 'text/plain')], { onFirstImage });


### PR DESCRIPTION
<!-- auto-dev -->

## Summary

The `architecture-audit` sweep flagged a ~35-line image/SVG attachment-processing loop duplicated near-verbatim between the **external-drop** handler and the **clipboard-paste** handler in `src/ui/agent-view/agent-view-ui.ts`. Both copies ran the identical per-file pipeline (`isSupportedImageType` → cumulative-size check → `fileToBase64` → build `InlineAttachment` → `addAttachment` → bump counters, with an `isSvgFile` rasterization branch), differing only in the iterable source and the paste path's `e.preventDefault()` guard. This PR extracts the shared loop into one private helper so the two paths can no longer drift.

Pure code-motion — **no behavior change intended**. The size-limit break, SVG rasterization fallback, and unsupported-count semantics are preserved exactly. The distinct post-loop notice logic (drop vs. paste show different messages) stays in each handler.

Produced by the auto-dev pipeline from the approved plan on #1170.

Fixes #1170

## Changes

- `src/ui/agent-view/agent-view-ui.ts` — add `private async processAttachmentFiles(files, callbacks, opts?)` owning the cumulative-size seed (`getCurrentAttachmentSize`), the size-limit `break`, the image and SVG branches (including the `attachExternalSvgFile` rasterization fallback and its `unsupportedCount++` on failure), and the counter bookkeeping. The paste-only `e.preventDefault()` is parameterized via the optional `onFirstImage` callback, invoked the first time an image or SVG is accepted (`imagesProcessed === 0`, before the accepted item is processed — matching the prior pre-`await` placement).
- Rewire the **drop** handler to call the helper with no `onFirstImage` (it already calls `e.preventDefault()` unconditionally before the loop), and the **paste** handler to call it with `onFirstImage: () => e.preventDefault()`; each keeps its own trailing notice block unchanged.
- `test/ui/agent-view-ui.test.ts` — add a `processAttachmentFiles` describe block exercising the helper directly: supported image accepted, cumulative-size-limit break, SVG delegation (success and rasterization-failure), non-image ignored, unsupported image MIME counted, and `onFirstImage` firing exactly once (and not at all when nothing is accepted).

## Screenshots / Screencast

N/A — internal DRY refactor with no user-visible behavior change.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards)
- [x] Documentation has been updated (if applicable) — N/A (internal refactor; no user-facing behavior, settings, commands, or API change)
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude (auto-dev pipeline)
- [x] I have reviewed and understand all AI-generated code in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01USJpJiEwBfBvd2Jt14idqh)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved drag-and-drop and paste handling for external images, including SVG/SVGZ files.
  * Better consistency when accepting images, rejecting unsupported image types, and enforcing attachment size limits.
  * Paste behavior now correctly applies the first-image action only once, matching expected editor behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->