### PR TITLE
chore(daily): 2026-07-09 daily update

### DIFF
--- a/planning/changelog/2026-07-08.md
+++ b/planning/changelog/2026-07-08.md
@@ -1,0 +1,20 @@
+# Daily changelog — July 08, 2026
+
+**Date:** 2026-07-08
+**PRs merged:** 2
+
+---
+
+## Summary
+
+Quiet day — one housekeeping PR and one small DRY refactor from the automated architecture-audit sweep.
+
+## What shipped
+
+### [#1171 chore(daily): 2026-07-07 daily update](https://github.com/allenhutchison/obsidian-gemini/pull/1171)
+
+The automated daily-update run for 2026-07-07: `daily-changelog` wrote up the 8 PRs that merged that day (the lint-hardening epic closing out circular imports and `no-explicit-any`), `audit-docs` found no drift, and `triage-issues` had nothing to label. The bundled-skill drift check errored again because this session's GitHub scope is limited to `allenhutchison/obsidian-gemini`, so `kepano/obsidian-skills` upstream still needs a human or broader-scoped session to check.
+
+### [#1169 refactor: dedup isCurrentSession into shared isSameSession helper](https://github.com/allenhutchison/obsidian-gemini/pull/1169)
+
+The nightly architecture-audit sweep flagged a DRY violation: the "is this session the current session?" predicate (matching on `id` or `historyPath`) was copy-pasted, doc comment included, into `AgentViewSession`, `AgentView`, and `AgentViewMessages`. This extracts it into a single pure helper, `isSameSession()` in a new `session-identity.ts`, and has all three call sites delegate to it. Pure code-motion, no behavior change.


### PR DESCRIPTION
## Summary

Automated daily housekeeping run (`daily-update` meta-skill) bundling `daily-changelog`, `audit-docs`, `triage-issues`, and the bundled-skill drift check for 2026-07-09.

## Changes

- **daily-changelog**: wrote `planning/changelog/2026-07-08.md` — 2 PRs merged on 2026-07-08, a quiet day: [#1171](https://github.com/allenhutchison/obsidian-gemini/pull/1171) (prior day's automated daily-update run) and [#1169](https://github.com/allenhutchison/obsidian-gemini/pull/1169) (dedup `isCurrentSession` into a shared `isSameSession` helper, from the architecture-audit sweep).
- **audit-docs**: no drift found. Full pass validated settings + defaults, command palette IDs, tool names, scheduled-task schedule grammar, lifecycle-hook timings, turn budgets/loop-detection thresholds, tool policy presets, RAG constants, MCP timeouts, i18n language list, skill-name validation, and file-classification limits against the current code — everything matched. No new docs warranted.
- **triage-issues**: no-op — 0 unlabeled open issues (17 open issues total, all already labeled).
- **bundled-skill drift check**: errored — this session's GitHub access is scoped to `allenhutchison/obsidian-gemini` only, so the `kepano/obsidian-skills` upstream comparison could not be run. Same limitation as recent daily runs; still needs a human, or a session with broader GitHub scope, to check upstream drift for `obsidian-markdown`, `json-canvas`, and `obsidian-bases`.

This is a housekeeping-only PR — no source code changes.

## Screenshots / Screencast

N/A — changelog-only change, no UI change.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A; routine automated daily housekeeping run
- [x] All CI checks pass (`npm test` — 3364 passing, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop — N/A, changelog-only change; verified via local pre-flight checks
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A, no code change
- [x] Documentation has been updated (if applicable) — this PR's own audit-docs pass is the documentation update (no drift found)
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01A6VUbJYZkdmboeZEFfSove)_