### PR TITLE
build(deps): declare @typescript-eslint/parser explicitly + hold TypeScript at 6.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,13 @@ updates:
       # Group all dev dependencies together
       dev-dependencies:
         dependency-type: 'development'
+    ignore:
+      # TypeScript 7 is not yet supported by typescript-eslint (peer typescript
+      # ">=4.8.4 <6.1.0"), so a major bump breaks `npm install` with ERESOLVE and
+      # takes down the whole lint/type toolchain. Hold at 6.x until the toolchain
+      # adds TS 7 support, then remove this ignore. Tracked in #1188.
+      - dependency-name: 'typescript'
+        update-types: ['version-update:semver-major']
 
   - package-ecosystem: 'github-actions'
     directory: '/'

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
 				"@google/genai": "^2.10.0",
 				"@modelcontextprotocol/sdk": "^1.29.0",
 				"@types/node": "^26.1.0",
+				"@typescript-eslint/parser": "^8.62.1",
 				"@vitest/coverage-v8": "^4.1.9",
 				"@vitest/ui": "^4.1.5",
 				"builtin-modules": "5.3.0",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
 		"@google/genai": "^2.10.0",
 		"@modelcontextprotocol/sdk": "^1.29.0",
 		"@types/node": "^26.1.0",
+		"@typescript-eslint/parser": "^8.62.1",
 		"@vitest/coverage-v8": "^4.1.9",
 		"@vitest/ui": "^4.1.5",
 		"builtin-modules": "5.3.0",


### PR DESCRIPTION
## Summary

Fixes the CI failures on the dev-dependencies bump (#1187) at the root cause, so Dependabot's group PR can go green on its own once it rebases. Two independent problems were breaking that PR:

### 1. Phantom `@typescript-eslint/parser` import (the `lint` failure)

`eslint.config.mjs` does `import '@typescript-eslint/parser'` but the package was never declared — it only resolved because npm happened to **hoist** it from `typescript-eslint`'s dependency tree. That's luck, not a guarantee: bumping `typescript-eslint` to 8.63.0 changes npm's dedup so `parser` installs **nested** under `typescript-eslint/node_modules/` instead of top-level, and the bare import fails with `ERR_MODULE_NOT_FOUND`.

**Fix:** declare `@typescript-eslint/parser` as an explicit `devDependency` (matched to the family at `^8.62.1`), so it resolves reliably no matter how npm dedupes. One-line lockfile change (the package was already in the tree).

### 2. TypeScript 7 is incompatible with the toolchain (the `ERESOLVE` install failure)

`typescript-eslint@8.63.0` peer-requires `typescript ">=4.8.4 <6.1.0"`, and no release supports TS 7 yet, so the `typescript` 6→7 major bump breaks `npm install` outright.

**Fix:** add a Dependabot ignore for `typescript` **major** updates so the impossible bump stops being re-proposed weekly. Tracked for revisit in #1188.

## Result

Once this lands and #1187 rebases, the group PR carries its 9 valid updates (genai 2.11.0, eslint 10.7.0, vitest 4.1.10, typescript-eslint 8.63.0, …) with no `typescript` major and a properly-declared parser — I verified that exact combination locally: **format, lint, typecheck:test, build, knip all pass; 3379 tests green.**

## Testing

- Full local gate on this branch: format-check, lint, typecheck:test, build, knip, `npm test` (3379 passed) — all green.
- Separately verified the #1187 target state (this fix + the 9 bumps, TS held at 6.x) resolves and passes the same gate.

## Docs

No user-facing change (build/tooling only); no doc updates required.

Closes part of #1187. Related: #1188.

https://claude.ai/code/session_01KN19Cqw1eF31JprXdhRNP5
