### PR TITLE
refactor(agent-view): extract shared buildCompactionEntry helper

### DIFF
--- a/src/ui/agent-view/agent-view-send.ts
+++ b/src/ui/agent-view/agent-view-send.ts
@@ -11,6 +11,7 @@ import { getErrorMessage } from '../../utils/error-utils';
 import { formatLocalTimestamp } from '../../utils/format-utils';
 import { buildTurnPreamble } from '../../utils/turn-preamble';
 import { InlineAttachment } from './inline-attachment';
+import { buildCompactionEntry } from './compaction-notice';
 import planModeInstructionContent from '../../../prompts/planModeInstruction.hbs';
 import { AgentViewProgress } from './agent-view-progress';
 import { AgentViewMessages } from './agent-view-messages';
@@ -463,13 +464,7 @@ To reference an attachment in your response, use the path shown above.`;
 					});
 					await this.ctx.updateTokenUsage();
 
-					const compactionEntry: GeminiConversationEntry = {
-						role: 'model',
-						message: `> [!info] Context Compacted\n> Older conversation turns have been summarized to maintain performance.\n\n${compactionResult.summaryText}`,
-						notePath: '',
-						created_at: new Date(),
-						model: modelName,
-					};
+					const compactionEntry = buildCompactionEntry(compactionResult.summaryText, modelName);
 					await this.ctx.displayMessage(compactionEntry);
 					await this.ctx.plugin.sessionHistory.addEntryToSession(currentSession, compactionEntry);
 					this.ctx.plugin.logger.log(

--- a/src/ui/agent-view/agent-view-tools.ts
+++ b/src/ui/agent-view/agent-view-tools.ts
@@ -10,6 +10,7 @@ import { DEFAULT_TURN_BUDGET_REMIND_AT } from '../../agent/turn-budget';
 import type { ToolCall, StreamChunk } from '../../api/interfaces/model-api';
 import { AgentViewToolDisplay } from './agent-view-tool-display';
 import type { PerTurnContext } from './agent-view-tool-followup';
+import { buildCompactionEntry } from './compaction-notice';
 import { t } from '../../i18n';
 
 /**
@@ -220,13 +221,10 @@ export class AgentViewTools {
 							// this hook, so refreshing the header just re-reads it.
 							await this.context.updateTokenUsage?.();
 							if (!summaryText) return;
-							const compactionEntry: GeminiConversationEntry = {
-								role: 'model',
-								message: `> [!info] Context Compacted\n> Older conversation turns have been summarized to maintain performance.\n\n${summaryText}`,
-								notePath: '',
-								created_at: new Date(),
-								model: currentSession.modelConfig?.model || getActiveChatModel(this.plugin.settings),
-							};
+							const compactionEntry = buildCompactionEntry(
+								summaryText,
+								currentSession.modelConfig?.model || getActiveChatModel(this.plugin.settings)
+							);
 							await this.context.displayMessage(compactionEntry);
 							await this.plugin.sessionHistory.addEntryToSession(currentSession, compactionEntry);
 						},

--- a/src/ui/agent-view/compaction-notice.ts
+++ b/src/ui/agent-view/compaction-notice.ts
@@ -1,0 +1,24 @@
+import { GeminiConversationEntry } from '../../types/conversation';
+
+/**
+ * Build the "Context Compacted" conversation entry that is displayed and
+ * persisted to session history when older turns are summarized to stay within
+ * the token budget.
+ *
+ * Both compaction paths surface the identical notice — the pre-turn path in
+ * `agent-view-send.ts` and the mid-loop `onMidLoopCompaction` hook in
+ * `agent-view-tools.ts` (#662) — so the callout markup and entry shape live
+ * here to keep the two in lockstep.
+ *
+ * The message is persisted to the session markdown as an `[!info]` callout, so
+ * it stays English (not routed through `t()`) per the repo string invariant.
+ */
+export function buildCompactionEntry(summaryText: string, model: string): GeminiConversationEntry {
+	return {
+		role: 'model',
+		message: `> [!info] Context Compacted\n> Older conversation turns have been summarized to maintain performance.\n\n${summaryText}`,
+		notePath: '',
+		created_at: new Date(),
+		model,
+	};
+}


### PR DESCRIPTION
## Summary

The `audit-architecture` nightly sweep flagged a **DRY violation**: the two code paths that surface the "Context Compacted" notice each constructed a byte-identical `GeminiConversationEntry`.

- Pre-turn compaction path — `src/ui/agent-view/agent-view-send.ts`
- Mid-loop `onMidLoopCompaction` hook (#662) — `src/ui/agent-view/agent-view-tools.ts`

Both built the same `[!info] Context Compacted` callout string (which is persisted verbatim to session-history markdown), then called `displayMessage` + `addEntryToSession`. The tools-side code even carried a comment noting it "mirrors the pre-turn notice." Extracting a single `buildCompactionEntry(summaryText, model)` helper in a new leaf module removes the drift risk on that user-visible/persisted string.

Pure code motion; no behavior change. The only per-site difference — how the model name is resolved — stays at each call site and is passed into the helper.

## Changes

- Add `src/ui/agent-view/compaction-notice.ts` exporting `buildCompactionEntry(summaryText, model)`, which builds the `[!info] Context Compacted` entry. The message stays English (persisted callout markup, not routed through `t()`) per the repo string invariant.
- `agent-view-send.ts`: replace the inline entry literal with a `buildCompactionEntry` call.
- `agent-view-tools.ts`: same, keeping the existing `modelConfig?.model || getActiveChatModel(...)` resolution at the call site.

## Screenshots / Screencast

N/A — no UI change; the rendered notice and persisted markup are byte-identical to before.

## Checklist

### Required

- [x] I have read and agree to the Contributing Guidelines
- [x] I have read and agree to the AI Policy
- [ ] This PR is linked to an approved issue — N/A: automated `audit-architecture` DRY finding, routed to a PR per the skill's mechanical-fix rule (small, single-purpose code motion).
- [x] All CI checks pass (`npm test` — 3438 passed, `npm run build`, `npm run format-check`, `npm run lint` 0 errors, `npm run typecheck:test`)
- [x] I have tested this change on Desktop — verified via the full unit suite; the compaction entry shape and callout string are unchanged.
- [x] I have verified this change does not break Mobile — no platform-specific APIs touched.
- [ ] Documentation has been updated — N/A: purely internal refactor, no user-facing behavior change.
- [x] I understand that I must address all review comments from CodeRabbit and maintainers

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude (audit-architecture skill)
- [x] I have reviewed and understand all AI-generated code in this PR

---

_Filed by the `audit-architecture` skill._

---
_Generated by [Claude Code](https://claude.ai/code/session_01NTinywztV5wn7yUa4jN8QA)_