### PR TITLE
fix(gemini): restore Gemini 2.5 compatibility on both API paths

### DIFF
--- a/docs/guide/agent-mode.md
+++ b/docs/guide/agent-mode.md
@@ -204,6 +204,7 @@ When you use a thinking model (e.g. Gemini 2.5 Pro), the agent captures the mode
 - The final answer's reasoning appears as a 🧠 line directly beneath the answer.
 - Reasoning is persisted to the session history file as a collapsed `[!reasoning]` callout, so it round-trips when you reopen a past session — making session files a faithful, self-contained record of the whole interaction: your request → reasoning → tools → answer.
 - Sessions created before this feature simply have no reasoning lines — nothing changes for them.
+- Reasoning depth is tuned automatically per task and model family — Gemini 3.x models use per-task thinking levels (deepest for agent chat, lightest for completions), while Gemini 2.5 models use a dynamic thinking budget. There is no setting to configure.
 
 ### Plan Mode
 

--- a/src/api/providers/gemini/client.ts
+++ b/src/api/providers/gemini/client.ts
@@ -47,7 +47,9 @@ import { renderGroundingSources } from './grounding-render';
 
 /**
  * Per-use-case reasoning depth for Gemini 3.x `thinkingConfig.thinkingLevel`,
- * replacing the legacy global `thinkingBudget: -1`. These are starting points
+ * replacing the legacy global `thinkingBudget: -1` (which Gemini 2.5 models
+ * still require on `generateContent` — see `supportsThinkingLevel`). These are
+ * starting points
  * (see #621; tune against the eval suite in #619): latency-sensitive paths
  * think the least, while CHAT — which is the agent loop — thinks the most.
  *
@@ -490,15 +492,19 @@ export class GeminiClient implements ModelApi {
 			...(systemInstruction && { systemInstruction }),
 		};
 
-		// Add thinking config if model supports it. We steer reasoning depth with
-		// `thinkingLevel` (Gemini 3.x) per use case — never the legacy
-		// `thinkingBudget`, and never both knobs in one request. `includeThoughts`
-		// stays true so reasoning persistence (#965) keeps receiving thought parts.
+		// Add thinking config if model supports it. Gemini 3.x models take a
+		// per-use-case `thinkingLevel`; older thinking models (Gemini 2.5,
+		// thinking-exp) reject that knob with a 400 ("Thinking level is not
+		// supported for this model") and take the legacy `thinkingBudget` instead
+		// — send exactly one knob, never both. `includeThoughts` stays true so
+		// reasoning persistence (#965) keeps receiving thought parts.
 		if (this.supportsThinking(model)) {
-			config.thinkingConfig = {
-				includeThoughts: true,
-				thinkingLevel: THINKING_LEVEL_BY_USE_CASE[this.config.useCase ?? ModelUseCase.CHAT],
-			};
+			config.thinkingConfig = this.supportsThinkingLevel(model)
+				? {
+						includeThoughts: true,
+						thinkingLevel: THINKING_LEVEL_BY_USE_CASE[this.config.useCase ?? ModelUseCase.CHAT],
+					}
+				: { includeThoughts: true, thinkingBudget: -1 };
 		}
 
 		// Add function calling tools
@@ -690,6 +696,19 @@ export class GeminiClient implements ModelApi {
 	/**
 	 * Check if a model supports thinking/reasoning mode
 	 */
+	/**
+	 * Whether the model takes the Gemini 3.x `thinkingConfig.thinkingLevel` knob
+	 * on `generateContent`. Older thinking-capable models (Gemini 2.5,
+	 * thinking-exp) reject it with a 400 INVALID_ARGUMENT ("Thinking level is
+	 * not supported for this model") and use the legacy `thinkingBudget`
+	 * instead. The Interactions path is unaffected — that API accepts
+	 * `thinking_level` for 2.5 models and normalizes it server-side (while
+	 * rejecting `thinking_budget` outright), so it always sends the level.
+	 */
+	private supportsThinkingLevel(model: string): boolean {
+		return model.toLowerCase().includes('gemini-3');
+	}
+
 	private supportsThinking(model: string | undefined): boolean {
 		if (!model) {
 			this.plugin?.logger.debug('[GeminiClient] No model specified for thinking check');

--- a/src/api/providers/gemini/interactions-mapper.ts
+++ b/src/api/providers/gemini/interactions-mapper.ts
@@ -49,10 +49,15 @@ function inlineDataToContentItem(mimeType: string, data: string): InteractionCon
 	return { type: mediaType, data, mime_type: mimeType };
 }
 
-/** Serialize a tool's `functionResponse.response` into the `function_result.result` shape. */
-function functionResponseToResult(response: unknown): InteractionContentItem[] {
-	const text = typeof response === 'string' ? response : JSON.stringify(response ?? {});
-	return [{ type: 'text', text }];
+/**
+ * Serialize a tool's `functionResponse.response` into the `function_result.result`
+ * shape. Always a plain string: the content-array form (`[{type:'text',…}]`) is a
+ * "multimodal function response", which Gemini 2.5 models reject with a 400
+ * ("Multimodal function responses are not supported for this model"). The string
+ * form is accepted by both 2.5 and 3.x, so it's used unconditionally.
+ */
+function functionResponseToResult(response: unknown): string {
+	return typeof response === 'string' ? response : JSON.stringify(response ?? {});
 }
 
 /**

--- a/test/api/providers/gemini/client.test.ts
+++ b/test/api/providers/gemini/client.test.ts
@@ -317,9 +317,11 @@ describe('GeminiClient', () => {
 	});
 
 	// Per-use-case thinkingLevel (#621): the client maps the ModelUseCase it was
-	// created for to a thinkingConfig.thinkingLevel, replacing the old global
-	// thinkingBudget. Reasoning persistence (#965) relies on includeThoughts, and
-	// the API rejects sending both knobs — so assert exactly one is present.
+	// created for to a thinkingConfig.thinkingLevel — but only for Gemini 3.x.
+	// Gemini 2.5 models reject thinkingLevel with a 400 ("Thinking level is not
+	// supported for this model") and take the legacy thinkingBudget instead.
+	// Reasoning persistence (#965) relies on includeThoughts, and the API
+	// rejects sending both knobs — so assert exactly one is present.
 	describe('per-use-case thinkingLevel', () => {
 		const THINKING_MODEL = 'gemini-3-pro';
 
@@ -333,9 +335,9 @@ describe('GeminiClient', () => {
 
 		// Captures the thinkingConfig the SDK is handed for a client created with
 		// the given use case against a thinking-capable model.
-		const thinkingConfigFor = async (useCase?: ModelUseCase): Promise<any> => {
+		const thinkingConfigFor = async (useCase?: ModelUseCase, model: string = THINKING_MODEL): Promise<any> => {
 			const client = new GeminiClient(
-				{ apiKey: 'test-api-key', model: THINKING_MODEL, useCase },
+				{ apiKey: 'test-api-key', model, useCase },
 				new GeminiPrompts(mockPlugin),
 				mockPlugin
 			);
@@ -363,6 +365,27 @@ describe('GeminiClient', () => {
 			expect(thinkingConfig.thinkingLevel).toBe('HIGH');
 			expect(thinkingConfig.includeThoughts).toBe(true);
 			expect(thinkingConfig.thinkingBudget).toBeUndefined();
+		});
+
+		// Regression: sending thinkingLevel to a 2.5 model is a guaranteed 400
+		// INVALID_ARGUMENT ("Thinking level is not supported for this model").
+		test.each(['gemini-2.5-flash', 'gemini-2.5-pro', 'gemini-2.5-flash-lite', 'thinking-exp-1234'])(
+			'%s gets legacy thinkingBudget, never thinkingLevel',
+			async (model) => {
+				const thinkingConfig = await thinkingConfigFor(ModelUseCase.CHAT, model);
+				expect(thinkingConfig.thinkingBudget).toBe(-1);
+				expect(thinkingConfig.includeThoughts).toBe(true);
+				expect(thinkingConfig.thinkingLevel).toBeUndefined();
+			}
+		);
+
+		test('gemini-3.x variants still get thinkingLevel', async () => {
+			for (const model of ['gemini-3-flash-preview', 'gemini-3.1-pro-preview', 'gemini-3.5-flash']) {
+				generateContentMock.mockClear();
+				const thinkingConfig = await thinkingConfigFor(ModelUseCase.CHAT, model);
+				expect(thinkingConfig.thinkingLevel).toBe('HIGH');
+				expect(thinkingConfig.thinkingBudget).toBeUndefined();
+			}
 		});
 
 		test('omits thinkingConfig entirely for non-thinking models', async () => {
@@ -1179,7 +1202,9 @@ describe('GeminiClient', () => {
 					type: 'function_result',
 					call_id: 'c1',
 					name: 'read_file',
-					result: [{ type: 'text', text: JSON.stringify({ content: 'hi' }) }],
+					// Plain string, never a content array — the array form is a
+					// "multimodal function response" that Gemini 2.5 rejects with a 400.
+					result: JSON.stringify({ content: 'hi' }),
 				},
 				{ type: 'model_output', content: [{ type: 'text', text: 'foo.md says hi' }] },
 				{ type: 'user_input', content: [{ type: 'text', text: 'and now?' }] },


### PR DESCRIPTION
## Summary

Gemini 2.5 models (e.g. `gemini-2.5-flash`) failed with 400 INVALID_ARGUMENT on both API paths. Two distinct root causes, both confirmed against the live API by replaying the exact captured failing requests:

1. **generateContent path**: the client sent `thinkingConfig.thinkingLevel` to every thinking-capable model, but that knob is Gemini 3.x-only. 2.5 rejects it with `"Thinking level is not supported for this model"`. This broke chat *and* completions/summary/rewrite (which always use `generateContent` even when the Interactions API is enabled).
2. **Interactions path**: the mapper serialized `function_result.result` as a content-item array (`[{type:'text',…}]`), which the API treats as a *multimodal function response*. 2.5 rejects it with `"Multimodal function responses are not supported for this model"` — so the first request worked, but every follow-up after a tool call failed.

## Changes

- `src/api/providers/gemini/client.ts`: `generateContent` requests now branch on model family — Gemini 3.x keeps the per-use-case `thinkingLevel`, while 2.5/`thinking-exp` get the legacy `thinkingBudget: -1` (dynamic). Exactly one knob is ever sent. New `supportsThinkingLevel()` helper documents the split.
- `src/api/providers/gemini/interactions-mapper.ts`: `functionResponseToResult` returns a plain string instead of a content array. Verified via direct API calls that the string form is accepted by both 2.5 (`completed`) and 3.x (`requires_action`), so no model branching is needed on this path. The Interactions path keeps sending `thinking_level` — that API accepts it for 2.5 and normalizes it server-side (and rejects `thinking_budget` outright).
- `test/api/providers/gemini/client.test.ts`: regression tests — 2.5 variants and `thinking-exp` get `thinkingBudget` and never `thinkingLevel`; 3.x variants keep `thinkingLevel`; the interactions round-trip test now asserts the string result shape.

## Screenshots / Screencast

N/A — API request construction only, no UI change.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: maintainer-driven fix, reproduced and verified live in-session
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — request-construction change only, no platform-specific code
- [x] Documentation has been updated (if applicable) — N/A: internal API behavior fix; existing docs on reasoning capture are correct again with this fix
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (Opus 4.8)
- [x] I have reviewed and understand all AI-generated code in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Gemini reasoning configuration across Gemini 2.5 and Gemini 3.x models.
  * Fixed compatibility issues that could cause requests to fail when using unsupported reasoning settings.
  * Improved handling of function results in Gemini interactions, reducing errors when replaying tool responses.
  * Preserved reasoning details where supported for more consistent responses across model versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->