### PR TITLE
Default the Interactions API transport to on (#1017)

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ _A large feature release — a full visual refresh plus smarter, more responsive
       - **Temperature:** Control AI creativity and randomness (0-2.0, automatically adjusted based on available models).
       - **Top P:** Control response diversity and focus (0-1.0).
       - **Model Discovery:** Gemini models are automatically fetched on startup (cached for 24h); click **Refresh model list** in General settings or run the "Gemini Scribe: Refresh model list" command to fetch a newly-published model immediately. Ollama users can click the same **Refresh model list** button after pulling new models.
-      - **API configuration:** Configure retry behavior, backoff delays, and the optional Use Interactions API transport (Gemini provider only).
+      - **API configuration:** Configure retry behavior, backoff delays, and the Use Interactions API transport (Gemini provider only; on by default, with `generateContent` retained as a fallback).
       - **Tool Execution:** Control whether to stop agent execution on tool errors.
       - **Tool loop detection:** Prevent infinite tool execution loops.
       - **Developer Options:** Debug mode, file logging, and advanced configuration tools.

--- a/docs/reference/advanced-settings.md
+++ b/docs/reference/advanced-settings.md
@@ -55,13 +55,13 @@ Gemini Scribe automatically discovers the parameter limits for your available mo
 
 ### Use Interactions API
 
-Route Gemini requests through Google's newer [Interactions API](https://ai.google.dev/gemini-api/docs/interactions) (`interactions.create`) instead of the legacy `generateContent` API. Google has made the Interactions API generally available and is steering new development toward it.
+Route Gemini requests through Google's newer [Interactions API](https://ai.google.dev/gemini-api/docs/interactions) (`interactions.create`) instead of the legacy `generateContent` API. Google has made the Interactions API generally available and is steering new development toward it, so it is now the plugin's default transport.
 
 - **Setting name**: Use Interactions API
-- **Default**: off (uses `generateContent`)
+- **Default**: on. Existing installs are migrated to the Interactions API automatically on upgrade — a one-time flip you can reverse by turning the toggle off, which is then respected on future launches.
 - **Scope**: Gemini provider only — the toggle is hidden when the provider is Ollama.
 - **Privacy**: The plugin runs the Interactions API **statelessly** (`store: false`). Conversation history is replayed with each request, and the plugin does not persist Interactions state on Google's side between turns. (Requests are still sent to Google to generate each response, subject to Google's standard API data-handling terms.)
-- **Status**: Experimental while the SDK surface settles. If you hit problems, turn it off to fall back to the proven `generateContent` path. Responses stream incrementally, including reasoning and tool calls.
+- **Status**: Default transport. If you hit problems, turn it off to fall back to the proven `generateContent` path. Responses stream incrementally, including reasoning and tool calls.
 
 ### Custom API Endpoint
 

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -305,11 +305,11 @@ Advanced settings for developers and power users. Access by clicking "Show advan
 
 - **Setting**: `useInteractionsApi`
 - **Type**: Boolean
-- **Default**: `false`
+- **Default**: `true`
 - **Only applies when**: Provider is `gemini`
-- **Description**: Routes Gemini requests through Google's GA [Interactions API](https://ai.google.dev/gemini-api/docs/interactions) (`interactions.create`) instead of the legacy `generateContent` API.
+- **Description**: Routes Gemini requests through Google's GA [Interactions API](https://ai.google.dev/gemini-api/docs/interactions) (`interactions.create`) instead of the legacy `generateContent` API. This is now the default transport; existing installs are migrated to it automatically (a one-time flip you can reverse by turning the toggle off).
 - **Privacy**: Runs statelessly (`store: false`) — conversation history is replayed with each request, and the plugin does not persist Interactions state on Google's side between turns. (Requests are still sent to Google to generate each response, subject to Google's standard API data-handling terms.)
-- **Status**: Experimental. Responses stream incrementally (text, reasoning, and tool calls); turn it off to fall back to `generateContent` if you hit issues.
+- **Status**: Default-on. Responses stream incrementally (text, reasoning, and tool calls); turn it off to fall back to the legacy `generateContent` path if you hit issues.
 - **Scope**: Governs the conversational chat transport only. Image generation (the `generate_image` tool and **Generate image** command) always uses `generateContent` regardless of this setting.
 
 #### Custom API Endpoint

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -478,7 +478,7 @@ export const en = {
 	},
 	'settings.agentConfig.useInteractionsApiDesc': {
 		message:
-			'Route Gemini requests through Google’s newer Interactions API instead of the legacy generateContent API. Runs statelessly — conversation history is replayed each turn and not persisted on Google’s side between turns. Experimental — leave off if you hit issues.',
+			'Route Gemini requests through Google’s newer Interactions API instead of the legacy generateContent API. This is the default transport. Runs statelessly — conversation history is replayed each turn and not persisted on Google’s side between turns. Turn it off to fall back to generateContent if you hit issues.',
 		context:
 			'Settings toggle description for the Interactions API. "Interactions API" and "generateContent" are Google API names; keep them in English.',
 	},

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,7 @@ import { GeminiHistory } from './history/history';
 import { GeminiCompletions } from './completions';
 import { Notice } from 'obsidian';
 import { getDefaultModelForRole, migrateOllamaModelSetting, ModelProvider } from './models';
+import { migrateInteractionsApiDefault } from './utils/settings-migrations';
 import { ModelManager } from './services/model-manager';
 import { PromptManager, GeminiPrompts } from './prompts';
 import { SelectionRewriter } from './rewrite-selection';
@@ -72,7 +73,8 @@ const DEFAULT_SETTINGS: ObsidianGeminiSettings = {
 	maxRetries: 3,
 	initialBackoffDelay: 1000,
 	streamingEnabled: true,
-	useInteractionsApi: false,
+	useInteractionsApi: true,
+	useInteractionsApiMigrated: true,
 	allowSystemPromptOverride: false,
 	temperature: 0.7,
 	topP: 1,
@@ -433,6 +435,12 @@ export default class ObsidianGemini extends Plugin implements ObsidianGeminiApi 
 			delete (this.settings as { modelDiscoveryCache?: unknown }).modelDiscoveryCache;
 			await this.saveData(this.settings);
 			this.logger?.log('Removed deprecated model discovery settings');
+		}
+
+		// One-time migration: default-on rollout for the Interactions API transport (#1017).
+		if (migrateInteractionsApiDefault(this.settings, data)) {
+			await this.saveData(this.settings);
+			this.logger?.log('Migrated useInteractionsApi to on (default-on rollout, #1017)');
 		}
 
 		// Note: Stale model reconciliation happens later in LifecycleService.syncModels(),

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -40,10 +40,18 @@ export interface ObsidianGeminiSettings {
 	/**
 	 * Use Google's GA Interactions API (`client.interactions.create`) as the
 	 * Gemini transport instead of the legacy `generateContent`. Runs stateless
-	 * (`store: false`); we still own and replay conversation history. Opt-in
-	 * while the SDK surface settles — see epic #1013.
+	 * (`store: false`); we still own and replay conversation history. Default-on
+	 * as of the default-on rollout (#1017); `generateContent` stays reachable as
+	 * a fallback — see epic #1013.
 	 */
 	useInteractionsApi: boolean;
+	/**
+	 * Internal marker for the one-time default-on migration (#1017): once the
+	 * false→true flip has run for an existing install, we never re-run it, so a
+	 * user who deliberately turns the transport back off is respected. New
+	 * installs are seeded `true` and skip the migration entirely.
+	 */
+	useInteractionsApiMigrated?: boolean;
 	allowSystemPromptOverride: boolean;
 	temperature: number;
 	topP: number;

--- a/src/utils/settings-migrations.ts
+++ b/src/utils/settings-migrations.ts
@@ -1,0 +1,34 @@
+/**
+ * One-time settings migrations that run in `ObsidianGemini.loadSettings`.
+ *
+ * These are pure helpers (mutate the merged settings in place, return whether a
+ * change was applied) so the caller can persist + log once and so the migration
+ * logic is unit-testable without standing up a full plugin instance. They detect
+ * the pre-migration shape from the raw persisted data (pre-merge) rather than the
+ * merged settings, whose defaults already backfill new fields.
+ */
+
+/**
+ * Default-on rollout for the Interactions API transport (#1017).
+ *
+ * The transport shipped opt-in with `useInteractionsApi` defaulting to `false`,
+ * so existing installs persisted `false`. This flips them to the new default
+ * exactly once. A dedicated marker (`useInteractionsApiMigrated`) guards re-runs
+ * so a user who later turns the transport back off is respected on subsequent
+ * loads; new installs are seeded with the marker via `DEFAULT_SETTINGS` and skip
+ * this entirely.
+ *
+ * @param settings - freshly merged settings (mutated in place)
+ * @param rawData - raw persisted data as loaded from disk, pre-merge
+ */
+export function migrateInteractionsApiDefault(
+	settings: { useInteractionsApi: boolean; useInteractionsApiMigrated?: boolean },
+	rawData: Record<string, unknown> | null | undefined
+): boolean {
+	if (rawData && rawData.useInteractionsApi === false && !rawData.useInteractionsApiMigrated) {
+		settings.useInteractionsApi = true;
+		settings.useInteractionsApiMigrated = true;
+		return true;
+	}
+	return false;
+}

--- a/test/utils/settings-migrations.test.ts
+++ b/test/utils/settings-migrations.test.ts
@@ -1,0 +1,44 @@
+import { migrateInteractionsApiDefault } from '../../src/utils/settings-migrations';
+
+describe('migrateInteractionsApiDefault', () => {
+	it('flips an existing opt-in-era install (persisted false, no marker) to on and marks it', () => {
+		const settings = {
+			useInteractionsApi: false as boolean,
+			useInteractionsApiMigrated: undefined as boolean | undefined,
+		};
+		const migrated = migrateInteractionsApiDefault(settings, { useInteractionsApi: false });
+
+		expect(migrated).toBe(true);
+		expect(settings.useInteractionsApi).toBe(true);
+		expect(settings.useInteractionsApiMigrated).toBe(true);
+	});
+
+	it('does not re-flip a user who turned the transport back off after migrating', () => {
+		const settings = { useInteractionsApi: false as boolean, useInteractionsApiMigrated: true };
+		const migrated = migrateInteractionsApiDefault(settings, {
+			useInteractionsApi: false,
+			useInteractionsApiMigrated: true,
+		});
+
+		expect(migrated).toBe(false);
+		expect(settings.useInteractionsApi).toBe(false);
+	});
+
+	it('leaves an install that already had the transport on untouched', () => {
+		const settings = {
+			useInteractionsApi: true as boolean,
+			useInteractionsApiMigrated: undefined as boolean | undefined,
+		};
+		const migrated = migrateInteractionsApiDefault(settings, { useInteractionsApi: true });
+
+		expect(migrated).toBe(false);
+		expect(settings.useInteractionsApi).toBe(true);
+	});
+
+	it('does not migrate a fresh install (no persisted value)', () => {
+		const settings = { useInteractionsApi: true as boolean, useInteractionsApiMigrated: true };
+		expect(migrateInteractionsApiDefault(settings, {})).toBe(false);
+		expect(migrateInteractionsApiDefault(settings, null)).toBe(false);
+		expect(migrateInteractionsApiDefault(settings, undefined)).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary

Flips the Interactions API transport (`useInteractionsApi`) to **on by default** and rolls it out fleet-wide, completing the default-on portion of Phase 4 of the stateless-first Interactions migration (#1017, part of epic #1013). The legacy `generateContent` path is retained as a reachable fallback.

Per maintainer decision, this is a **fleet-wide** rollout, not new-installs-only: existing installs (which persisted `useInteractionsApi: false` back when it was opt-in) are migrated to on via a one-time flip.

## Changes

- **`src/main.ts`** — `DEFAULT_SETTINGS.useInteractionsApi` `false → true`; seed `useInteractionsApiMigrated: true` so fresh installs skip the migration. Wire the migration into `loadSettings`.
- **`src/utils/settings-migrations.ts`** (new) — `migrateInteractionsApiDefault()`, a pure/testable helper mirroring the existing `migrateOllamaModelSetting` precedent. Flips existing installs (persisted `false`, no marker) to `true` **once**; a dedicated marker guards re-runs so a user who later turns the transport back off is respected on future launches.
- **`src/types/settings.ts`** — add the `useInteractionsApiMigrated?` marker field; refresh the doc comment.
- **Docs (mandatory):** `docs/reference/settings.md` (default `false → true`, status → Default-on), `docs/reference/advanced-settings.md` (default off → on + migration note), `README.md`, and the `en.ts` toggle description.

## User-visible impact

- New and existing Gemini users route through the Interactions API by default after upgrade.
- The migration is one-time and reversible: turning the toggle off is respected on all subsequent launches (the marker prevents re-flipping).
- Image generation still always uses `generateContent`, unchanged.

## Testing

- `test/utils/settings-migrations.test.ts` (new) — covers flip / no-reflip-after-deliberate-off / already-on / fresh-install.
- `npm test` — 3383 passed (158 files).
- `npm run typecheck:test` — clean.
- `npm run build` (prod tsc + esbuild) — clean.
- `npm run lint:cycles` — no circular deps (new module is a leaf util).

## Docs updated

- `docs/reference/settings.md`
- `docs/reference/advanced-settings.md`
- `README.md`
- `src/i18n/en.ts` (toggle description; per-language files regenerate via the `Update UI translations` workflow when `en.ts` lands on master)

## Follow-up

The remaining Phase 4 acceptance item — the eval-harness soak run confirming no agent solve-rate regression vs. the `generateContent` baseline — is a separate, API-spending step and is not included here.

https://claude.ai/code/session_01KN19Cqw1eF31JprXdhRNP5