### PR TITLE
fix(ci): fail check-models loudly on real errors, exit 0 on no-op

### DIFF
--- a/.github/workflows/model-update.yml
+++ b/.github/workflows/model-update.yml
@@ -28,21 +28,23 @@ jobs:
 
       - name: Check for new models
         id: update
-        continue-on-error: true
+        # Exits 0 whether or not new models were found (`updated` output says
+        # which); a non-zero exit is a real error (bad API key, API failure)
+        # and should fail the run loudly.
         run: node scripts/update-models.mjs
         env:
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
 
       - name: Install dependencies
-        if: steps.update.outcome == 'success'
+        if: steps.update.outputs.updated == 'true'
         run: npm ci
 
       - name: Format models.json
-        if: steps.update.outcome == 'success'
+        if: steps.update.outputs.updated == 'true'
         run: npm run format
 
       - name: Create PR if models changed
-        if: steps.update.outcome == 'success'
+        if: steps.update.outputs.updated == 'true'
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           commit-message: 'chore: update models.json with new Gemini models'

--- a/scripts/update-models.mjs
+++ b/scripts/update-models.mjs
@@ -7,11 +7,16 @@
  * Usage: GOOGLE_API_KEY=... node scripts/update-models.mjs
  *
  * Exit codes:
- *   0 — models.json was updated with new models
- *   1 — no new models found (or error)
+ *   0 — success (whether or not new models were found)
+ *   1 — error (missing API key, API failure, validation failure)
+ *
+ * When run inside GitHub Actions, writes `updated=true|false` to $GITHUB_OUTPUT
+ * so the workflow can gate the PR-creation steps. Errors must exit non-zero so
+ * a broken API key or schema change fails the run loudly instead of looking
+ * like a quiet "no new models" week.
  */
 
-import { readFileSync, writeFileSync } from 'fs';
+import { readFileSync, writeFileSync, appendFileSync } from 'fs';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
 
@@ -107,6 +112,13 @@ function gaModelId(modelId) {
 	return modelId.replace(/-preview.*$/, '');
 }
 
+// Report whether models.json changed to the calling workflow (no-op outside CI).
+function setUpdatedOutput(updated) {
+	if (process.env.GITHUB_OUTPUT) {
+		appendFileSync(process.env.GITHUB_OUTPUT, `updated=${updated}\n`, 'utf-8');
+	}
+}
+
 function main() {
 	const apiKey = process.env.GOOGLE_API_KEY;
 	if (!apiKey) {
@@ -186,7 +198,8 @@ function main() {
 
 		if (newModels.length === 0) {
 			console.log('No new models found.');
-			process.exit(1);
+			setUpdatedOutput(false);
+			process.exit(0);
 		}
 
 		console.log(`Found ${newModels.length} new model(s):`);
@@ -219,6 +232,7 @@ function main() {
 		// Write with tab indentation to match Prettier's output for this repo
 		writeFileSync(MODELS_PATH, JSON.stringify(modelsFile, null, '\t') + '\n', 'utf-8');
 		console.log(`Updated ${MODELS_PATH}`);
+		setUpdatedOutput(true);
 		process.exit(0);
 	});
 }


### PR DESCRIPTION
## Summary

The weekly `check-models` workflow signaled "no new models found" with exit code 1 — the same code as a real failure. Two problems followed:

1. Every routine no-op run got a red `##[error]Process completed with exit code 1` annotation, making a healthy run look broken (this is what prompted the investigation of [run 29545295189](https://github.com/allenhutchison/obsidian-gemini/actions/runs/29545295189), which had actually succeeded).
2. `continue-on-error: true` swallowed real failures identically — an expired `GOOGLE_API_KEY` or an API schema change would keep the workflow green forever while silently never opening model-update PRs again.

`scripts/update-models.mjs` now exits 0 on both success paths and writes `updated=true|false` to `$GITHUB_OUTPUT` (a no-op when run locally); non-zero exits are reserved for real errors. The workflow drops `continue-on-error` and gates the npm/format/PR steps on the `updated` output, so genuine failures fail the run visibly.

Verified during diagnosis: the live API listing was compared against `models.json` — no eligible models are missing, and the two "Skipping … superseded" lines in the failing-looking run were correct preview-retirement behavior. The `models.list` endpoint exposes no output-modality or Interactions-only markers, so those remain manual curation via the PR checklist (unchanged).

## Changes

- `scripts/update-models.mjs`: exit 0 whether or not new models are found; report the distinction via `GITHUB_OUTPUT`; keep exit 1 for real errors (missing key, API failure, validation failure); document the new contract in the header comment
- `.github/workflows/model-update.yml`: remove `continue-on-error` from the check step; gate `npm ci` / `npm run format` / PR creation on `steps.update.outputs.updated == 'true'`

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: diagnosed and fixed directly with the maintainer in-session
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop — all three script paths exercised locally against the live API: no-op (exit 0, `updated=false`, models.json untouched), error (exit 1, no output), new model (exit 0, `updated=true`, entry appended)
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A: CI/tooling only, no plugin code
- [x] Documentation has been updated (if applicable) — N/A: no docs reference the workflow's exit-code contract; the script's own header comment is updated
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (Opus 4.8)
- [x] I have reviewed and understand all AI-generated code in this PR