### PR TITLE
chore(daily): 2026-07-16 daily update

### DIFF
--- a/docs/guide/agent-mode.md
+++ b/docs/guide/agent-mode.md
@@ -170,7 +170,7 @@ Context files are displayed in a **unified file shelf** — a horizontal strip a
 3. Click the file icon in the session header to open the multi-select modal:
    - Already-added files appear pre-checked
    - Type to fuzzy-search; **Enter** toggles a file or folder; **Esc** confirms and closes
-   - Selecting a folder adds all markdown files inside it (folders are re-expanded each turn, so newly added files are automatically included)
+   - Selecting a folder adds all text files inside it — markdown plus other text formats like `.canvas`, `.base`, `.json` (folders are re-expanded each turn, so newly added files are automatically included)
    - Unchecking a file or folder removes it from context
 4. Drag and drop files or folders from the file explorer or your OS
 5. Paste images from your clipboard
@@ -188,7 +188,7 @@ For detailed information about context files and advanced usage, see the [Contex
 ### Session Management
 
 - Each conversation is a separate session
-- Sessions persist across Obsidian restarts
+- Sessions persist across Obsidian restarts when the "Session History" setting is enabled (off by default — see [Settings Reference](/reference/settings))
 - Access previous sessions from the dropdown
 - Configure session-specific settings
 - Sessions are automatically titled with a YYYY-MM-DD date prefix and AI-generated description after the first exchange

--- a/docs/guide/context-system.md
+++ b/docs/guide/context-system.md
@@ -116,7 +116,7 @@ For adding, reviewing, or removing multiple files at once:
 
 **Folder support:**
 
-Folders appear alongside files in the list (identified by a folder icon and a trailing `/`). Selecting a folder toggles all the markdown files inside it at once. The check icon reflects the folder's state:
+Folders appear alongside files in the list (identified by a folder icon and a trailing `/`). Selecting a folder toggles all the text files inside it at once (markdown plus other text formats like `.canvas`, `.base`, `.json`). The check icon reflects the folder's state:
 
 - **☑ Filled** — all files in the folder are selected
 - **☐ Partial** (minus) — some files selected
@@ -190,7 +190,7 @@ To remove a file from context:
 Context files persist:
 
 - ✅ Throughout the current session
-- ✅ Across Obsidian restarts
+- ✅ Across Obsidian restarts, when the "Session History" setting is enabled (off by default — see [Settings Reference](/reference/settings))
 - ✅ When loading saved sessions
 - ❌ When creating a new session
 

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -247,8 +247,8 @@ Compaction isn't only checked before the initial request — `AgentLoop` re-chec
 - **Type**: Boolean
 - **Default**: `false`
 - **Description**: Display estimated token count in the agent input area
-- **Display format**: `Tokens: ~N (Y new) / M (X%)` showing total prompt tokens, uncached (new) tokens, model limit, and percentage used
-- **How it works**: Token counts update live after each API response, including during tool call chains. Gemini's implicit caching means repeated content (system prompt, tool definitions) is served from cache — the "new" count shows tokens that aren't cached
+- **Display format**: `Tokens: ~N / M (X%)` showing total prompt tokens, model limit, and percentage used. When part of the prompt was served from Gemini's cache, an additional `· Y% cached` suffix appears
+- **How it works**: Token counts update live after each API response, including during tool call chains. Gemini's implicit caching means repeated content (system prompt, tool definitions) is often served from cache — the cached percentage rewards stable prefixes (system prompt, pinned history)
 - **Visual indicators**:
   - Normal (muted text) — well under threshold
   - Yellow — approaching compaction threshold (≥80% of threshold)

--- a/planning/changelog/2026-07-16.md
+++ b/planning/changelog/2026-07-16.md
@@ -1,0 +1,32 @@
+# Daily changelog — July 16, 2026
+
+**Date:** 2026-07-16
+**PRs merged:** 5
+
+---
+
+## Summary
+
+A busy day: two live-API bugs got fixed same-day (a session auto-label collision and a Gemini 2.5 compatibility break on both API paths), a retired model was migrated cleanly, an `audit-architecture` DRY refactor landed, and the previous day's housekeeping PR merged.
+
+## What shipped
+
+### [#1218 refactor(agent): dedup session tool-migration into shared migrator](https://github.com/allenhutchison/obsidian-gemini/pull/1218)
+
+The `audit-architecture` nightly sweep flagged that `SessionManager`'s private `migrateLegacyEnabledTools` was byte-for-byte identical to the shared `migrateLegacyToolCategoryArray` in `src/services/feature-policy-yaml.ts`, already used by hooks and scheduled tasks. This PR deletes the private copy and points session parsing at the shared function — a pure internal refactor with no behavior change. It also removes a same-name collision with an unrelated exported function in `feature-definition.ts`.
+
+### [#1223 chore(daily): 2026-07-15 daily update](https://github.com/allenhutchison/obsidian-gemini/pull/1223)
+
+The automated daily housekeeping run for 2026-07-15: a changelog covering that day's 3 PRs, 3 conceptual doc-drift fixes across the FAQ, provider-capabilities reference, and custom-prompts guide, and a no-op triage pass.
+
+### [#1222 fix(gemini): restore Gemini 2.5 compatibility on both API paths](https://github.com/allenhutchison/obsidian-gemini/pull/1222)
+
+Gemini 2.5 models were failing with 400 INVALID_ARGUMENT on both API paths, for two separate reasons confirmed against the live API. On `generateContent`, the client was sending `thinkingConfig.thinkingLevel` to every thinking-capable model, but that knob is 3.x-only — 2.5 needs the legacy `thinkingBudget: -1` instead, so `generateContent` requests now branch on model family. On the Interactions path, function results were serialized as a multimodal content-item array, which 2.5 rejects; they're now sent as a plain string, which both 2.5 and 3.x accept.
+
+### [#1221 fix(agent-view): make session auto-label rename collision-safe](https://github.com/allenhutchison/obsidian-gemini/pull/1221)
+
+Session auto-labeling could throw "Destination file already exists!" when the AI-generated title collided with an existing file in `Agent-Sessions/`, leaving the session title updated in memory but the history file un-renamed. The rename now resolves through the existing `resolveUniquePath` helper, appending `-1`, `-2`, … until a free slot is found, and skips the rename entirely when the generated path already matches the current file.
+
+### [#1224 fix(models): retire gemini-3-pro-preview, migrate users to 3.1 successor](https://github.com/allenhutchison/obsidian-gemini/pull/1224)
+
+Google removed `gemini-3-pro-preview` from the API (confirmed live via 404s on both API paths). This PR drops it from the bundled catalog and adds a `RETIRED_MODEL_SUCCESSORS` map so any user still configured on the retired model migrates to `gemini-3.1-pro-preview` instead of falling back to the generic role default. The model-updater script is also guarded against re-adding the retired id.


### PR DESCRIPTION
## Summary

Automated daily housekeeping run (`daily-update` meta-skill via the `maintainerd` plugin marketplace) bundling `daily-changelog`, `audit-product-docs`, and `triage-issues` for 2026-07-16.

Fixes N/A — routine automated daily housekeeping run.

## Changes

- **daily-changelog**: wrote [`planning/changelog/2026-07-16.md`](https://github.com/allenhutchison/obsidian-gemini/blob/daily-update-2026-07-17/planning/changelog/2026-07-16.md) — 5 PRs merged on 2026-07-16: [#1218](https://github.com/allenhutchison/obsidian-gemini/pull/1218) (session tool-migration dedup refactor), [#1223](https://github.com/allenhutchison/obsidian-gemini/pull/1223) (2026-07-15 daily update), [#1222](https://github.com/allenhutchison/obsidian-gemini/pull/1222) (Gemini 2.5 compatibility fix on both API paths), [#1221](https://github.com/allenhutchison/obsidian-gemini/pull/1221) (session auto-label rename collision fix), and [#1224](https://github.com/allenhutchison/obsidian-gemini/pull/1224) (retire `gemini-3-pro-preview`, migrate users to the 3.1 successor).
- **audit-product-docs**: read and validated all 23 files under `config.paths.productDocs` (README.md, AGENTS.md, all of `docs/guide/`, all of `docs/reference/`) against current `src/`. Fixed 3 conceptual drift items:
  - `docs/reference/settings.md` — the "Show Token Usage" **Display format** entry claimed an `(Y new)` uncached-token segment that doesn't exist in the actual format strings (`src/i18n/en.ts`'s `agent.tokens.usage`/`agent.tokens.usageCached`); corrected to describe the real cached-percentage suffix.
  - `docs/guide/agent-mode.md` and `docs/guide/context-system.md` — both stated session/context persistence "across Obsidian restarts" as an unconditional fact. In reality this depends on the "Session History" setting (`chatHistory`), which is **off by default** (`src/agent/session-history.ts` early-returns when it's disabled). Added the caveat with a link to the settings reference.
  - `docs/guide/agent-mode.md` and `docs/guide/context-system.md` — both claimed folder selection adds "all markdown files inside it." The code (`getTextFilesFromFolder` in `src/ui/agent-view/agent-view-shelf.ts`) actually adds every file classified as `FileCategory.TEXT`, which includes `.canvas`, `.base`, `.json`, etc., not just `.md`. Corrected the wording to "text files."
  - No new docs warranted — recent commits since the prior audit were internal fixes/refactors with no uncovered user-visible surface.
- **triage-issues**: no-op — no unlabeled open issues (all 19 open issues already carry labels).

This is a housekeeping-only PR — no `src/` behavior changes.

## Screenshots / Screencast

N/A — changelog and docs-only change, no UI change.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A; routine automated daily housekeeping run
- [x] All CI checks pass (`npm test` — 3454 passing, `npm run build`, `npm run format-check`, `npm run lint`, `npm run typecheck:test`)
- [x] I have tested this change on Desktop — N/A, changelog/docs-only change; verified via local pre-flight checks
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A, no code change
- [x] Documentation has been updated (if applicable) — this PR's own `audit-product-docs` pass is the documentation update (see Changes above)
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR


---
_Generated by [Claude Code](https://claude.ai/code/session_01EVSWPQ3heSqD9KtB5rJwzb)_