### PR TITLE
Insert literal /skill-name token in agent input instead of verbose sentence

### DIFF
--- a/docs/guide/agent-skills.md
+++ b/docs/guide/agent-skills.md
@@ -22,7 +22,7 @@ Skills and [custom prompts](/guide/custom-prompts) serve different purposes:
 Skills use **progressive disclosure** — the agent always knows which skills are available (name and description), but only loads the full instructions when it activates a skill. This keeps conversations focused while making specialized knowledge available when needed.
 
 1. **Discovery** — Skill summaries are included in every agent session
-2. **Activation** — When the agent encounters a matching task, it activates the skill to load full instructions. You can also type `/` in an empty chat input to browse and select skills directly via the slash command picker.
+2. **Activation** — When the agent encounters a matching task, it activates the skill to load full instructions. You can also type `/` in an empty chat input to browse and select a skill directly: picking one inserts a `/skill-name` token into the input, and you can then add instructions or just send it as-is to invoke the skill.
 3. **Execution** — The agent follows the skill's instructions to complete the task
 
 ## Built-in Skills
@@ -127,6 +127,20 @@ Agent: I'll activate the code-review skill to help with this...
 [Activates code-review skill]
 [Follows skill instructions to review code]
 ```
+
+### Slash Activation
+
+To invoke a skill explicitly, type `/` in an empty chat input, pick a skill from the
+picker, and a `/skill-name` token is inserted into the input. Add instructions after it,
+or send it on its own:
+
+```
+/code-review                      → activates the skill with no extra instruction
+/code-review focus on error paths → activates the skill and applies your instruction
+```
+
+The `/skill-name` token is sent verbatim; the agent recognizes the convention and
+activates the matching skill.
 
 ### Manual Activation
 

--- a/docs/guide/agent-skills.md
+++ b/docs/guide/agent-skills.md
@@ -134,7 +134,7 @@ To invoke a skill explicitly, type `/` in an empty chat input, pick a skill from
 picker, and a `/skill-name` token is inserted into the input. Add instructions after it,
 or send it on its own:
 
-```
+```text
 /code-review                      → activates the skill with no extra instruction
 /code-review focus on error paths → activates the skill and applies your instruction
 ```

--- a/prompts/toolCatalogPrompt.hbs
+++ b/prompts/toolCatalogPrompt.hbs
@@ -36,6 +36,8 @@ Example: If asked to "create a file", you must call write_file with the path, co
 
 You have access to the following skills. Use the `activate_skill` tool to load a skill's full instructions when you need its capabilities. Skills provide specialized knowledge, workflows, and reference materials.
 
+If the user's message begins with `/skill-name` (matching one of the skills below), treat it as an explicit request to activate that skill with `activate_skill` and apply it to the rest of the message (which may be empty).
+
 {{#each availableSkills}}
 - **{{this.name}}**: {{this.description}}
 {{/each}}

--- a/prompts/toolCatalogPrompt.hbs
+++ b/prompts/toolCatalogPrompt.hbs
@@ -36,7 +36,7 @@ Example: If asked to "create a file", you must call write_file with the path, co
 
 You have access to the following skills. Use the `activate_skill` tool to load a skill's full instructions when you need its capabilities. Skills provide specialized knowledge, workflows, and reference materials.
 
-If the user's message begins with `/skill-name` (matching one of the skills below), treat it as an explicit request to activate that skill with `activate_skill` and apply it to the rest of the message (which may be empty).
+If the user's message begins with `/skill-name` — the exact name of one of the skills below, followed by a space or the end of the message — treat it as an explicit request to activate that skill with `activate_skill` and apply it to the rest of the message (which may be empty). Match the exact name: a longer name always wins, so `/code-review` activates `code-review`, not a shorter `code`.
 
 {{#each availableSkills}}
 - **{{this.name}}**: {{this.description}}

--- a/src/ui/agent-view/agent-view.ts
+++ b/src/ui/agent-view/agent-view.ts
@@ -24,9 +24,9 @@ import { ProjectPickerModal } from './project-picker-modal';
 // Import modals from agent-view directory
 import { FilePickerModal } from './file-picker-modal';
 import { SessionListModal } from './session-list-modal';
-import { SkillMentionModal } from './skill-mention-modal';
+import { SkillMentionModal, formatSkillTrigger } from './skill-mention-modal';
 import { SessionSettingsModal } from './session-settings-modal';
-import { moveCursorToEnd } from '../../utils/dom-context';
+import { insertTextAtCursor, moveCursorToEnd } from '../../utils/dom-context';
 import { t } from '../../i18n';
 
 export const VIEW_TYPE_AGENT = 'gemini-agent-view';
@@ -509,7 +509,10 @@ export class AgentView extends ItemView {
 			(skill) => {
 				this.attachments.removeTrailingTriggerChar('/');
 				if (this.userInput) {
-					this.userInput.innerText = `Use the "${skill.name}" skill to help me with: `;
+					// Insert the literal `/skill-name ` token and leave it in the box so the
+					// user can append instructions or send as-is. The model recognizes this
+					// convention (see prompts/toolCatalogPrompt.hbs) and activates the skill.
+					insertTextAtCursor(this.userInput, formatSkillTrigger(skill.name));
 					moveCursorToEnd(this.userInput);
 				}
 			},

--- a/src/ui/agent-view/skill-mention-modal.ts
+++ b/src/ui/agent-view/skill-mention-modal.ts
@@ -2,6 +2,18 @@ import { App, FuzzySuggestModal } from 'obsidian';
 import type { SkillSummary } from '../../services/skill-manager';
 import { t } from '../../i18n';
 
+/**
+ * Format the literal slash-command token inserted into the agent input when a
+ * skill is picked, e.g. `code-review` → `/code-review `. The trailing space
+ * places the cursor ready for the user to type free-form instructions (or send
+ * as-is). This token is model-facing and persisted verbatim, so it stays English
+ * and must match the `/skill-name` convention documented in the system prompt
+ * (`prompts/toolCatalogPrompt.hbs`).
+ */
+export function formatSkillTrigger(name: string): string {
+	return `/${name} `;
+}
+
 export class SkillMentionModal extends FuzzySuggestModal<SkillSummary> {
 	private onSelect: (skill: SkillSummary) => void;
 	private skills: SkillSummary[];

--- a/test/prompts/gemini-prompts.test.ts
+++ b/test/prompts/gemini-prompts.test.ts
@@ -115,6 +115,25 @@ describe('GeminiPrompts', () => {
 		});
 	});
 
+	describe('available skills rendering', () => {
+		// The skills section lives in the tool catalog, which only renders when tools exist.
+		const tools = [
+			{ name: 'read_file', description: 'Read a file', parameters: { properties: {}, required: [] } },
+		] as any;
+		const skills = [{ name: 'code-review', description: 'Review code for quality' }];
+
+		it('includes the /skill-name activation convention when skills are available', () => {
+			const prompt = geminiPrompts.getSystemPromptWithCustom(tools, undefined, null, skills, undefined);
+			expect(prompt).toContain('begins with `/skill-name`');
+			expect(prompt).toContain('code-review');
+		});
+
+		it('omits the /skill-name convention when no skills are available', () => {
+			const prompt = geminiPrompts.getSystemPromptWithCustom(tools, undefined, null, undefined, undefined);
+			expect(prompt).not.toContain('begins with `/skill-name`');
+		});
+	});
+
 	describe('buildExtendedSystemInstruction', () => {
 		const baseRequest: ExtendedModelRequest = {
 			kind: 'extended',

--- a/test/prompts/gemini-prompts.test.ts
+++ b/test/prompts/gemini-prompts.test.ts
@@ -128,6 +128,15 @@ describe('GeminiPrompts', () => {
 			expect(prompt).toContain('code-review');
 		});
 
+		it('spells out exact-name/boundary matching so overlapping names are unambiguous', () => {
+			// Token→skill resolution is model-driven (no parser in code), so the prompt
+			// wording is the mitigation: the exact name, a whitespace/EOM boundary, and
+			// longest-match win must all be stated for /code-review not to read as /code.
+			const prompt = geminiPrompts.getSystemPromptWithCustom(tools, undefined, null, skills, undefined);
+			expect(prompt).toContain('followed by a space or the end of the message');
+			expect(prompt).toContain('a longer name always wins');
+		});
+
 		it('omits the /skill-name convention when no skills are available', () => {
 			const prompt = geminiPrompts.getSystemPromptWithCustom(tools, undefined, null, undefined, undefined);
 			expect(prompt).not.toContain('begins with `/skill-name`');

--- a/test/ui/skill-mention-modal.test.ts
+++ b/test/ui/skill-mention-modal.test.ts
@@ -1,5 +1,5 @@
 import type { Mock } from 'vitest';
-import { SkillMentionModal } from '../../src/ui/agent-view/skill-mention-modal';
+import { SkillMentionModal, formatSkillTrigger } from '../../src/ui/agent-view/skill-mention-modal';
 import type { SkillSummary } from '../../src/services/skill-manager';
 
 vi.mock('obsidian', async () => {
@@ -45,5 +45,11 @@ describe('SkillMentionModal', () => {
 	it('should handle empty skills list', () => {
 		const emptyModal = new SkillMentionModal({} as any, onSelect, []);
 		expect(emptyModal.getItems()).toEqual([]);
+	});
+});
+
+describe('formatSkillTrigger', () => {
+	it('formats a skill name as a slash token with a trailing space', () => {
+		expect(formatSkillTrigger('code-review')).toBe('/code-review ');
 	});
 });

--- a/test/ui/skill-mention-modal.test.ts
+++ b/test/ui/skill-mention-modal.test.ts
@@ -1,5 +1,6 @@
 import type { Mock } from 'vitest';
 import { SkillMentionModal, formatSkillTrigger } from '../../src/ui/agent-view/skill-mention-modal';
+import { insertTextAtCursor } from '../../src/utils/dom-context';
 import type { SkillSummary } from '../../src/services/skill-manager';
 
 vi.mock('obsidian', async () => {
@@ -51,5 +52,58 @@ describe('SkillMentionModal', () => {
 describe('formatSkillTrigger', () => {
 	it('formats a skill name as a slash token with a trailing space', () => {
 		expect(formatSkillTrigger('code-review')).toBe('/code-review ');
+	});
+});
+
+// Regression coverage for the picker insertion flow (agent-view.ts showSkillPicker):
+// the `/` trigger is stripped, then the token is inserted at the cursor verbatim
+// without disturbing surrounding text. showSkillPicker itself wires a modal to an
+// AgentView, so this exercises the observable insertion behavior it delegates to
+// (removeTrailingTriggerChar + formatSkillTrigger + insertTextAtCursor).
+describe('skill-token insertion flow', () => {
+	let input: HTMLDivElement;
+
+	beforeEach(() => {
+		input = document.createElement('div');
+		input.contentEditable = 'true';
+		document.body.appendChild(input);
+	});
+
+	afterEach(() => {
+		document.body.removeChild(input);
+		window.getSelection()?.removeAllRanges();
+	});
+
+	// Mirror removeTrailingTriggerChar: drop a trailing trigger char at the cursor.
+	function stripTrailingTrigger(el: HTMLDivElement, char: string): void {
+		const node = el.firstChild;
+		if (node?.nodeType === Node.TEXT_NODE) {
+			const text = node.textContent || '';
+			if (text.endsWith(char)) node.textContent = text.slice(0, -1);
+		}
+		const range = document.createRange();
+		range.selectNodeContents(el);
+		range.collapse(false);
+		const sel = window.getSelection()!;
+		sel.removeAllRanges();
+		sel.addRange(range);
+	}
+
+	it('replaces the lone `/` trigger with the skill token', () => {
+		input.textContent = '/';
+		stripTrailingTrigger(input, '/');
+
+		insertTextAtCursor(input, formatSkillTrigger('code-review'));
+
+		expect(input.textContent).toBe('/code-review ');
+	});
+
+	it('inserts the token at the cursor without disturbing surrounding text', () => {
+		input.textContent = 'note this /';
+		stripTrailingTrigger(input, '/');
+
+		insertTextAtCursor(input, formatSkillTrigger('worklog'));
+
+		expect(input.textContent).toBe('note this /worklog ');
 	});
 });


### PR DESCRIPTION
## Summary

Selecting a skill from the `/` picker in the agent view previously **wiped the input** and overwrote it with `Use the "X" skill to help me with: `. That forced a sentence structure and discarded context already implied by a self-contained skill.

This changes the picker to insert a literal **`/skill-name `** token (cursor placed after it) and leave it in the box, matching the convention in Claude Code, GitHub Copilot Chat, Slack, and Cursor: the user appends free-form instructions or just sends it as-is. The user stays in control of the prose; the slash token is a lightweight directive, not a forced rewrite.

The model learns the convention via a single new line in `toolCatalogPrompt.hbs`, so the sent message and the persisted history entry stay **byte-identical** (no send-time rewriting) — preserving the existing implicit-cache / bit-identical-replay invariant.

## Changes

- `src/ui/agent-view/skill-mention-modal.ts` — new pure helper `formatSkillTrigger(name)` → `/${name} ` (colocated with the modal; stays English since it's model-facing and persisted).
- `src/ui/agent-view/agent-view.ts` — `showSkillPicker`'s `onSelect` now `insertTextAtCursor(...)` the token instead of overwriting `innerText`; still strips the trailing `/` trigger and moves the cursor to the end.
- `prompts/toolCatalogPrompt.hbs` — one new line teaching the model that a message beginning with `/skill-name` means activate that skill via `activate_skill` and apply it to the rest of the message.
- `docs/guide/agent-skills.md` — updated the discovery bullet and added a "Slash Activation" section with examples (`/code-review`, `/code-review focus on error paths`).
- Tests: helper unit test in `test/ui/skill-mention-modal.test.ts`; two system-prompt rendering cases in `test/prompts/gemini-prompts.test.ts` (convention present with skills, absent without).

The `/` trigger is still empty-input-only, so slashes typed mid-prose (paths, dates, fractions) aren't hijacked.

## Screenshots / Screencast

_Text-input behavior change; before → after:_ selecting a skill now shows `/skill-name ` in the input rather than `Use the "skill-name" skill to help me with: `.

## Checklist

### Required

- [x] I have read and agree to the Contributing Guidelines
- [x] I have read and agree to the AI Policy
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards)
- [x] Documentation has been updated (if applicable)
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (Opus 4.8)
- [x] I have reviewed and understand all AI-generated code in this PR

https://claude.ai/code/session_01E3bhquLtm5uABf3PafCw17

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added slash-command activation for skills, including `/skill-name` tokens with optional additional instructions.
  * Selecting a skill now inserts its slash command at the cursor without replacing existing text.
  * Added guidance and examples for using slash commands.

* **Bug Fixes**
  * Improved skill matching to require exact names and avoid ambiguous activations.

* **Tests**
  * Added coverage for slash-command formatting, insertion behavior, and activation prompt handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->