### PR TITLE
chore(daily): 2026-07-12 daily update

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,7 +134,7 @@ The plugin uses a factory pattern (`ModelClientFactory` in `src/api/factory.ts`)
 
 12. **YAML Frontmatter**: Agent instructions include guidance for respecting YAML frontmatter when modifying files
 
-- The AI is trained to place "top of note" content after frontmatter blocks (defined in `prompts/agentToolsPrompt.hbs`)
+- The AI is trained to place "top of note" content after frontmatter blocks (defined in `prompts/agentRulesPrompt.hbs`)
 - YAML frontmatter must start with `---` on line 1 and end with `---`
 - Content is only placed before frontmatter when explicitly instructed to modify frontmatter
 

--- a/docs/guide/agent-mode.md
+++ b/docs/guide/agent-mode.md
@@ -46,6 +46,9 @@ Choose which operations require confirmation in **Settings → Gemini Scribe →
 - **update_frontmatter**: Modifying note properties (frontmatter)
 - **create_skill**: Creating new skill packages
 - **edit_skill**: Updating existing skill instructions
+- **generate_image**: Generating and saving images
+- **update_memory**: Updating vault memory (AGENTS.md)
+- **google_search**, **google_maps**, **fetch_url**, **deep_research**: External web/research calls (Gemini provider only)
 
 When the agent needs to perform these operations, an **in-chat confirmation request** appears with interactive buttons. You can also use "Don't ask again this session" for trusted workflows. See [Tool Confirmations](#tool-confirmations) for details.
 
@@ -613,6 +616,9 @@ By default, these operations require confirmation:
 - **update_frontmatter**: Modifying note properties (frontmatter)
 - **create_skill**: Creating new skill packages
 - **edit_skill**: Updating existing skill instructions
+- **generate_image**: Generating and saving images
+- **update_memory**: Updating vault memory (AGENTS.md)
+- **google_search**, **google_maps**, **fetch_url**, **deep_research**: External web/research calls (Gemini provider only)
 
 You can configure which operations require confirmation in **Settings → Gemini Scribe → Tool permissions** (enable **Show advanced settings** first).
 

--- a/docs/reference/provider-capabilities.md
+++ b/docs/reference/provider-capabilities.md
@@ -23,9 +23,9 @@ Gemini Scribe can run on either the **Google Gemini (cloud)** or **Ollama (local
 
 - **Tool calling** — Whether an Ollama model can call tools depends on the model itself; most modern instruct models (Llama 3.2, Qwen 2.5, Mistral 0.3, …) support it, smaller or older models may not.
 - **Vision** — Ollama vision support is auto-detected per model from its `/api/show` capabilities (with a template/name-hint fallback for older Ollama versions) — no manual configuration is needed when you pull a new multimodal model.
-- **RAG, image generation, Google Search, URL Context, and Deep Research** all call Google's cloud APIs directly and require a Gemini API key regardless of the active provider setting; they are hidden from the UI when Ollama is selected rather than failing at call time.
+- **RAG, image generation, Google Search, URL Context, and Deep Research** all call Google's cloud APIs directly and require a Gemini API key regardless of the active provider setting. Google Search, URL Context, and Deep Research are hidden from the agent's tool list when Ollama is selected. RAG and image generation stay visible instead — their settings and commands remain in the UI, but invoking them with Ollama active is a silent no-op (RAG) or shows a "not available" notice (image generation) rather than failing at call time.
 - **Scheduled tasks** run through the same chat/tool-calling path as interactive agent sessions, so a task that needs vision or tool calling on Ollama is still bound by that model's capabilities.
 
-Switching the **Provider** setting between Gemini and Ollama at any time restores or hides these features immediately — no data is lost, and settings persist across switches.
+Switching the **Provider** setting between Gemini and Ollama at any time restores or hides the Google-only tools immediately — no data is lost, and settings persist across switches.
 
 See the [Ollama Setup Guide](/guide/ollama-setup) for installation steps and local-model tips.

--- a/planning/changelog/2026-07-11.md
+++ b/planning/changelog/2026-07-11.md
@@ -1,0 +1,32 @@
+# Daily changelog — July 11, 2026
+
+**Date:** 2026-07-11
+**PRs merged:** 5
+
+---
+
+## Summary
+
+A quiet-ish day dominated by dependency-toolchain maintenance and one feature milestone. The prior day's automated housekeeping PR and a dashboard-hygiene fix landed first, then a root-cause fix cleared the way for a stuck Dependabot dev-dependencies bump to merge, and the day closed with the Interactions API transport flipping to on by default fleet-wide — completing the default-on portion of the stateless-first Interactions migration.
+
+## What shipped
+
+### [#1186 chore(daily): 2026-07-11 daily update](https://github.com/allenhutchison/obsidian-gemini/pull/1186)
+
+The prior day's automated `daily-update` run: wrote `planning/changelog/2026-07-10.md` (10 PRs, headlined by the `#1166` TS-strictness sweep finishing), fixed a genuine doc/behavior mismatch in `audit-product-docs` (the completions debounce was documented as 750ms in four places but the code has always used the `codemirror-companion-extension`'s 500ms default; also corrected fabricated retry/backoff bounds in `docs/reference/advanced-settings.md`), and a no-op `triage-issues` pass. Housekeeping-only.
+
+### [#1185 fix: clear Obsidian dashboard security + source-hygiene flags](https://github.com/allenhutchison/obsidian-gemini/pull/1185)
+
+Clears several flags from the Obsidian community-plugin directory scorecard. Pins `protobufjs` (via `@google/genai`) and `ip-address` (via the MCP SDK's `express-rate-limit`) to patched versions through `overrides`, clearing two shipped-dependency security advisories. Also removes 6 unused `_`-prefixed bindings the dashboard's unused-var scan flags (ESLint ignores them, the dashboard doesn't) and switches 3 detached-node sites from bare `document` to `activeDocument` for the `prefer-active-doc` scan, with a matching jsdom shim added to the test setup. No behavior change.
+
+### [#1189 build(deps): declare @typescript-eslint/parser explicitly + hold TypeScript at 6.x](https://github.com/allenhutchison/obsidian-gemini/pull/1189)
+
+Fixes the CI failures blocking the pending Dependabot dev-dependencies group PR (#1187) at the root cause. `@typescript-eslint/parser` was only resolving because npm happened to hoist it from `typescript-eslint`'s dependency tree — bumping `typescript-eslint` to 8.63.0 changed the dedup layout and broke the bare import. Declares the package as an explicit `devDependency` instead of relying on hoisting luck. Separately, `typescript-eslint@8.63.0` peer-requires `typescript <6.1.0`, so a pending TypeScript 6→7 major bump would have broken `npm install` outright; adds a Dependabot ignore for `typescript` major updates (tracked for revisit in #1188).
+
+### [#1191 Default the Interactions API transport to on (#1017)](https://github.com/allenhutchison/obsidian-gemini/pull/1191)
+
+Flips `useInteractionsApi` to on by default and rolls it out fleet-wide, completing the default-on portion of Phase 4 of the stateless-first Interactions migration (part of epic #1013). Existing installs that persisted `useInteractionsApi: false` from when it was opt-in are migrated to `true` once, via a new `migrateInteractionsApiDefault()` helper guarded by a `useInteractionsApiMigrated` marker — a user who deliberately turns the transport back off stays off on future launches. The legacy `generateContent` path remains a reachable fallback, and image generation is unaffected (always uses `generateContent`). Docs updated across `docs/reference/settings.md`, `docs/reference/advanced-settings.md`, `README.md`, and the `en.ts` toggle description. The remaining Phase 4 acceptance item — an eval-harness soak run confirming no solve-rate regression — is a separate, API-spending step not included here.
+
+### [#1190 chore(deps-dev): bump the dev-dependencies group across 1 directory with 10 updates](https://github.com/allenhutchison/obsidian-gemini/pull/1190)
+
+Dependency bumps: `@google/genai` 2.10.0→2.11.0, `@types/node` 26.1.0→26.1.1, `@typescript-eslint/parser` and `typescript-eslint` 8.62.1→8.63.0, `@vitest/coverage-v8`/`@vitest/ui`/`vitest` 4.1.9→4.1.10, `eslint` 10.6.0→10.7.0, `knip` 6.24.0→6.26.0, and `prettier` 3.9.4→3.9.5 — the group Dependabot PR (#1187/superseded) that #1189 unblocked.


### PR DESCRIPTION
## Summary

Automated daily housekeeping run (`daily-update` meta-skill via the `maintainerd` plugin marketplace) bundling `daily-changelog`, `audit-product-docs`, and `triage-issues` for 2026-07-12.

## Changes

- **daily-changelog**: wrote `planning/changelog/2026-07-11.md` — 5 PRs merged on 2026-07-11, headlined by the Interactions API transport flipping to on by default fleet-wide ([#1191](https://github.com/allenhutchison/obsidian-gemini/pull/1191)), plus a Dependabot dev-dependencies unblock ([#1189](https://github.com/allenhutchison/obsidian-gemini/pull/1189) fixing the root cause, [#1190](https://github.com/allenhutchison/obsidian-gemini/pull/1190) landing the bump), an Obsidian dashboard security/hygiene fix ([#1185](https://github.com/allenhutchison/obsidian-gemini/pull/1185)), and the prior day's automated daily-update PR ([#1186](https://github.com/allenhutchison/obsidian-gemini/pull/1186)).
- **audit-product-docs**: fixed 2 conceptual drift items (both verified against source before patching):
  - `docs/guide/agent-mode.md`'s two "What Operations Require Confirmation" lists were missing 6 tools that require confirmation by default under the Cautious preset (`src/types/tool-policy.ts`): `generate_image`, `update_memory`, `google_search`, `google_maps`, `fetch_url`, `deep_research`. Added them to both lists.
  - `docs/reference/provider-capabilities.md` claimed RAG, image generation, Google Search, URL Context, and Deep Research are all "hidden from the UI" when Ollama is active. That's only true for Google Search / URL Context / Deep Research (filtered out of the tool registry). RAG and image generation actually stay visible in Settings and the command palette — invoking them with Ollama active is a silent no-op (RAG) or shows a "not available" notice (image generation) rather than being hidden. Corrected the note.
  - Also fixed a stale filename reference in `AGENTS.md` (`prompts/agentToolsPrompt.hbs` → `prompts/agentRulesPrompt.hbs`, renamed in a prior PR).
  - Reference-doc coverage (`evals.md`, `loop-detection.md`, the rest of `settings.md`/`advanced-settings.md`, the rest of `README.md`) and a check for undocumented new features both came back clean.
- **triage-issues**: no-op — no unlabeled open issues.

This is a housekeeping-only PR — no `src/` behavior changes.

## Screenshots / Screencast

N/A — changelog and docs-only change, no UI change.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A; routine automated daily housekeeping run
- [x] All CI checks pass (`npm test` — 3383 passing, `npm run build`, `npm run format-check`, `npm run lint`, `npm run typecheck:test`)
- [x] I have tested this change on Desktop — N/A, changelog/docs-only change; verified via local pre-flight checks
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A, no code change
- [x] Documentation has been updated (if applicable) — this PR's own audit-product-docs pass is the documentation update (fixed drift, see Changes above)
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR


---
_Generated by [Claude Code](https://claude.ai/code/session_01Jg3t8Un88BSgMmR57qB84C)_