### PR TITLE
fix: stop Node built-ins loading at startup via gemini-utils subpaths (#1154)

### DIFF
--- a/docs/contributing/contributing.md
+++ b/docs/contributing/contributing.md
@@ -77,6 +77,8 @@ Gemini Scribe runs on **both Desktop and Mobile** (iOS/Android via Obsidian Mobi
 
 Do not use Node.js-specific APIs, browser-only APIs, or desktop-only Electron APIs without checking platform availability first. Test on mobile if your change touches UI or file system operations.
 
+**Never let a Node built-in (`fs`, `path`, `crypto`, `url`, …) evaluate at plugin load.** Even a value import of a module that _transitively_ requires a built-in makes Obsidian raise "attempted to load NodeJS package" warnings on every load (the plugin declares mobile support via `isDesktopOnly: false`). In particular, import `@allenhutchison/gemini-utils` helpers from its built-in-free subpaths (`/mime`, `/support-registry`) rather than the barrel, keep type-only imports as `import type`, and lazy-load desktop-only managers (`FileUploader`, etc.) via `await import('@allenhutchison/gemini-utils/file-search')` at first use so their `fs`/`crypto` requires never run at load. See [testing.md → Mobile Testing](testing.md#mobile-testing) for how to verify.
+
 ### 5. Use the Obsidian API
 
 This project follows an **Obsidian API First** principle. The `obsidian` package provides a rich set of utilities — use them instead of rolling your own:

--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -104,6 +104,21 @@ this.app.emulateMobile(!this.app.isMobile);
 
 This is the fastest way to catch mobile-specific issues without deploying to a device.
 
+### Verifying No Node Built-ins Load at Startup
+
+Because the plugin declares mobile support (`isDesktopOnly: false`), Obsidian raises an "attempted to load NodeJS package" warning (as a Notice toast and a `console.error`) whenever a `require('fs'|'path'|'crypto'|'url'|…)` runs at plugin load. After any change that touches imports of `@allenhutchison/gemini-utils` or other Node-dependent packages, confirm the load path stays clean using the Obsidian CLI:
+
+```bash
+npm run build && npm run install:test-vault
+obsidian dev:debug on            # REQUIRED — dev:console captures nothing until the debugger is attached
+obsidian dev:console clear
+obsidian plugin:reload id=gemini-scribe
+sleep 3
+obsidian dev:console limit=300 | grep -iE "nodejs|attempt.*load"   # expect NO output
+```
+
+An empty grep means no built-ins evaluated at load. (Common footgun: forgetting `dev:debug on` makes every check falsely pass — `dev:console` returns "Debugger not attached".) Repeat with `obsidian dev:mobile on` (then `off`) to confirm under mobile emulation. See the **obsidian-cli** skill for the full recipe.
+
 ### Getting Builds onto a Device
 
 There is no way to run `npm run dev` directly on mobile. Instead, build on desktop and sync the output files to your mobile device.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "4.10.2",
 			"license": "MIT",
 			"dependencies": {
-				"@allenhutchison/gemini-utils": "^1.1.0",
+				"@allenhutchison/gemini-utils": "^1.2.0",
 				"@codemirror/merge": "^6.12.2",
 				"@types/turndown": "^5.0.6",
 				"ollama": "^0.6.3",
@@ -303,9 +303,9 @@
 			}
 		},
 		"node_modules/@allenhutchison/gemini-utils": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@allenhutchison/gemini-utils/-/gemini-utils-1.1.0.tgz",
-			"integrity": "sha512-0mQdXXro0XXh7qsNlEBR2AoIYg5OJKbIowl2L4NDNqvGC+UBdmFXPBjgwNZ0MUYirTmG7efqErEQZXlNRAUY4Q==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@allenhutchison/gemini-utils/-/gemini-utils-1.2.0.tgz",
+			"integrity": "sha512-8fGIp0fUpQyUoSO6bOuXY/xSAuXxSaJ2f0V2niggyvBDYWciWuEuuGHEHTU0nWGYjF6EsfZ4iN94UgqSdfYMmA==",
 			"license": "MIT",
 			"dependencies": {
 				"commander": "^15.0.0",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
 		"vitest": "^4.1.5"
 	},
 	"dependencies": {
-		"@allenhutchison/gemini-utils": "^1.1.0",
+		"@allenhutchison/gemini-utils": "^1.2.0",
 		"@codemirror/merge": "^6.12.2",
 		"@types/turndown": "^5.0.6",
 		"ollama": "^0.6.3",

--- a/src/services/deep-research.ts
+++ b/src/services/deep-research.ts
@@ -2,7 +2,10 @@ import { TFile, normalizePath } from 'obsidian';
 import type { ObsidianGemini } from '../types/plugin';
 import { isPathInFolder } from '../utils/file-utils';
 import type { Interactions } from '@google/genai';
-import { ResearchManager, ReportGenerator, Interaction, InteractionOutput } from '@allenhutchison/gemini-utils';
+// The `/research` subpath is built-in-free (no fs/path/crypto), unlike the
+// barrel — import from it so this module stays mobile-safe at load (#1154).
+import { ResearchManager, ReportGenerator } from '@allenhutchison/gemini-utils/research';
+import type { Interaction, InteractionOutput } from '@allenhutchison/gemini-utils/research';
 import { proxyFetch } from '../utils/proxy-fetch';
 import { executeWithRetry, RetryConfig, DEFAULT_RETRY_CONFIG } from '../utils/retry';
 import { createGoogleGenAI } from '../api/providers/gemini/google-genai-factory';

--- a/src/services/obsidian-file-adapter.ts
+++ b/src/services/obsidian-file-adapter.ts
@@ -1,11 +1,9 @@
 import { TFile, Vault, MetadataCache } from 'obsidian';
-import {
-	FileSystemAdapter,
-	FileInfo,
-	FileContent,
-	getMimeTypeWithFallback,
-	isExtensionSupportedWithFallback,
-} from '@allenhutchison/gemini-utils';
+// Types are erased at compile time, so importing them from the barrel is free.
+import type { FileSystemAdapter, FileInfo, FileContent } from '@allenhutchison/gemini-utils';
+// The MIME helpers are runtime values — import them from the built-in-free
+// `/mime` subpath so this module never pulls Node built-ins at load (#1154).
+import { getMimeTypeWithFallback, isExtensionSupportedWithFallback } from '@allenhutchison/gemini-utils/mime';
 import { isPathInFolder } from '../utils/file-utils';
 
 /**

--- a/src/services/rag-indexing.ts
+++ b/src/services/rag-indexing.ts
@@ -1,6 +1,9 @@
 import { GoogleGenAI } from '@google/genai';
 import { TFile, Notice } from 'obsidian';
-import { FileUploader } from '@allenhutchison/gemini-utils';
+// FileUploader lives in the `/file-search` group, which pulls Node built-ins
+// (fs/path/crypto). Import the type only, and lazy-load the implementation at
+// first use so those built-ins never evaluate at plugin load (#1154).
+import type { FileUploader } from '@allenhutchison/gemini-utils';
 import type { ObsidianGemini } from '../types/plugin';
 import { ObsidianVaultAdapter } from './obsidian-file-adapter';
 import { getErrorMessage } from '../utils/error-utils';
@@ -120,7 +123,10 @@ export class RagIndexingService {
 				logError: (msg, ...args) => this.plugin.logger.error(msg, ...args),
 			});
 
-			// Create file uploader with logger
+			// Create file uploader with logger. Lazy-load the desktop-only
+			// implementation so its fs/path/crypto requires never run at plugin
+			// load (they'd raise mobile-compat warning toasts — #1154).
+			const { FileUploader } = await import('@allenhutchison/gemini-utils/file-search');
 			this.fileUploader = new FileUploader(this.ai, {
 				debug: (msg, ...args) => this.plugin.logger.debug(msg, ...args),
 				error: (msg, ...args) => this.plugin.logger.error(msg, ...args),

--- a/src/utils/file-classification.ts
+++ b/src/utils/file-classification.ts
@@ -5,7 +5,10 @@
  * or UNSUPPORTED based on their extension.
  */
 
-import { EXTENSION_TO_MIME, TEXT_FALLBACK_EXTENSIONS } from '@allenhutchison/gemini-utils';
+// Import from the built-in-free `/mime` subpath (not the barrel) so this hot,
+// load-time module never pulls Node built-ins (fs/path/crypto) into a mobile
+// bundle. See #1154 and gemini-utils 1.2.0 subpath exports.
+import { EXTENSION_TO_MIME, TEXT_FALLBACK_EXTENSIONS } from '@allenhutchison/gemini-utils/mime';
 
 /** Maximum size for inline data sent to Gemini (20 MB) */
 export const GEMINI_INLINE_DATA_LIMIT = 20 * 1024 * 1024;

--- a/test/services/deep-research.test.ts
+++ b/test/services/deep-research.test.ts
@@ -18,7 +18,7 @@ const mockPoll = vi.fn();
 const mockCancel = vi.fn();
 const mockGenerateMarkdown = vi.fn();
 
-vi.mock('@allenhutchison/gemini-utils', () => ({
+vi.mock('@allenhutchison/gemini-utils/research', () => ({
 	ResearchManager: vi.fn().mockImplementation(function () {
 		return {
 			startResearch: mockStartResearch,

--- a/test/services/mobile-node-builtins.test.ts
+++ b/test/services/mobile-node-builtins.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync, statSync } from 'fs';
+import { join } from 'path';
+
+/**
+ * Regression guard for #1154.
+ *
+ * `@allenhutchison/gemini-utils` groups Node-built-in-touching modules
+ * (`FileUploader`, transcription, etc.) behind its barrel entry. A *value*
+ * import from the bare barrel pulls those `fs`/`path`/`crypto`/`url` requires
+ * into the plugin's load path, which Obsidian warns about on every load because
+ * the plugin declares mobile support (`isDesktopOnly: false`).
+ *
+ * Rule: any static import from the *bare* barrel specifier must be `import type`
+ * (erased at build). Runtime values must come from a built-in-free subpath
+ * (`/mime`, `/support-registry`, `/research`) or be lazy-loaded via
+ * `await import(...)`.
+ */
+
+const BARE_BARREL = '@allenhutchison/gemini-utils';
+
+function collectTsFiles(dir: string, acc: string[] = []): string[] {
+	for (const entry of readdirSync(dir)) {
+		const full = join(dir, entry);
+		if (statSync(full).isDirectory()) {
+			collectTsFiles(full, acc);
+		} else if (entry.endsWith('.ts')) {
+			acc.push(full);
+		}
+	}
+	return acc;
+}
+
+describe('gemini-utils barrel is never a load-time value import (#1154)', () => {
+	// Matches a static import whose specifier is EXACTLY the bare barrel
+	// (a trailing `/subpath` or `/mime'` is fine and won't match). Group 1 is
+	// the import clause (`type { … }`, `{ … }`, `Foo`, …).
+	const bareBarrelImport = /import\s+([^;]*?)\s+from\s+['"]@allenhutchison\/gemini-utils['"]/g;
+
+	const files = collectTsFiles(join(process.cwd(), 'src'));
+
+	it('scans a non-trivial number of source files', () => {
+		expect(files.length).toBeGreaterThan(50);
+	});
+
+	it('every bare-barrel import is type-only', () => {
+		const offenders: string[] = [];
+		for (const file of files) {
+			const src = readFileSync(file, 'utf8');
+			for (const match of src.matchAll(bareBarrelImport)) {
+				const clause = match[1] ?? '';
+				// `import type { … }` and `import type Foo` are erased — allowed.
+				if (!clause.startsWith('type ')) {
+					offenders.push(`${file.replace(process.cwd() + '/', '')}: import ${clause} from '${BARE_BARREL}'`);
+				}
+			}
+		}
+		expect(
+			offenders,
+			`Value imports from the bare barrel force Node built-ins into the load path (#1154). Use a subpath (/mime, /support-registry, /research) or a lazy await import().\n${offenders.join('\n')}`
+		).toEqual([]);
+	});
+});

--- a/test/services/obsidian-file-adapter.test.ts
+++ b/test/services/obsidian-file-adapter.test.ts
@@ -1,7 +1,7 @@
 import { TFile } from 'obsidian';
 
-// Mock gemini-utils
-vi.mock('@allenhutchison/gemini-utils', () => ({
+// Mock gemini-utils MIME helpers (imported from the built-in-free /mime subpath)
+vi.mock('@allenhutchison/gemini-utils/mime', () => ({
 	getMimeTypeWithFallback: vi.fn((filePath: string) => {
 		if (filePath.endsWith('.md')) return { mimeType: 'text/markdown' };
 		if (filePath.endsWith('.pdf')) return { mimeType: 'application/pdf' };
@@ -19,7 +19,7 @@ vi.mock('@allenhutchison/gemini-utils', () => ({
 
 // Import after mocks
 import { ObsidianVaultAdapter } from '../../src/services/obsidian-file-adapter';
-import { isExtensionSupportedWithFallback } from '@allenhutchison/gemini-utils';
+import { isExtensionSupportedWithFallback } from '@allenhutchison/gemini-utils/mime';
 
 // --- Helpers ---
 

--- a/test/services/rag-indexing.test.ts
+++ b/test/services/rag-indexing.test.ts
@@ -35,7 +35,7 @@ vi.mock('@google/genai', () => ({
 }));
 
 // Mock FileUploader
-vi.mock('@allenhutchison/gemini-utils', () => ({
+vi.mock('@allenhutchison/gemini-utils/file-search', () => ({
 	FileUploader: vi.fn().mockImplementation(function () {
 		return {
 			uploadWithAdapter: vi.fn().mockResolvedValue(undefined),

--- a/test/services/rag-vault-scanner.test.ts
+++ b/test/services/rag-vault-scanner.test.ts
@@ -44,7 +44,7 @@ vi.mock('@google/genai', () => ({
 }));
 
 // Mock FileUploader
-vi.mock('@allenhutchison/gemini-utils', () => ({
+vi.mock('@allenhutchison/gemini-utils/file-search', () => ({
 	FileUploader: vi.fn().mockImplementation(function () {
 		return {
 			uploadWithAdapter: vi.fn().mockResolvedValue(undefined),

--- a/test/tools/execution-engine.test.ts
+++ b/test/tools/execution-engine.test.ts
@@ -15,7 +15,7 @@ const denyProvider: IConfirmationProvider = {
 };
 
 // Mock gemini-utils (needed by file-classification, imported by vault-tools)
-vi.mock('@allenhutchison/gemini-utils', () => ({
+vi.mock('@allenhutchison/gemini-utils/mime', () => ({
 	EXTENSION_TO_MIME: { '.md': 'text/markdown', '.txt': 'text/plain' },
 	TEXT_FALLBACK_EXTENSIONS: new Set(['.ts', '.js', '.json']),
 }));

--- a/test/tools/tool-integration.test.ts
+++ b/test/tools/tool-integration.test.ts
@@ -17,7 +17,7 @@ const denyProvider: IConfirmationProvider = {
 };
 
 // Mock gemini-utils (needed by file-classification, imported by vault-tools)
-vi.mock('@allenhutchison/gemini-utils', () => ({
+vi.mock('@allenhutchison/gemini-utils/mime', () => ({
 	EXTENSION_TO_MIME: { '.md': 'text/markdown', '.txt': 'text/plain' },
 	TEXT_FALLBACK_EXTENSIONS: new Set(['.ts', '.js', '.json']),
 }));

--- a/test/tools/vault/create-folder-tool.test.ts
+++ b/test/tools/vault/create-folder-tool.test.ts
@@ -2,7 +2,7 @@ import { CreateFolderTool } from '../../../src/tools/vault';
 import { ToolExecutionContext } from '../../../src/tools/types';
 
 // Mock gemini-utils (needed by file-classification, imported by vault-tools)
-vi.mock('@allenhutchison/gemini-utils', () => ({
+vi.mock('@allenhutchison/gemini-utils/mime', () => ({
 	EXTENSION_TO_MIME: {
 		'.md': 'text/markdown',
 		'.txt': 'text/plain',

--- a/test/tools/vault/delete-file-tool.test.ts
+++ b/test/tools/vault/delete-file-tool.test.ts
@@ -2,7 +2,7 @@ import { DeleteFileTool } from '../../../src/tools/vault';
 import { ToolExecutionContext } from '../../../src/tools/types';
 
 // Mock gemini-utils (needed by file-classification, imported by vault-tools)
-vi.mock('@allenhutchison/gemini-utils', () => ({
+vi.mock('@allenhutchison/gemini-utils/mime', () => ({
 	EXTENSION_TO_MIME: {
 		'.md': 'text/markdown',
 		'.txt': 'text/plain',

--- a/test/tools/vault/get-workspace-state-tool.test.ts
+++ b/test/tools/vault/get-workspace-state-tool.test.ts
@@ -2,7 +2,7 @@ import { GetWorkspaceStateTool } from '../../../src/tools/vault';
 import { ToolExecutionContext } from '../../../src/tools/types';
 
 // Mock gemini-utils (needed by file-classification, imported by vault-tools)
-vi.mock('@allenhutchison/gemini-utils', () => ({
+vi.mock('@allenhutchison/gemini-utils/mime', () => ({
 	EXTENSION_TO_MIME: {
 		'.md': 'text/markdown',
 		'.txt': 'text/plain',

--- a/test/tools/vault/list-files-tool.test.ts
+++ b/test/tools/vault/list-files-tool.test.ts
@@ -2,7 +2,7 @@ import { ListFilesTool } from '../../../src/tools/vault';
 import { ToolExecutionContext } from '../../../src/tools/types';
 
 // Mock gemini-utils (needed by file-classification, imported by vault-tools)
-vi.mock('@allenhutchison/gemini-utils', () => ({
+vi.mock('@allenhutchison/gemini-utils/mime', () => ({
 	EXTENSION_TO_MIME: {
 		'.md': 'text/markdown',
 		'.txt': 'text/plain',

--- a/test/tools/vault/move-file-tool.test.ts
+++ b/test/tools/vault/move-file-tool.test.ts
@@ -2,7 +2,7 @@ import { MoveFileTool } from '../../../src/tools/vault';
 import { ToolExecutionContext } from '../../../src/tools/types';
 
 // Mock gemini-utils (needed by file-classification, imported by vault-tools)
-vi.mock('@allenhutchison/gemini-utils', () => ({
+vi.mock('@allenhutchison/gemini-utils/mime', () => ({
 	EXTENSION_TO_MIME: {
 		'.md': 'text/markdown',
 		'.txt': 'text/plain',

--- a/test/tools/vault/read-file-tool.test.ts
+++ b/test/tools/vault/read-file-tool.test.ts
@@ -2,7 +2,7 @@ import { ReadFileTool } from '../../../src/tools/vault';
 import { ToolExecutionContext } from '../../../src/tools/types';
 
 // Mock gemini-utils (needed by file-classification, imported by vault-tools)
-vi.mock('@allenhutchison/gemini-utils', () => ({
+vi.mock('@allenhutchison/gemini-utils/mime', () => ({
 	EXTENSION_TO_MIME: {
 		'.md': 'text/markdown',
 		'.txt': 'text/plain',

--- a/test/tools/vault/search-file-contents-tool.test.ts
+++ b/test/tools/vault/search-file-contents-tool.test.ts
@@ -2,7 +2,7 @@ import { SearchFileContentsTool } from '../../../src/tools/vault';
 import { ToolExecutionContext } from '../../../src/tools/types';
 
 // Mock gemini-utils (needed by file-classification, imported by vault-tools)
-vi.mock('@allenhutchison/gemini-utils', () => ({
+vi.mock('@allenhutchison/gemini-utils/mime', () => ({
 	EXTENSION_TO_MIME: {
 		'.md': 'text/markdown',
 		'.txt': 'text/plain',

--- a/test/tools/vault/search-files-tool.test.ts
+++ b/test/tools/vault/search-files-tool.test.ts
@@ -2,7 +2,7 @@ import { SearchFilesTool } from '../../../src/tools/vault';
 import { ToolExecutionContext } from '../../../src/tools/types';
 
 // Mock gemini-utils (needed by file-classification, imported by vault-tools)
-vi.mock('@allenhutchison/gemini-utils', () => ({
+vi.mock('@allenhutchison/gemini-utils/mime', () => ({
 	EXTENSION_TO_MIME: {
 		'.md': 'text/markdown',
 		'.txt': 'text/plain',

--- a/test/tools/vault/utils.test.ts
+++ b/test/tools/vault/utils.test.ts
@@ -1,7 +1,7 @@
 import { resolvePathToFile, resolvePathToFileOrFolder } from '../../../src/tools/vault/utils';
 
 // Mock gemini-utils (needed by file-classification, imported by vault-tools)
-vi.mock('@allenhutchison/gemini-utils', () => ({
+vi.mock('@allenhutchison/gemini-utils/mime', () => ({
 	EXTENSION_TO_MIME: {
 		'.md': 'text/markdown',
 		'.txt': 'text/plain',

--- a/test/tools/vault/write-file-tool.test.ts
+++ b/test/tools/vault/write-file-tool.test.ts
@@ -2,7 +2,7 @@ import { WriteFileTool } from '../../../src/tools/vault';
 import { ToolExecutionContext } from '../../../src/tools/types';
 
 // Mock gemini-utils (needed by file-classification, imported by vault-tools)
-vi.mock('@allenhutchison/gemini-utils', () => ({
+vi.mock('@allenhutchison/gemini-utils/mime', () => ({
 	EXTENSION_TO_MIME: {
 		'.md': 'text/markdown',
 		'.txt': 'text/plain',

--- a/test/ui/agent-view-ui.test.ts
+++ b/test/ui/agent-view-ui.test.ts
@@ -18,10 +18,12 @@ vi.mock('../../src/utils/dom-context');
 vi.mock('../../src/utils/file-utils');
 
 // Mock external ESM dependencies
-vi.mock('@allenhutchison/gemini-utils', () => ({
+vi.mock('@allenhutchison/gemini-utils/research', () => ({
 	ResearchManager: class {},
 	ReportGenerator: class {},
 	Interaction: class {},
+}));
+vi.mock('@allenhutchison/gemini-utils/mime', () => ({
 	EXTENSION_TO_MIME: {
 		'.md': 'text/markdown',
 		'.txt': 'text/plain',

--- a/test/ui/agent-view.test.ts
+++ b/test/ui/agent-view.test.ts
@@ -13,10 +13,12 @@ vi.mock('../../src/ui/agent-view/file-picker-modal');
 vi.mock('../../src/ui/agent-view/session-settings-modal');
 
 // Mock external ESM dependencies
-vi.mock('@allenhutchison/gemini-utils', () => ({
+vi.mock('@allenhutchison/gemini-utils/research', () => ({
 	ResearchManager: class {},
 	ReportGenerator: class {},
 	Interaction: class {},
+}));
+vi.mock('@allenhutchison/gemini-utils/mime', () => ({
 	EXTENSION_TO_MIME: {
 		'.md': 'text/markdown',
 		'.txt': 'text/plain',

--- a/test/utils/file-classification.test.ts
+++ b/test/utils/file-classification.test.ts
@@ -9,7 +9,7 @@ import {
 } from '../../src/utils/file-classification';
 
 // Mock the gemini-utils module
-vi.mock('@allenhutchison/gemini-utils', () => ({
+vi.mock('@allenhutchison/gemini-utils/mime', () => ({
 	EXTENSION_TO_MIME: {
 		'.md': 'text/markdown',
 		'.txt': 'text/plain',


### PR DESCRIPTION
## Summary

Importing any **value** from the `@allenhutchison/gemini-utils` barrel evaluated its entire module graph, dragging `fs`/`path`/`crypto`/`url` requires into the plugin's load path. Because the plugin declares mobile support (`isDesktopOnly: false`), Obsidian raised a cascade of "attempted to load NodeJS package" warning toasts (and matching `console.error`s) on **every plugin (re)load**.

gemini-utils **1.2.0** adds built-in-free subpath exports (`/mime`, `/support-registry`, `/research`) plus `sideEffects: false` (allenhutchison/gemini-utils#55). This PR consumes them so the offending requires never run at load.

Fixes #1154

## Changes

- **Bump** `@allenhutchison/gemini-utils` to `^1.2.0`.
- `src/utils/file-classification.ts` (hot load path) & `src/services/obsidian-file-adapter.ts` — import the MIME helpers/constants from the built-in-free **`/mime`** subpath; keep gemini-utils types as `import type` (erased).
- `src/services/deep-research.ts` — import `ResearchManager`/`ReportGenerator` from the built-in-free **`/research`** subpath.
- `src/services/rag-indexing.ts` — `FileUploader` genuinely needs `fs`/`crypto`, so import the **type only** and **lazy-load** the implementation via `await import('@allenhutchison/gemini-utils/file-search')` at first use.
- Repoint the affected Vitest mocks at the subpaths their code now imports (`/mime`, `/research`, `/file-search`).
- **Regression guard**: `test/services/mobile-node-builtins.test.ts` fails if any `src/` module reintroduces a bare-barrel *value* import of gemini-utils.
- **Docs**: contributing guide gains a "never let a Node built-in evaluate at load" rule; testing guide gains a CLI verification recipe (incl. the `dev:debug on` footgun).

## Proof of functionality

Verified with the Obsidian CLI against a live vault, **desktop and mobile emulation**:

```
obsidian dev:debug on        # required — capture is silent without it
obsidian dev:console clear
obsidian plugin:reload id=gemini-scribe
obsidian dev:console limit=300 | grep -iE "nodejs|attempt.*load"   # → no output
```

- The four `Attempting to load NodeJS package` warnings are **gone** at load (desktop + `dev:mobile on`); plugin loads clean.
- Confirmed the capture pipeline actually catches that exact message pattern (injected marker), so the empty result is a true negative — not a broken check.
- Static closure walk on installed 1.2.0 confirms `/mime`, `/research`, `/support-registry` reach **zero** Node built-ins.

## Screenshots / Screencast

N/A — internal/load-path change; effect is the **absence** of warning toasts on load (verified via console capture above).

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards)
- [x] Documentation has been updated (if applicable)
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

https://claude.ai/code/session_01ATYuqvrvDTbASN7TD2QHW1