### PR TITLE
chore(daily): 2026-07-12 daily update

### DIFF
--- a/docs/guide/agent-mode.md
+++ b/docs/guide/agent-mode.md
@@ -44,6 +44,7 @@ Choose which operations require confirmation in **Settings → Gemini Scribe →
 - **move_file**: Moving or renaming files
 - **append_content**: Adding text to the end of files
 - **update_frontmatter**: Modifying note properties (frontmatter)
+- **create_folder**: Creating new folders
 - **create_skill**: Creating new skill packages
 - **edit_skill**: Updating existing skill instructions
 - **generate_image**: Generating and saving images
@@ -614,6 +615,7 @@ By default, these operations require confirmation:
 - **move_file**: Moving or renaming files
 - **append_content**: Adding text to the end of files
 - **update_frontmatter**: Modifying note properties (frontmatter)
+- **create_folder**: Creating new folders
 - **create_skill**: Creating new skill packages
 - **edit_skill**: Updating existing skill instructions
 - **generate_image**: Generating and saving images

--- a/planning/changelog/2026-07-12.md
+++ b/planning/changelog/2026-07-12.md
@@ -1,0 +1,44 @@
+# Daily changelog — July 12, 2026
+
+**Date:** 2026-07-12
+**PRs merged:** 8
+
+---
+
+## Summary
+
+A busy day mixing routine automation with two rounds of audit-driven refactors. The morning cleared the previous day's automated housekeeping PR, an automated i18n translation refresh, and two architecture-audit-filed DRY cleanups collapsing duplicated collapsible/truncation logic in the agent view's tool-display. Mid-afternoon brought a UX change to the skill picker. The evening closed with two `auto-dev` pipeline PRs built off approved plans — a security-hardening refactor that unifies the Gemini provider's two divergent grounding-source HTML renderers onto one escaped, scheme-validated implementation, and the first slice of the `sendMessage` decomposition — plus CodeRabbit-generated tests backfilled for the grounding-renderer PR.
+
+## What shipped
+
+### [#1197 chore(daily): 2026-07-12 daily update](https://github.com/allenhutchison/obsidian-gemini/pull/1197)
+
+The prior day's automated `daily-update` run: wrote `planning/changelog/2026-07-11.md` (5 PRs, headlined by the Interactions API transport flipping to on by default fleet-wide), fixed two conceptual drift items in `docs/guide/agent-mode.md` and `docs/reference/provider-capabilities.md` (missing confirmation-required tools under the Cautious preset; an inaccurate claim about which features are hidden with Ollama active) plus a stale filename reference in `AGENTS.md`, and a no-op `triage-issues` pass. Housekeeping-only.
+
+### [#1194 refactor: extract shared collapsible helpers in tool-display](https://github.com/allenhutchison/obsidian-gemini/pull/1194)
+
+An `audit-architecture` nightly sweep flagged the expand/collapse logic for tool groups and tool rows as duplicated four ways in `agent-view-tool-display.ts` — identical DOM operations and click/keyboard wiring repeated across two toggle closures and two auto-expand-on-error blocks. Extracts `setCollapsibleExpanded` and `wireCollapsibleToggle` helpers so the collapsible state has one source of truth. Pure code motion, no behavior change.
+
+### [#1193 refactor: extract renderTruncatableCode helper in tool-display](https://github.com/allenhutchison/obsidian-gemini/pull/1193)
+
+A companion audit-architecture fix: the "truncate to 500 chars with a _Show full content_ expand button" logic was duplicated verbatim across the raw-string and file-content branches of `renderToolResult`. Extracts a single `renderTruncatableCode` helper used by both. No behavior change.
+
+### [#1192 chore(i18n): Update UI translations](https://github.com/allenhutchison/obsidian-gemini/pull/1192)
+
+Automated translation refresh regenerating `src/i18n/` for keys whose English source changed since the last run.
+
+### [#1198 Insert literal /skill-name token in agent input instead of verbose sentence](https://github.com/allenhutchison/obsidian-gemini/pull/1198)
+
+Selecting a skill from the `/` picker in the agent view previously wiped the input and replaced it with `Use the "X" skill to help me with: `. Now it inserts a lightweight `/skill-name ` token at the cursor and leaves the rest of the input intact, matching the convention in Claude Code, Copilot Chat, Slack, and Cursor. The model learns the convention via one new line in `toolCatalogPrompt.hbs`, keeping the sent message and persisted history entry byte-identical (no send-time rewriting, preserving the implicit-cache invariant).
+
+### [#1199 refactor(gemini): unify grounding-source renderer into shared leaf module](https://github.com/allenhutchison/obsidian-gemini/pull/1199)
+
+Fixes #1195. The Gemini provider had two functions producing the `.rendered` HTML block for search-grounding citations that had drifted apart: `client.ts`'s streaming/non-streaming path built it via raw string concatenation with no escaping or scheme validation, while `interactions-mapper.ts`'s version escaped both href and label and restricted to `http(s)`. Since `.rendered` has no runtime DOM consumer today this was a latent injection risk rather than live XSS, but a genuine consistency defect. Collapses both onto a new hardened leaf module, `grounding-render.ts`, exporting `renderGroundingSources`, `escapeHtml`, and `safeExternalUrl`.
+
+### [#1200 refactor(agent-view): extract persistAttachments from sendMessage (#1196)](https://github.com/allenhutchison/obsidian-gemini/pull/1200)
+
+Fixes #1196. First slice of the planned `AgentViewSend.sendMessage` decomposition (~540 lines today). Extracts the dropped/pasted attachment vault-persistence block into a private `persistAttachments` method returning the saved attachment/path pairs, leaving `sendMessage` a thinner orchestrator. Pure code motion; call order and turn/cache alignment are unchanged. Remaining seams (`buildDisplayPreview`, `assembleInstructions`, `buildSendRequest`) are tracked as follow-up PRs.
+
+### [#1201 CodeRabbit Generated Unit Tests: Generate Unit Tests for PR Changes](https://github.com/allenhutchison/obsidian-gemini/pull/1201)
+
+CodeRabbit-generated test coverage for #1199, requested during that PR's review — adds cases to `test/api/providers/gemini/client.test.ts` and `test/api/providers/gemini/grounding-render.test.ts`.

--- a/test/api/providers/gemini/client.test.ts
+++ b/test/api/providers/gemini/client.test.ts
@@ -725,9 +725,7 @@ describe('GeminiClient', () => {
 					{
 						content: { parts: [{ text: 'ok' }] },
 						groundingMetadata: {
-							groundingChunks: [
-								{ web: { uri: 'javascript:alert(1)', title: '<img src=x onerror=alert(1)>' } },
-							],
+							groundingChunks: [{ web: { uri: 'javascript:alert(1)', title: '<img src=x onerror=alert(1)>' } }],
 						},
 					},
 				],


### PR DESCRIPTION
## Summary

Automated daily housekeeping run (`daily-update` meta-skill via the `maintainerd` plugin marketplace) bundling `daily-changelog`, `audit-product-docs`, and `triage-issues` for 2026-07-12.

## Changes

- **daily-changelog**: wrote `planning/changelog/2026-07-12.md` — 8 PRs merged on 2026-07-12. Headlined by two `auto-dev` pipeline PRs: [#1199](https://github.com/allenhutchison/obsidian-gemini/pull/1199) (unifies the Gemini provider's two divergent grounding-source HTML renderers onto one escaped, scheme-validated implementation, fixing #1195) and [#1200](https://github.com/allenhutchison/obsidian-gemini/pull/1200) (first slice of the `sendMessage` decomposition, fixing #1196). Also covers two architecture-audit DRY refactors in `agent-view-tool-display.ts` ([#1193](https://github.com/allenhutchison/obsidian-gemini/pull/1193), [#1194](https://github.com/allenhutchison/obsidian-gemini/pull/1194)), an automated i18n translation refresh ([#1192](https://github.com/allenhutchison/obsidian-gemini/pull/1192)), the prior day's `daily-update` PR ([#1197](https://github.com/allenhutchison/obsidian-gemini/pull/1197)), the `/skill-name` slash-activation UX change to the skill picker ([#1198](https://github.com/allenhutchison/obsidian-gemini/pull/1198)), and CodeRabbit-generated tests backfilled for the grounding-renderer PR ([#1201](https://github.com/allenhutchison/obsidian-gemini/pull/1201)).
- **audit-product-docs**: fixed 1 mechanical drift item in `docs/guide/agent-mode.md` — both "operations require confirmation" lists were missing `create_folder`. It's classified `ToolClassification.WRITE` (`src/tools/vault/create-folder-tool.ts`), so it requires confirmation under the Cautious preset exactly like the other write tools, but was never listed. Everything else cross-checked clean: settings defaults, the tool-permission preset matrix, all 26 registered tool names, command palette IDs, hook/scheduled-task/MCP/RAG constants, the i18n language list, the `/skill-name` slash-trigger docs added in #1198, and the generated help-references index.
- **triage-issues**: no-op — no unlabeled open issues.

This is a housekeeping-only PR — no `src/` behavior changes.

## Screenshots / Screencast

N/A — changelog and docs-only change, no UI change.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A; routine automated daily housekeeping run
- [x] All CI checks pass (`npm test` — 3413 passing, `npm run build`, `npm run format-check`, `npm run lint`, `npm run typecheck:test`)
- [x] I have tested this change on Desktop — N/A, changelog/docs-only change; verified via local pre-flight checks
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A, no code change
- [x] Documentation has been updated (if applicable) — this PR's own `audit-product-docs` pass is the documentation update (see Changes above)
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR


---
_Generated by [Claude Code](https://claude.ai/code/session_01YHYXt6dMDvLEPGPdTCuGjG)_