### PR TITLE
fix(gemini): route interactions-only models (Gemini Omni) via Interactions API

### DIFF
--- a/docs/reference/advanced-settings.md
+++ b/docs/reference/advanced-settings.md
@@ -62,6 +62,7 @@ Route Gemini requests through Google's newer [Interactions API](https://ai.googl
 - **Scope**: Gemini provider only — the toggle is hidden when the provider is Ollama.
 - **Privacy**: The plugin runs the Interactions API **statelessly** (`store: false`). Conversation history is replayed with each request, and the plugin does not persist Interactions state on Google's side between turns. (Requests are still sent to Google to generate each response, subject to Google's standard API data-handling terms.)
 - **Status**: Default transport. If you hit problems, turn it off to fall back to the proven `generateContent` path. Responses stream incrementally, including reasoning and tool calls.
+- **Interactions-only models**: Some models (e.g. Gemini Omni Flash Preview, an image-generation model) are only served by the Interactions API — `generateContent` rejects them outright. Requests to these models always use the Interactions API, even when this toggle is off; that includes image generation when an interactions-only model is selected as the image model. Features that still run on `generateContent` (Google Search grounding, web fetch, RAG semantic search) substitute the default chat model if an interactions-only model ever ends up configured as the chat model.
 
 ### Custom API Endpoint
 

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -145,6 +145,7 @@ The active model list depends on the [`provider`](#provider) setting:
 - **Default**: `gemini-2.5-flash-image`
 - **Only available when**: Provider is `gemini`
 - **Description**: Model used for image generation via the `generate_image` tool and the **Generate image** command. Only models with image-generation capability appear in this dropdown.
+- **Note**: Interactions-only image models (e.g. `gemini-omni-flash-preview`) generate through the Interactions API instead of `generateContent`, regardless of the [Use Interactions API](#use-interactions-api) toggle.
 
 ### Ollama model
 
@@ -310,7 +311,8 @@ Advanced settings for developers and power users. Access by clicking "Show advan
 - **Description**: Routes Gemini requests through Google's GA [Interactions API](https://ai.google.dev/gemini-api/docs/interactions) (`interactions.create`) instead of the legacy `generateContent` API. This is now the default transport; existing installs are migrated to it automatically (a one-time flip you can reverse by turning the toggle off).
 - **Privacy**: Runs statelessly (`store: false`) — conversation history is replayed with each request, and the plugin does not persist Interactions state on Google's side between turns. (Requests are still sent to Google to generate each response, subject to Google's standard API data-handling terms.)
 - **Status**: Default-on. Responses stream incrementally (text, reasoning, and tool calls); turn it off to fall back to the legacy `generateContent` path if you hit issues.
-- **Scope**: Governs the conversational chat transport only. Image generation (the `generate_image` tool and **Generate image** command) always uses `generateContent` regardless of this setting.
+- **Scope**: Governs the conversational chat transport only. Image generation (the `generate_image` tool and **Generate image** command) always uses `generateContent` regardless of this setting — unless the selected image model is interactions-only (see below), in which case it uses the Interactions API.
+- **Interactions-only models**: Models flagged `interactionsOnly` in the model catalog (e.g. `gemini-omni-flash-preview`, an image-generation model) are only served by the Interactions API, so requests to them always route through it even when this toggle is off. Features that still run on `generateContent` (Google Search grounding, web fetch, RAG semantic search) substitute the default chat model if an interactions-only model ever ends up configured as the chat model.
 
 #### Custom API Endpoint
 

--- a/src/api/providers/gemini/client.ts
+++ b/src/api/providers/gemini/client.ts
@@ -29,7 +29,7 @@ import {
 } from '../../interfaces/model-api';
 import { GeminiPrompts } from '../../../prompts';
 import type { ObsidianGemini } from '../../../types/plugin';
-import { getDefaultModelForRole } from '../../../models';
+import { getDefaultModelForRole, isInteractionsOnlyModel } from '../../../models';
 import { decodeHtmlEntities } from '../../../utils/html-entities';
 import { normalizeToContent } from '../../../utils/history-normalize';
 import type { GeminiClientConfig } from './config';
@@ -37,6 +37,7 @@ import { ModelUseCase } from '../../model-use-case';
 import {
 	buildUserInputStep,
 	contentToSteps,
+	extractImageDataFromInteraction,
 	extractModelResponseFromInteraction,
 	toolsToInteractionTools,
 	InteractionStreamAccumulator,
@@ -98,11 +99,27 @@ export class GeminiClient implements ModelApi {
 	}
 
 	/**
-	 * Whether this client routes through the GA Interactions API. Reads the
-	 * per-client config first (set by the factory), falling back to live plugin
-	 * settings for `createCustom` callers that don't thread the flag through.
+	 * Resolve the effective model for a request: per-request override, then the
+	 * client's configured model, then the bundled chat default. Single source of
+	 * truth for the routing decision and both param builders.
 	 */
-	private get useInteractions(): boolean {
+	private resolveModel(request: BaseModelRequest | ExtendedModelRequest): string {
+		return request.model || this.config.model || getDefaultModelForRole('chat');
+	}
+
+	/**
+	 * Whether a request for `model` routes through the GA Interactions API.
+	 * Interactions-only models (e.g. gemini-omni-flash-preview) always do —
+	 * `generateContent` rejects them with a 400 ("This model only supports
+	 * Interactions API") — regardless of the user's transport toggle. Otherwise
+	 * the per-client config decides (set by the factory), falling back to live
+	 * plugin settings for `createCustom` callers that don't thread the flag
+	 * through.
+	 */
+	private usesInteractions(model: string): boolean {
+		if (isInteractionsOnlyModel(model)) {
+			return true;
+		}
 		return this.config.useInteractionsApi ?? this.plugin?.settings?.useInteractionsApi ?? false;
 	}
 
@@ -110,7 +127,7 @@ export class GeminiClient implements ModelApi {
 	 * Generate a non-streaming response
 	 */
 	async generateModelResponse(request: BaseModelRequest | ExtendedModelRequest): Promise<ModelResponse> {
-		if (this.useInteractions) {
+		if (this.usesInteractions(this.resolveModel(request))) {
 			return this.generateViaInteractions(request);
 		}
 
@@ -253,7 +270,7 @@ export class GeminiClient implements ModelApi {
 		request: BaseModelRequest | ExtendedModelRequest
 	): Promise<Record<string, unknown>> {
 		const isExtended = isExtendedRequest(request);
-		const model = request.model || this.config.model || getDefaultModelForRole('chat');
+		const model = this.resolveModel(request);
 
 		const generationConfig: Record<string, unknown> = {
 			temperature: request.temperature ?? this.config.temperature,
@@ -344,7 +361,7 @@ export class GeminiClient implements ModelApi {
 		request: BaseModelRequest | ExtendedModelRequest,
 		onChunk: StreamCallback
 	): StreamingModelResponse {
-		if (this.useInteractions) {
+		if (this.usesInteractions(this.resolveModel(request))) {
 			return this.streamViaInteractions(request, onChunk);
 		}
 
@@ -468,7 +485,7 @@ export class GeminiClient implements ModelApi {
 		request: BaseModelRequest | ExtendedModelRequest
 	): Promise<GenerateContentParameters> {
 		const isExtended = isExtendedRequest(request);
-		const model = request.model || this.config.model || getDefaultModelForRole('chat');
+		const model = this.resolveModel(request);
 
 		// Build system instruction
 		let systemInstruction = '';
@@ -797,14 +814,19 @@ export class GeminiClient implements ModelApi {
 	 * on (see #1016): image generation is a distinct one-shot capability on a
 	 * dedicated image model — not the conversational transport the flag governs —
 	 * and the existing path is proven across image-tools and scheduled tasks.
-	 * Migrating it to the Interactions image-output surface is deferred until
-	 * there's a concrete reason to (no user-facing benefit today).
+	 * The exception is interactions-only image models (e.g.
+	 * gemini-omni-flash-preview), which `generateContent` rejects with a 400 —
+	 * those route through the Interactions image-output surface.
 	 *
 	 * @param prompt - Text description of the image to generate
 	 * @param model - Image generation model (defaults to gemini-2.5-flash-image-preview)
 	 * @returns Base64 encoded image data
 	 */
 	async generateImage(prompt: string, model: string): Promise<string> {
+		if (isInteractionsOnlyModel(model)) {
+			return this.generateImageViaInteractions(prompt, model);
+		}
+
 		try {
 			const params: GenerateContentParameters = {
 				model,
@@ -836,6 +858,34 @@ export class GeminiClient implements ModelApi {
 			throw new Error('No image data in response. The model may have returned only text.');
 		} catch (error) {
 			this.plugin?.logger.error('[GeminiClient] Error generating image:', error);
+			throw error;
+		}
+	}
+
+	/**
+	 * Image generation via the Interactions API, for models `generateContent`
+	 * refuses to serve. One-shot and stateless like the generateContent path:
+	 * the prompt is the whole input, and the base64 image is pulled from the
+	 * response's `model_output` steps (via the `output_image` convenience when
+	 * the SDK provides it).
+	 */
+	private async generateImageViaInteractions(prompt: string, model: string): Promise<string> {
+		this.ensureInteractionsFetch();
+
+		try {
+			const interaction = await this.interactionsClient.create({
+				model,
+				store: false,
+				input: prompt,
+			});
+
+			const imageData = extractImageDataFromInteraction(interaction);
+			if (!imageData) {
+				throw new Error('No image data in response. The model may have returned only text.');
+			}
+			return imageData;
+		} catch (error) {
+			this.plugin?.logger.error('[GeminiClient] Error generating image via interactions:', error);
 			throw error;
 		}
 	}

--- a/src/api/providers/gemini/interactions-mapper.ts
+++ b/src/api/providers/gemini/interactions-mapper.ts
@@ -139,6 +139,33 @@ export function toolsToInteractionTools(tools: ToolDefinition[]): InteractionSte
 	}));
 }
 
+/**
+ * Extract the base64 data of the last generated image from a completed
+ * `Interaction`. Prefers the SDK's `output_image` convenience property (the
+ * last image block of the response), falling back to scanning `model_output`
+ * steps for `image` content items. Returns null when the response carries no
+ * image data (e.g. the model answered with text only).
+ */
+export function extractImageDataFromInteraction(interaction: Record<string, unknown>): string | null {
+	const outputImage = interaction.output_image as { data?: unknown } | undefined;
+	if (outputImage && typeof outputImage.data === 'string' && outputImage.data) {
+		return outputImage.data;
+	}
+
+	const steps = Array.isArray(interaction.steps) ? (interaction.steps as InteractionStep[]) : [];
+	let lastImageData: string | null = null;
+	for (const step of steps) {
+		if (step.type !== 'model_output' || !Array.isArray(step.content)) continue;
+		for (const item of step.content) {
+			const i = item as { type?: string; data?: unknown };
+			if (i.type === 'image' && typeof i.data === 'string' && i.data) {
+				lastImageData = i.data;
+			}
+		}
+	}
+	return lastImageData;
+}
+
 /** Pull the concatenated text out of a step's `content` array. */
 function textFromContentArray(content: unknown): string {
 	if (!Array.isArray(content)) return '';

--- a/src/data/models.json
+++ b/src/data/models.json
@@ -1,6 +1,6 @@
 {
 	"version": 1,
-	"lastUpdated": "2026-07-06T09:16:20.824Z",
+	"lastUpdated": "2026-07-16T00:00:00.000Z",
 	"models": [
 		{
 			"value": "gemini-pro-latest",
@@ -97,7 +97,9 @@
 		{
 			"value": "gemini-omni-flash-preview",
 			"label": "Gemini Omni Flash Preview",
-			"maxTemperature": 2
+			"supportsImageGeneration": true,
+			"maxTemperature": 2,
+			"interactionsOnly": true
 		}
 	]
 }

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -478,7 +478,7 @@ export const en = {
 	},
 	'settings.agentConfig.useInteractionsApiDesc': {
 		message:
-			'Route Gemini requests through Google’s newer Interactions API instead of the legacy generateContent API. This is the default transport. Runs statelessly — conversation history is replayed each turn and not persisted on Google’s side between turns. Turn it off to fall back to generateContent if you hit issues.',
+			'Route Gemini requests through Google’s newer Interactions API instead of the legacy generateContent API. This is the default transport. Runs statelessly — conversation history is replayed each turn and not persisted on Google’s side between turns. Turn it off to fall back to generateContent if you hit issues. Models that only support the Interactions API (such as Gemini Omni) always use it, regardless of this setting.',
 		context:
 			'Settings toggle description for the Interactions API. "Interactions API" and "generateContent" are Google API names; keep them in English.',
 	},

--- a/src/models.ts
+++ b/src/models.ts
@@ -18,6 +18,14 @@ export interface GeminiModel {
 	supportsVision?: boolean;
 	/** Context window in tokens (used for compaction thresholds). */
 	contextWindow?: number;
+	/**
+	 * The model is only served by the Interactions API — `generateContent`
+	 * rejects it with a 400 ("This model only supports Interactions API").
+	 * The Gemini client routes these through the Interactions path regardless
+	 * of the `useInteractionsApi` setting, and generateContent-only callers
+	 * (search grounding, web fetch, RAG) must not send requests to them.
+	 */
+	interactionsOnly?: boolean;
 }
 
 export const DEFAULT_GEMINI_MODELS: GeminiModel[] = modelData.models as GeminiModel[];
@@ -70,6 +78,32 @@ export function getDefaultModelForRole(role: ModelRole, provider: ModelProvider 
 	// `GEMINI_MODELS[0]` could be an Ollama entry and we'd return a
 	// cross-provider model name as the Gemini default.
 	throw new Error('CRITICAL: GEMINI_MODELS array is empty. Please configure available models.');
+}
+
+/**
+ * Whether a model is served exclusively by the Interactions API (see
+ * `GeminiModel.interactionsOnly`). Checks the live model list first (which may
+ * be a newer remote list), then the bundled defaults — a stale remote cache
+ * fetched before the flag existed would otherwise hide it.
+ */
+export function isInteractionsOnlyModel(modelValue: string | null | undefined): boolean {
+	if (!modelValue) return false;
+	const flagIn = (list: GeminiModel[]) => list.find((m) => m.value === modelValue)?.interactionsOnly;
+	return flagIn(GEMINI_MODELS) ?? flagIn(DEFAULT_GEMINI_MODELS) ?? false;
+}
+
+/**
+ * Resolve a model for callers that can only use `generateContent` (search
+ * grounding, web fetch, RAG — features the plugin hasn't migrated to the
+ * Interactions API). Returns `preferred` unless it's empty or
+ * interactions-only, in which case the bundled Gemini default for the role is
+ * substituted so the request doesn't hard-fail with a 400.
+ */
+export function resolveGenerateContentModel(preferred: string | null | undefined, role: ModelRole = 'chat'): string {
+	if (preferred && !isInteractionsOnlyModel(preferred)) {
+		return preferred;
+	}
+	return getDefaultModelForRole(role, 'gemini');
 }
 
 /**

--- a/src/services/context-manager.ts
+++ b/src/services/context-manager.ts
@@ -17,6 +17,7 @@ import { executeWithRetry } from '../utils/retry';
 import { createGoogleGenAI } from '../api/providers/gemini/google-genai-factory';
 import { truncateOldToolResults } from '../agent/agent-loop-helpers';
 import { getLegacyEntryTextTruthy } from '../utils/history-normalize';
+import { isInteractionsOnlyModel, resolveGenerateContentModel } from '../models';
 
 import contextSummaryPromptContent from '../../prompts/contextSummaryPrompt.hbs';
 
@@ -326,7 +327,11 @@ export class ContextManager {
 			const response = await executeWithRetry(
 				() =>
 					this.ai!.models.countTokens({
-						model: modelName,
+						// countTokens is a generateContent-family endpoint; for an
+						// interactions-only model, count against the bundled default
+						// instead — tokenization is close enough for compaction
+						// thresholds, and the real call would 400.
+						model: resolveGenerateContentModel(modelName),
 						contents: sanitizedContents,
 					}),
 				undefined,
@@ -615,8 +620,11 @@ export class ContextManager {
 
 		try {
 			// Ollama has no SDK instance here; route through the factory so we use
-			// whichever provider the user has configured.
-			if (this.plugin.settings.provider === 'ollama' || !this.ai) {
+			// whichever provider the user has configured. An interactions-only
+			// model also goes through the factory (its summary client routes
+			// interactions-only models via the Interactions API) since the direct
+			// generateContent call below would 400.
+			if (this.plugin.settings.provider === 'ollama' || !this.ai || isInteractionsOnlyModel(modelName)) {
 				// Pass ModelUseCase.SUMMARY to the factory and let its
 				// resolveModelName populate the request — overriding `model`
 				// here would route compaction through the chat model on Ollama

--- a/src/tools/grounding-tool-runner.ts
+++ b/src/tools/grounding-tool-runner.ts
@@ -1,6 +1,6 @@
 import { ToolResult } from './types';
 import type { ObsidianGemini } from '../types/plugin';
-import { getDefaultModelForRole } from '../models';
+import { resolveGenerateContentModel } from '../models';
 import { createGoogleGenAI } from '../api/providers/gemini/google-genai-factory';
 import { executeWithRetry } from '../utils/retry';
 import { getRawErrorMessage } from '../utils/error-utils';
@@ -62,9 +62,11 @@ export async function runGroundingTool(plugin: ObsidianGemini, req: GroundingToo
 			};
 		}
 
-		// Create a separate model instance with the requested grounding tool enabled
+		// Create a separate model instance with the requested grounding tool enabled.
+		// Grounding runs on generateContent, so an interactions-only chat model is
+		// swapped for the bundled default instead of hard-failing with a 400.
 		const genAI = createGoogleGenAI(plugin);
-		const modelToUse = plugin.settings.chatModelName || getDefaultModelForRole('chat');
+		const modelToUse = resolveGenerateContentModel(plugin.settings.chatModelName);
 		const config = {
 			temperature: plugin.settings.temperature,
 			maxOutputTokens: 8192, // Default max tokens

--- a/src/tools/rag-search-tool.ts
+++ b/src/tools/rag-search-tool.ts
@@ -2,6 +2,7 @@ import { Tool, ToolResult, ToolExecutionContext } from './types';
 import { ToolCategory } from '../types/agent';
 import { ToolClassification } from '../types/tool-policy';
 import { getRawErrorMessage } from '../utils/error-utils';
+import { resolveGenerateContentModel } from '../models';
 
 /**
  * Search result from RAG semantic search
@@ -200,10 +201,12 @@ export class RagSearchTool implements Tool {
 				fileSearchConfig.metadataFilter = metadataFilter;
 			}
 
-			// Perform search using generateContent with File Search tool
-			// Use the configured chat model for consistency
+			// Perform search using generateContent with File Search tool.
+			// Use the configured chat model for consistency; an interactions-only
+			// chat model falls back to the bundled default since File Search runs
+			// on generateContent.
 			const response = await ai.models.generateContent({
-				model: plugin.settings.chatModelName,
+				model: resolveGenerateContentModel(plugin.settings.chatModelName),
 				contents: `Search for information about: ${params.query}\n\nProvide a summary of the most relevant findings from the indexed documents. Include specific file references when available.`,
 				config: {
 					tools: [

--- a/src/tools/web-fetch-tool.ts
+++ b/src/tools/web-fetch-tool.ts
@@ -7,6 +7,7 @@ import { executeWithRetry } from '../utils/retry';
 import TurndownService from 'turndown';
 import { decodeHtmlEntities } from '../utils/html-entities';
 import { createGoogleGenAI } from '../api/providers/gemini/google-genai-factory';
+import { resolveGenerateContentModel } from '../models';
 import { getRawErrorMessageOr } from '../utils/error-utils';
 
 /**
@@ -74,9 +75,10 @@ export class WebFetchTool implements Tool {
 
 			// Create a new instance of GoogleGenAI
 			const genAI = createGoogleGenAI(plugin);
-			// Use the same model that's configured for chat
-			// This ensures consistency with the main conversation
-			const modelToUse = plugin.settings.chatModelName || 'gemini-2.5-flash';
+			// Use the same model that's configured for chat for consistency with the
+			// main conversation. URL context runs on generateContent, so an
+			// interactions-only chat model falls back to the bundled default.
+			const modelToUse = resolveGenerateContentModel(plugin.settings.chatModelName);
 
 			// Create a prompt that includes the URL and the query
 			const prompt = `${params.query} for ${params.url}`;
@@ -250,9 +252,10 @@ export class WebFetchTool implements Tool {
 				content = content.substring(0, 10000) + '\n\n[Content truncated...]';
 			}
 
-			// Now use Gemini to analyze the content
+			// Now use Gemini to analyze the content (generateContent path — an
+			// interactions-only chat model falls back to the bundled default).
 			const genAI = createGoogleGenAI(plugin);
-			const modelToUse = plugin.settings.chatModelName || 'gemini-2.5-flash';
+			const modelToUse = resolveGenerateContentModel(plugin.settings.chatModelName);
 
 			// Create a prompt with the content
 			const prompt = `Based on the following web page content from ${params.url}, ${params.query}\n\nWeb Page Title: ${title}\n\nContent:\n${content}`;

--- a/test/api/providers/gemini/client.test.ts
+++ b/test/api/providers/gemini/client.test.ts
@@ -1427,4 +1427,153 @@ describe('GeminiClient', () => {
 			});
 		});
 	});
+
+	describe('interactions-only model routing (useInteractionsApi off)', () => {
+		// gemini-omni-flash-preview is flagged interactionsOnly in the bundled
+		// catalog: generateContent rejects it with a 400 ("This model only
+		// supports Interactions API"), so the client must route it through the
+		// Interactions path even when the transport toggle is off.
+		const makeClient = (model: string) =>
+			new GeminiClient(
+				{ apiKey: 'test-api-key', model, useInteractionsApi: false },
+				new GeminiPrompts(mockPlugin),
+				mockPlugin
+			);
+
+		beforeEach(() => {
+			interactionsCreateMock.mockReset();
+			interactionsCreateMock.mockResolvedValue({
+				id: 'int_2',
+				status: 'completed',
+				output_text: 'Hello from interactions',
+				steps: [{ type: 'model_output', content: [{ type: 'text', text: 'Hello from interactions' }] }],
+			});
+			generateContentMock.mockReset();
+			generateContentMock.mockResolvedValue({
+				candidates: [{ content: { parts: [{ text: 'Hello from generateContent' }] } }],
+			});
+
+			// Stub the plugin surface buildExtendedSystemInstruction depends on.
+			mockPlugin.agentsMemory = { read: vi.fn().mockResolvedValue('') };
+			mockPlugin.skillManager = { getSkillSummaries: vi.fn().mockResolvedValue([]) };
+			mockPlugin.settings = { userName: 'Tester', ragIndexing: { enabled: false }, useInteractionsApi: false };
+		});
+
+		test('configured interactions-only model routes via interactions.create despite the toggle being off', async () => {
+			const client = makeClient('gemini-omni-flash-preview');
+			const response = await client.generateModelResponse({
+				prompt: '',
+				userMessage: 'hi',
+				kind: 'extended',
+				conversationHistory: [],
+			});
+
+			expect(interactionsCreateMock).toHaveBeenCalledTimes(1);
+			expect(generateContentMock).not.toHaveBeenCalled();
+			expect(interactionsCreateMock.mock.calls[0][0].model).toBe('gemini-omni-flash-preview');
+			expect(response.markdown).toBe('Hello from interactions');
+		});
+
+		test('per-request model override to an interactions-only model routes via interactions.create', async () => {
+			const client = makeClient('gemini-flash-latest');
+			await client.generateModelResponse({
+				prompt: '',
+				userMessage: 'hi',
+				kind: 'extended',
+				conversationHistory: [],
+				model: 'gemini-omni-flash-preview',
+			});
+
+			expect(interactionsCreateMock).toHaveBeenCalledTimes(1);
+			expect(generateContentMock).not.toHaveBeenCalled();
+			expect(interactionsCreateMock.mock.calls[0][0].model).toBe('gemini-omni-flash-preview');
+		});
+
+		test('regular model keeps using generateContent when the toggle is off', async () => {
+			const client = makeClient('gemini-flash-latest');
+			const response = await client.generateModelResponse({
+				prompt: '',
+				userMessage: 'hi',
+				kind: 'extended',
+				conversationHistory: [],
+			});
+
+			expect(generateContentMock).toHaveBeenCalledTimes(1);
+			expect(interactionsCreateMock).not.toHaveBeenCalled();
+			expect(response.markdown).toBe('Hello from generateContent');
+		});
+
+		test('generateImage routes an interactions-only image model via interactions.create', async () => {
+			interactionsCreateMock.mockReset();
+			interactionsCreateMock.mockResolvedValue({
+				id: 'int_img',
+				status: 'completed',
+				output_image: { data: 'BASE64_IMAGE', mime_type: 'image/png' },
+				steps: [{ type: 'model_output', content: [{ type: 'image', data: 'BASE64_IMAGE' }] }],
+			});
+
+			const client = makeClient('gemini-flash-latest');
+			const data = await client.generateImage('a nano banana dish', 'gemini-omni-flash-preview');
+
+			expect(interactionsCreateMock).toHaveBeenCalledTimes(1);
+			expect(generateContentMock).not.toHaveBeenCalled();
+			const params = interactionsCreateMock.mock.calls[0][0];
+			expect(params.model).toBe('gemini-omni-flash-preview');
+			expect(params.input).toBe('a nano banana dish');
+			expect(params.store).toBe(false);
+			expect(data).toBe('BASE64_IMAGE');
+		});
+
+		test('generateImage via interactions throws when the response has no image data', async () => {
+			interactionsCreateMock.mockReset();
+			interactionsCreateMock.mockResolvedValue({
+				id: 'int_img',
+				status: 'completed',
+				output_text: 'Sorry, cannot draw that.',
+				steps: [{ type: 'model_output', content: [{ type: 'text', text: 'Sorry, cannot draw that.' }] }],
+			});
+
+			const client = makeClient('gemini-flash-latest');
+			await expect(client.generateImage('a nano banana dish', 'gemini-omni-flash-preview')).rejects.toThrow(
+				'No image data in response'
+			);
+		});
+
+		test('generateImage keeps using generateContent for regular image models', async () => {
+			generateContentMock.mockReset();
+			generateContentMock.mockResolvedValue({
+				candidates: [{ content: { parts: [{ inlineData: { data: 'GC_IMAGE' } }] } }],
+			});
+
+			const client = makeClient('gemini-flash-latest');
+			const data = await client.generateImage('a nano banana dish', 'gemini-2.5-flash-image');
+
+			expect(generateContentMock).toHaveBeenCalledTimes(1);
+			expect(interactionsCreateMock).not.toHaveBeenCalled();
+			expect(data).toBe('GC_IMAGE');
+		});
+
+		test('streaming an interactions-only model routes via the interactions stream despite the toggle being off', async () => {
+			interactionsCreateMock.mockReset();
+			interactionsCreateMock.mockImplementation(async () => {
+				return (async function* () {
+					yield { event_type: 'step.start', index: 0, step: { type: 'model_output' } };
+					yield { event_type: 'step.delta', index: 0, delta: { type: 'text', text: 'streamed' } };
+				})();
+			});
+
+			const client = makeClient('gemini-omni-flash-preview');
+			const chunks: Array<{ text: string }> = [];
+			const stream = client.generateStreamingResponse(
+				{ prompt: '', userMessage: 'hi', kind: 'extended', conversationHistory: [] },
+				(chunk) => chunks.push(chunk)
+			);
+
+			const response = await stream.complete;
+			expect(interactionsCreateMock).toHaveBeenCalledTimes(1);
+			expect(interactionsCreateMock.mock.calls[0][0].stream).toBe(true);
+			expect(chunks).toEqual([{ text: 'streamed' }]);
+			expect(response.markdown).toBe('streamed');
+		});
+	});
 });

--- a/test/api/providers/gemini/interactions-mapper.test.ts
+++ b/test/api/providers/gemini/interactions-mapper.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect } from 'vitest';
 import {
 	InteractionStreamAccumulator,
+	extractImageDataFromInteraction,
 	extractModelResponseFromInteraction,
 	contentToSteps,
 	buildUserInputStep,
@@ -282,5 +283,53 @@ describe('inline attachments (all media classes)', () => {
 		expect(contentToSteps(content)).toEqual([
 			{ type: 'user_input', content: [{ type: 'document', data: 'BBBB', mime_type: 'application/pdf' }] },
 		]);
+	});
+});
+
+describe('extractImageDataFromInteraction', () => {
+	test('prefers the output_image convenience property', () => {
+		const interaction = {
+			output_image: { data: 'BASE64_CONVENIENCE', mime_type: 'image/png' },
+			steps: [{ type: 'model_output', content: [{ type: 'image', data: 'BASE64_STEP' }] }],
+		};
+		expect(extractImageDataFromInteraction(interaction)).toBe('BASE64_CONVENIENCE');
+	});
+
+	test('falls back to scanning model_output steps for image content', () => {
+		const interaction = {
+			steps: [
+				{ type: 'thought', summary: [{ type: 'text', text: 'planning' }] },
+				{
+					type: 'model_output',
+					content: [
+						{ type: 'text', text: 'Here is your image:' },
+						{ type: 'image', data: 'BASE64_STEP', mime_type: 'image/png' },
+					],
+				},
+			],
+		};
+		expect(extractImageDataFromInteraction(interaction)).toBe('BASE64_STEP');
+	});
+
+	test('returns the last image when the output interleaves several', () => {
+		const interaction = {
+			steps: [
+				{ type: 'model_output', content: [{ type: 'image', data: 'FIRST' }] },
+				{ type: 'model_output', content: [{ type: 'image', data: 'LAST' }] },
+			],
+		};
+		expect(extractImageDataFromInteraction(interaction)).toBe('LAST');
+	});
+
+	test('returns null for a text-only response', () => {
+		const interaction = {
+			output_text: 'Sorry, no image.',
+			steps: [{ type: 'model_output', content: [{ type: 'text', text: 'Sorry, no image.' }] }],
+		};
+		expect(extractImageDataFromInteraction(interaction)).toBeNull();
+	});
+
+	test('returns null when steps are missing entirely', () => {
+		expect(extractImageDataFromInteraction({})).toBeNull();
 	});
 });

--- a/test/models.test.ts
+++ b/test/models.test.ts
@@ -4,7 +4,9 @@ import {
 	getDefaultModelForRole,
 	GeminiModel,
 	getUpdatedModelSettings,
+	isInteractionsOnlyModel,
 	migrateOllamaModelSetting,
+	resolveGenerateContentModel,
 	setGeminiModels,
 } from '../src/models';
 
@@ -427,5 +429,79 @@ describe('migrateOllamaModelSetting', () => {
 		expect(migrated).toBe(true);
 		expect(settings.ollamaModelName).toBe('');
 		expect(settings.chatModelName).toBe('gemini-chat-default');
+	});
+});
+
+describe('isInteractionsOnlyModel', () => {
+	let originalModels: GeminiModel[];
+
+	beforeEach(() => {
+		originalModels = [...GEMINI_MODELS];
+	});
+
+	afterEach(() => {
+		setGeminiModels(originalModels);
+	});
+
+	it('flags the bundled gemini-omni-flash-preview as interactions-only', () => {
+		expect(isInteractionsOnlyModel('gemini-omni-flash-preview')).toBe(true);
+	});
+
+	it('returns false for regular bundled models', () => {
+		expect(isInteractionsOnlyModel('gemini-flash-latest')).toBe(false);
+		expect(isInteractionsOnlyModel('gemini-2.5-flash')).toBe(false);
+	});
+
+	it('returns false for unknown models and empty values', () => {
+		expect(isInteractionsOnlyModel('some-unknown-model')).toBe(false);
+		expect(isInteractionsOnlyModel('')).toBe(false);
+		expect(isInteractionsOnlyModel(undefined)).toBe(false);
+		expect(isInteractionsOnlyModel(null)).toBe(false);
+	});
+
+	it('reads the flag from the live model list (remote updates)', () => {
+		setGeminiModels([{ value: 'future-interactions-model', label: 'Future', interactionsOnly: true }]);
+		expect(isInteractionsOnlyModel('future-interactions-model')).toBe(true);
+	});
+
+	it('falls back to the bundled defaults when the live list lacks the entry (stale remote cache)', () => {
+		// Simulate a remote cache fetched before the flag existed: the live list
+		// carries the model without the flag... actually without the entry at all.
+		setGeminiModels([{ value: 'gemini-flash-latest', label: 'Gemini Flash Latest' }]);
+		expect(isInteractionsOnlyModel('gemini-omni-flash-preview')).toBe(true);
+	});
+
+	it('honors an explicit false in the live list over the bundled flag', () => {
+		setGeminiModels([{ value: 'gemini-omni-flash-preview', label: 'Omni', interactionsOnly: false }]);
+		expect(isInteractionsOnlyModel('gemini-omni-flash-preview')).toBe(false);
+	});
+});
+
+describe('resolveGenerateContentModel', () => {
+	let originalModels: GeminiModel[];
+
+	beforeEach(() => {
+		originalModels = [...GEMINI_MODELS];
+	});
+
+	afterEach(() => {
+		setGeminiModels(originalModels);
+	});
+
+	it('returns the preferred model when it can use generateContent', () => {
+		expect(resolveGenerateContentModel('gemini-2.5-flash')).toBe('gemini-2.5-flash');
+	});
+
+	it('substitutes the bundled chat default for an interactions-only model', () => {
+		expect(resolveGenerateContentModel('gemini-omni-flash-preview')).toBe('gemini-flash-latest');
+	});
+
+	it('substitutes the bundled default for empty values', () => {
+		expect(resolveGenerateContentModel('')).toBe('gemini-flash-latest');
+		expect(resolveGenerateContentModel(undefined)).toBe('gemini-flash-latest');
+	});
+
+	it('resolves against the requested role', () => {
+		expect(resolveGenerateContentModel('gemini-omni-flash-preview', 'completions')).toBe('gemini-flash-lite-latest');
 	});
 });

--- a/test/tools/grounding-tool-runner.test.ts
+++ b/test/tools/grounding-tool-runner.test.ts
@@ -112,6 +112,21 @@ describe('runGroundingTool', () => {
 				expect.objectContaining({ model: getDefaultModelForRole('chat') })
 			);
 		});
+
+		it('substitutes the default chat model when the chat model is interactions-only', async () => {
+			// Grounding runs on generateContent, which rejects interactions-only
+			// models with a 400 — the runner must not send them.
+			mockPlugin.settings.chatModelName = 'gemini-omni-flash-preview';
+			mockGenAI.models.generateContent.mockResolvedValue({
+				candidates: [{ content: { parts: [{ text: 'answer' }] } }],
+			});
+
+			await runGroundingTool(mockPlugin, makeRequest());
+
+			expect(mockGenAI.models.generateContent).toHaveBeenCalledWith(
+				expect.objectContaining({ model: getDefaultModelForRole('chat') })
+			);
+		});
 	});
 
 	describe('text extraction', () => {


### PR DESCRIPTION
## Summary

`gemini-omni-flash-preview` is only served by the Interactions API — `generateContent` returns a 400 ("This model only supports Interactions API", verified against the live API 2026-07-16). It is also an image-generation model, not a text model. The catalog listed it as a plain text entry, so it appeared in the chat/summary/completions dropdowns and hard-failed for users who had turned **Use Interactions API** off — and image generation, which always ran on `generateContent`, could never use it at all.

This PR adds an `interactionsOnly` flag to the model catalog and routes requests for such models through the Interactions API regardless of the transport toggle. Routing by model (rather than filtering dropdowns) was chosen because it also covers per-session model overrides and stale persisted settings, and matches the client's existing per-model capability branching (`supportsThinkingLevel` etc.).

One premise correction discovered along the way: completions/summary/rewrite do **not** bypass the Interactions transport — all `ModelApi` paths honor the toggle. What always uses `generateContent` are the direct-SDK helpers (search grounding, web fetch, RAG file search, compaction summarization/token counting); those now substitute a `generateContent`-capable model instead of hard-failing.

## Changes

- **Catalog** (`src/models.ts`, `src/data/models.json`): new `GeminiModel.interactionsOnly` field; `gemini-omni-flash-preview` flagged `interactionsOnly` + `supportsImageGeneration`, moving it from the text dropdowns to the image-model dropdown. New helpers `isInteractionsOnlyModel()` (live list first, bundled fallback for stale remote caches) and `resolveGenerateContentModel()`.
- **Client routing** (`src/api/providers/gemini/client.ts`): `resolveModel()` + `usesInteractions(model)` — interactions-only models always route via the Interactions path on both non-streaming and streaming entry points, even with the toggle off.
- **Image generation**: `generateImage()` routes interactions-only image models through a new `generateImageViaInteractions()` (stateless `interactions.create` with the prompt as input; base64 pulled via the `output_image` convenience with a `model_output` step scan fallback, in `interactions-mapper.ts`). Regular image models stay on the proven `generateContent` path per #1016.
- **generateContent-only callers**: grounding tool runner, web fetch (both call sites), and RAG file search substitute the bundled default chat model when the configured chat model is interactions-only; compaction summarization routes through the factory summary client and `countTokens` counts against the substituted default. These paths failed with a 400 even when the toggle was on.
- **Docs**: `docs/reference/settings.md` and `docs/reference/advanced-settings.md` document interactions-only routing and the image-model behavior; `useInteractionsApi` toggle description updated in `src/i18n/en.ts` (translations regenerate via the i18n workflow on master).

## Known gaps

- Grounding/web-fetch/RAG substitute the default chat model rather than running these features through the Interactions API; migrating those tool surfaces is out of scope here.
- The remote model list fetched from master carries the new flag once this merges; until then, stale remote caches are covered by the bundled-defaults fallback in `isInteractionsOnlyModel()`.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: maintainer-initiated change, requested and scoped directly in session
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop (unit suite: 3466 tests across 160 files; routing and fallbacks covered by new tests)
- [x] I have verified this change does not break Mobile (no platform-specific APIs touched; pure request-routing logic)
- [x] Documentation has been updated (settings.md, advanced-settings.md, en.ts toggle description)
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (Opus 4.8)
- [x] I have reviewed and understand all AI-generated code in this PR