### PR TITLE
chore(daily): 2026-07-09 daily update

### DIFF
--- a/planning/changelog/2026-07-09.md
+++ b/planning/changelog/2026-07-09.md
@@ -1,0 +1,24 @@
+# Daily changelog — July 09, 2026
+
+**Date:** 2026-07-09
+**PRs merged:** 3
+
+---
+
+## Summary
+
+A TS-strictness and DRY cleanup day, followed by the previous day's automated housekeeping PR landing. The two substantive PRs both came out of the `architecture-audit` sweep: one clears a slice of `no-unsafe-*` lint violations, the other de-duplicates a UI attachment-processing loop.
+
+## What shipped
+
+### [#1172 refactor: clear no-unsafe-\* in src/utils and src/mcp (#1166)](https://github.com/allenhutchison/obsidian-gemini/pull/1172)
+
+First slice of #1166 (part of the larger #1032 TS-strictness sweep). Clears the `@typescript-eslint/no-unsafe-*` family (21 violations) in `src/utils/` and `src/mcp/` by typing each untyped boundary at its source — narrowing `ToolResult.data` access via a new `readStringProp` helper, annotating `String.replace` capture groups, replacing two `@ts-expect-error` suppressions with a single typed `AppWithSetting` cast, and narrowing MCP content blocks with the existing `asRecord` helper. Adds a scoped ESLint override enforcing the five rules for `src/utils/**` and `src/mcp/**`; the global softened-rules list stays off until the final slice flips everything at once. Type-only change, no behavior difference.
+
+### [#1173 refactor(ui): de-duplicate external image/SVG attachment loop (#1170)](https://github.com/allenhutchison/obsidian-gemini/pull/1173)
+
+Also from the `architecture-audit` sweep: extracts a ~35-line image/SVG attachment-processing loop that was duplicated near-verbatim between the external-drop and clipboard-paste handlers in `agent-view-ui.ts` into a single private `processAttachmentFiles` helper. Preserves the size-limit break, SVG rasterization fallback, and unsupported-count semantics exactly; the paste-only `preventDefault()` call is parameterized via an `onFirstImage` callback. Pure code-motion, no behavior change intended.
+
+### [#1174 chore(daily): 2026-07-09 daily update](https://github.com/allenhutchison/obsidian-gemini/pull/1174)
+
+The prior day's automated `daily-update` run, bundling `daily-changelog` (wrote `planning/changelog/2026-07-08.md`), a clean `audit-docs` pass (no drift), a no-op `triage-issues` pass, and an errored bundled-skill drift check (GitHub scope limited to this repo, so the `kepano/obsidian-skills` upstream comparison couldn't run). Housekeeping-only, no source changes.


### PR DESCRIPTION
## Summary

Automated daily housekeeping run (`daily-update` meta-skill) bundling `daily-changelog`, `audit-docs`, `triage-issues`, and the bundled-skill drift check for 2026-07-09.

## Changes

- **daily-changelog**: wrote `planning/changelog/2026-07-09.md` — 3 PRs merged on 2026-07-09: [#1172](https://github.com/allenhutchison/obsidian-gemini/pull/1172) (clear `no-unsafe-*` ESLint violations in `src/utils/` and `src/mcp/`, type-only), [#1173](https://github.com/allenhutchison/obsidian-gemini/pull/1173) (de-duplicate the external image/SVG attachment loop in `agent-view-ui.ts`), and [#1174](https://github.com/allenhutchison/obsidian-gemini/pull/1174) (prior day's automated daily-update run).
- **audit-docs**: no drift found. Verified #1172 and #1173 were genuinely behavior-preserving as claimed, cross-checked the 20 MB attachment limit and all 5 MCP timeout values against code, and spot-checked settings defaults, command palette IDs, loop-detection thresholds, scheduled-task grammar, and permission tier names — everything matched. No new docs warranted.
- **triage-issues**: no-op — 0 unlabeled open issues.
- **bundled-skill drift check**: errored — this session's GitHub access is scoped to `allenhutchison/obsidian-gemini` only (no `gh` CLI available either), so the `kepano/obsidian-skills` upstream comparison could not be run. Same limitation as recent daily runs; still needs a human, or a session with broader GitHub scope, to check upstream drift for `obsidian-markdown`, `json-canvas`, and `obsidian-bases`.

This is a housekeeping-only PR — no source code changes.

## Screenshots / Screencast

N/A — changelog-only change, no UI change.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A; routine automated daily housekeeping run
- [x] All CI checks pass (`npm test` — 3374 passing, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop — N/A, changelog-only change; verified via local pre-flight checks
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A, no code change
- [x] Documentation has been updated (if applicable) — this PR's own audit-docs pass is the documentation update (no drift found)
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01CzuSeSA5wxfkPsmpgpNFV5)_