### PR TITLE
refactor: extract renderTruncatableCode helper in tool-display

### DIFF
--- a/src/ui/agent-view/agent-view-tool-display.ts
+++ b/src/ui/agent-view/agent-view-tool-display.ts
@@ -110,6 +110,30 @@ export class AgentViewToolDisplay {
 	}
 
 	/**
+	 * Render text into a `<pre><code>` block, truncating to the first 500 chars
+	 * with a "Show full content" button when it's longer. Used for both raw string
+	 * results and file-read `content` payloads, which rendered this identically.
+	 */
+	private renderTruncatableCode(container: HTMLElement, text: string): void {
+		if (text.length > 500) {
+			const codeBlock = container.createEl('pre', { cls: 'gemini-agent-tool-code-result' });
+			const code = codeBlock.createEl('code');
+			code.textContent = text.substring(0, 500) + '\n\n' + t('agent.tools.truncatedSuffix');
+
+			const expandBtn = container.createEl('button', {
+				text: t('agent.tools.showFullContent'),
+				cls: 'gemini-agent-tool-expand-content',
+			});
+			expandBtn.addEventListener('click', () => {
+				code.textContent = text;
+				expandBtn.remove();
+			});
+		} else {
+			container.createEl('pre', { cls: 'gemini-agent-tool-code-result' }).createEl('code', { text });
+		}
+	}
+
+	/**
 	 * The full, untruncated text to copy for a tool result: the error message on
 	 * failure, the raw string for string data, otherwise pretty-printed JSON.
 	 */
@@ -472,22 +496,7 @@ export class AgentViewToolDisplay {
 				const data: unknown = result.data;
 
 				if (typeof data === 'string') {
-					if (data.length > 500) {
-						const codeBlock = resultContent.createEl('pre', { cls: 'gemini-agent-tool-code-result' });
-						const code = codeBlock.createEl('code');
-						code.textContent = data.substring(0, 500) + '\n\n' + t('agent.tools.truncatedSuffix');
-
-						const expandBtn = resultContent.createEl('button', {
-							text: t('agent.tools.showFullContent'),
-							cls: 'gemini-agent-tool-expand-content',
-						});
-						expandBtn.addEventListener('click', () => {
-							code.textContent = data;
-							expandBtn.remove();
-						});
-					} else {
-						resultContent.createEl('pre', { cls: 'gemini-agent-tool-code-result' }).createEl('code', { text: data });
-					}
+					this.renderTruncatableCode(resultContent, data);
 				} else if (Array.isArray(data)) {
 					if (data.length === 0) {
 						resultContent.createEl('p', {
@@ -635,26 +644,7 @@ export class AgentViewToolDisplay {
 							});
 						}
 
-						const content = data.content;
-						if (content.length > 500) {
-							const codeBlock = resultContent.createEl('pre', {
-								cls: 'gemini-agent-tool-code-result',
-							});
-							const code = codeBlock.createEl('code');
-							code.textContent = content.substring(0, 500) + '\n\n' + t('agent.tools.truncatedSuffix');
-							const expandBtn = resultContent.createEl('button', {
-								text: t('agent.tools.showFullContent'),
-								cls: 'gemini-agent-tool-expand-content',
-							});
-							expandBtn.addEventListener('click', () => {
-								code.textContent = content;
-								expandBtn.remove();
-							});
-						} else {
-							resultContent
-								.createEl('pre', { cls: 'gemini-agent-tool-code-result' })
-								.createEl('code', { text: content });
-						}
+						this.renderTruncatableCode(resultContent, data.content);
 					} else {
 						const resultList = resultContent.createDiv({ cls: 'gemini-agent-tool-result-object' });
 						for (const [key, value] of Object.entries(data)) {


### PR DESCRIPTION
## Summary

audit-architecture nightly sweep flagged a **DRY violation** in `src/ui/agent-view/agent-view-tool-display.ts`.

The "truncate to the first 500 chars in a `<pre><code>` block with a *Show full content* expand button, otherwise render inline" logic was duplicated verbatim in two branches of `renderToolResult` — once for raw string `data` and once for a file-read `content` payload — the two copies differing only in the source variable name. This extracts a single private `renderTruncatableCode(container, text)` helper and calls it from both sites. Pure code motion, no behavior change.

## Changes

- `src/ui/agent-view/agent-view-tool-display.ts`: add `renderTruncatableCode(container, text)` helper; replace the string-data branch and the file-content branch with calls to it (net −10 lines).

## Screenshots / Screencast

N/A — no visual change; the rendered output (truncation threshold, button label/behavior, CSS classes) is byte-for-byte identical to before.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: mechanical audit-filed refactor, not a feature.
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — 3383 tests pass, build clean, format clean, `typecheck:test` clean, lint 0 errors.
- [x] I have tested this change on Desktop — verified via the full unit suite; change is a pure code-motion refactor of DOM construction.
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — no platform-specific APIs touched.
- [ ] Documentation has been updated (if applicable) — N/A: internal refactor, no user-facing or settings change.
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude (audit-architecture skill)
- [x] I have reviewed and understand all AI-generated code in this PR

---

_Filed by the `audit-architecture` skill._

---
_Generated by [Claude Code](https://claude.ai/code/session_01BJFmHPXQFawos24TsXje12)_