### PR TITLE
refactor(tools): extract shared system-folder guard for vault tools

### DIFF
--- a/src/tools/vault/create-folder-tool.ts
+++ b/src/tools/vault/create-folder-tool.ts
@@ -2,7 +2,8 @@ import { Tool, ToolResult, ToolExecutionContext } from '../types';
 import { ToolCategory } from '../../types/agent';
 import { ToolClassification } from '../../types/tool-policy';
 import { TFolder, normalizePath } from 'obsidian';
-import { shouldExcludePathForPlugin as shouldExcludePath, ensureFolderExists } from '../../utils/file-utils';
+import { ensureFolderExists } from '../../utils/file-utils';
+import { guardExcludedPath } from './utils';
 import { t } from '../../i18n';
 import { getRawErrorMessageOr } from '../../utils/error-utils';
 
@@ -47,12 +48,12 @@ export class CreateFolderTool implements Tool {
 			const normalizedPath = normalizePath(params.path);
 
 			// Check if path is excluded
-			if (shouldExcludePath(normalizedPath, plugin)) {
-				return {
-					success: false,
-					error: `Cannot create folder in system directory: ${params.path}`,
-				};
-			}
+			const excluded = guardExcludedPath(
+				normalizedPath,
+				plugin,
+				`Cannot create folder in system directory: ${params.path}`
+			);
+			if (excluded) return excluded;
 
 			const existing = plugin.app.vault.getAbstractFileByPath(normalizedPath);
 

--- a/src/tools/vault/delete-file-tool.ts
+++ b/src/tools/vault/delete-file-tool.ts
@@ -2,8 +2,7 @@ import { Tool, ToolResult, ToolExecutionContext } from '../types';
 import { ToolCategory } from '../../types/agent';
 import { ToolClassification } from '../../types/tool-policy';
 import { normalizePath } from 'obsidian';
-import { shouldExcludePathForPlugin as shouldExcludePath } from '../../utils/file-utils';
-import { resolvePathToFileOrFolder } from './utils';
+import { guardExcludedPath, resolvePathToFileOrFolder } from './utils';
 import { t } from '../../i18n';
 import { getRawErrorMessageOr } from '../../utils/error-utils';
 
@@ -48,12 +47,8 @@ export class DeleteFileTool implements Tool {
 			const normalizedPath = normalizePath(params.path);
 
 			// Check if path is excluded
-			if (shouldExcludePath(normalizedPath, plugin)) {
-				return {
-					success: false,
-					error: `Cannot delete system folder: ${params.path}`,
-				};
-			}
+			const excluded = guardExcludedPath(normalizedPath, plugin, `Cannot delete system folder: ${params.path}`);
+			if (excluded) return excluded;
 
 			// Use shared file/folder resolution helper
 			const { item, type } = resolvePathToFileOrFolder(params.path, plugin);

--- a/src/tools/vault/move-file-tool.ts
+++ b/src/tools/vault/move-file-tool.ts
@@ -2,8 +2,8 @@ import { Tool, ToolResult, ToolExecutionContext } from '../types';
 import { ToolCategory } from '../../types/agent';
 import { ToolClassification } from '../../types/tool-policy';
 import { normalizePath } from 'obsidian';
-import { shouldExcludePathForPlugin as shouldExcludePath, ensureFolderExists } from '../../utils/file-utils';
-import { resolvePathToFileOrFolder } from './utils';
+import { ensureFolderExists } from '../../utils/file-utils';
+import { guardExcludedPath, resolvePathToFileOrFolder } from './utils';
 import { t } from '../../i18n';
 import { getRawErrorMessageOr } from '../../utils/error-utils';
 
@@ -59,19 +59,19 @@ export class MoveFileTool implements Tool {
 			const targetNormalizedPath = normalizePath(params.targetPath);
 
 			// Check if either path is excluded
-			if (shouldExcludePath(sourceNormalizedPath, plugin)) {
-				return {
-					success: false,
-					error: `Cannot move from system folder: ${params.sourcePath}`,
-				};
-			}
+			const sourceExcluded = guardExcludedPath(
+				sourceNormalizedPath,
+				plugin,
+				`Cannot move from system folder: ${params.sourcePath}`
+			);
+			if (sourceExcluded) return sourceExcluded;
 
-			if (shouldExcludePath(targetNormalizedPath, plugin)) {
-				return {
-					success: false,
-					error: `Cannot move to system folder: ${params.targetPath}`,
-				};
-			}
+			const targetExcluded = guardExcludedPath(
+				targetNormalizedPath,
+				plugin,
+				`Cannot move to system folder: ${params.targetPath}`
+			);
+			if (targetExcluded) return targetExcluded;
 
 			// Use shared file/folder resolution helper
 			const { item: sourceItem, type } = resolvePathToFileOrFolder(params.sourcePath, plugin);

--- a/src/tools/vault/utils.ts
+++ b/src/tools/vault/utils.ts
@@ -1,7 +1,19 @@
 import { TFile, TFolder, normalizePath } from 'obsidian';
 import type { TAbstractFile } from 'obsidian';
 import type { ObsidianGemini } from '../../types/plugin';
+import type { ToolResult } from '../types';
 import { shouldExcludePathForPlugin as shouldExcludePath } from '../../utils/file-utils';
+
+/**
+ * System-folder guard shared by the write/destructive vault tools. Returns a
+ * failure `ToolResult` when `normalizedPath` lands inside a protected folder
+ * (the plugin state folder or `.obsidian`), or `null` when the path is allowed.
+ * Callers pass the fully-formed, tool-specific error message so each tool keeps
+ * its own wording ("Cannot write to…", "Cannot delete…", etc.).
+ */
+export function guardExcludedPath(normalizedPath: string, plugin: ObsidianGemini, error: string): ToolResult | null {
+	return shouldExcludePath(normalizedPath, plugin) ? { success: false, error } : null;
+}
 
 /** Plain, serializable description of a vault file or folder. */
 export interface VaultFileEntry {

--- a/src/tools/vault/write-file-tool.ts
+++ b/src/tools/vault/write-file-tool.ts
@@ -2,7 +2,8 @@ import { Tool, ToolResult, ToolExecutionContext } from '../types';
 import { ToolCategory } from '../../types/agent';
 import { ToolClassification } from '../../types/tool-policy';
 import { TFile, normalizePath } from 'obsidian';
-import { shouldExcludePathForPlugin as shouldExcludePath, ensureFolderExists } from '../../utils/file-utils';
+import { ensureFolderExists } from '../../utils/file-utils';
+import { guardExcludedPath } from './utils';
 import { t } from '../../i18n';
 import { getRawErrorMessageOr } from '../../utils/error-utils';
 
@@ -62,12 +63,8 @@ export class WriteFileTool implements Tool {
 			const normalizedPath = normalizePath(params.path);
 
 			// Check if path is excluded
-			if (shouldExcludePath(normalizedPath, plugin)) {
-				return {
-					success: false,
-					error: `Cannot write to system folder: ${params.path}`,
-				};
-			}
+			const excluded = guardExcludedPath(normalizedPath, plugin, `Cannot write to system folder: ${params.path}`);
+			if (excluded) return excluded;
 
 			let file = plugin.app.vault.getAbstractFileByPath(normalizedPath);
 			const isNewFile = !file;


### PR DESCRIPTION
## Summary

The audit-architecture nightly sweep flagged a **DRY violation**: the system-folder exclusion guard is copy-pasted across the write/destructive vault tools.

Every write or destructive vault tool opened `execute()` with the identical block — `shouldExcludePath(normalizedPath, plugin)` → early-return a failure `ToolResult` — differing only in the verb inside the error string. It was duplicated across `write-file-tool`, `move-file-tool` (twice, source and target), `delete-file-tool`, and `create-folder-tool`. System-folder protection is a load-bearing security invariant, so re-implementing it per tool means five places to keep in lockstep.

This extracts a single `guardExcludedPath(normalizedPath, plugin, error)` helper into the existing `src/tools/vault/utils.ts` (the established home for shared vault-tool helpers). Each caller passes its own fully-formed, tool-specific error message, so the returned `ToolResult.error` strings are byte-for-byte unchanged — this is a pure code-motion refactor with no behavior change. The caller still owns its own `normalizePath` call, so the guard stays a thin, single-responsibility check.

## Changes

- `src/tools/vault/utils.ts` — add `guardExcludedPath(normalizedPath, plugin, error): ToolResult | null`.
- `src/tools/vault/write-file-tool.ts` — use the shared guard; drop the now-unused `shouldExcludePath` import.
- `src/tools/vault/move-file-tool.ts` — use the shared guard for both the source and target path checks.
- `src/tools/vault/delete-file-tool.ts` — use the shared guard; fold the `shouldExcludePath` import into the existing `./utils` import.
- `src/tools/vault/create-folder-tool.ts` — use the shared guard.

## Checklist

### Required

- [x] I have read and agree to the Contributing Guidelines
- [x] I have read and agree to the AI Policy
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: filed by the audit-architecture skill as a mechanically-safe DRY cleanup, not a feature. Close if unwanted.
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — also ran `npm run lint` (0 errors) and `npm run typecheck:test`; full suite 3413/3413 green.
- [x] I have tested this change on Desktop — covered by the existing vault-tool unit tests (unchanged and passing); the extraction preserves the exact error strings and control flow.
- [x] I have verified this change does not break Mobile — no platform-specific APIs touched; pure TypeScript code motion.
- [x] Documentation has been updated (if applicable) — N/A: internal refactor with no user-facing behavior change.
- [x] I understand that I must address all review comments from CodeRabbit and maintainers.

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude (audit-architecture skill)
- [x] I have reviewed and understand all AI-generated code in this PR

---

_Filed by the `audit-architecture` skill._

---
_Generated by [Claude Code](https://claude.ai/code/session_01PZuhMPke9MqzQrj5CxCBS5)_