### PR TITLE
fix(models): retire gemini-3-pro-preview, migrate users to 3.1 successor

### DIFF
--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -369,6 +369,8 @@ Model discovery is automatic — no user-configurable settings are required. On 
 
 To pick up a newly-published model without waiting for the cache to expire, click **Refresh model list** in Settings → General, or run the **Gemini Scribe: Refresh model list** command (`gemini-scribe:refresh-model-list`). Both honor the same skip conditions as the auto-fetch — they no-op when the provider is Ollama or the host reports offline, and surface the outcome via a `Notice`. When the Ollama provider is active, the same row appears but re-queries the Ollama daemon for newly pulled models instead.
 
+When Google retires a model (the API starts returning 404 "no longer available" — e.g. `gemini-3-pro-preview` in July 2026), it is removed from the catalog and any settings still pointing at it are migrated automatically on the next reload: to the retired model's designated successor when one exists (`gemini-3-pro-preview` → `gemini-3.1-pro-preview`), otherwise to the default model for that role.
+
 ### Tool Execution
 
 #### Stop on Tool Error

--- a/scripts/update-models.mjs
+++ b/scripts/update-models.mjs
@@ -33,6 +33,10 @@ const EXCLUDE_PATTERNS = [
 	'computer',
 	'robotics',
 	'gemini-2.0',
+	// Retired by Google 2026-07 (API returns 404 "no longer available"); keep it
+	// out even if ListModels still advertises it. Settings migration lives in
+	// RETIRED_MODEL_SUCCESSORS in src/models.ts.
+	'gemini-3-pro-preview',
 ];
 
 async function fetchAllModels(apiKey) {

--- a/src/data/models.json
+++ b/src/data/models.json
@@ -1,6 +1,6 @@
 {
 	"version": 1,
-	"lastUpdated": "2026-07-06T09:16:20.824Z",
+	"lastUpdated": "2026-07-16T00:00:00.000Z",
 	"models": [
 		{
 			"value": "gemini-pro-latest",
@@ -59,11 +59,6 @@
 		{
 			"value": "gemini-3.1-flash-lite-preview",
 			"label": "Gemini 3.1 Flash Lite Preview",
-			"maxTemperature": 2
-		},
-		{
-			"value": "gemini-3-pro-preview",
-			"label": "Gemini 3 Pro Preview",
 			"maxTemperature": 2
 		},
 		{

--- a/src/models.ts
+++ b/src/models.ts
@@ -22,6 +22,20 @@ export interface GeminiModel {
 
 export const DEFAULT_GEMINI_MODELS: GeminiModel[] = modelData.models as GeminiModel[];
 
+/**
+ * Retired Gemini model IDs mapped to their direct successors. When Google
+ * removes a model from the API (404 "no longer available") the entry is
+ * dropped from the bundled list; users who still have it configured are
+ * migrated to the successor here instead of falling back to the generic role
+ * default, so e.g. a Pro user stays on a Pro-class model. Keep each entry
+ * pointing at a model that is still in the bundled list — when a successor is
+ * itself retired, re-point the older entries at the newest live model.
+ */
+export const RETIRED_MODEL_SUCCESSORS: Record<string, string> = {
+	// Removed by Google 2026-07: both API paths return 404 "no longer available".
+	'gemini-3-pro-preview': 'gemini-3.1-pro-preview',
+};
+
 export let GEMINI_MODELS: GeminiModel[] = [...DEFAULT_GEMINI_MODELS];
 
 /**
@@ -169,12 +183,18 @@ export function getUpdatedModelSettings<T extends ModelSettingsSlice>(currentSet
 	) => {
 		const previous = modelFields[key];
 		if (previous && geminiModelValues.has(previous)) return;
-		const next = getDefaultModelForRole(role, 'gemini');
+		// A retired model migrates to its designated successor when that successor
+		// is available; anything else falls back to the role default.
+		const successor = previous ? RETIRED_MODEL_SUCCESSORS[previous] : undefined;
+		const useSuccessor = successor !== undefined && geminiModelValues.has(successor);
+		const next = useSuccessor ? successor : getDefaultModelForRole(role, 'gemini');
 		// Image generation has no dedicated default in some model lists; leave a
 		// stale image model untouched rather than blanking it.
 		if (!next) return;
 		modelFields[key] = next;
-		changedSettingsInfo.push(`${label}: '${previous}' -> '${next}' (legacy model update)`);
+		changedSettingsInfo.push(
+			`${label}: '${previous}' -> '${next}' ${useSuccessor ? '(retired model migrated to successor)' : '(legacy model update)'}`
+		);
 		settingsChanged = true;
 	};
 

--- a/src/models.ts
+++ b/src/models.ts
@@ -182,10 +182,14 @@ export function getUpdatedModelSettings<T extends ModelSettingsSlice>(currentSet
 		label: string
 	) => {
 		const previous = modelFields[key];
-		if (previous && geminiModelValues.has(previous)) return;
+		// The retired-model lookup runs BEFORE the validity short-circuit: the
+		// current list may come from a stale persisted remoteModelCache that still
+		// advertises a retired model, but Google 404s these server-side, so list
+		// membership doesn't make it usable — migrate it regardless.
+		const successor = previous ? RETIRED_MODEL_SUCCESSORS[previous] : undefined;
+		if (successor === undefined && previous && geminiModelValues.has(previous)) return;
 		// A retired model migrates to its designated successor when that successor
 		// is available; anything else falls back to the role default.
-		const successor = previous ? RETIRED_MODEL_SUCCESSORS[previous] : undefined;
 		const useSuccessor = successor !== undefined && geminiModelValues.has(successor);
 		const next = useSuccessor ? successor : getDefaultModelForRole(role, 'gemini');
 		// Image generation has no dedicated default in some model lists; leave a

--- a/test/api/providers/gemini/client.test.ts
+++ b/test/api/providers/gemini/client.test.ts
@@ -98,10 +98,10 @@ describe('GeminiClient', () => {
 		};
 
 		describe('should return true for models that support thinking', () => {
-			test('gemini-3-pro-preview', () => {
-				expect(testSupportsThinking('gemini-3-pro-preview')).toBe(true);
+			test('gemini-3.1-pro-preview', () => {
+				expect(testSupportsThinking('gemini-3.1-pro-preview')).toBe(true);
 				expect(mockLogger.debug).toHaveBeenCalledWith(
-					'[GeminiClient] Enabling thinking mode for model: gemini-3-pro-preview'
+					'[GeminiClient] Enabling thinking mode for model: gemini-3.1-pro-preview'
 				);
 			});
 

--- a/test/models.test.ts
+++ b/test/models.test.ts
@@ -1,10 +1,12 @@
 import {
+	DEFAULT_GEMINI_MODELS,
 	GEMINI_MODELS,
 	getActiveChatModel,
 	getDefaultModelForRole,
 	GeminiModel,
 	getUpdatedModelSettings,
 	migrateOllamaModelSetting,
+	RETIRED_MODEL_SUCCESSORS,
 	setGeminiModels,
 } from '../src/models';
 
@@ -237,6 +239,44 @@ describe('getUpdatedModelSettings', () => {
 		]);
 	});
 
+	it('migrates a retired model to its designated successor instead of the role default', () => {
+		setTestModels([
+			{ value: 'gemini-chat-default', label: 'Chat Default', defaultForRoles: ['chat'] },
+			{ value: 'gemini-summary-default', label: 'Summary Default', defaultForRoles: ['summary'] },
+			{ value: 'gemini-completions-default', label: 'Completions Default', defaultForRoles: ['completions'] },
+			{ value: 'gemini-image-default', label: 'Image Default', defaultForRoles: ['image'] },
+			{ value: 'gemini-3.1-pro-preview', label: 'Gemini 3.1 Pro Preview' },
+		]);
+		const currentSettings = {
+			chatModelName: 'gemini-3-pro-preview', // retired by Google (404 "no longer available")
+			summaryModelName: 'gemini-summary-default',
+			completionsModelName: 'gemini-completions-default',
+			imageModelName: 'gemini-image-default',
+		};
+		const result = getUpdatedModelSettings(currentSettings);
+		expect(result.settingsChanged).toBe(true);
+		expect(result.updatedSettings.chatModelName).toBe('gemini-3.1-pro-preview');
+		expect(result.changedSettingsInfo).toEqual([
+			"Chat model: 'gemini-3-pro-preview' -> 'gemini-3.1-pro-preview' (retired model migrated to successor)",
+		]);
+	});
+
+	it('falls back to the role default when a retired model’s successor is not in the list', () => {
+		// Default test models from beforeEach do NOT include gemini-3.1-pro-preview.
+		const currentSettings = {
+			chatModelName: 'gemini-3-pro-preview',
+			summaryModelName: 'gemini-summary-default',
+			completionsModelName: 'gemini-completions-default',
+			imageModelName: 'gemini-image-default',
+		};
+		const result = getUpdatedModelSettings(currentSettings);
+		expect(result.settingsChanged).toBe(true);
+		expect(result.updatedSettings.chatModelName).toBe('gemini-chat-default');
+		expect(result.changedSettingsInfo).toEqual([
+			"Chat model: 'gemini-3-pro-preview' -> 'gemini-chat-default' (legacy model update)",
+		]);
+	});
+
 	it('tolerates an empty Ollama model while the daemon list has not loaded yet', () => {
 		// Only Gemini models are registered here — the Ollama list loads later via
 		// /api/tags. The Gemini fields stay valid and the empty ollamaModelName is
@@ -317,6 +357,18 @@ describe('getUpdatedModelSettings', () => {
 		expect(() => getUpdatedModelSettings(currentSettings)).toThrow(
 			'CRITICAL: GEMINI_MODELS array is empty. Please configure available models.'
 		);
+	});
+});
+
+describe('bundled model catalog', () => {
+	it('no longer ships retired models, and every retired model’s successor is bundled', () => {
+		const bundledIds = new Set(DEFAULT_GEMINI_MODELS.map((m) => m.value));
+		for (const [retired, successor] of Object.entries(RETIRED_MODEL_SUCCESSORS)) {
+			// Retired models must be out of the catalog (the API 404s on them)...
+			expect(bundledIds.has(retired)).toBe(false);
+			// ...and their successor must still be live, or the migration is a no-op.
+			expect(bundledIds.has(successor)).toBe(true);
+		}
 	});
 });
 

--- a/test/models.test.ts
+++ b/test/models.test.ts
@@ -261,6 +261,32 @@ describe('getUpdatedModelSettings', () => {
 		]);
 	});
 
+	it('migrates a retired model even when a stale model list still advertises it', () => {
+		// GEMINI_MODELS can be populated from a persisted remoteModelCache that
+		// predates the retirement, so the retired id may still pass the validity
+		// check — it must migrate anyway, since Google 404s it server-side.
+		setTestModels([
+			{ value: 'gemini-chat-default', label: 'Chat Default', defaultForRoles: ['chat'] },
+			{ value: 'gemini-summary-default', label: 'Summary Default', defaultForRoles: ['summary'] },
+			{ value: 'gemini-completions-default', label: 'Completions Default', defaultForRoles: ['completions'] },
+			{ value: 'gemini-image-default', label: 'Image Default', defaultForRoles: ['image'] },
+			{ value: 'gemini-3-pro-preview', label: 'Gemini 3 Pro Preview' }, // stale cache entry
+			{ value: 'gemini-3.1-pro-preview', label: 'Gemini 3.1 Pro Preview' },
+		]);
+		const currentSettings = {
+			chatModelName: 'gemini-3-pro-preview',
+			summaryModelName: 'gemini-summary-default',
+			completionsModelName: 'gemini-completions-default',
+			imageModelName: 'gemini-image-default',
+		};
+		const result = getUpdatedModelSettings(currentSettings);
+		expect(result.settingsChanged).toBe(true);
+		expect(result.updatedSettings.chatModelName).toBe('gemini-3.1-pro-preview');
+		expect(result.changedSettingsInfo).toEqual([
+			"Chat model: 'gemini-3-pro-preview' -> 'gemini-3.1-pro-preview' (retired model migrated to successor)",
+		]);
+	});
+
 	it('falls back to the role default when a retired model’s successor is not in the list', () => {
 		// Default test models from beforeEach do NOT include gemini-3.1-pro-preview.
 		const currentSettings = {


### PR DESCRIPTION
## Summary

Google has removed `gemini-3-pro-preview` from the Gemini API — both the `generateContent` and Interactions paths now return 404 "This model models/gemini-3-pro-preview is no longer available" (verified live 2026-07-16). This PR drops the model from the bundled catalog and auto-migrates users who still have it configured to its successor, `gemini-3.1-pro-preview`, instead of letting the existing reconciliation drop them to the generic role default (`gemini-flash-latest`).

## Changes

- **`src/data/models.json`**: removed the `gemini-3-pro-preview` entry and bumped `lastUpdated`. Once on `master` this also propagates to existing installs via the remote model-list fetch.
- **`src/models.ts`**: added a `RETIRED_MODEL_SUCCESSORS` map (`gemini-3-pro-preview` → `gemini-3.1-pro-preview`). `getUpdatedModelSettings` now prefers a retired model's designated successor over the role default when the successor is in the current list, so a Pro user stays on a Pro-class model. Falls back to the role default otherwise, and logs `(retired model migrated to successor)` in `changedSettingsInfo`.
- **`scripts/update-models.mjs`**: added `gemini-3-pro-preview` to `EXCLUDE_PATTERNS` so the model-updater workflow can't re-add it even if `ListModels` still advertises it. The existing GA-retirement logic would not catch this case (`gemini-3.1-pro-preview` is not the GA form of `gemini-3-pro-preview`). The substring does not match `gemini-3-pro-image` / `gemini-3-pro-image-preview`, so Nano Banana Pro is unaffected.
- **`test/models.test.ts`**: new coverage — migrates to the successor when present, falls back to the role default when absent, plus a catalog regression test asserting no `RETIRED_MODEL_SUCCESSORS` key ships in `DEFAULT_GEMINI_MODELS` and every successor value does.
- **`test/api/providers/gemini/client.test.ts`**: updated the `supportsThinking` case from `gemini-3-pro-preview` to `gemini-3.1-pro-preview` (still exercises the `gemini-3` pattern, now with a live id).
- **`docs/reference/settings.md`**: documented the retired-model migration behavior in the Model Discovery section. The docs' model lists never included `gemini-3-pro-preview`, so nothing needed removing.

Known gap: I could not verify against `ListModels` locally (no API key in this environment), so whether Google still lists the retired id is unconfirmed — the `EXCLUDE_PATTERNS` guard covers both outcomes.

## Screenshots / Screencast

N/A — no UI changes; catalog data, settings reconciliation, and docs only.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: change requested directly by the maintainer in-session
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop — full test suite (3446 tests), build, and `typecheck:test` pass locally
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — no platform-specific code paths touched
- [x] Documentation has been updated (if applicable)
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (Opus 4.8)
- [x] I have reviewed and understand all AI-generated code in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Retired Gemini models are automatically migrated to designated successor models when available.
  * Settings fall back to the default model when no successor is available.
* **Bug Fixes**
  * Removed the retired Gemini 3 Pro Preview model from the available model catalog.
  * Updated thinking-model support for the current Gemini model.
* **Documentation**
  * Documented model retirement and automatic settings migration behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->