### PR TITLE
refactor: consolidate legacy history-entry decode into a leaf helper (#1203)

### DIFF
--- a/src/api/providers/gemini/client.ts
+++ b/src/api/providers/gemini/client.ts
@@ -31,6 +31,7 @@ import { GeminiPrompts } from '../../../prompts';
 import type { ObsidianGemini } from '../../../types/plugin';
 import { getDefaultModelForRole } from '../../../models';
 import { decodeHtmlEntities } from '../../../utils/html-entities';
+import { normalizeToContent } from '../../../utils/history-normalize';
 import type { GeminiClientConfig } from './config';
 import { ModelUseCase } from '../../model-use-case';
 import {
@@ -294,15 +295,7 @@ export class GeminiClient implements ModelApi {
 	 * canonical `{ role, parts }`. Returns null for unrecognized entries.
 	 */
 	private normalizeHistoryEntry(entry: Content): Content | null {
-		if ('role' in entry && 'parts' in entry) {
-			return entry;
-		}
-		if ('role' in entry && ('text' in entry || 'message' in entry)) {
-			const legacy = entry as Content & { role?: string; text?: string; message?: string };
-			const text = legacy.text ?? legacy.message ?? '';
-			return { role: this.coerceHistoryRole(legacy.role), parts: [{ text }] };
-		}
-		return null;
+		return normalizeToContent(entry, (role) => this.coerceHistoryRole(role));
 	}
 
 	/**

--- a/src/api/providers/ollama/client.ts
+++ b/src/api/providers/ollama/client.ts
@@ -34,6 +34,7 @@ import {
 import { GeminiPrompts } from '../../../prompts';
 import type { ObsidianGemini } from '../../../types/plugin';
 import type { OllamaClientConfig } from './config';
+import { getLegacyEntryText } from '../../../utils/history-normalize';
 
 export class OllamaClient implements ModelApi {
 	private client: Ollama;
@@ -373,7 +374,7 @@ export class OllamaClient implements ModelApi {
 
 		// Internal shape: { role, text } or { role, message }
 		if ('role' in record) {
-			const text = record.text ?? record.message;
+			const text = getLegacyEntryText(record);
 			if (typeof text !== 'string' || !text.trim()) return null;
 			const role = record.role === 'model' || record.role === 'assistant' ? 'assistant' : 'user';
 			return [{ role, content: text }];

--- a/src/services/context-manager.ts
+++ b/src/services/context-manager.ts
@@ -16,6 +16,7 @@ import { ModelClientFactory, ModelUseCase } from '../api';
 import { executeWithRetry } from '../utils/retry';
 import { createGoogleGenAI } from '../api/providers/gemini/google-genai-factory';
 import { truncateOldToolResults } from '../agent/agent-loop-helpers';
+import { getLegacyEntryTextTruthy } from '../utils/history-normalize';
 
 import contextSummaryPromptContent from '../../prompts/contextSummaryPrompt.hbs';
 
@@ -268,12 +269,11 @@ export class ContextManager {
 		const result: Content[] = [];
 		for (const entry of contents) {
 			if (!entry.parts || !Array.isArray(entry.parts)) {
-				// Legacy stored entries may have top-level text/message fields.
-				const legacy = entry as Content & { text?: string; message?: string };
-				if (legacy.text) {
-					result.push({ role: entry.role || 'user', parts: [{ text: legacy.text }] });
-				} else if (legacy.message) {
-					result.push({ role: entry.role || 'user', parts: [{ text: legacy.message }] });
+				// Legacy stored entries may have top-level text/message fields
+				// (truthiness precedence: an empty-string `text` falls back to `message`).
+				const legacyText = getLegacyEntryTextTruthy(entry);
+				if (legacyText) {
+					result.push({ role: entry.role || 'user', parts: [{ text: legacyText }] });
 				}
 				continue;
 			}
@@ -526,8 +526,7 @@ export class ContextManager {
 		// History entries may use parts[].text (API format) or message (stored format)
 		while (splitIndex > 0 && splitIndex < totalTurns) {
 			const entry = conversationHistory[splitIndex];
-			const legacy = entry as Content & { message?: string; text?: string };
-			if (entry.role === 'user' && (entry.parts?.[0]?.text || legacy.message || legacy.text)) {
+			if (entry.role === 'user' && (entry.parts?.[0]?.text || getLegacyEntryTextTruthy(entry))) {
 				break;
 			}
 			splitIndex--;
@@ -598,11 +597,10 @@ export class ContextManager {
 						.join('\n');
 				} else {
 					// Legacy stored format: top-level text or message fields
-					const legacy = turn as Content & { text?: string; message?: string };
-					if (legacy.text) {
-						text = legacy.text;
-					} else if (legacy.message) {
-						text = legacy.message;
+					// (truthiness precedence: an empty-string `text` falls back to `message`).
+					const legacyText = getLegacyEntryTextTruthy(turn);
+					if (legacyText) {
+						text = legacyText;
 					}
 				}
 

--- a/src/utils/history-normalize.ts
+++ b/src/utils/history-normalize.ts
@@ -68,7 +68,11 @@ export function normalizeToContent(
 	entry: Content,
 	coerceRole: (role: string | undefined) => 'user' | 'model'
 ): Content | null {
-	if ('role' in entry && 'parts' in entry) {
+	// Require `parts` to actually be an array before treating the entry as
+	// canonical — a malformed `{ parts: null }` entry must fall through to the
+	// legacy branch (so a co-present `text`/`message` is still recovered) rather
+	// than pass through, matching the sibling guard in `context-manager.ts`.
+	if ('role' in entry && Array.isArray((entry as { parts?: unknown }).parts)) {
 		return entry;
 	}
 	if ('role' in entry && ('text' in entry || 'message' in entry)) {

--- a/src/utils/history-normalize.ts
+++ b/src/utils/history-normalize.ts
@@ -1,0 +1,79 @@
+import type { Content } from '@google/genai';
+
+/**
+ * Legacy read-side decode helpers for stored conversation-history entries.
+ *
+ * A stored entry may predate the canonical `{ role, parts }` `Content` shape and
+ * instead carry its text in a top-level `text` or `message` field. Historically
+ * this backward-compat rule was re-implemented from scratch at five call sites
+ * across three modules (the Gemini/Ollama API clients and the context manager),
+ * each casting to an ad-hoc `Content & { text?; message? }` shape. This leaf
+ * module owns that shape and the decode precedence in one place so the sites stay
+ * consistent. It never imports back into `api/` or `services/`.
+ *
+ * Two precedence variants exist because the historical sites did not agree:
+ * - {@link getLegacyEntryText} uses **nullish** precedence (`text ?? message`) —
+ *   the API-replay paths treat an explicit empty-string `text` as intentional.
+ * - {@link getLegacyEntryTextTruthy} uses **truthiness** precedence
+ *   (`text || message`) — the context-manager sites fall back to `message` when
+ *   `text` is an empty string.
+ * The two differ only when `text === ''`; the split is preserved deliberately.
+ */
+
+/** Minimal structural shape a raw `Record<string, unknown>` entry satisfies. */
+export interface LegacyTextCarrier {
+	text?: unknown;
+	message?: unknown;
+}
+
+/** A history entry as seen by the decode helpers: canonical `Content` or a legacy carrier. */
+type LegacyEntry = Content | LegacyTextCarrier;
+
+function readLegacyFields(entry: LegacyEntry): LegacyTextCarrier {
+	return entry as LegacyTextCarrier;
+}
+
+/**
+ * Extract the text of a legacy history entry using **nullish** precedence
+ * (`text ?? message`): an explicit empty-string `text` is returned as-is and does
+ * NOT fall back to `message`. Use on the API-replay paths (Gemini/Ollama). Returns
+ * `undefined` when neither field carries a string.
+ */
+export function getLegacyEntryText(entry: LegacyEntry): string | undefined {
+	const { text, message } = readLegacyFields(entry);
+	const value = text ?? message;
+	return typeof value === 'string' ? value : undefined;
+}
+
+/**
+ * Extract the text of a legacy history entry using **truthiness** precedence
+ * (`text || message`): an empty-string `text` falls back to `message`. Use where
+ * the historical behavior branched on truthiness (context-manager sanitize /
+ * summarize / boundary-scan). Differs from {@link getLegacyEntryText} only when
+ * `text === ''`. Returns `undefined` when neither field carries a non-empty string.
+ */
+export function getLegacyEntryTextTruthy(entry: LegacyEntry): string | undefined {
+	const { text, message } = readLegacyFields(entry);
+	const value = text || message;
+	return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+/**
+ * Normalize a stored history entry to a `Content`, tolerating the two legacy
+ * shapes (`{ role, text }`, `{ role, message }`) alongside canonical
+ * `{ role, parts }`. Role coercion is provider-specific, so the caller supplies
+ * it (e.g. Gemini's user/model coercion). Returns `null` for unrecognized entries.
+ */
+export function normalizeToContent(
+	entry: Content,
+	coerceRole: (role: string | undefined) => 'user' | 'model'
+): Content | null {
+	if ('role' in entry && 'parts' in entry) {
+		return entry;
+	}
+	if ('role' in entry && ('text' in entry || 'message' in entry)) {
+		const role = (entry as { role?: string }).role;
+		return { role: coerceRole(role), parts: [{ text: getLegacyEntryText(entry) ?? '' }] };
+	}
+	return null;
+}

--- a/test/utils/history-normalize.test.ts
+++ b/test/utils/history-normalize.test.ts
@@ -1,0 +1,106 @@
+import type { Content } from '@google/genai';
+import { getLegacyEntryText, getLegacyEntryTextTruthy, normalizeToContent } from '../../src/utils/history-normalize';
+
+describe('history-normalize', () => {
+	// Identity coercion for tests that don't exercise role logic.
+	const identityCoerce = (role: string | undefined): 'user' | 'model' => (role === 'user' ? 'user' : 'model');
+
+	describe('getLegacyEntryText (nullish precedence)', () => {
+		it('returns text when present', () => {
+			expect(getLegacyEntryText({ text: 'hello' })).toBe('hello');
+		});
+
+		it('falls back to message when text is absent', () => {
+			expect(getLegacyEntryText({ message: 'from message' })).toBe('from message');
+		});
+
+		it('prefers text over message when both are present', () => {
+			expect(getLegacyEntryText({ text: 'the text', message: 'the message' })).toBe('the text');
+		});
+
+		it('keeps an empty-string text and does NOT fall back to message (nullish)', () => {
+			// The distinguishing edge: `'' ?? message` === '', so message is not used.
+			expect(getLegacyEntryText({ text: '', message: 'ignored' })).toBe('');
+		});
+
+		it('returns undefined when neither field is present', () => {
+			expect(getLegacyEntryText({})).toBeUndefined();
+		});
+
+		it('returns undefined for non-string field values', () => {
+			expect(getLegacyEntryText({ text: 42 })).toBeUndefined();
+		});
+	});
+
+	describe('getLegacyEntryTextTruthy (truthiness precedence)', () => {
+		it('returns text when present and non-empty', () => {
+			expect(getLegacyEntryTextTruthy({ text: 'hello' })).toBe('hello');
+		});
+
+		it('falls back to message when text is absent', () => {
+			expect(getLegacyEntryTextTruthy({ message: 'from message' })).toBe('from message');
+		});
+
+		it('prefers text over message when both are non-empty', () => {
+			expect(getLegacyEntryTextTruthy({ text: 'the text', message: 'the message' })).toBe('the text');
+		});
+
+		it('falls back to message when text is an empty string (truthiness)', () => {
+			// The distinguishing edge vs. getLegacyEntryText: '' is falsy, so message wins.
+			expect(getLegacyEntryTextTruthy({ text: '', message: 'used' })).toBe('used');
+		});
+
+		it('returns undefined when both fields are empty strings', () => {
+			expect(getLegacyEntryTextTruthy({ text: '', message: '' })).toBeUndefined();
+		});
+
+		it('returns undefined when neither field is present', () => {
+			expect(getLegacyEntryTextTruthy({})).toBeUndefined();
+		});
+	});
+
+	describe('normalizeToContent', () => {
+		it('passes through a canonical { role, parts } entry unchanged', () => {
+			const entry: Content = { role: 'user', parts: [{ text: 'hi' }] };
+			expect(normalizeToContent(entry, identityCoerce)).toBe(entry);
+		});
+
+		it('normalizes a legacy { role, text } entry to Content', () => {
+			const entry = { role: 'user', text: 'legacy text' } as unknown as Content;
+			expect(normalizeToContent(entry, identityCoerce)).toEqual({
+				role: 'user',
+				parts: [{ text: 'legacy text' }],
+			});
+		});
+
+		it('normalizes a legacy { role, message } entry to Content', () => {
+			const entry = { role: 'model', message: 'legacy message' } as unknown as Content;
+			expect(normalizeToContent(entry, identityCoerce)).toEqual({
+				role: 'model',
+				parts: [{ text: 'legacy message' }],
+			});
+		});
+
+		it('prefers text over message with nullish precedence (keeps empty text)', () => {
+			const entry = { role: 'user', text: '', message: 'ignored' } as unknown as Content;
+			expect(normalizeToContent(entry, identityCoerce)).toEqual({
+				role: 'user',
+				parts: [{ text: '' }],
+			});
+		});
+
+		it('applies the caller-supplied role coercion', () => {
+			const entry = { role: 'system', message: 'x' } as unknown as Content;
+			const coerceToModel = (): 'user' | 'model' => 'model';
+			expect(normalizeToContent(entry, coerceToModel)).toEqual({
+				role: 'model',
+				parts: [{ text: 'x' }],
+			});
+		});
+
+		it('returns null for an unrecognized entry (no parts, no text/message)', () => {
+			const entry = { role: 'user' } as unknown as Content;
+			expect(normalizeToContent(entry, identityCoerce)).toBeNull();
+		});
+	});
+});

--- a/test/utils/history-normalize.test.ts
+++ b/test/utils/history-normalize.test.ts
@@ -102,5 +102,22 @@ describe('history-normalize', () => {
 			const entry = { role: 'user' } as unknown as Content;
 			expect(normalizeToContent(entry, identityCoerce)).toBeNull();
 		});
+
+		it('does not treat a malformed non-array parts entry as canonical', () => {
+			// `'parts' in entry` is true but the value is not an array; with no legacy
+			// text/message to recover, the entry is rejected rather than passed through.
+			const entry = { role: 'user', parts: null } as unknown as Content;
+			expect(normalizeToContent(entry, identityCoerce)).toBeNull();
+		});
+
+		it('recovers legacy text when parts is present but not an array', () => {
+			// A malformed `{ parts: null }` entry that also carries a legacy `text`
+			// field falls through to the legacy branch instead of losing the text.
+			const entry = { role: 'user', parts: null, text: 'recovered' } as unknown as Content;
+			expect(normalizeToContent(entry, identityCoerce)).toEqual({
+				role: 'user',
+				parts: [{ text: 'recovered' }],
+			});
+		});
 	});
 });


### PR DESCRIPTION
## Summary

The backward-compat rule "a stored history entry may carry a top-level `text` **or** `message` field instead of canonical `parts`" was re-implemented from scratch at five sites across three modules (the Gemini and Ollama API clients, and the context manager), each with its own ad-hoc `Content & { text?; message? }` cast. If the legacy stored format ever changes, all five sites must be found and edited in lockstep with nothing forcing them to agree.

This is a pure read-side consolidation into a single leaf module — no stored-format or on-disk change.

Fixes #1203

## Changes

- **New `src/utils/history-normalize.ts`** (leaf module, never imports back into `api/` or `services/`) owning the legacy shape and decode precedence:
  - `getLegacyEntryText(entry)` — **nullish** precedence (`text ?? message`) for the API-replay paths, which treat an empty-string `text` as intentional.
  - `getLegacyEntryTextTruthy(entry)` — **truthiness** precedence (`text || message`) for the context-manager sites, which fall back to `message` when `text === ''`.
  - `normalizeToContent(entry, coerceRole)` — the former private `normalizeHistoryEntry` behavior (parts pass-through, legacy → `{ role, parts:[{text}] }`, unrecognized → `null`), with provider-specific role coercion passed in by the caller.
- `src/api/providers/gemini/client.ts` — `normalizeHistoryEntry` now delegates to `normalizeToContent`, keeping `coerceHistoryRole` local; ad-hoc cast removed.
- `src/api/providers/ollama/client.ts` — consumes `getLegacyEntryText`; the provider-specific `{ role, content }` assembly and `model`/`assistant` role-coercion stay in place.
- `src/services/context-manager.ts` — three sites (`sanitizeContentsForTokenCount`, `compactHistory` split-boundary scan, `summarizeConversation`) route through `getLegacyEntryTextTruthy`, preserving each site's exact truthiness precedence.
- `test/utils/history-normalize.test.ts` — new unit test covering the `parts`/`text`/`message` shapes, the unrecognized-entry → `null` case, and the empty-string edge that pins the nullish-vs-truthiness distinction.

### Precedence note (deviation from the plan's literal suggestion)

The approved plan suggested truthiness sites keep their behavior via a `getLegacyEntryText(entry) || ''`-style guard. That does **not** preserve the original behavior at the empty-string edge: when `text === ''` and `message` is set, the historical context-manager sites fall back to `message`, but `'' ?? message` returns `''`. To preserve behavior exactly, this PR provides a dedicated truthiness extractor (`getLegacyEntryTextTruthy`) alongside the nullish one, and the two differ only when `text === ''`. This is a small, documented adaptation that keeps the field knowledge fully centralized while preserving each call site's observable behavior.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer (#1203, plan approved)
- [x] All CI checks pass (`npm test` — 3431 passing, `npm run build`, `npm run format-check`, `npm run typecheck:test`, `npm run lint` — 0 errors)
- [x] I have tested this change on Desktop — behavior-preserving refactor; verified via the existing Gemini/Ollama/context-manager suites plus the new precedence-edge test. No new runtime surface to exercise beyond those decode paths.
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — no platform-specific APIs; pure TypeScript decode logic
- [ ] Documentation has been updated (N/A — internal refactor with no user-facing behavior change)
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude (auto-dev pipeline)
- [x] I have reviewed and understand all AI-generated code in this PR

---

<!-- auto-dev -->
Produced by the auto-dev pipeline from the approved plan on #1203.

---
_Generated by [Claude Code](https://claude.ai/code/session_016KRagpkaEx9Wza5fZZ1rTo)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with older conversation-history formats across Gemini and Ollama.
  * Ensured legacy messages are consistently recognized, including entries using either text or message fields.
  * Preserved empty-message content where appropriate and improved fallback handling.
  * Improved conversation compaction and summarization when processing older history entries.

* **Tests**
  * Added coverage for legacy-history conversion, role mapping, fallback behavior, and invalid entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->