### PR TITLE
chore(daily): 2026-07-21 daily update

### DIFF
--- a/planning/changelog/2026-07-21.md
+++ b/planning/changelog/2026-07-21.md
@@ -1,0 +1,16 @@
+# Daily changelog — July 21, 2026
+
+**Date:** 2026-07-21
+**PRs merged:** 1
+
+---
+
+## Summary
+
+Quiet day — the only PR merged was the automated daily-housekeeping run from the prior day.
+
+## What shipped
+
+### [#1236 chore(daily): 2026-07-20 daily update](https://github.com/allenhutchison/obsidian-gemini/pull/1236)
+
+Automated daily housekeeping run bundling `daily-changelog`, `audit-product-docs`, and `triage-issues` for 2026-07-20: wrote the 2026-07-20 changelog (a quiet day with no PRs), found no product-doc drift, and confirmed all open issues already carried labels.


### PR DESCRIPTION
## Summary

Automated daily housekeeping run (`daily-update` meta-skill via the `maintainerd` plugin marketplace) bundling `daily-changelog`, `audit-product-docs`, and `triage-issues` for 2026-07-21.

Fixes N/A — routine automated daily housekeeping run.

## Changes

- **daily-changelog**: wrote [`planning/changelog/2026-07-21.md`](https://github.com/allenhutchison/obsidian-gemini/blob/daily-update-2026-07-22/planning/changelog/2026-07-21.md) — 1 PR merged on 2026-07-21 (#1236, the prior day's automated daily-update PR — a quiet day itself).
- **audit-product-docs**: read all files under `config.paths.productDocs` (README.md, all of `docs/guide/`, all of `docs/reference/`, AGENTS.md) and cross-checked settings names/defaults, tool names, command IDs, and model defaults against `src/`. No `src/` changes landed since the prior audit (2026-07-20), so this confirms the doc set is still accurate — no drift found, no new docs warranted.
- **triage-issues**: no unlabeled open issues — no-op.

This is a housekeeping-only PR — no `src/` behavior changes.

## Screenshots / Screencast

N/A — changelog-only change, no UI change.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A; routine automated daily housekeeping run
- [x] All CI checks pass (`npm test` — 3477 passing, `npm run build`, `npm run format-check`, `npm run lint`, `npm run typecheck:test`)
- [x] I have tested this change on Desktop — N/A, changelog-only change; verified via local pre-flight checks
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A, no code change
- [x] Documentation has been updated (if applicable) — N/A, this PR's content is the changelog itself; the docs audit found no drift to fix
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR


---
_Generated by [Claude Code](https://claude.ai/code/session_015bBCF2SV9KSZZEjUxhCx2N)_