### PR TITLE
refactor(tools): extract shared isFileInAgentScope predicate (#1204)

### DIFF
--- a/src/tools/vault/search-file-contents-tool.ts
+++ b/src/tools/vault/search-file-contents-tool.ts
@@ -1,8 +1,8 @@
 import { Tool, ToolResult, ToolExecutionContext } from '../types';
 import { ToolCategory } from '../../types/agent';
 import { ToolClassification } from '../../types/tool-policy';
-import { shouldExcludePathForPlugin as shouldExcludePath } from '../../utils/file-utils';
 import { getRawErrorMessageOr } from '../../utils/error-utils';
+import { isFileInAgentScope } from './utils';
 
 /**
  * Search for text content within files
@@ -110,12 +110,8 @@ export class SearchFileContentsTool implements Tool {
 
 			// Search through each file
 			for (const file of allFiles) {
-				// Skip system folders
-				if (shouldExcludePath(file.path, plugin)) {
-					continue;
-				}
-				// Scope to project root when active
-				if (projectRoot && !file.path.startsWith(projectRoot + '/')) {
+				// Skip files outside agent scope (system folders, or outside the active project root)
+				if (!isFileInAgentScope(file, plugin, projectRoot)) {
 					continue;
 				}
 

--- a/src/tools/vault/search-files-tool.ts
+++ b/src/tools/vault/search-files-tool.ts
@@ -1,8 +1,8 @@
 import { Tool, ToolResult, ToolExecutionContext } from '../types';
 import { ToolCategory } from '../../types/agent';
 import { ToolClassification } from '../../types/tool-policy';
-import { shouldExcludePathForPlugin as shouldExcludePath } from '../../utils/file-utils';
 import { getRawErrorMessageOr } from '../../utils/error-utils';
+import { isFileInAgentScope } from './utils';
 
 /**
  * Search for files by name pattern
@@ -76,8 +76,7 @@ export class SearchFilesTool implements Tool {
 
 			const projectRoot = context.projectRootPath;
 			const scopedMatches = allFiles.filter((file) => {
-				if (shouldExcludePath(file.path, plugin)) return false;
-				if (projectRoot && !file.path.startsWith(projectRoot + '/')) return false;
+				if (!isFileInAgentScope(file, plugin, projectRoot)) return false;
 				return regex.test(file.name) || regex.test(file.path);
 			});
 

--- a/src/tools/vault/utils.ts
+++ b/src/tools/vault/utils.ts
@@ -15,6 +15,20 @@ export function guardExcludedPath(normalizedPath: string, plugin: ObsidianGemini
 	return shouldExcludePath(normalizedPath, plugin) ? { success: false, error } : null;
 }
 
+/**
+ * Agent-scope predicate shared by the read-only vault search tools. A file is in
+ * scope when it is not inside a protected system folder (the plugin state folder
+ * or `.obsidian`) and — when a project is active — it lives under `projectRoot`.
+ *
+ * The `projectRoot + '/'` boundary is load-bearing: without the trailing slash a
+ * `projectRoot` of `Foo` would spuriously match `Foobar/note.md`.
+ */
+export function isFileInAgentScope(file: TFile, plugin: ObsidianGemini, projectRoot: string | undefined): boolean {
+	if (shouldExcludePath(file.path, plugin)) return false;
+	if (projectRoot && !file.path.startsWith(projectRoot + '/')) return false;
+	return true;
+}
+
 /** Plain, serializable description of a vault file or folder. */
 export interface VaultFileEntry {
 	name: string;

--- a/test/tools/vault/utils.test.ts
+++ b/test/tools/vault/utils.test.ts
@@ -1,4 +1,4 @@
-import { resolvePathToFile, resolvePathToFileOrFolder } from '../../../src/tools/vault/utils';
+import { isFileInAgentScope, resolvePathToFile, resolvePathToFileOrFolder } from '../../../src/tools/vault/utils';
 
 // Mock gemini-utils (needed by file-classification, imported by vault-tools)
 vi.mock('@allenhutchison/gemini-utils/mime', () => ({
@@ -228,6 +228,38 @@ describe('resolvePathToFile', () => {
 
 		expect(result.file).toBeNull();
 		expect(result.suggestions).toEqual([]);
+	});
+});
+
+describe('isFileInAgentScope', () => {
+	const makeFile = (path: string): TFile => {
+		const file = new TFile();
+		(file as any).path = path;
+		(file as any).name = path.split('/').pop();
+		return file;
+	};
+
+	it('excludes system-folder files regardless of project root', () => {
+		expect(isFileInAgentScope(makeFile('.obsidian/workspace.json'), mockPlugin, undefined)).toBe(false);
+		expect(isFileInAgentScope(makeFile('test-history-folder/session.md'), mockPlugin, undefined)).toBe(false);
+	});
+
+	it('includes any non-system file when no project root is active', () => {
+		expect(isFileInAgentScope(makeFile('notes/todo.md'), mockPlugin, undefined)).toBe(true);
+	});
+
+	it('includes files under the active project root', () => {
+		expect(isFileInAgentScope(makeFile('Foo/note.md'), mockPlugin, 'Foo')).toBe(true);
+	});
+
+	it('excludes files outside the active project root', () => {
+		expect(isFileInAgentScope(makeFile('Bar/note.md'), mockPlugin, 'Foo')).toBe(false);
+	});
+
+	it('does not treat a sibling with a shared prefix as in-scope (boundary case)', () => {
+		// Without the trailing-slash boundary, projectRoot "Foo" would spuriously
+		// match "Foobar/x.md" — this pins that it does not.
+		expect(isFileInAgentScope(makeFile('Foobar/x.md'), mockPlugin, 'Foo')).toBe(false);
 	});
 });
 


### PR DESCRIPTION
## Summary

The two vault search tools (`find_files_by_name`, `find_files_by_content`) each filtered their candidate file set with the same two-clause agent-scope predicate, written out inline and independently: exclude system folders (`shouldExcludePath`), then — when a project is active — scope to it via the `projectRoot + '/'` boundary check. That trailing-slash boundary is a subtle, easy-to-get-wrong invariant (without it, `projectRoot = "Foo"` would spuriously match `Foobar/note.md`) that was duplicated verbatim, so any change to agent scoping had to be made in lockstep across both tools with nothing enforcing that they agree.

This extracts a single `isFileInAgentScope(file, plugin, projectRoot)` predicate into `src/tools/vault/utils.ts` (the established home for shared vault-tool helpers, alongside `resolvePathToFile` and `guardExcludedPath`) and routes both tools through it. Pure behavior-preserving code motion — the filter logic is byte-for-byte equivalent to the inline versions it replaces.

Fixes #1204

## Changes

- `src/tools/vault/utils.ts` — add `isFileInAgentScope(file: TFile, plugin, projectRoot: string | undefined): boolean`, returning `false` when the file is in a protected system folder or outside the active project root, `true` otherwise. Docstring calls out the load-bearing `projectRoot + '/'` boundary.
- `src/tools/vault/search-files-tool.ts` — use it as the single `.filter()` predicate; drop the now-unused `shouldExcludePath` import.
- `src/tools/vault/search-file-contents-tool.ts` — use it as an inverted loop guard (`if (!isFileInAgentScope(...)) continue;`), collapsing the two separate `continue` guards into one; drop the now-unused `shouldExcludePath` import.
- `test/tools/vault/utils.test.ts` — new `isFileInAgentScope` describe block covering system-folder exclusion, no-project-root inclusion, in-/out-of-project-root scoping, and the `Foo` vs `Foobar/x.md` prefix boundary case.

**Out of scope** (per the approved plan): `list-files-tool` (its boundary is a user-supplied `folderPath`, a different concept), the search tools' matching/ranking logic, and any change to what "agent scope" means — this is a pure extraction that preserves current behavior.

## Screenshots / Screencast

N/A — internal refactor with no UI or user-visible behavior change.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer (#1204, plan approved)
- [x] All CI checks pass (`npm test` — 3418 passing, `npm run build`, `npm run format-check`, `npm run typecheck:test`, `npm run lint` — 0 errors)
- [x] I have tested this change on Desktop — behavior-preserving refactor; the extracted predicate is byte-for-byte equivalent to the inline logic, verified via the unchanged `search-files-tool` / `search-file-contents-tool` suites plus 5 new `isFileInAgentScope` unit tests (including the `Foo`/`Foobar` boundary). As a pure code-motion refactor there is no divergent runtime surface to drive end-to-end beyond what those tests exercise.
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — no platform-specific APIs touched; pure TypeScript predicate logic.
- [ ] Documentation has been updated (N/A — internal refactor with no user-facing behavior or settings change)
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude (auto-dev pipeline)
- [x] I have reviewed and understand all AI-generated code in this PR

<!-- auto-dev -->

Produced by the auto-dev pipeline from the approved plan on #1204.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P1E1XFqcKM6HqyuJtvkksq

---
_Generated by [Claude Code](https://claude.ai/code/session_01P1E1XFqcKM6HqyuJtvkksq)_