### PR TITLE
chore(daily): 2026-07-11 daily update

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,7 +102,7 @@ The plugin uses a factory pattern (`ModelClientFactory` in `src/api/factory.ts`)
 2. **File Operations**: Always use Obsidian's normalized paths and metadata cache
 3. **Error Handling**: API calls wrapped with retry logic and exponential backoff
 4. **Prompts**: Handlebars templates in `prompts/` directory, loaded as text files
-5. **Debouncing**: Completions use 750ms debounce to prevent excessive API calls
+5. **Debouncing**: Completions use a 500ms debounce (the `codemirror-companion-extension` default; the plugin doesn't override `delay`) to prevent excessive API calls
 6. **State Management**: Plugin instance holds all component references with proper cleanup
 7. **Folder Structure**: Plugin uses structured state folder:
    - `[state-folder]/` - Main plugin state folder (default: `gemini-scribe`)

--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ Precisely rewrite any portion of your text with AI assistance. This feature prov
 
 1.  **Toggle Completions:** Use the command palette (Ctrl/Cmd + P) and select "Gemini Scribe: Toggle completions". A notice will confirm whether completions are enabled or disabled.
 2.  **Write:** Begin typing in a Markdown file.
-3.  **Suggestions:** After a short pause in typing (750ms), Gemini will provide an inline suggestion based on your current context.
+3.  **Suggestions:** After a short pause in typing (500ms), Gemini will provide an inline suggestion based on your current context.
 4.  **Accept/Dismiss:**
     - Press `Tab` to accept the suggestion.
     - Press any other key to dismiss the suggestion and continue typing.

--- a/docs/guide/completions.md
+++ b/docs/guide/completions.md
@@ -46,7 +46,7 @@ Completions provide:
 
 1. Open any markdown note
 2. Type a few words and pause
-3. After ~750ms, a gray suggestion appears
+3. After ~500ms, a gray suggestion appears
 4. Press `Tab` to accept or any other key to dismiss
 
 ## How Completions Work
@@ -54,7 +54,7 @@ Completions provide:
 ### The Completion Process
 
 1. **You type** in your note
-2. **Pause detected** (750ms without typing)
+2. **Pause detected** (500ms without typing)
 3. **Context gathered** from surrounding text
 4. **AI generates** a suggestion
 5. **Suggestion appears** in gray text
@@ -141,7 +141,7 @@ The dropdown reflects whatever models the bundled list and Model Discovery have 
 
 Completions are optimized for:
 
-- 750ms debounce (prevents excessive API calls)
+- 500ms debounce (prevents excessive API calls)
 - Smart context extraction
 - Efficient caching
 - Minimal UI disruption
@@ -354,7 +354,7 @@ Train the AI by:
    - Not in code blocks
 
 3. **Check timing**
-   - Wait full 750ms
+   - Wait full 500ms
    - Don't type too quickly
 
 4. **API issues**

--- a/docs/reference/advanced-settings.md
+++ b/docs/reference/advanced-settings.md
@@ -83,13 +83,13 @@ Configure how the plugin handles API failures:
 **Maximum retries**
 
 - **Default**: 3 attempts
-- **Range**: 0-10 retries
+- **Range**: any integer ≥ 0 (no upper bound is enforced)
 - **Purpose**: Handles temporary network issues or API rate limits
 
 **Initial Backoff Delay**
 
 - **Default**: 1000ms (1 second)
-- **Range**: 100-10000ms
+- **Range**: any integer ≥ 0 (no upper bound is enforced)
 - **Purpose**: Time to wait before first retry (uses exponential backoff)
 
 **How retry works:**

--- a/planning/changelog/2026-07-10.md
+++ b/planning/changelog/2026-07-10.md
@@ -1,0 +1,54 @@
+# Daily changelog — July 10, 2026
+
+**Date:** 2026-07-10
+**PRs merged:** 10
+
+---
+
+## Summary
+
+The day the `#1166` TS-strictness sweep finished: six stacked slices landed back-to-back, clearing every remaining `@typescript-eslint/no-unsafe-*` violation across `src/` and finally flipping the five global `SOFTENED_TS_RULES` entries to `'error'`. Bookending that, the repo adopted the shared `maintainerd` plugin marketplace in place of its hand-vendored skill fork, a mobile-load-path bug (Node built-ins loading via `gemini-utils`) got fixed, the previous day's automated housekeeping PR landed, and a docs dead-link fix closed out the day.
+
+## What shipped
+
+### [#1175 chore: adopt maintainerd toolkit via plugin marketplace](https://github.com/allenhutchison/obsidian-gemini/pull/1175)
+
+Replaces the hand-vendored fork of the shared agent skills with the maintainerd plugin marketplace: `.claude/settings.json` now declares the `maintainerd` marketplace and enables `maintainerd-core`, `repo-ops`, `audits`, `auto-dev`, and `journal`; `.claude/maintainerd.json` captures the repo-specific config those skills read (commands, paths, labels, audit caps, auto-dev cadence); and `.claude/guidelines/{coding,testing,invariants,release}.md` hold the prose rules extracted from `AGENTS.md` and the testing/release docs. Removes the 9 vendored shared skills, keeping the 7 obsidian-specific local ones (`triage-issues`, `eval-harness`, `plugin-test`, `obsidian-cli`, `obsidian-plugin-development`, `gemini-api-dev`, `ui-ux-guidelines`). Also relocates the kepano bundled-skill drift check out of `daily-update` (which lacks the `gh` access it needs) and into the release flow. Config/docs/tooling only — no `src/` changes.
+
+### [#1176 refactor(ui): clear no-unsafe-\* in src/ui and enforce the rules (#1166 slice 2)](https://github.com/allenhutchison/obsidian-gemini/pull/1176)
+
+Second slice of the `#1166` cleanup: clears all 53 `no-unsafe-*` violations in `src/ui/` by narrowing `ToolResult.data` (declared `any`) through small typed shapes and type guards at the same discrimination points the code already branched on, and adds a scoped `no-unsafe-*: 'error'` override for `src/ui/**`. Type-only, `main.js` byte-identical.
+
+### [#1177 chore(daily): 2026-07-09 daily update](https://github.com/allenhutchison/obsidian-gemini/pull/1177)
+
+The prior day's automated `daily-update` run: wrote `planning/changelog/2026-07-09.md`, a clean `audit-docs` pass (no drift), a no-op `triage-issues` pass, and an errored bundled-skill drift check (GitHub scope limited to this repo, no upstream comparison possible). Housekeeping-only.
+
+### [#1178 fix: stop Node built-ins loading at startup via gemini-utils subpaths (#1154)](https://github.com/allenhutchison/obsidian-gemini/pull/1178)
+
+Importing any value from the `@allenhutchison/gemini-utils` barrel pulled in its whole module graph, including `fs`/`path`/`crypto`/`url` requires — since the plugin supports mobile (`isDesktopOnly: false`), this triggered a cascade of "attempted to load NodeJS package" warning toasts on every plugin reload. Bumps `gemini-utils` to 1.2.0, which adds built-in-free subpath exports (`/mime`, `/support-registry`, `/research`), and switches the hot load paths (`file-classification.ts`, `obsidian-file-adapter.ts`, `deep-research.ts`) to import from those subpaths instead. `rag-indexing.ts`'s `FileUploader` genuinely needs `fs`/`crypto`, so it's lazy-loaded via dynamic `import()` at first use instead. Adds a regression test (`test/services/mobile-node-builtins.test.ts`) that fails if any module reintroduces a bare-barrel value import. Verified via the Obsidian CLI on both desktop and mobile emulation that the warning toasts are gone.
+
+### [#1179 refactor: clear no-unsafe-\* in src/services (#1166 slice 3)](https://github.com/allenhutchison/obsidian-gemini/pull/1179)
+
+Slice 3: clears 41 violations across `src/services` by narrowing `JSON.parse` results, frontmatter access, and `processFrontMatter` callbacks through `asRecord` and type predicates, then enforces the rules for `src/services/**`.
+
+### [#1180 refactor: clear no-unsafe-\* in src/main.ts (#1166 slice 4)](https://github.com/allenhutchison/obsidian-gemini/pull/1180)
+
+Slice 4: clears the 13 violations in `main.ts`, all in `loadSettings()` flowing from `loadData()`'s untyped return — typed as `unknown` and narrowed with `asRecord` before feeding `Object.assign` and the settings-migration helpers.
+
+### [#1181 refactor: clear no-unsafe-\* in src/agent (#1166 slice 5)](https://github.com/allenhutchison/obsidian-gemini/pull/1181)
+
+Slice 5: clears 11 violations in `src/agent`, including typing the deliberate cycle-breaking `require('./agent-factory')` in `agent-loop.ts` as `typeof import('./agent-factory')` and narrowing session-manager frontmatter access.
+
+### [#1182 refactor: clear no-unsafe-\* in src/prompts (#1166 slice 6)](https://github.com/allenhutchison/obsidian-gemini/pull/1182)
+
+Slice 6: clears the last 11 violations, all in `prompt-manager.ts`'s `loadPromptFromFile`, by routing frontmatter through `asRecord` and coercing each `CustomPrompt` field at its boundary.
+
+### [#1183 refactor: clear no-unsafe-\* tail + enforce globally (#1166 final slice)](https://github.com/allenhutchison/obsidian-gemini/pull/1183)
+
+The final slice: clears the last 8 violations in the small tail (`src/api`, `src/files`, `src/i18n`, `src/summary.ts`, `src/tools`), then flips the five global `SOFTENED_TS_RULES` entries to `'error'` and removes the scoped per-directory override — `no-unsafe-*` is now enforced across all of `src/` (tests keep it off, alongside `no-explicit-any`). Closes out the `#1166` tracker (part of the larger `#1032` epic) and clears the last remaining softened `@typescript-eslint` rule family. All six slices in this stack are type-only; `main.js` is unchanged throughout.
+
+### [#1184 Fix docs build dead link to release guidelines](https://github.com/allenhutchison/obsidian-gemini/pull/1184)
+
+The docs deploy workflow's `build` job was failing because VitePress dead-link validation can't resolve links pointing outside `docs/`. Repoints `docs/contributing/bundled-skills.md`'s relative link to `.claude/guidelines/release.md` at the equivalent GitHub blob URL instead, keeping the release-guidelines reference discoverable while unblocking the docs build.
+
+Authored by the GitHub Copilot coding agent.


### PR DESCRIPTION
## Summary

Automated daily housekeeping run (`daily-update` meta-skill via the `maintainerd` plugin marketplace) bundling `daily-changelog`, `audit-product-docs`, and `triage-issues` for 2026-07-11.

## Changes

- **daily-changelog**: wrote `planning/changelog/2026-07-10.md` — 10 PRs merged on 2026-07-10, headlined by the `#1166` TS-strictness sweep finishing (six stacked slices: [#1176](https://github.com/allenhutchison/obsidian-gemini/pull/1176), [#1179](https://github.com/allenhutchison/obsidian-gemini/pull/1179)–[#1183](https://github.com/allenhutchison/obsidian-gemini/pull/1183) — clearing every `@typescript-eslint/no-unsafe-*` violation in `src/` and flipping the rules on globally), plus the maintainerd plugin-marketplace adoption ([#1175](https://github.com/allenhutchison/obsidian-gemini/pull/1175)), a mobile Node-built-ins load fix ([#1178](https://github.com/allenhutchison/obsidian-gemini/pull/1178)), the prior day's automated daily-update PR ([#1177](https://github.com/allenhutchison/obsidian-gemini/pull/1177)), and a docs dead-link fix ([#1184](https://github.com/allenhutchison/obsidian-gemini/pull/1184)).
- **audit-product-docs**: fixed a genuine behavioral misrepresentation — the completions debounce was documented as 750ms in `AGENTS.md`, `README.md`, and `docs/guide/completions.md` (4 spots), but the code never overrides the `codemirror-companion-extension`'s actual 500ms default; corrected all 6 occurrences. Also fixed `docs/reference/advanced-settings.md`, which claimed fabricated upper bounds ("0-10 retries", "100-10000ms") for the retry/backoff settings when the code only enforces a `>= 0` floor with no ceiling. Everything else audited (settings/defaults, command IDs, state-folder layout, tool registry names, permission tiers, model lists, the 20MB attachment limit, MCP timeouts, loop-detection thresholds, and yesterday's PR-specific doc claims for #1175 and #1178) checked out clean against the code.
- **triage-issues**: no-op — all 13 open issues already carry labels.

This is a housekeeping-only PR — no `src/` behavior changes.

## Screenshots / Screencast

N/A — changelog and docs-only change, no UI change.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A; routine automated daily housekeeping run
- [x] All CI checks pass (`npm test` — 3379 passing, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop — N/A, changelog/docs-only change; verified via local pre-flight checks
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A, no code change
- [x] Documentation has been updated (if applicable) — this PR's own audit-product-docs pass is the documentation update (fixed drift, see Changes above)
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR


---
_Generated by [Claude Code](https://claude.ai/code/session_01PAzyZ1BE6ww2LPckx7C1Pj)_