### PR TITLE
refactor(agent-view): share collapsible-toggle helpers via leaf module

### DIFF
--- a/src/ui/agent-view/agent-view-messages.ts
+++ b/src/ui/agent-view/agent-view-messages.ts
@@ -9,6 +9,7 @@ import { Tool, DiffContext, ConfirmationResult } from '../../tools/types';
 import { t, getResolvedLocale } from '../../i18n';
 import { isToolExecutionMessage, parseToolSections } from './tool-section-parser';
 import { TOOL_ICONS } from './tool-icons';
+import { wireCollapsibleToggle } from './collapsible';
 
 // Documentation and help content
 const DOCS_BASE_URL = 'https://allenhutchison.github.io/obsidian-gemini';
@@ -308,19 +309,12 @@ export class AgentViewMessages {
 		details.hide();
 		await MarkdownRenderer.render(this.app, formatModelMessage(thoughts), details, sourcePath, this.viewContext);
 
-		const toggle = () => {
-			const nowExpanded = header.getAttribute('aria-expanded') !== 'true';
-			details.style.display = nowExpanded ? 'block' : 'none';
-			setIcon(chevron, nowExpanded ? 'chevron-down' : 'chevron-right');
-			row.toggleClass('gemini-tool-row-expanded', nowExpanded);
-			header.setAttribute('aria-expanded', String(nowExpanded));
-		};
-		header.addEventListener('click', toggle);
-		header.addEventListener('keydown', (e: KeyboardEvent) => {
-			if (e.key === 'Enter' || e.key === ' ') {
-				e.preventDefault();
-				toggle();
-			}
+		wireCollapsibleToggle({
+			control: header,
+			body: details,
+			chevron,
+			host: row,
+			expandedClass: 'gemini-tool-row-expanded',
 		});
 	}
 

--- a/src/ui/agent-view/agent-view-tool-display.ts
+++ b/src/ui/agent-view/agent-view-tool-display.ts
@@ -4,6 +4,7 @@ import { ToolResult } from '../../tools/types';
 import { formatFileSize } from '../../utils/format-utils';
 import { t } from '../../i18n';
 import { TOOL_ICONS } from './tool-icons';
+import { setCollapsibleExpanded, wireCollapsibleToggle } from './collapsible';
 
 /** Citation entry rendered for google_search / google_maps results. */
 interface SearchCitation {
@@ -51,44 +52,6 @@ function isGeneratedImageResult(
 
 function isFileContentResult(value: Record<string, unknown>): value is Record<string, unknown> & FileContentResult {
 	return typeof value.content === 'string' && typeof value.path === 'string';
-}
-
-/** Elements that make up one collapsible section (a tool group or a tool row). */
-interface CollapsibleRefs {
-	/** The clickable header; `aria-expanded` lives here and is the source of truth. */
-	control: HTMLElement;
-	/** The collapsible content shown/hidden. */
-	body: HTMLElement;
-	/** The chevron icon span, swapped between right/down. */
-	chevron: HTMLElement;
-	/** The element that carries the `*-expanded` class. */
-	host: HTMLElement;
-	/** e.g. `gemini-tool-group-expanded` / `gemini-tool-row-expanded`. */
-	expandedClass: string;
-}
-
-/** Apply the expanded/collapsed visual state to a collapsible section. */
-function setCollapsibleExpanded(refs: CollapsibleRefs, expanded: boolean): void {
-	refs.body.style.display = expanded ? 'block' : 'none';
-	setIcon(refs.chevron, expanded ? 'chevron-down' : 'chevron-right');
-	refs.host.toggleClass(refs.expandedClass, expanded);
-	refs.control.setAttribute('aria-expanded', String(expanded));
-}
-
-/**
- * Wire a header so click / Enter / Space toggles its collapsible body. State is
- * derived from `aria-expanded` so programmatic expansion (auto-expand on error)
- * and user toggling stay in sync.
- */
-function wireCollapsibleToggle(refs: CollapsibleRefs): void {
-	const toggle = () => setCollapsibleExpanded(refs, refs.control.getAttribute('aria-expanded') !== 'true');
-	refs.control.addEventListener('click', toggle);
-	refs.control.addEventListener('keydown', (e: KeyboardEvent) => {
-		if (e.key === 'Enter' || e.key === ' ') {
-			e.preventDefault();
-			toggle();
-		}
-	});
 }
 
 /**

--- a/src/ui/agent-view/collapsible.ts
+++ b/src/ui/agent-view/collapsible.ts
@@ -1,0 +1,39 @@
+import { setIcon } from 'obsidian';
+
+/** Elements that make up one collapsible section (a tool group, tool row, or reasoning row). */
+export interface CollapsibleRefs {
+	/** The clickable header; `aria-expanded` lives here and is the source of truth. */
+	control: HTMLElement;
+	/** The collapsible content shown/hidden. */
+	body: HTMLElement;
+	/** The chevron icon span, swapped between right/down. */
+	chevron: HTMLElement;
+	/** The element that carries the `*-expanded` class. */
+	host: HTMLElement;
+	/** e.g. `gemini-tool-group-expanded` / `gemini-tool-row-expanded`. */
+	expandedClass: string;
+}
+
+/** Apply the expanded/collapsed visual state to a collapsible section. */
+export function setCollapsibleExpanded(refs: CollapsibleRefs, expanded: boolean): void {
+	refs.body.style.display = expanded ? 'block' : 'none';
+	setIcon(refs.chevron, expanded ? 'chevron-down' : 'chevron-right');
+	refs.host.toggleClass(refs.expandedClass, expanded);
+	refs.control.setAttribute('aria-expanded', String(expanded));
+}
+
+/**
+ * Wire a header so click / Enter / Space toggles its collapsible body. State is
+ * derived from `aria-expanded` so programmatic expansion (auto-expand on error)
+ * and user toggling stay in sync.
+ */
+export function wireCollapsibleToggle(refs: CollapsibleRefs): void {
+	const toggle = () => setCollapsibleExpanded(refs, refs.control.getAttribute('aria-expanded') !== 'true');
+	refs.control.addEventListener('click', toggle);
+	refs.control.addEventListener('keydown', (e: KeyboardEvent) => {
+		if (e.key === 'Enter' || e.key === ' ') {
+			e.preventDefault();
+			toggle();
+		}
+	});
+}


### PR DESCRIPTION
## Summary

audit-architecture nightly sweep flagged a **DRY violation**: the collapsible expand/collapse wiring was factored into `wireCollapsibleToggle` / `setCollapsibleExpanded` inside `agent-view-tool-display.ts`, but those helpers were module-private. `agent-view-messages.ts`'s `renderReasoningSection` re-implemented the identical behavior by hand on the same `gemini-tool-row-*` class family — a line-for-line copy of the display toggle, chevron swap, `*-expanded` class flip, `aria-expanded` update, and Enter/Space keydown handler.

This is the natural next step of #1194 (which extracted those helpers within tool-display), following the same "unify into a shared leaf module" pattern as #1199 and #1214. Pure code motion plus reuse; no behavior change.

Not linked to a tracking issue — surfaced directly by the audit sweep as a mechanically-safe fix.

## Changes

- Add `src/ui/agent-view/collapsible.ts` — a leaf module exporting `CollapsibleRefs`, `setCollapsibleExpanded`, and `wireCollapsibleToggle`, moved verbatim from `agent-view-tool-display.ts`.
- `agent-view-tool-display.ts`: remove the local definitions; import the two helpers from `./collapsible` (existing call sites unchanged).
- `agent-view-messages.ts`: replace the hand-rolled toggle in `renderReasoningSection` with `wireCollapsibleToggle`, mapping the existing header/details/chevron/row elements onto `CollapsibleRefs`.

Left deliberately out of scope: the older tool-section toggle in `displayMessage` (`agent-view-messages.ts:191-201`) uses an inverse `gemini-agent-tool-content-collapsed` class with no `aria-expanded`/keyboard support; reusing the shared helper there would change behavior (add a11y, switch CSS strategy), so it belongs to a separate change, not this mechanical dedup.

## Screenshots / Screencast

N/A — no visual change. The reasoning callout renders and toggles exactly as before; the shared helper is byte-for-byte the same logic the hand-rolled copy implemented.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: mechanical DRY fix surfaced by the audit-architecture sweep
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — 3454 tests pass; build, lint (0 errors), and `typecheck:test` clean locally
- [x] I have tested this change on Desktop — verified via the full unit suite; behavior-preserving refactor with existing reasoning-render coverage
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A: no platform-specific APIs; DOM-only UI helper
- [x] Documentation has been updated (if applicable) — N/A: purely internal refactor, no user-facing behavior change
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (Opus 4.8)
- [x] I have reviewed and understand all AI-generated code in this PR

---

_Filed by the `audit-architecture` skill._

---
_Generated by [Claude Code](https://claude.ai/code/session_015GwxirtkHrXV4k4ugFWtsi)_