### PR TITLE
chore(daily): 2026-07-14 daily update

### DIFF
--- a/docs/guide/agent-mode.md
+++ b/docs/guide/agent-mode.md
@@ -20,7 +20,7 @@ In v4.0+, the agent is always available and can:
 ### 1. Open Agent Chat
 
 - Use Command Palette: "Gemini Scribe: Open Gemini chat"
-- Or click the sparkles icon (⭐) in the ribbon
+- Or click the sparkles icon (✨) in the ribbon
 - Or use your configured hotkey
 - You can also manage sessions directly from the command palette with:
   - "New agent session"

--- a/docs/guide/ai-writing.md
+++ b/docs/guide/ai-writing.md
@@ -313,7 +313,7 @@ The Ask about selection feature lets you ask any question about selected text. T
 1. **Select text** in your document
 2. **Right-click** and choose "Gemini Scribe: Ask question..."
 3. **Type your question** in the modal
-4. **Press Enter** or click "Ask"
+4. **Press Ctrl/Cmd + Enter** or click "Ask"
 5. **View the response** and choose an action:
    - **Insert as callout**: Adds the Q&A as a callout block
    - **Copy**: Copies the response to clipboard

--- a/docs/guide/completions.md
+++ b/docs/guide/completions.md
@@ -40,7 +40,7 @@ Completions provide:
 1. Open Command Palette (`Ctrl/Cmd + P`)
 2. Search for "Gemini Scribe: Toggle completions"
 3. Press Enter
-4. See confirmation notice: "Completions enabled" or "Completions disabled"
+4. See confirmation notice: "Gemini Scribe completions are now enabled." or "Gemini Scribe completions are now disabled."
 
 ### Quick Test
 
@@ -350,8 +350,7 @@ Train the AI by:
    - Look for confirmation
 
 2. **Verify file type**
-   - Must be markdown (.md)
-   - Not in code blocks
+   - Must be an open Markdown view (.md file)
 
 3. **Check timing**
    - Wait full 500ms
@@ -492,9 +491,9 @@ Turn off for:
 
 ### With Custom Prompts
 
-- Completions respect active prompts
-- Suggestions match prompt style
-- Consistency across features
+- Completions use a fixed, dedicated prompt template and do not read the session's active custom prompt
+- Suggestions are based only on the surrounding document text, not any custom prompt's style or persona
+- Custom prompts affect Chat, Rewrite, and selection features, not completions
 
 ### With Chat
 

--- a/docs/guide/context-system.md
+++ b/docs/guide/context-system.md
@@ -94,7 +94,7 @@ The fastest way to add context files:
 5. File appears in the shelf above the input
 6. The file is now persistent context for the session
 
-To type a literal `@` symbol without triggering the picker, press `@` twice or continue typing without selecting from the list.
+Typing `@` always opens the picker (focus moves to its search box). To keep a literal `@` in your message instead of picking a file, press **Esc** to dismiss the picker — the `@` you already typed stays in the input.
 
 **Example:**
 

--- a/docs/guide/custom-prompts.md
+++ b/docs/guide/custom-prompts.md
@@ -46,7 +46,7 @@ Custom prompts are stored in: `[state-folder]/Prompts/`
 
 For example, if your plugin state folder is `gemini-scribe`, prompts will be in `gemini-scribe/Prompts/`.
 
-The plugin automatically creates this folder structure and adds an example prompt when you first enable the feature:
+The plugin automatically creates this folder structure and adds an example prompt the first time it loads (there's no separate toggle to turn the feature on):
 
 - `gemini-scribe/` - Main plugin state folder
 - `gemini-scribe/Prompts/` - Custom prompt templates

--- a/docs/guide/mcp-servers.md
+++ b/docs/guide/mcp-servers.md
@@ -34,15 +34,16 @@ When you connect an MCP server to Gemini Scribe, its tools appear alongside the 
 
 1. Open Obsidian Settings
 2. Navigate to **Gemini Scribe** settings
-3. Scroll to the **MCP servers** section
-4. Toggle **Enable MCP servers** on
-5. Click **Add server**
-6. Select the **Transport** type:
+3. Enable **Show advanced settings** if you haven't already — the **MCP servers** section only appears once it's on
+4. Scroll to the **MCP servers** section
+5. Toggle **Enable MCP servers** on
+6. Click **Add server**
+7. Select the **Transport** type:
    - **Stdio (local process)**: Enter the command, arguments, and optional environment variables
    - **HTTP (remote server)**: Enter the server URL
-7. Click **Test connection** to verify and discover available tools
-8. Configure tool trust settings (see below)
-9. Click **Save**
+8. Click **Test connection** to verify and discover available tools
+9. Configure tool trust settings (see below)
+10. Click **Save**
 
 ### Tool Trust
 
@@ -102,7 +103,7 @@ Some MCP servers require OAuth authentication. Gemini Scribe handles the full OA
 6. Tokens are stored securely in Obsidian's SecretStorage (OS keychain)
 
 ::: tip
-OAuth tokens persist across Obsidian restarts. To clear stored credentials, click **Clear OAuth Credentials** in the server's edit dialog.
+OAuth tokens persist across Obsidian restarts. To clear stored credentials, click **Clear credentials** in the server's edit dialog.
 :::
 
 ::: warning

--- a/docs/guide/semantic-search.md
+++ b/docs/guide/semantic-search.md
@@ -122,10 +122,11 @@ Agent: [Uses vault_semantic_search with query "project deadlines", folder="work"
 **With "Include attachments" enabled:**
 
 - PDFs (`.pdf`)
-- Office documents (`.docx`, `.xlsx`, `.pptx`)
 - Text files (`.txt`, `.json`, `.yaml`, `.csv`)
 - Code files (`.js`, `.ts`, `.py`, `.sh`, etc.)
 - HTML, XML, and other text-based formats
+
+Office documents (`.docx`, `.xlsx`, `.pptx`) are **not** currently supported by the underlying Gemini File Search API integration and are skipped even with attachments enabled.
 
 ## Privacy & Data Storage
 

--- a/docs/reference/provider-capabilities.md
+++ b/docs/reference/provider-capabilities.md
@@ -15,6 +15,7 @@ Gemini Scribe can run on either the **Google Gemini (cloud)** or **Ollama (local
 | RAG / Vault Semantic Search     |   ✓    | ✗ — tracked in [#705](https://github.com/allenhutchison/obsidian-gemini/issues/705) |
 | Image generation                |   ✓    | ✗ — tracked in [#706](https://github.com/allenhutchison/obsidian-gemini/issues/706) |
 | Google Search grounding         |   ✓    | ✗                                                                                   |
+| Google Maps grounding           |   ✓    | ✗                                                                                   |
 | URL Context (web fetch tool)    |   ✓    | ✗                                                                                   |
 | Deep Research                   |   ✓    | ✗                                                                                   |
 | PDF / audio / video attachments |   ✓    | ✗ (images only)                                                                     |
@@ -23,7 +24,7 @@ Gemini Scribe can run on either the **Google Gemini (cloud)** or **Ollama (local
 
 - **Tool calling** — Whether an Ollama model can call tools depends on the model itself; most modern instruct models (Llama 3.2, Qwen 2.5, Mistral 0.3, …) support it, smaller or older models may not.
 - **Vision** — Ollama vision support is auto-detected per model from its `/api/show` capabilities (with a template/name-hint fallback for older Ollama versions) — no manual configuration is needed when you pull a new multimodal model.
-- **RAG, image generation, Google Search, URL Context, and Deep Research** all call Google's cloud APIs directly and require a Gemini API key regardless of the active provider setting. Google Search, URL Context, and Deep Research are hidden from the agent's tool list when Ollama is selected. RAG and image generation stay visible instead — their settings and commands remain in the UI, but invoking them with Ollama active is a silent no-op (RAG) or shows a "not available" notice (image generation) rather than failing at call time.
+- **RAG, image generation, Google Search, Google Maps, URL Context, and Deep Research** all call Google's cloud APIs directly and require a Gemini API key regardless of the active provider setting. Google Search, Google Maps, URL Context, and Deep Research are hidden from the agent's tool list when Ollama is selected. RAG and image generation stay visible instead — their settings and commands remain in the UI, but invoking them with Ollama active is a silent no-op (RAG) or shows a "not available" notice (image generation) rather than failing at call time.
 - **Scheduled tasks** run through the same chat/tool-calling path as interactive agent sessions, so a task that needs vision or tool calling on Ollama is still bound by that model's capabilities.
 
 Switching the **Provider** setting between Gemini and Ollama at any time restores or hides the Google-only tools immediately — no data is lost, and settings persist across switches.

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -261,7 +261,7 @@ Compaction isn't only checked before the initial request — `AgentLoop` re-chec
 - **Default**: `true`
 - **Description**: Append a summary of each tool execution to the session history file for auditing
 - **Format**: Collapsible callout blocks showing tool name, key parameters, status, and duration
-- **Note**: Requires plugin reload to take effect when toggled
+- **Note**: Takes effect immediately when toggled — no plugin reload needed
 
 ### Always Show Diff view for File Writes
 

--- a/planning/changelog/2026-07-13.md
+++ b/planning/changelog/2026-07-13.md
@@ -1,0 +1,20 @@
+# Daily changelog — July 13, 2026
+
+**Date:** 2026-07-13
+**PRs merged:** 2
+
+---
+
+## Summary
+
+Quiet day — one architecture-audit DRY refactor in the vault tools, plus the prior day's automated housekeeping PR.
+
+## What shipped
+
+### [#1202 refactor(tools): extract shared system-folder guard for vault tools](https://github.com/allenhutchison/obsidian-gemini/pull/1202)
+
+An `audit-architecture` nightly sweep flagged the system-folder exclusion guard (`shouldExcludePath` → early-return a failure `ToolResult`) as copy-pasted across every write/destructive vault tool, differing only in the error string. Since system-folder protection is a load-bearing security invariant, five independent copies meant five places to keep in lockstep. Extracts a single `guardExcludedPath(normalizedPath, plugin, error)` helper into `src/tools/vault/utils.ts`, used by `write-file-tool`, `move-file-tool` (both source and target checks), `delete-file-tool`, and `create-folder-tool`. Pure code motion — returned error strings are byte-for-byte unchanged.
+
+### [#1205 chore(daily): 2026-07-12 daily update](https://github.com/allenhutchison/obsidian-gemini/pull/1205)
+
+The prior day's automated `daily-update` run: wrote `planning/changelog/2026-07-12.md` (8 PRs merged on 2026-07-12, headlined by the grounding-renderer unification and the first slice of the `sendMessage` decomposition), fixed one mechanical drift item in `docs/guide/agent-mode.md` (both confirmation-required tool lists were missing `create_folder`), and a no-op `triage-issues` pass. Housekeeping-only.


### PR DESCRIPTION
## Summary

Automated daily housekeeping run (`daily-update` meta-skill via the `maintainerd` plugin marketplace) bundling `daily-changelog`, `audit-product-docs`, and `triage-issues` for 2026-07-14.

## Changes

- **daily-changelog**: wrote `planning/changelog/2026-07-13.md` — 2 PRs merged on 2026-07-13: [#1202](https://github.com/allenhutchison/obsidian-gemini/pull/1202) (architecture-audit refactor extracting a shared system-folder guard for vault tools) and [#1205](https://github.com/allenhutchison/obsidian-gemini/pull/1205) (the prior day's automated `daily-update` PR).
- **audit-product-docs**: fixed 9 drift items across `docs/guide/` and `docs/reference/`. Several were conceptual behavior fixes, not just stale names:
  - `docs/guide/completions.md` — removed false claims that completions respect the active custom prompt and suppress inside code blocks (neither is implemented; also fixed a misquoted toggle notice)
  - `docs/guide/context-system.md` — the documented "press `@` twice" escape for a literal `@` doesn't exist; the real mechanism is pressing Esc to dismiss the picker
  - `docs/guide/custom-prompts.md` — removed an implied enable/disable toggle that doesn't exist
  - `docs/guide/semantic-search.md` — Office documents (`.docx`/`.xlsx`/`.pptx`) were listed as supported under "Include attachments", but the underlying Gemini File Search integration doesn't support them
  - `docs/guide/mcp-servers.md` — the MCP servers settings section is gated behind "Show advanced settings" (missing setup step); fixed the OAuth "Clear credentials" button label
  - `docs/guide/agent-mode.md` — ribbon icon emoji corrected (sparkle, not star)
  - `docs/guide/ai-writing.md` — "Ask about selection" submits via Ctrl/Cmd+Enter, not plain Enter
  - `docs/reference/provider-capabilities.md` — added the missing Google Maps grounding row (Gemini-only, like its sibling tools)
  - `docs/reference/settings.md` — `logToolExecution` takes effect immediately; it does not require a plugin reload
  - Noted but did not fix (out of scope for this skill, not a docs file): `prompts/agentRulesPrompt.hbs` has stale background-task output path descriptions — flagged for a follow-up PR.
- **triage-issues**: no-op — no unlabeled open issues.

This is a housekeeping-only PR — no `src/` behavior changes.

## Screenshots / Screencast

N/A — changelog and docs-only change, no UI change.

## Checklist

### Required

- [x] I have read and agree to the Contributing Guidelines
- [x] I have read and agree to the AI Policy
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A; routine automated daily housekeeping run
- [x] All CI checks pass (`npm test` — 3413 passing, `npm run build`, `npm run format-check`, `npm run lint`, `npm run typecheck:test`)
- [x] I have tested this change on Desktop — N/A, changelog/docs-only change; verified via local pre-flight checks
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A, no code change
- [x] Documentation has been updated (if applicable) — this PR's own `audit-product-docs` pass is the documentation update (see Changes above)
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR


---
_Generated by [Claude Code](https://claude.ai/code/session_01YLQCwhotWk2Y3QjMp3A1Nr)_