### PR TITLE
fix(agent-view): make session auto-label rename collision-safe

### DIFF
--- a/src/ui/agent-view/agent-view-session.ts
+++ b/src/ui/agent-view/agent-view-session.ts
@@ -7,7 +7,13 @@ import type { ObsidianGemini } from '../../types/plugin';
 import { ModelClientFactory } from '../../api';
 import { HandlerPriority } from '../../types/agent-events';
 import { sanitizeFileName } from '../../utils/file-utils';
-import { resolveUniquePath } from '../../services/headless-run-output';
+import { isAlreadyExistsError, resolveUniquePath } from '../../services/headless-run-output';
+
+/**
+ * How many times the auto-label rename re-resolves a unique path after a
+ * destination-exists collision before giving up (leaving the file un-renamed).
+ */
+const AUTO_LABEL_RENAME_ATTEMPTS = 3;
 import { formatLocalDate } from '../../utils/format-utils';
 import { t } from '../../i18n';
 
@@ -273,12 +279,26 @@ Assistant: ${modelSummary}`;
 				// Rename the history file. Skip when the generated name already matches
 				// the current file, and resolve a numeric-suffixed path when another
 				// session file already occupies the target — renameFile throws
-				// "Destination file already exists!" otherwise.
+				// "Destination file already exists!" otherwise. resolveUniquePath +
+				// renameFile is non-atomic, so a concurrent writer can still occupy the
+				// candidate between the check and the rename; retry on that specific
+				// error (re-resolving each attempt), and give up gracefully after a few
+				// collisions — the title is still applied, only the rename is skipped.
 				const oldFile = this.app.vault.getAbstractFileByPath(oldPath);
 				if (oldFile && newPath !== oldPath) {
-					const targetPath = resolveUniquePath(this.app.vault, newPath);
-					await this.app.fileManager.renameFile(oldFile, targetPath);
-					this.currentSession.historyPath = targetPath;
+					for (let attempt = 0; attempt < AUTO_LABEL_RENAME_ATTEMPTS; attempt++) {
+						const targetPath = resolveUniquePath(this.app.vault, newPath);
+						try {
+							await this.app.fileManager.renameFile(oldFile, targetPath);
+							this.currentSession.historyPath = targetPath;
+							break;
+						} catch (renameError) {
+							if (!isAlreadyExistsError(renameError)) throw renameError;
+							if (attempt === AUTO_LABEL_RENAME_ATTEMPTS - 1) {
+								this.plugin.logger.warn('Auto-label rename skipped after repeated collisions:', targetPath);
+							}
+						}
+					}
 				}
 
 				// Update session metadata

--- a/src/ui/agent-view/agent-view-session.ts
+++ b/src/ui/agent-view/agent-view-session.ts
@@ -7,6 +7,7 @@ import type { ObsidianGemini } from '../../types/plugin';
 import { ModelClientFactory } from '../../api';
 import { HandlerPriority } from '../../types/agent-events';
 import { sanitizeFileName } from '../../utils/file-utils';
+import { resolveUniquePath } from '../../services/headless-run-output';
 import { formatLocalDate } from '../../utils/format-utils';
 import { t } from '../../i18n';
 
@@ -269,11 +270,15 @@ Assistant: ${modelSummary}`;
 				const newFileName = sanitizeFileName(fullTitle);
 				const newPath = oldPath.substring(0, oldPath.lastIndexOf('/') + 1) + newFileName + '.md';
 
-				// Rename the history file
+				// Rename the history file. Skip when the generated name already matches
+				// the current file, and resolve a numeric-suffixed path when another
+				// session file already occupies the target — renameFile throws
+				// "Destination file already exists!" otherwise.
 				const oldFile = this.app.vault.getAbstractFileByPath(oldPath);
-				if (oldFile) {
-					await this.app.fileManager.renameFile(oldFile, newPath);
-					this.currentSession.historyPath = newPath;
+				if (oldFile && newPath !== oldPath) {
+					const targetPath = resolveUniquePath(this.app.vault, newPath);
+					await this.app.fileManager.renameFile(oldFile, targetPath);
+					this.currentSession.historyPath = targetPath;
 				}
 
 				// Update session metadata

--- a/test/ui/agent-view/agent-view-session-autolabel.test.ts
+++ b/test/ui/agent-view/agent-view-session-autolabel.test.ts
@@ -1,0 +1,138 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import { AgentViewSession } from '../../../src/ui/agent-view/agent-view-session';
+import { formatLocalDate } from '../../../src/utils/format-utils';
+
+// Mock the model factory so autoLabelSessionIfNeeded gets a deterministic
+// generated title without touching a real API client.
+const generateModelResponse = vi.fn();
+vi.mock('../../../src/api', () => ({
+	ModelClientFactory: {
+		createChatModel: vi.fn(() => ({ generateModelResponse })),
+	},
+}));
+
+vi.mock('../../../src/models', () => ({
+	getActiveChatModel: vi.fn(() => 'test-model'),
+}));
+
+// Regression coverage for the auto-label rename collision: when the
+// AI-generated title matches an existing file in Agent-Sessions/,
+// fileManager.renameFile used to throw "Destination file already exists!".
+// The rename must resolve a numeric-suffixed path instead, and skip entirely
+// when the file already carries the generated name.
+
+const SESSIONS_DIR = 'gemini-scribe/Agent-Sessions/';
+
+function makeHarness(existingPaths: string[], oldPath: string) {
+	const existing = new Set([oldPath, ...existingPaths]);
+	const renameFile = vi.fn(async (_file: unknown, newPath: string) => {
+		if (existing.has(newPath)) throw new Error('Destination file already exists!');
+		existing.add(newPath);
+	});
+	const app = {
+		vault: {
+			getAbstractFileByPath: vi.fn((path: string) => (existing.has(path) ? { path } : null)),
+		},
+		fileManager: { renameFile },
+	} as any;
+
+	const logError = vi.fn();
+	const plugin = {
+		// No agentEventBus — the constructor's optional chaining tolerates it.
+		agentEventBus: undefined,
+		settings: {},
+		logger: { log: vi.fn(), error: logError, warn: vi.fn() },
+		sessionHistory: {
+			getHistoryForSession: vi.fn(async () => [
+				{ role: 'user', message: 'hello' },
+				{ role: 'model', message: 'hi there' },
+			]),
+			updateSessionMetadata: vi.fn(async () => undefined),
+		},
+	} as any;
+
+	const uiCallbacks = {
+		clearChat: vi.fn(),
+		displayMessage: vi.fn(),
+		updateSessionHeader: vi.fn(),
+		updateContextPanel: vi.fn(),
+		showEmptyState: vi.fn(),
+		focusInput: vi.fn(),
+	};
+	const state = { allowedWithoutConfirmation: new Set<string>(), userInput: null as any };
+
+	const manager = new AgentViewSession(app, plugin, uiCallbacks, state);
+	const session = {
+		id: 's1',
+		title: 'Agent Session 2026-07-16',
+		metadata: {},
+		historyPath: oldPath,
+		context: { contextFiles: [] },
+	} as any;
+	manager.setCurrentSession(session);
+
+	return { manager, session, renameFile, logError };
+}
+
+describe('AgentViewSession.autoLabelSessionIfNeeded rename collisions', () => {
+	const datePrefix = formatLocalDate();
+	const generatedTitle = 'My Topic';
+	const targetPath = `${SESSIONS_DIR}${datePrefix} ${generatedTitle}.md`;
+
+	beforeEach(() => {
+		generateModelResponse.mockReset();
+		generateModelResponse.mockResolvedValue({ markdown: generatedTitle });
+	});
+
+	test('renames to the generated title when the target path is free', async () => {
+		const oldPath = `${SESSIONS_DIR}Agent Session 1.md`;
+		const { manager, session, renameFile, logError } = makeHarness([], oldPath);
+
+		await manager.autoLabelSessionIfNeeded();
+
+		expect(renameFile).toHaveBeenCalledWith(expect.objectContaining({ path: oldPath }), targetPath);
+		expect(session.historyPath).toBe(targetPath);
+		expect(session.title).toBe(`${datePrefix} ${generatedTitle}`);
+		expect(logError).not.toHaveBeenCalled();
+	});
+
+	test('appends a numeric suffix when the target path already exists', async () => {
+		const oldPath = `${SESSIONS_DIR}Agent Session 1.md`;
+		const { manager, session, renameFile, logError } = makeHarness([targetPath], oldPath);
+
+		await manager.autoLabelSessionIfNeeded();
+
+		const suffixedPath = `${SESSIONS_DIR}${datePrefix} ${generatedTitle}-1.md`;
+		expect(renameFile).toHaveBeenCalledWith(expect.objectContaining({ path: oldPath }), suffixedPath);
+		expect(session.historyPath).toBe(suffixedPath);
+		// The rename must not have thrown into the catch-all error handler.
+		expect(logError).not.toHaveBeenCalled();
+	});
+
+	test('skips past multiple occupied suffixes', async () => {
+		const oldPath = `${SESSIONS_DIR}Agent Session 1.md`;
+		const stem = `${SESSIONS_DIR}${datePrefix} ${generatedTitle}`;
+		const { manager, session, renameFile } = makeHarness([targetPath, `${stem}-1.md`, `${stem}-2.md`], oldPath);
+
+		await manager.autoLabelSessionIfNeeded();
+
+		expect(renameFile).toHaveBeenCalledWith(expect.anything(), `${stem}-3.md`);
+		expect(session.historyPath).toBe(`${stem}-3.md`);
+	});
+
+	test('skips the rename when the file already has the generated name', async () => {
+		// The session file already carries the generated title — renaming would
+		// self-collide (the "existing file" is the file being renamed).
+		const oldPath = targetPath;
+		const { manager, session, renameFile, logError } = makeHarness([], oldPath);
+
+		await manager.autoLabelSessionIfNeeded();
+
+		expect(renameFile).not.toHaveBeenCalled();
+		expect(session.historyPath).toBe(oldPath);
+		// Title and metadata still update even though no rename was needed.
+		expect(session.title).toBe(`${datePrefix} ${generatedTitle}`);
+		expect(session.metadata.autoLabeled).toBe(true);
+		expect(logError).not.toHaveBeenCalled();
+	});
+});

--- a/test/ui/agent-view/agent-view-session-autolabel.test.ts
+++ b/test/ui/agent-view/agent-view-session-autolabel.test.ts
@@ -1,6 +1,5 @@
-import { describe, test, expect, vi, beforeEach } from 'vitest';
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
 import { AgentViewSession } from '../../../src/ui/agent-view/agent-view-session';
-import { formatLocalDate } from '../../../src/utils/format-utils';
 
 // Mock the model factory so autoLabelSessionIfNeeded gets a deterministic
 // generated title without touching a real API client.
@@ -18,7 +17,8 @@ vi.mock('../../../src/models', () => ({
 // Regression coverage for the auto-label rename collision: when the
 // AI-generated title matches an existing file in Agent-Sessions/,
 // fileManager.renameFile used to throw "Destination file already exists!".
-// The rename must resolve a numeric-suffixed path instead, and skip entirely
+// The rename must resolve a numeric-suffixed path instead, retry when a
+// concurrent writer occupies the candidate mid-flight, and skip entirely
 // when the file already carries the generated name.
 
 const SESSIONS_DIR = 'gemini-scribe/Agent-Sessions/';
@@ -37,11 +37,12 @@ function makeHarness(existingPaths: string[], oldPath: string) {
 	} as any;
 
 	const logError = vi.fn();
+	const logWarn = vi.fn();
 	const plugin = {
 		// No agentEventBus — the constructor's optional chaining tolerates it.
 		agentEventBus: undefined,
 		settings: {},
-		logger: { log: vi.fn(), error: logError, warn: vi.fn() },
+		logger: { log: vi.fn(), error: logError, warn: logWarn },
 		sessionHistory: {
 			getHistoryForSession: vi.fn(async () => [
 				{ role: 'user', message: 'hello' },
@@ -71,17 +72,26 @@ function makeHarness(existingPaths: string[], oldPath: string) {
 	} as any;
 	manager.setCurrentSession(session);
 
-	return { manager, session, renameFile, logError };
+	return { manager, session, existing, renameFile, logError, logWarn };
 }
 
 describe('AgentViewSession.autoLabelSessionIfNeeded rename collisions', () => {
-	const datePrefix = formatLocalDate();
+	// The generated file name embeds formatLocalDate() evaluated inside
+	// autoLabelSessionIfNeeded — pin the clock so the expected paths cannot
+	// drift if a test run crosses midnight.
+	const datePrefix = '2026-07-16';
 	const generatedTitle = 'My Topic';
 	const targetPath = `${SESSIONS_DIR}${datePrefix} ${generatedTitle}.md`;
 
 	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date(2026, 6, 16, 12, 0, 0));
 		generateModelResponse.mockReset();
 		generateModelResponse.mockResolvedValue({ markdown: generatedTitle });
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
 	});
 
 	test('renames to the generated title when the target path is free', async () => {
@@ -118,6 +128,54 @@ describe('AgentViewSession.autoLabelSessionIfNeeded rename collisions', () => {
 
 		expect(renameFile).toHaveBeenCalledWith(expect.anything(), `${stem}-3.md`);
 		expect(session.historyPath).toBe(`${stem}-3.md`);
+	});
+
+	test('retries when a concurrent writer occupies the target mid-flight', async () => {
+		// resolveUniquePath + renameFile is non-atomic: the target is free at
+		// check time, but another writer lands it before renameFile runs.
+		const oldPath = `${SESSIONS_DIR}Agent Session 1.md`;
+		const { manager, session, existing, renameFile, logError } = makeHarness([], oldPath);
+		renameFile.mockImplementationOnce(async () => {
+			existing.add(targetPath); // concurrent writer wins the race
+			throw new Error('Destination file already exists!');
+		});
+
+		await manager.autoLabelSessionIfNeeded();
+
+		const suffixedPath = `${SESSIONS_DIR}${datePrefix} ${generatedTitle}-1.md`;
+		expect(renameFile).toHaveBeenCalledTimes(2);
+		expect(renameFile).toHaveBeenNthCalledWith(1, expect.anything(), targetPath);
+		expect(renameFile).toHaveBeenNthCalledWith(2, expect.anything(), suffixedPath);
+		expect(session.historyPath).toBe(suffixedPath);
+		expect(logError).not.toHaveBeenCalled();
+	});
+
+	test('gives up gracefully after repeated mid-flight collisions', async () => {
+		const oldPath = `${SESSIONS_DIR}Agent Session 1.md`;
+		const { manager, session, renameFile, logError, logWarn } = makeHarness([], oldPath);
+		renameFile.mockRejectedValue(new Error('Destination file already exists!'));
+
+		await manager.autoLabelSessionIfNeeded();
+
+		expect(renameFile).toHaveBeenCalledTimes(3);
+		// Rename skipped, but the title and metadata still updated.
+		expect(session.historyPath).toBe(oldPath);
+		expect(session.title).toBe(`${datePrefix} ${generatedTitle}`);
+		expect(logWarn).toHaveBeenCalled();
+		expect(logError).not.toHaveBeenCalled();
+	});
+
+	test('does not retry or swallow non-collision rename errors', async () => {
+		const oldPath = `${SESSIONS_DIR}Agent Session 1.md`;
+		const { manager, session, renameFile, logError } = makeHarness([], oldPath);
+		renameFile.mockRejectedValue(new Error('EACCES: permission denied'));
+
+		await manager.autoLabelSessionIfNeeded();
+
+		// A single attempt only — the error propagates to the catch-all logger.
+		expect(renameFile).toHaveBeenCalledTimes(1);
+		expect(session.historyPath).toBe(oldPath);
+		expect(logError).toHaveBeenCalled();
 	});
 
 	test('skips the rename when the file already has the generated name', async () => {


### PR DESCRIPTION
## Summary

Session auto-labeling could fail with `Failed to auto-label session: Destination file already exists!` when the AI-generated title matched an existing file in `[state-folder]/Agent-Sessions/` (e.g. two sessions about the same topic labeled on the same day). The error was swallowed by the catch-all, leaving the session title updated in memory but the history file un-renamed.

Fixes # — no pre-existing issue; bug found and fixed directly.

## Changes

- `autoLabelSessionIfNeeded` now resolves the rename target through the existing `resolveUniquePath` helper (`src/services/headless-run-output.ts`), which appends `-1`, `-2`, … before the extension until a free slot is found, so a title collision renames to e.g. `2026-07-16 My Topic-1.md` instead of throwing.
- The rename is skipped when the generated path equals the current `historyPath` — previously this self-collision would also have thrown.
- Still uses `app.fileManager.renameFile` per project conventions; session `title` (persisted in frontmatter, which wins over the filename on load) is unchanged by the suffix.
- New unit test `test/ui/agent-view/agent-view-session-autolabel.test.ts` covering the collision case: free target, occupied target (suffix `-1`), multiple occupied suffixes (skips to `-3`), and the self-collision skip.

No new import cycles (`npm run lint:cycles` clean — `headless-run-output` only imports utils).

## Screenshots / Screencast

N/A — no UI change; the fix removes a background error during session renaming.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: maintainer-initiated fix, no pre-existing issue
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop (unit tests exercise the rename path; no platform-specific APIs involved)
- [x] I have verified this change does not break Mobile (pure vault-path logic, no Node.js or desktop-only APIs)
- [ ] Documentation has been updated (if applicable) — N/A: user-visible behavior (auto-titled sessions) is unchanged; docs describe it at a level unaffected by the collision fix
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic session renaming to avoid overwriting existing files.
  * Added unique filename handling when generated session titles conflict with existing files.
  * Prevented unnecessary renames when the session already uses the generated title.
  * Ensured session metadata and titles remain updated after automatic labeling.

* **Tests**
  * Added coverage for filename collisions, multiple suffixes, successful renames, and skipped renames.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->