### PR TITLE
test(agent-view): add regression coverage for tool-display result dispatch

### DIFF
--- a/test/ui/agent-view/agent-view-tool-display.test.ts
+++ b/test/ui/agent-view/agent-view-tool-display.test.ts
@@ -1,0 +1,250 @@
+import { AgentViewToolDisplay } from '../../../src/ui/agent-view/agent-view-tool-display';
+import type { ToolResult } from '../../../src/tools/types';
+
+// The obsidian alias (see vitest.config.ts) resolves `obsidian` to __mocks__/obsidian.js,
+// which stubs setIcon as a no-op and exports TFile. The renderer under test dispatches on
+// the *runtime shape* of a tool result through a set of module-private type guards
+// (isCitationAnswerResult / isGeneratedImageResult / isFileContentResult); these tests pin
+// that dispatch through the public showToolResult render path so they survive helper
+// reshuffling, rather than reaching into the private guards directly.
+
+/**
+ * Add the Obsidian DOM sugar (createDiv/createEl/createSpan/addClass/removeClass/hasClass/
+ * empty/appendText) that jsdom lacks. The global vitest setup already patches
+ * hide/show/toggle/toggleClass onto HTMLElement.prototype; the element-factory helpers with
+ * cls/text/attr options stay per-test, mirroring test/ui/agent-view/agent-view-progress.test.ts.
+ */
+function addObsidianMethods(el: HTMLElement): HTMLElement {
+	const anyEl = el as any;
+	anyEl.createEl = function (tag: string, opts?: any) {
+		const elem = document.createElement(tag);
+		if (opts?.cls) elem.className = opts.cls;
+		if (opts?.text !== undefined) elem.textContent = opts.text;
+		if (opts?.href) (elem as HTMLAnchorElement).href = opts.href;
+		if (opts?.attr) {
+			for (const [key, val] of Object.entries(opts.attr)) {
+				elem.setAttribute(key, val as string);
+			}
+		}
+		addObsidianMethods(elem);
+		this.appendChild(elem);
+		return elem;
+	};
+	anyEl.createDiv = function (opts?: any) {
+		return this.createEl('div', opts);
+	};
+	anyEl.createSpan = function (opts?: any) {
+		return this.createEl('span', opts);
+	};
+	anyEl.addClass = function (cls: string) {
+		this.classList.add(cls);
+	};
+	anyEl.removeClass = function (cls: string) {
+		this.classList.remove(cls);
+	};
+	anyEl.hasClass = function (cls: string) {
+		return this.classList.contains(cls);
+	};
+	anyEl.empty = function () {
+		this.innerHTML = '';
+	};
+	anyEl.appendText = function (text: string) {
+		this.appendChild(document.createTextNode(text));
+	};
+	return el;
+}
+
+describe('AgentViewToolDisplay', () => {
+	let container: HTMLElement;
+	let display: AgentViewToolDisplay;
+	let plugin: any;
+	let execCounter = 0;
+
+	beforeEach(() => {
+		document.body.innerHTML = '';
+		container = addObsidianMethods(document.createElement('div'));
+		document.body.appendChild(container);
+
+		plugin = {
+			logger: { log: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+			toolRegistry: { getTool: vi.fn().mockReturnValue({ displayName: 'Tool' }) },
+			app: {
+				vault: {
+					// Null keeps the generate_image branch on its "no TFile" path so the test
+					// doesn't depend on resource-path plumbing; the branch is still chosen.
+					getAbstractFileByPath: vi.fn().mockReturnValue(null),
+					getResourcePath: vi.fn().mockReturnValue('app://resource'),
+				},
+			},
+		};
+
+		display = new AgentViewToolDisplay(container, plugin);
+	});
+
+	afterEach(() => {
+		document.body.innerHTML = '';
+	});
+
+	/**
+	 * Render a tool result through the full public path (create the row, then feed the
+	 * result) and return the row's details element that holds the rendered output.
+	 */
+	async function renderResult(toolName: string, result: ToolResult): Promise<HTMLElement> {
+		const executionId = `exec-${++execCounter}`;
+		await display.showToolExecution(toolName, {}, executionId);
+		await display.showToolResult(toolName, result, executionId);
+		const details = container.querySelector('.gemini-tool-row-details') as HTMLElement;
+		expect(details).toBeTruthy();
+		return details;
+	}
+
+	describe('citation-answer dispatch (isCitationAnswerResult)', () => {
+		it('renders the search-answer + citations branch for a well-formed google_search result', async () => {
+			const details = await renderResult('google_search', {
+				success: true,
+				data: {
+					answer: 'The capital is [Paris](https://example.com/paris).',
+					citations: [{ title: 'Paris', url: 'https://example.com/paris', snippet: 'A city.' }],
+				},
+			});
+
+			expect(details.querySelector('.gemini-agent-tool-search-answer')).toBeTruthy();
+			const citations = details.querySelector('.gemini-agent-tool-citations');
+			expect(citations).toBeTruthy();
+			// The markdown link in the answer becomes a real anchor.
+			const answerLink = details.querySelector('.gemini-agent-tool-search-answer a') as HTMLAnchorElement;
+			expect(answerLink?.textContent).toBe('Paris');
+			expect(answerLink?.getAttribute('href')).toBe('https://example.com/paris');
+			// It is NOT the generic object fallback.
+			expect(details.querySelector('.gemini-agent-tool-result-object')).toBeFalsy();
+		});
+
+		it('falls back to the generic object branch when the toolName is not a search tool', async () => {
+			// Citation-shaped payload, but read_file is not a search tool: the toolName gate
+			// keeps it out of the citation branch.
+			const details = await renderResult('read_file', {
+				success: true,
+				data: { answer: 'hi', citations: [{ url: 'https://example.com' }] },
+			});
+
+			expect(details.querySelector('.gemini-agent-tool-search-answer')).toBeFalsy();
+			expect(details.querySelector('.gemini-agent-tool-result-object')).toBeTruthy();
+		});
+
+		it('falls back to the generic object branch for a near-miss shape (citations not an array)', async () => {
+			const details = await renderResult('google_search', {
+				success: true,
+				data: { answer: 'hi', citations: 'not-an-array' },
+			});
+
+			expect(details.querySelector('.gemini-agent-tool-search-answer')).toBeFalsy();
+			expect(details.querySelector('.gemini-agent-tool-result-object')).toBeTruthy();
+		});
+	});
+
+	describe('generated-image dispatch (isGeneratedImageResult)', () => {
+		it('renders the image-result branch for a well-formed generate_image result', async () => {
+			const details = await renderResult('generate_image', {
+				success: true,
+				data: { path: 'images/out.png', wikilink: '![[images/out.png]]', prompt: 'a cat' },
+			});
+
+			expect(details.querySelector('.gemini-agent-tool-image-result')).toBeTruthy();
+			expect(details.querySelector('.gemini-agent-tool-result-object')).toBeFalsy();
+		});
+
+		it('falls back to the generic object branch for a near-miss shape (missing wikilink)', async () => {
+			const details = await renderResult('generate_image', {
+				success: true,
+				data: { path: 'images/out.png' },
+			});
+
+			expect(details.querySelector('.gemini-agent-tool-image-result')).toBeFalsy();
+			expect(details.querySelector('.gemini-agent-tool-result-object')).toBeTruthy();
+		});
+	});
+
+	describe('file-content dispatch (isFileContentResult)', () => {
+		it('renders the file-info branch plus code for a well-formed read_file result', async () => {
+			const details = await renderResult('read_file', {
+				success: true,
+				data: { content: 'file body', path: 'notes/todo.md', size: 1234 },
+			});
+
+			expect(details.querySelector('.gemini-agent-tool-file-info')).toBeTruthy();
+			expect(details.querySelector('.gemini-agent-tool-code-result')).toBeTruthy();
+			expect(details.querySelector('.gemini-agent-tool-result-object')).toBeFalsy();
+		});
+
+		it('falls back to the generic object branch for a near-miss shape (missing path)', async () => {
+			const details = await renderResult('read_file', {
+				success: true,
+				data: { content: 'file body' },
+			});
+
+			expect(details.querySelector('.gemini-agent-tool-file-info')).toBeFalsy();
+			expect(details.querySelector('.gemini-agent-tool-result-object')).toBeTruthy();
+		});
+	});
+
+	describe('generic object fallback', () => {
+		it('renders key/value items for a record matching no guard', async () => {
+			const details = await renderResult('some_tool', {
+				success: true,
+				data: { foo: 'bar', count: 3 },
+			});
+
+			const object = details.querySelector('.gemini-agent-tool-result-object');
+			expect(object).toBeTruthy();
+			expect(object?.querySelectorAll('.gemini-agent-tool-result-item').length).toBe(2);
+		});
+	});
+
+	describe('renderTruncatableCode (via string result data)', () => {
+		it('renders short string data inline with no expand button', async () => {
+			const details = await renderResult('some_tool', { success: true, data: 'short output' });
+
+			const code = details.querySelector('.gemini-agent-tool-code-result code') as HTMLElement;
+			expect(code).toBeTruthy();
+			expect(code.textContent).toBe('short output');
+			expect(details.querySelector('.gemini-agent-tool-expand-content')).toBeFalsy();
+		});
+
+		it('truncates over-threshold string data and expands to full text on click', async () => {
+			const longText = 'A'.repeat(600);
+			const details = await renderResult('some_tool', { success: true, data: longText });
+
+			const code = details.querySelector('.gemini-agent-tool-code-result code') as HTMLElement;
+			const expandBtn = details.querySelector('.gemini-agent-tool-expand-content') as HTMLButtonElement;
+			expect(expandBtn).toBeTruthy();
+			// Truncated: shorter than the full text and does not contain all 600 chars.
+			expect(code.textContent.length).toBeLessThan(longText.length);
+
+			expandBtn.click();
+
+			expect(code.textContent).toBe(longText);
+			expect(details.querySelector('.gemini-agent-tool-expand-content')).toBeFalsy();
+		});
+	});
+
+	describe('array and error results', () => {
+		it('renders array data as a list', async () => {
+			const details = await renderResult('list_files', { success: true, data: ['a.md', 'b.md', 'c.md'] });
+
+			const list = details.querySelector('.gemini-agent-tool-result-list');
+			expect(list).toBeTruthy();
+			expect(list?.querySelectorAll('li').length).toBe(3);
+		});
+
+		it('renders the error branch for a failed result', async () => {
+			const details = await renderResult('write_file', { success: false, error: 'permission denied' });
+
+			const errorContent = details.querySelector('.gemini-agent-tool-error-content');
+			expect(errorContent).toBeTruthy();
+			expect(errorContent?.querySelector('.gemini-agent-tool-error-message')?.textContent).toBe('permission denied');
+			// Failed rows auto-expand their details.
+			const row = container.querySelector('.gemini-tool-row') as HTMLElement;
+			expect(row.classList.contains('gemini-tool-row-expanded')).toBe(true);
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Adds the first regression harness for `src/ui/agent-view/agent-view-tool-display.ts`, which rendered every tool-execution result with zero test coverage despite three recent refactors (#1193 / #1194 / #1176) landing without a safety net. The correctness-sensitive part is that the renderer dispatches on the runtime shape of a tool result via three module-private type guards; a mis-classified payload silently renders the wrong branch with nothing to catch the regression.

This is coverage-only — no change to the renderer. The suite pins current behavior and drives the private guards through the public `showToolResult` render path (rather than exporting them), so the tests survive future helper reshuffling.

Fixes #1210

## Changes

- `test/ui/agent-view/agent-view-tool-display.test.ts` (new jsdom suite, following the existing `agent-view-progress.test.ts` pattern):
  - **Shape-guard dispatch** for `isCitationAnswerResult` / `isGeneratedImageResult` / `isFileContentResult`: a well-formed payload selects the specialized branch (search-answer + citations, image-result, file-info + code), and near-miss payloads fall back to the generic object branch — including the `google_search` / `google_maps` `toolName` gate on the citation branch.
  - **`renderTruncatableCode`** via the string-result path: short text renders inline with no expand button; over-threshold text truncates and expands to full text on click.
  - **Array and error branches**: array data renders as a list; a failed result renders the error content and auto-expands the row.
  - Generic key/value fallback for a record matching no guard.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer (#1210, plan approved)
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — also ran `npm run typecheck:test`; full suite: 3489 tests green
- [x] I have tested this change on Desktop — N/A: unit-test-only change, no runtime behavior; verified via `npm test`
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A: test-only, no plugin code changed
- [x] Documentation has been updated (if applicable) — N/A: internal test coverage only, no user-facing behavior
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude (auto-dev pipeline)
- [x] I have reviewed and understand all AI-generated code in this PR

---

This PR was produced by the auto-dev pipeline from the approved plan on #1210.

<!-- auto-dev -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015dYQFj95izXAsof6pLZ2Cy)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive coverage for displaying tool execution results across search, citations, generated images, file content, generic data, and list results.
  * Verified truncated content can be expanded and failed tool results display errors with expanded details.
  * Confirmed rendering behavior for missing or incomplete result data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->