### PR TITLE
chore(daily): 2026-07-18 daily update

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ _A large feature release — a full visual refresh plus smarter, more responsive
 5. Manage sessions directly with command palette actions: "New agent session", "Browse agent sessions", "Link project to agent session", and "Agent session settings"
 6. Start using the AI agent to work with your vault!
 
-**Prefer running models locally?** Gemini Scribe also supports [Ollama](https://ollama.com) — install Ollama, pull a model with `ollama pull llama3.2`, and switch the **Provider** in settings to "Ollama (local)". A few Gemini-built-in features (Google Search, URL Context, Deep Research, image generation, RAG) are unavailable on Ollama; see [docs/guide/ollama-setup.md](docs/guide/ollama-setup.md) for details.
+**Prefer running models locally?** Gemini Scribe also supports [Ollama](https://ollama.com) — install Ollama, pull a model with `ollama pull llama3.2`, and switch the **Provider** in settings to "Ollama (local)". A few Gemini-built-in features (Google Search, Google Maps, URL Context, Deep Research, image generation, RAG) are unavailable on Ollama; see [docs/guide/ollama-setup.md](docs/guide/ollama-setup.md) for details.
 
 ## Installation
 

--- a/docs/guide/faq.md
+++ b/docs/guide/faq.md
@@ -92,6 +92,7 @@ A few Gemini-specific features are unavailable on Ollama — these all depend on
 - **Deep Research** (requires Google Search grounding)
 - **Semantic vault search / RAG** (requires the Gemini File Search API)
 - **Google Search grounding** in agent mode
+- **Google Maps grounding** in agent mode
 - **URL Context** web-fetch tool
 - **Image generation** (Imagen API)
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -30,7 +30,7 @@ Welcome to Gemini Scribe, an Obsidian plugin that integrates Google's Gemini AI 
 
 ### Prefer running models locally?
 
-Gemini Scribe also supports [Ollama](https://ollama.com) as a provider so you can use local models such as Llama 3.2, Qwen 2.5, or Gemma 3 without an API key. Some Gemini-built-in features (Google Search, URL Context, Deep Research, image generation, RAG) are unavailable on Ollama. See the [Ollama Setup Guide](/guide/ollama-setup) for details.
+Gemini Scribe also supports [Ollama](https://ollama.com) as a provider so you can use local models such as Llama 3.2, Qwen 2.5, or Gemma 3 without an API key. Some Gemini-built-in features (Google Search, Google Maps, URL Context, Deep Research, image generation, RAG) are unavailable on Ollama. See the [Ollama Setup Guide](/guide/ollama-setup) for details.
 
 ## Feature Overview
 

--- a/planning/changelog/2026-07-18.md
+++ b/planning/changelog/2026-07-18.md
@@ -1,0 +1,20 @@
+# Daily changelog — July 18, 2026
+
+**Date:** 2026-07-18
+**PRs merged:** 2
+
+---
+
+## Summary
+
+Quiet day — just the automated AI-translation refresh and the previous day's housekeeping PR landing.
+
+## What shipped
+
+### [#1231 chore(i18n): Update UI translations](https://github.com/allenhutchison/obsidian-gemini/pull/1231)
+
+Automated translation update regenerating `src/i18n/` from the current English source strings in `src/i18n/en.ts`. Only keys whose English message or context changed were retranslated — hand-refined translations for unchanged keys were preserved, and keys removed from `en.ts` were pruned from every language.
+
+### [#1232 chore(daily): 2026-07-18 daily update](https://github.com/allenhutchison/obsidian-gemini/pull/1232)
+
+The automated daily housekeeping run for 2026-07-17: a changelog covering that day's 5 PRs, 3 documentation drift fixes (a loop-detector history-clearing claim, a Deep Research background-save default, and a settings-label casing fix), and a no-op triage pass.


### PR DESCRIPTION
## Summary

Automated daily housekeeping run (`daily-update` meta-skill via the `maintainerd` plugin marketplace) bundling `daily-changelog`, `audit-product-docs`, and `triage-issues` for 2026-07-18.

Fixes N/A — routine automated daily housekeeping run.

## Changes

- **daily-changelog**: wrote [`planning/changelog/2026-07-18.md`](https://github.com/allenhutchison/obsidian-gemini/blob/daily-update-2026-07-19/planning/changelog/2026-07-18.md) — 2 PRs merged on 2026-07-18: [#1231](https://github.com/allenhutchison/obsidian-gemini/pull/1231) (automated i18n translation refresh) and [#1232](https://github.com/allenhutchison/obsidian-gemini/pull/1232) (the prior day's daily-update PR).
- **audit-product-docs**: read all files under `config.paths.productDocs` (README.md, AGENTS.md, all of `docs/guide/`, all of `docs/reference/`) against current `src/`, cross-checking settings defaults, command IDs, the tool registry, timeouts, frontmatter schemas, and other constants via direct greps and parallel research passes. Everything checked out clean except one recurring omission: the "unavailable on Ollama" feature enumeration in three docs listed Google Search, URL Context, Deep Research, image generation, and RAG as Gemini-only — but omitted **Google Maps grounding**, which is also Gemini-only (confirmed against `docs/guide/agent-mode.md` and `docs/reference/provider-capabilities.md`, which already had it right). Fixed in:
  - `README.md`
  - `docs/guide/getting-started.md`
  - `docs/guide/faq.md`
  - No new docs warranted — the recent commit range (#1224 retired-model migration, #1225 Interactions-API-only model routing, #1198 skill slash-token insertion, plus assorted internal refactors) is either already accurately documented or has no user-facing surface.
- **triage-issues**: no-op — no unlabeled open issues (`no:label` search returned 0 results).

This is a housekeeping-only PR — no `src/` behavior changes.

## Screenshots / Screencast

N/A — changelog and docs-only change, no UI change.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A; routine automated daily housekeeping run
- [x] All CI checks pass (`npm test` — 3477 passing, `npm run build`, `npm run format-check`, `npm run lint`, `npm run typecheck:test`)
- [x] I have tested this change on Desktop — N/A, changelog/docs-only change; verified via local pre-flight checks
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A, no code change
- [x] Documentation has been updated (if applicable) — this PR's own `audit-product-docs` pass is the documentation update (see Changes above)
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR


---
_Generated by [Claude Code](https://claude.ai/code/session_01EpAzV2oXZ3HBTLXxnHVDmL)_