### PR TITLE
chore(daily): 2026-07-18 daily update

### DIFF
--- a/docs/guide/background-tasks.md
+++ b/docs/guide/background-tasks.md
@@ -32,7 +32,7 @@ Completed tasks with output files show an **Open result** link that opens the fi
 
 Background tasks are created automatically when you trigger long-running operations:
 
-- **Deep Research** — starts a research task; result saved to `[state-folder]/Background-Tasks/YYYY-MM-DD <topic>.md` by default (you can specify a custom path via the `outputFile` parameter)
+- **Deep Research** — the agent is steered to run research in the background by default (via its system prompt), and when it does, the result is saved to `[state-folder]/Background-Tasks/YYYY-MM-DD <topic>.md` (you can specify a custom path via the `outputFile` parameter). This is a prompted default, not enforced by the tool itself — if the agent runs research in the foreground instead, no file is saved unless `outputFile` is set.
 - **Image Generation** — generates and saves an image; result path shown in the completion notice. The **Generate image** command palette entry also routes through the background system: it returns control immediately and inserts the wikilink at your captured cursor position when the task completes (or shows a Notice with the wikilink to copy if you've moved on from the source note).
 
 Both operations fire a completion notice with a clickable vault link when done. If a task fails, a notice explains the error.

--- a/docs/guide/custom-prompts.md
+++ b/docs/guide/custom-prompts.md
@@ -163,7 +163,7 @@ When a custom prompt is active, you'll see a badge in the session header showing
 For advanced users who want complete control:
 
 1. Set `override_system_prompt: true` in your prompt file
-2. Enable "Allow System Prompt Override" in plugin settings
+2. Enable "Allow system prompt override" in plugin settings
 3. Your prompt will completely replace the default system instructions
 
 **Warning:** Use with caution as this removes built-in safety features and Obsidian-specific knowledge.

--- a/docs/reference/loop-detection.md
+++ b/docs/reference/loop-detection.md
@@ -41,5 +41,5 @@ In addition to the per-tool detection above, the agent loop counts how many time
 - Uses deterministic key generation for tool calls to ensure consistent detection
 - Automatically cleans up old execution history to prevent memory issues
 - Session-specific tracking - each agent session has its own loop detection history
-- History is cleared when creating new sessions or loading from history
+- History is keyed per session ID, so a brand-new session starts with no prior detection state; loading an existing session's history does not clear it (prior detector state for that session persists)
 - Per-turn abort threshold is fixed at 3 fires; the per-tool threshold and time window above are user-configurable

--- a/planning/changelog/2026-07-17.md
+++ b/planning/changelog/2026-07-17.md
@@ -1,0 +1,32 @@
+# Daily changelog — July 17, 2026
+
+**Date:** 2026-07-17
+**PRs merged:** 5
+
+---
+
+## Summary
+
+Two live-API routing fixes landed (an Interactions-only model and a noisy-but-harmless CI exit code), followed by a pair of mechanical `audit-architecture` cleanups and the previous day's housekeeping PR.
+
+## What shipped
+
+### [#1225 fix(gemini): route interactions-only models (Gemini Omni) via Interactions API](https://github.com/allenhutchison/obsidian-gemini/pull/1225)
+
+`gemini-omni-flash-preview` is an image-generation model only served by the Interactions API — `generateContent` returned a 400, verified against the live API. The catalog gains a new `interactionsOnly` flag, and the client routes flagged models through the Interactions path regardless of the `useInteractionsApi` toggle, covering per-session overrides and stale persisted settings. Direct-SDK callers that always used `generateContent` (search grounding, web fetch, RAG file search, compaction) now substitute a `generateContent`-capable model instead of hard-failing, and image generation for interactions-only models routes through a new `generateImageViaInteractions()`.
+
+### [#1226 fix(ci): fail check-models loudly on real errors, exit 0 on no-op](https://github.com/allenhutchison/obsidian-gemini/pull/1226)
+
+The weekly `check-models` workflow used exit code 1 for both "no new models found" and genuine failures, so every routine no-op run showed a red error annotation while `continue-on-error: true` masked real problems (an expired API key would keep the workflow green forever). `scripts/update-models.mjs` now exits 0 on both success paths and reports the distinction via a `updated=true|false` `$GITHUB_OUTPUT`; the workflow drops `continue-on-error` and gates its remaining steps on that output.
+
+### [#1227 refactor(agent-view): share collapsible-toggle helpers via leaf module](https://github.com/allenhutchison/obsidian-gemini/pull/1227)
+
+The `audit-architecture` sweep found that `agent-view-messages.ts`'s `renderReasoningSection` had hand-rolled a line-for-line copy of the collapsible expand/collapse wiring already factored into `agent-view-tool-display.ts` (chevron swap, `*-expanded` class flip, `aria-expanded`, Enter/Space keydown). Both call sites now share `wireCollapsibleToggle`/`setCollapsibleExpanded` from a new `src/ui/agent-view/collapsible.ts` leaf module. Pure code motion, no behavior change.
+
+### [#1228 chore(knip): drop two redundant knip config entries](https://github.com/allenhutchison/obsidian-gemini/pull/1228)
+
+Another `audit-architecture` finding: `knip.json` carried two entries knip no longer needs — `@typescript-eslint/parser` in `ignoreDependencies` (knip now detects it as used via the ESLint flat config) and `src/main.ts!` in `entry` (already resolved via `package.json`'s `main` field). Removing both leaves `npm run knip` fully clean, with no dead-export regressions.
+
+### [#1230 chore(daily): 2026-07-16 daily update](https://github.com/allenhutchison/obsidian-gemini/pull/1230)
+
+The automated daily housekeeping run for 2026-07-16: a changelog covering that day's 5 PRs, 3 conceptual doc-drift fixes (a token-usage display format claim, two "persists across restarts" claims missing the Session History setting caveat, and a folder-selection wording fix), and a no-op triage pass.


### PR DESCRIPTION
## Summary

Automated daily housekeeping run (`daily-update` meta-skill via the `maintainerd` plugin marketplace) bundling `daily-changelog`, `audit-product-docs`, and `triage-issues` for 2026-07-17.

Fixes N/A — routine automated daily housekeeping run.

## Changes

- **daily-changelog**: wrote [`planning/changelog/2026-07-17.md`](https://github.com/allenhutchison/obsidian-gemini/blob/daily-update-2026-07-18/planning/changelog/2026-07-17.md) — 5 PRs merged on 2026-07-17: [#1225](https://github.com/allenhutchison/obsidian-gemini/pull/1225) (Interactions-only model routing for Gemini Omni), [#1226](https://github.com/allenhutchison/obsidian-gemini/pull/1226) (check-models CI exit-code fix), [#1227](https://github.com/allenhutchison/obsidian-gemini/pull/1227) (shared collapsible-toggle helper refactor), [#1228](https://github.com/allenhutchison/obsidian-gemini/pull/1228) (knip config cleanup), and [#1230](https://github.com/allenhutchison/obsidian-gemini/pull/1230) (the prior day's daily-update PR).
- **audit-product-docs**: read all files under `config.paths.productDocs` (README.md, all of `docs/guide/`, all of `docs/reference/`) against current `src/`. The Interactions-API / `interactionsOnly` documentation added by #1225 was spot-checked and found accurate. Fixed 3 further drift items:
  - `docs/reference/loop-detection.md` — conceptual: claimed loop-detector history "is cleared when creating new sessions or loading from history." `ToolExecutionEngine.clearExecutionHistory()` has no production callers anywhere in `src/` — only a fresh session's new sessionId key incidentally starts clean; loading an existing session's history does not clear prior detector state. Corrected the wording.
  - `docs/guide/background-tasks.md` — conceptual: implied Deep Research saves to `Background-Tasks/YYYY-MM-DD <topic>.md` automatically by default. In code, background mode is an explicit agent-tool parameter (`params.background`) the model sets — steered by the system prompt, not enforced by the tool. A foreground run with no `outputFile` saves nothing. Added the caveat.
  - `docs/guide/custom-prompts.md` — cosmetic: `"Allow System Prompt Override"` didn't match the actual settings-UI string, `"Allow system prompt override"` (sentence case). Corrected.
  - No new docs warranted — today's other PRs (#1226–#1228) were CI/tooling/internal-refactor changes with no uncovered user-visible surface.
- **triage-issues**: no-op — no unlabeled open issues.

This is a housekeeping-only PR — no `src/` behavior changes.

## Screenshots / Screencast

N/A — changelog and docs-only change, no UI change.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A; routine automated daily housekeeping run
- [x] All CI checks pass (`npm test` — 3477 passing, `npm run build`, `npm run format-check`, `npm run lint`, `npm run typecheck:test`)
- [x] I have tested this change on Desktop — N/A, changelog/docs-only change; verified via local pre-flight checks
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A, no code change
- [x] Documentation has been updated (if applicable) — this PR's own `audit-product-docs` pass is the documentation update (see Changes above)
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR


---
_Generated by [Claude Code](https://claude.ai/code/session_01NuaguDLQNn8gHbwux1d3F6)_