### PR TITLE
refactor(tools): move per-tool diff/edit logic behind Tool interface hooks

### DIFF
--- a/src/tools/execution-engine.ts
+++ b/src/tools/execution-engine.ts
@@ -6,16 +6,12 @@ import {
 	ToolExecution,
 	ToolParams,
 	IConfirmationProvider,
-	DiffContext,
 	ConfirmationResult,
 } from './types';
 import { getRawErrorMessageOr } from '../utils/error-utils';
 import { ToolRegistry } from './tool-registry';
 import { ToolLoopDetector } from './loop-detector';
-import { TFile, normalizePath } from 'obsidian';
 import type { ObsidianGemini } from '../types/plugin';
-import { shouldExcludePath } from '../utils/file-utils';
-import { resolvePathToFile } from './vault/utils';
 
 /**
  * Handles execution of tools with permission checks and UI feedback
@@ -121,7 +117,7 @@ export class ToolExecutionEngine {
 				const confirmationMessage = `Waiting for confirmation: ${toolDisplay}`;
 				confirmationProvider.updateProgress?.(confirmationMessage, 'waiting');
 
-				const result = await this.requestUserConfirmation(tool, toolCall.arguments, confirmationProvider);
+				const result = await this.requestUserConfirmation(tool, toolCall.arguments, confirmationProvider, context);
 
 				// Update progress back to tool execution
 				confirmationProvider.updateProgress?.(`Executing: ${toolDisplay}`, 'tool');
@@ -133,27 +129,14 @@ export class ToolExecutionEngine {
 					};
 				}
 
-				// If user edited the content in the diff view, use the edited content.
-				// write_file, create_skill, and edit_skill all use `arguments.content` as the
-				// full editable body, so a direct replacement works. append_content uses
-				// `arguments.content` for the suffix to append; when the user edits the
-				// diff we flip it into replace-mode so the tool overwrites the full file
-				// with the edited content instead of appending on top of it.
+				// If the user edited the content in the diff view, let the tool fold the
+				// edited content back into its own arguments — each content-editing tool
+				// owns its own write contract (write_file / create_skill / edit_skill
+				// replace the editable body; append_content flips to a full overwrite).
+				// Tools without an editable diff implement neither hook, so this is a
+				// no-op for them.
 				if (result.finalContent !== undefined) {
-					if (tool.name === 'write_file' || tool.name === 'create_skill' || tool.name === 'edit_skill') {
-						toolCall.arguments.content = result.finalContent;
-						toolCall.arguments._userEdited = result.userEdited;
-					} else if (tool.name === 'append_content') {
-						if (result.userEdited) {
-							// User edited the full-file diff, so we switch from append
-							// to full overwrite with the edited content.
-							toolCall.arguments.content = result.finalContent;
-							toolCall.arguments._userEdited = true;
-							toolCall.arguments._replaceFullContent = true;
-						}
-						// If user approved without editing, leave arguments unchanged
-						// so the tool appends the original suffix normally.
-					}
+					tool.applyConfirmedEdit?.(toolCall.arguments, result);
 				}
 
 				// If user allowed this action without future confirmation
@@ -220,136 +203,18 @@ export class ToolExecutionEngine {
 	private async requestUserConfirmation(
 		tool: Tool,
 		parameters: ToolParams,
-		confirmationProvider: IConfirmationProvider
+		confirmationProvider: IConfirmationProvider,
+		context: ToolExecutionContext
 	): Promise<ConfirmationResult> {
 		// Generate unique execution ID for tracking
 		const executionId = `tool-confirm-${Date.now()}-${Math.random().toString(36).substring(2, 11)}`;
 
-		// Build diff context based on the tool's shape
-		const diffContext = await this.buildDiffContext(tool, parameters);
+		// A content-editing tool builds its own diff-preview context; tools without
+		// an editable diff omit the hook and get a plain (non-diff) confirmation.
+		const diffContext = await tool.buildDiffContext?.(parameters, context);
 
 		// Show confirmation in chat instead of modal
 		return confirmationProvider.showConfirmationInChat(tool, parameters, executionId, diffContext);
-	}
-
-	/**
-	 * Build a diff context for the confirmation UI when the tool modifies file content.
-	 *
-	 * Supported tools:
-	 * - write_file: originalContent = current file (or empty for new), proposedContent = parameters.content
-	 * - append_content: originalContent = current file, proposedContent = current + parameters.content
-	 * - create_skill: originalContent = empty (new SKILL.md body), proposedContent = parameters.content
-	 * - edit_skill: originalContent = current SKILL.md body, proposedContent = parameters.content
-	 */
-	private async buildDiffContext(tool: Tool, parameters: ToolParams): Promise<DiffContext | undefined> {
-		const plugin = this.plugin;
-
-		// Narrow the dynamic, model-supplied fields this method reads to their
-		// expected string types once, so each branch works with concrete values.
-		const path = typeof parameters.path === 'string' ? parameters.path : undefined;
-		const content = typeof parameters.content === 'string' ? parameters.content : undefined;
-		const name = typeof parameters.name === 'string' ? parameters.name : undefined;
-		const description = typeof parameters.description === 'string' ? parameters.description : undefined;
-
-		if (tool.name === 'write_file' && path && content !== undefined) {
-			const normalizedPath = normalizePath(path);
-			if (shouldExcludePath(normalizedPath, plugin.settings.historyFolder, plugin.app.vault.configDir))
-				return undefined;
-
-			const file = plugin.app.vault.getAbstractFileByPath(normalizedPath);
-			const originalContent = file instanceof TFile ? await this.safeReadFile(file) : '';
-			return {
-				filePath: path,
-				originalContent,
-				proposedContent: content,
-				isNewFile: !file,
-			};
-		}
-
-		if (tool.name === 'append_content' && path && content !== undefined) {
-			// Use the canonical resolver, same as AppendContentTool — applies
-			// system-folder exclusion at every resolution strategy (including
-			// the wikilink path), so the diff matches what will actually be written.
-			const { file } = resolvePathToFile(path, plugin);
-			if (!file) return undefined; // Tool will return its own error
-
-			const originalContent = await this.safeReadFile(file);
-			// Mirror the newline-insertion logic from AppendContentTool.execute()
-			let contentToAppend = content;
-			if (originalContent.length > 0 && !originalContent.endsWith('\n') && !contentToAppend.startsWith('\n')) {
-				contentToAppend = '\n' + contentToAppend;
-			}
-			return {
-				filePath: file.path,
-				originalContent,
-				proposedContent: originalContent + contentToAppend,
-				isNewFile: false,
-			};
-		}
-
-		if (tool.name === 'create_skill' && name && content !== undefined) {
-			// Normalize name the same way CreateSkillTool.execute() does
-			const normalizedName = name.trim().toLowerCase();
-			const proposedBody = content.trim();
-			return {
-				filePath: this.getSkillFilePath(normalizedName),
-				originalContent: '',
-				proposedContent: proposedBody,
-				isNewFile: true,
-			};
-		}
-
-		if (tool.name === 'edit_skill' && name) {
-			// Normalize name the same way EditSkillTool.execute() does
-			const normalizedName = name.trim().toLowerCase();
-			const proposedContent = content?.trim();
-			const proposedDescription = description?.trim();
-
-			// Skip diff if neither content nor description is provided
-			if (!proposedContent && !proposedDescription) return undefined;
-
-			// Read the current skill body (excluding frontmatter) for the original side
-			// of the diff. If the file can't be found, skip diff context — the tool will
-			// surface its own not-found error at execution time.
-			const originalBody = plugin.skillManager ? ((await plugin.skillManager.loadSkill(normalizedName)) ?? '') : '';
-
-			// For content edits, show the body diff. For description-only edits,
-			// show the body unchanged (diff will be empty, but confirmation still triggers).
-			return {
-				filePath: this.getSkillFilePath(normalizedName),
-				originalContent: originalBody,
-				proposedContent: proposedContent ?? originalBody,
-				isNewFile: false,
-			};
-		}
-
-		return undefined;
-	}
-
-	/**
-	 * Build the SKILL.md file path for a given skill name, matching the path
-	 * layout that SkillManager uses (`{historyFolder}/Skills/{name}/SKILL.md`).
-	 * Used for diff context display only.
-	 */
-	private getSkillFilePath(skillName: string): string {
-		const plugin = this.plugin;
-		if (plugin.skillManager) {
-			return normalizePath(`${plugin.skillManager.getSkillsFolderPath()}/${skillName}/SKILL.md`);
-		}
-		return normalizePath(`${plugin.settings.historyFolder}/Skills/${skillName}/SKILL.md`);
-	}
-
-	/**
-	 * Read a file's content, swallowing errors and returning empty string.
-	 * Used when building diff context where a read failure shouldn't block execution.
-	 */
-	private async safeReadFile(file: TFile): Promise<string> {
-		try {
-			return await this.plugin.app.vault.read(file);
-		} catch (error) {
-			this.plugin.logger.warn(`Failed to read file for diff context: ${file.path}`, error);
-			return '';
-		}
 	}
 
 	/**

--- a/src/tools/skill-tools.ts
+++ b/src/tools/skill-tools.ts
@@ -1,8 +1,22 @@
-import { Tool, ToolResult, ToolExecutionContext } from './types';
+import { Tool, ToolResult, ToolExecutionContext, ToolParams, DiffContext, ConfirmationResult } from './types';
 import { ToolCategory } from '../types/agent';
 import { ToolClassification } from '../types/tool-policy';
 import { getRawErrorMessage } from '../utils/error-utils';
 import { t } from '../i18n';
+import { normalizePath } from 'obsidian';
+import type { ObsidianGemini } from '../types/plugin';
+
+/**
+ * Build the SKILL.md file path for a skill name, matching SkillManager's layout
+ * (`{skillsFolder}/{name}/SKILL.md`, falling back to the historyFolder default
+ * when the manager is unavailable). Used for diff-context display only.
+ */
+function skillFilePath(plugin: ObsidianGemini, skillName: string): string {
+	if (plugin.skillManager) {
+		return normalizePath(`${plugin.skillManager.getSkillsFolderPath()}/${skillName}/SKILL.md`);
+	}
+	return normalizePath(`${plugin.settings.historyFolder}/Skills/${skillName}/SKILL.md`);
+}
 
 /**
  * Tool for activating (loading) a skill's full instructions or resources
@@ -165,6 +179,30 @@ export class CreateSkillTool implements Tool {
 		return `Creating skill: ${params.name}`;
 	}
 
+	/**
+	 * Diff preview for a new skill: original is empty, proposed is the trimmed
+	 * body, at the normalized SKILL.md path (matching execute()'s normalization).
+	 */
+	async buildDiffContext(params: ToolParams, context: ToolExecutionContext): Promise<DiffContext | undefined> {
+		const name = typeof params.name === 'string' ? params.name : undefined;
+		const content = typeof params.content === 'string' ? params.content : undefined;
+		if (!name || content === undefined) return undefined;
+
+		const normalizedName = name.trim().toLowerCase();
+		return {
+			filePath: skillFilePath(context.plugin, normalizedName),
+			originalContent: '',
+			proposedContent: content.trim(),
+			isNewFile: true,
+		};
+	}
+
+	/** The SKILL.md body is the editable `content`, so a user edit replaces it. */
+	applyConfirmedEdit(params: ToolParams, result: ConfirmationResult): void {
+		params.content = result.finalContent;
+		params._userEdited = result.userEdited;
+	}
+
 	async execute(
 		params: { name: string; description: string; content: string; _userEdited?: boolean },
 		context: ToolExecutionContext
@@ -280,6 +318,38 @@ export class EditSkillTool implements Tool {
 
 	getProgressDescription(params: { name: string }): string {
 		return `Editing skill: ${params.name}`;
+	}
+
+	/**
+	 * Diff preview for a skill edit: original = current SKILL.md body, proposed =
+	 * the edited body (or the unchanged body for a description-only edit, so the
+	 * confirmation still triggers). Skips the diff when neither field is provided.
+	 */
+	async buildDiffContext(params: ToolParams, context: ToolExecutionContext): Promise<DiffContext | undefined> {
+		const plugin = context.plugin;
+		const name = typeof params.name === 'string' ? params.name : undefined;
+		const content = typeof params.content === 'string' ? params.content : undefined;
+		const description = typeof params.description === 'string' ? params.description : undefined;
+		if (!name) return undefined;
+
+		const normalizedName = name.trim().toLowerCase();
+		const proposedContent = content?.trim();
+		const proposedDescription = description?.trim();
+		if (!proposedContent && !proposedDescription) return undefined;
+
+		const originalBody = plugin.skillManager ? ((await plugin.skillManager.loadSkill(normalizedName)) ?? '') : '';
+		return {
+			filePath: skillFilePath(plugin, normalizedName),
+			originalContent: originalBody,
+			proposedContent: proposedContent ?? originalBody,
+			isNewFile: false,
+		};
+	}
+
+	/** The SKILL.md body is the editable `content`, so a user edit replaces it. */
+	applyConfirmedEdit(params: ToolParams, result: ConfirmationResult): void {
+		params.content = result.finalContent;
+		params._userEdited = result.userEdited;
 	}
 
 	async execute(

--- a/src/tools/types.ts
+++ b/src/tools/types.ts
@@ -126,6 +126,23 @@ export interface Tool {
 
 	/** Get a human-friendly description of this tool execution for progress display */
 	getProgressDescription?(params: ToolParams): string;
+
+	/**
+	 * Build a diff-preview context for the confirmation UI when this tool
+	 * modifies file content. The engine calls this polymorphically before
+	 * requesting confirmation, so the engine never needs to know a tool's
+	 * private write contract. A tool without an editable diff omits this hook
+	 * and the engine falls back to a non-diff confirmation.
+	 */
+	buildDiffContext?(params: ToolParams, context: ToolExecutionContext): Promise<DiffContext | undefined>;
+
+	/**
+	 * Fold user-edited diff content back into this tool's own arguments after a
+	 * confirmation in which the user edited the proposed content. Called (with
+	 * `params` mutated in place) only when the confirmation returned
+	 * `finalContent`. A tool without an editable diff omits this hook.
+	 */
+	applyConfirmedEdit?(params: ToolParams, result: ConfirmationResult): void;
 }
 
 /**

--- a/src/tools/vault-tools-extended.ts
+++ b/src/tools/vault-tools-extended.ts
@@ -1,7 +1,7 @@
-import { Tool, ToolResult, ToolExecutionContext } from './types';
+import { Tool, ToolResult, ToolExecutionContext, ToolParams, DiffContext, ConfirmationResult } from './types';
 import { ToolCategory } from '../types/agent';
 import { ToolClassification } from '../types/tool-policy';
-import { resolvePathToFile } from './vault/utils';
+import { resolvePathToFile, safeReadFileForDiff } from './vault/utils';
 import { t } from '../i18n';
 import { getRawErrorMessageOr } from '../utils/error-utils';
 
@@ -158,6 +158,46 @@ class AppendContentTool implements Tool {
 			return `Appending to ${params.path}`;
 		}
 		return 'Appending content';
+	}
+
+	/**
+	 * Diff preview: original = current file content, proposed = original with the
+	 * appended text (mirroring execute()'s newline-insertion so the preview matches
+	 * what is written). Resolves the path with the same resolver as execute().
+	 */
+	async buildDiffContext(params: ToolParams, context: ToolExecutionContext): Promise<DiffContext | undefined> {
+		const plugin = context.plugin;
+		const path = typeof params.path === 'string' ? params.path : undefined;
+		const content = typeof params.content === 'string' ? params.content : undefined;
+		if (!path || content === undefined) return undefined;
+
+		const { file } = resolvePathToFile(path, plugin);
+		if (!file) return undefined; // Tool surfaces its own not-found error at execution time
+
+		const originalContent = await safeReadFileForDiff(plugin, file);
+		let contentToAppend = content;
+		if (originalContent.length > 0 && !originalContent.endsWith('\n') && !contentToAppend.startsWith('\n')) {
+			contentToAppend = '\n' + contentToAppend;
+		}
+		return {
+			filePath: file.path,
+			originalContent,
+			proposedContent: originalContent + contentToAppend,
+			isNewFile: false,
+		};
+	}
+
+	/**
+	 * The append diff shows the full file, so a user edit means "replace the whole
+	 * file with this", not "append this suffix" — flip to overwrite mode. An
+	 * unedited approval leaves params untouched so the original suffix appends.
+	 */
+	applyConfirmedEdit(params: ToolParams, result: ConfirmationResult): void {
+		if (result.userEdited) {
+			params.content = result.finalContent;
+			params._userEdited = true;
+			params._replaceFullContent = true;
+		}
 	}
 
 	async execute(

--- a/src/tools/vault/utils.ts
+++ b/src/tools/vault/utils.ts
@@ -29,6 +29,21 @@ export function isFileInAgentScope(file: TFile, plugin: ObsidianGemini, projectR
 	return true;
 }
 
+/**
+ * Read a file's content for diff-context construction, swallowing errors and
+ * returning an empty string. A read failure while previewing a confirmation
+ * diff must not block the tool — the tool surfaces its own error at execution
+ * time. Shared by the content-editing tools' `buildDiffContext` hooks.
+ */
+export async function safeReadFileForDiff(plugin: ObsidianGemini, file: TFile): Promise<string> {
+	try {
+		return await plugin.app.vault.read(file);
+	} catch (error) {
+		plugin.logger.warn(`Failed to read file for diff context: ${file.path}`, error);
+		return '';
+	}
+}
+
 /** Plain, serializable description of a vault file or folder. */
 export interface VaultFileEntry {
 	name: string;

--- a/src/tools/vault/write-file-tool.ts
+++ b/src/tools/vault/write-file-tool.ts
@@ -1,9 +1,9 @@
-import { Tool, ToolResult, ToolExecutionContext } from '../types';
+import { Tool, ToolResult, ToolExecutionContext, ToolParams, DiffContext, ConfirmationResult } from '../types';
 import { ToolCategory } from '../../types/agent';
 import { ToolClassification } from '../../types/tool-policy';
 import { TFile, normalizePath } from 'obsidian';
-import { ensureFolderExists } from '../../utils/file-utils';
-import { guardExcludedPath } from './utils';
+import { ensureFolderExists, shouldExcludePathForPlugin } from '../../utils/file-utils';
+import { guardExcludedPath, safeReadFileForDiff } from './utils';
 import { t } from '../../i18n';
 import { getRawErrorMessageOr } from '../../utils/error-utils';
 
@@ -51,6 +51,38 @@ export class WriteFileTool implements Tool {
 			return `Writing to ${params.path}`;
 		}
 		return 'Writing file';
+	}
+
+	/**
+	 * Diff preview: original = current file content (empty for a new file),
+	 * proposed = the content to be written. Skips the diff for excluded paths.
+	 */
+	async buildDiffContext(params: ToolParams, context: ToolExecutionContext): Promise<DiffContext | undefined> {
+		const plugin = context.plugin;
+		const path = typeof params.path === 'string' ? params.path : undefined;
+		const content = typeof params.content === 'string' ? params.content : undefined;
+		if (!path || content === undefined) return undefined;
+
+		const normalizedPath = normalizePath(path);
+		if (shouldExcludePathForPlugin(normalizedPath, plugin)) return undefined;
+
+		const file = plugin.app.vault.getAbstractFileByPath(normalizedPath);
+		const originalContent = file instanceof TFile ? await safeReadFileForDiff(plugin, file) : '';
+		return {
+			filePath: path,
+			originalContent,
+			proposedContent: content,
+			isNewFile: !file,
+		};
+	}
+
+	/**
+	 * write_file treats `content` as the full editable body, so a user-edited
+	 * diff replaces it directly.
+	 */
+	applyConfirmedEdit(params: ToolParams, result: ConfirmationResult): void {
+		params.content = result.finalContent;
+		params._userEdited = result.userEdited;
 	}
 
 	async execute(

--- a/test/tools/execution-engine.test.ts
+++ b/test/tools/execution-engine.test.ts
@@ -1,9 +1,10 @@
 import { ToolExecutionEngine } from '../../src/tools/execution-engine';
 import { ToolRegistry } from '../../src/tools/tool-registry';
 import { ReadFileTool, ListFilesTool, WriteFileTool } from '../../src/tools/vault';
+import { getExtendedVaultTools } from '../../src/tools/vault-tools-extended';
 import { ToolCategory } from '../../src/types/agent';
 import { ToolClassification } from '../../src/types/tool-policy';
-import { IConfirmationProvider } from '../../src/tools/types';
+import { IConfirmationProvider, Tool } from '../../src/tools/types';
 import { TFile } from 'obsidian';
 
 // Deny-by-default provider used when a test never reaches the confirmation branch.
@@ -610,7 +611,12 @@ describe('ToolExecutionEngine - executeToolCalls with stopOnToolError=false', ()
 	});
 });
 
-describe('ToolExecutionEngine - buildDiffContext for write_file', () => {
+describe('ToolExecutionEngine - diff/confirm hook dispatch', () => {
+	// The per-tool diff/re-apply logic now lives on each tool (WriteFileTool,
+	// AppendContentTool, CreateSkillTool, EditSkillTool) behind the optional
+	// Tool.buildDiffContext / Tool.applyConfirmedEdit hooks — those are covered
+	// in the per-tool test files. Here we only assert the engine dispatches to
+	// those hooks polymorphically, with a no-diff fallback when a tool omits them.
 	let plugin: any;
 	let registry: ToolRegistry;
 	let engine: ToolExecutionEngine;
@@ -645,341 +651,104 @@ describe('ToolExecutionEngine - buildDiffContext for write_file', () => {
 		vi.clearAllMocks();
 	});
 
-	it('returns original content with proposed content when file exists', async () => {
-		const mockFile = new TFile();
-		(mockFile as any).path = 'existing.md';
-		plugin.app.vault.getAbstractFileByPath.mockReturnValue(mockFile);
-		plugin.app.vault.read.mockResolvedValue('original content');
-
-		const tool = { name: 'write_file' } as any;
-		const params = { path: 'existing.md', content: 'new content' };
-
-		const diff = await (engine as any).buildDiffContext(tool, params);
-
-		expect(diff).toBeDefined();
-		expect(diff.filePath).toBe('existing.md');
-		expect(diff.originalContent).toBe('original content');
-		expect(diff.proposedContent).toBe('new content');
-		expect(diff.isNewFile).toBe(false);
-	});
-
-	it('returns empty original content with isNewFile=true when file does not exist', async () => {
-		plugin.app.vault.getAbstractFileByPath.mockReturnValue(null);
-
-		const tool = { name: 'write_file' } as any;
-		const params = { path: 'brand-new.md', content: 'new file content' };
-
-		const diff = await (engine as any).buildDiffContext(tool, params);
-
-		expect(diff).toBeDefined();
-		expect(diff.filePath).toBe('brand-new.md');
-		expect(diff.originalContent).toBe('');
-		expect(diff.proposedContent).toBe('new file content');
-		expect(diff.isNewFile).toBe(true);
-	});
-
-	it('returns undefined when path is in excluded history folder', async () => {
-		const tool = { name: 'write_file' } as any;
-		const params = { path: 'gemini-scribe/History/log.md', content: 'content' };
-
-		const diff = await (engine as any).buildDiffContext(tool, params);
-
-		expect(diff).toBeUndefined();
-	});
-});
-
-describe('ToolExecutionEngine - buildDiffContext for append_content', () => {
-	let plugin: any;
-	let registry: ToolRegistry;
-	let engine: ToolExecutionEngine;
-
-	beforeEach(() => {
-		plugin = {
-			settings: {
-				loopDetectionThreshold: 3,
-				loopDetectionTimeWindowSeconds: 60,
-				historyFolder: 'gemini-scribe',
-			},
-			app: {
-				vault: {
-					getAbstractFileByPath: vi.fn(),
-					read: vi.fn(),
-					getMarkdownFiles: vi.fn().mockReturnValue([]),
-					getFiles: vi.fn().mockReturnValue([]),
-					getRoot: vi.fn().mockReturnValue({ children: [] }),
-				},
-				metadataCache: {
-					getFirstLinkpathDest: vi.fn().mockReturnValue(null),
+	const context = () =>
+		({
+			plugin,
+			session: {
+				id: 'hook-session',
+				type: 'agent-session',
+				context: {
+					contextFiles: [],
+					contextDepth: 2,
+					enabledTools: [ToolCategory.VAULT_OPERATIONS],
+					requireConfirmation: ['modify_files'],
 				},
 			},
-			logger: { log: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() },
+		}) as any;
+
+	function makeWriteTool(overrides: Partial<Tool> = {}): Tool {
+		return {
+			name: 'fake_write',
+			category: ToolCategory.VAULT_OPERATIONS,
+			classification: ToolClassification.WRITE,
+			description: 'fake write tool',
+			requiresConfirmation: true,
+			parameters: {
+				type: 'object' as const,
+				properties: { content: { type: 'string' as const, description: 'content' } },
+				required: [],
+			},
+			execute: vi.fn().mockResolvedValue({ success: true, data: {} }),
+			...overrides,
 		};
+	}
 
-		registry = new ToolRegistry(plugin);
-		engine = new ToolExecutionEngine(plugin, registry);
-	});
-
-	afterEach(() => {
-		vi.clearAllMocks();
-	});
-
-	it('returns proposed = original + content for normal append', async () => {
-		const mockFile = new TFile();
-		(mockFile as any).path = 'notes.md';
-		plugin.app.vault.getAbstractFileByPath.mockReturnValue(mockFile);
-		plugin.app.vault.read.mockResolvedValue('existing text\n');
-
-		const tool = { name: 'append_content' } as any;
-		const params = { path: 'notes.md', content: 'appended text' };
-
-		const diff = await (engine as any).buildDiffContext(tool, params);
-
-		expect(diff).toBeDefined();
-		expect(diff.filePath).toBe('notes.md');
-		expect(diff.originalContent).toBe('existing text\n');
-		expect(diff.proposedContent).toBe('existing text\nappended text');
-		expect(diff.isNewFile).toBe(false);
-	});
-
-	it('inserts newline when original does not end with one', async () => {
-		const mockFile = new TFile();
-		(mockFile as any).path = 'notes.md';
-		plugin.app.vault.getAbstractFileByPath.mockReturnValue(mockFile);
-		plugin.app.vault.read.mockResolvedValue('no trailing newline');
-
-		const tool = { name: 'append_content' } as any;
-		const params = { path: 'notes.md', content: 'suffix' };
-
-		const diff = await (engine as any).buildDiffContext(tool, params);
-
-		expect(diff).toBeDefined();
-		expect(diff.proposedContent).toBe('no trailing newline\nsuffix');
-	});
-
-	it('finds file via .md suffix fallback', async () => {
-		const mockFile = new TFile();
-		(mockFile as any).path = 'readme.md';
-		// First call (direct path) returns null, second call (.md suffix) returns the file
-		plugin.app.vault.getAbstractFileByPath.mockReturnValueOnce(null).mockReturnValueOnce(mockFile);
-		plugin.app.vault.read.mockResolvedValue('readme content\n');
-
-		const tool = { name: 'append_content' } as any;
-		const params = { path: 'readme', content: 'more text' };
-
-		const diff = await (engine as any).buildDiffContext(tool, params);
-
-		expect(diff).toBeDefined();
-		expect(diff.filePath).toBe('readme.md');
-		expect(plugin.app.vault.getAbstractFileByPath).toHaveBeenCalledWith('readme.md');
-	});
-
-	it('finds file via wikilink/metadataCache fallback', async () => {
-		const mockFile = new TFile();
-		(mockFile as any).path = 'resolved.md';
-		plugin.app.vault.getAbstractFileByPath.mockReturnValue(null);
-		plugin.app.metadataCache.getFirstLinkpathDest.mockReturnValue(mockFile);
-		plugin.app.vault.read.mockResolvedValue('resolved content\n');
-
-		const tool = { name: 'append_content' } as any;
-		const params = { path: '[[resolved]]', content: 'appended' };
-
-		const diff = await (engine as any).buildDiffContext(tool, params);
-
-		expect(diff).toBeDefined();
-		expect(diff.filePath).toBe('resolved.md');
-		expect(plugin.app.metadataCache.getFirstLinkpathDest).toHaveBeenCalledWith('resolved', '');
-	});
-
-	it('returns undefined when file not found (not a TFile instance)', async () => {
-		plugin.app.vault.getAbstractFileByPath.mockReturnValue(null);
-		plugin.app.metadataCache.getFirstLinkpathDest.mockReturnValue(null);
-
-		const tool = { name: 'append_content' } as any;
-		const params = { path: 'nonexistent.md', content: 'text' };
-
-		const diff = await (engine as any).buildDiffContext(tool, params);
-
-		expect(diff).toBeUndefined();
-	});
-
-	it('returns undefined when path is in excluded history folder', async () => {
-		const tool = { name: 'append_content' } as any;
-		const params = { path: 'gemini-scribe/sessions/log.md', content: 'text' };
-
-		const diff = await (engine as any).buildDiffContext(tool, params);
-
-		expect(diff).toBeUndefined();
-	});
-
-	it('returns undefined when wikilink resolves to a file inside the history folder', async () => {
-		// Regression for issue #910: the prior inline resolver only checked
-		// shouldExcludePath on the user-supplied input string, so a bare wikilink
-		// like "Foo" could resolve via metadataCache to gemini-scribe/Skills/Foo/SKILL.md
-		// and produce a diff preview for a file the tool would actually be blocked from writing.
-		const skillFile = new TFile();
-		(skillFile as any).path = 'gemini-scribe/Skills/Foo/SKILL.md';
-		plugin.app.vault.getAbstractFileByPath.mockReturnValue(null);
-		plugin.app.metadataCache.getFirstLinkpathDest.mockReturnValue(skillFile);
-
-		const tool = { name: 'append_content' } as any;
-		const params = { path: 'Foo', content: 'text' };
-
-		const diff = await (engine as any).buildDiffContext(tool, params);
-
-		expect(diff).toBeUndefined();
-	});
-});
-
-describe('ToolExecutionEngine - buildDiffContext for create_skill', () => {
-	let plugin: any;
-	let registry: ToolRegistry;
-	let engine: ToolExecutionEngine;
-
-	beforeEach(() => {
-		plugin = {
-			settings: {
-				loopDetectionThreshold: 3,
-				loopDetectionTimeWindowSeconds: 60,
-				historyFolder: 'gemini-scribe',
-			},
-			app: {
-				vault: {
-					getAbstractFileByPath: vi.fn(),
-					read: vi.fn(),
-				},
-				metadataCache: {
-					getFirstLinkpathDest: vi.fn().mockReturnValue(null),
-				},
-			},
-			logger: { log: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() },
-			skillManager: {
-				getSkillsFolderPath: vi.fn().mockReturnValue('gemini-scribe/Skills'),
-				loadSkill: vi.fn(),
-			},
+	function provider(result: any): IConfirmationProvider {
+		return {
+			showConfirmationInChat: vi.fn().mockResolvedValue(result),
+			isToolAllowedWithoutConfirmation: vi.fn().mockReturnValue(false),
+			allowToolWithoutConfirmation: vi.fn(),
+			updateProgress: vi.fn(),
 		};
+	}
 
-		registry = new ToolRegistry(plugin);
-		engine = new ToolExecutionEngine(plugin, registry);
+	it("passes the tool's buildDiffContext result to the confirmation provider", async () => {
+		const diff = { filePath: 'x.md', originalContent: 'a', proposedContent: 'b', isNewFile: false };
+		const buildDiffContext = vi.fn().mockResolvedValue(diff);
+		const tool = makeWriteTool({ buildDiffContext });
+		registry.registerTool(tool);
+
+		const p = provider({ confirmed: false, allowWithoutConfirmation: false });
+		const ctx = context();
+		await engine.executeTool({ name: 'fake_write', arguments: { content: 'b' } }, ctx, p);
+
+		expect(buildDiffContext).toHaveBeenCalledWith({ content: 'b' }, ctx);
+		expect(p.showConfirmationInChat).toHaveBeenCalledWith(tool, { content: 'b' }, expect.any(String), diff);
 	});
 
-	afterEach(() => {
-		vi.clearAllMocks();
+	it('passes undefined diffContext when the tool has no buildDiffContext hook', async () => {
+		const tool = makeWriteTool();
+		registry.registerTool(tool);
+
+		const p = provider({ confirmed: false, allowWithoutConfirmation: false });
+		await engine.executeTool({ name: 'fake_write', arguments: { content: 'b' } }, context(), p);
+
+		expect(p.showConfirmationInChat).toHaveBeenCalledWith(tool, { content: 'b' }, expect.any(String), undefined);
 	});
 
-	it('returns isNewFile=true with empty original and trimmed proposed content', async () => {
-		const tool = { name: 'create_skill' } as any;
-		const params = { name: 'My-Skill', content: '  skill body content  ' };
+	it('invokes applyConfirmedEdit with the confirmation result and the edit reaches execute()', async () => {
+		const applyConfirmedEdit = vi.fn((params: any, result: any) => {
+			params.content = result.finalContent;
+		});
+		const execute = vi.fn().mockResolvedValue({ success: true, data: {} });
+		const tool = makeWriteTool({ applyConfirmedEdit, execute });
+		registry.registerTool(tool);
 
-		const diff = await (engine as any).buildDiffContext(tool, params);
+		const p = provider({
+			confirmed: true,
+			allowWithoutConfirmation: false,
+			finalContent: 'edited',
+			userEdited: true,
+		});
+		await engine.executeTool({ name: 'fake_write', arguments: { content: 'original' } }, context(), p);
 
-		expect(diff).toBeDefined();
-		expect(diff.filePath).toBe('gemini-scribe/Skills/my-skill/SKILL.md');
-		expect(diff.originalContent).toBe('');
-		expect(diff.proposedContent).toBe('skill body content');
-		expect(diff.isNewFile).toBe(true);
-	});
-});
-
-describe('ToolExecutionEngine - buildDiffContext for edit_skill', () => {
-	let plugin: any;
-	let registry: ToolRegistry;
-	let engine: ToolExecutionEngine;
-
-	beforeEach(() => {
-		plugin = {
-			settings: {
-				loopDetectionThreshold: 3,
-				loopDetectionTimeWindowSeconds: 60,
-				historyFolder: 'gemini-scribe',
-			},
-			app: {
-				vault: {
-					getAbstractFileByPath: vi.fn(),
-					read: vi.fn(),
-				},
-				metadataCache: {
-					getFirstLinkpathDest: vi.fn().mockReturnValue(null),
-				},
-			},
-			logger: { log: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() },
-			skillManager: {
-				getSkillsFolderPath: vi.fn().mockReturnValue('gemini-scribe/Skills'),
-				loadSkill: vi.fn(),
-			},
-		};
-
-		registry = new ToolRegistry(plugin);
-		engine = new ToolExecutionEngine(plugin, registry);
+		expect(applyConfirmedEdit).toHaveBeenCalledWith(
+			expect.objectContaining({ content: 'edited' }),
+			expect.objectContaining({ finalContent: 'edited', userEdited: true })
+		);
+		// The mutation the hook made must reach execute()
+		expect(execute.mock.calls[0][0].content).toBe('edited');
 	});
 
-	afterEach(() => {
-		vi.clearAllMocks();
-	});
+	it('does not invoke applyConfirmedEdit when the confirmation returned no finalContent', async () => {
+		const applyConfirmedEdit = vi.fn();
+		const tool = makeWriteTool({ applyConfirmedEdit });
+		registry.registerTool(tool);
 
-	it('returns body diff when content edit is provided', async () => {
-		plugin.skillManager.loadSkill.mockResolvedValue('original skill body');
+		const p = provider({ confirmed: true, allowWithoutConfirmation: false });
+		await engine.executeTool({ name: 'fake_write', arguments: { content: 'original' } }, context(), p);
 
-		const tool = { name: 'edit_skill' } as any;
-		const params = { name: 'My-Skill', content: '  updated skill body  ' };
-
-		const diff = await (engine as any).buildDiffContext(tool, params);
-
-		expect(diff).toBeDefined();
-		expect(diff.filePath).toBe('gemini-scribe/Skills/my-skill/SKILL.md');
-		expect(diff.originalContent).toBe('original skill body');
-		expect(diff.proposedContent).toBe('updated skill body');
-		expect(diff.isNewFile).toBe(false);
-	});
-
-	it('returns proposed equals original body for description-only edit', async () => {
-		plugin.skillManager.loadSkill.mockResolvedValue('unchanged body');
-
-		const tool = { name: 'edit_skill' } as any;
-		const params = { name: 'My-Skill', description: 'new description' };
-
-		const diff = await (engine as any).buildDiffContext(tool, params);
-
-		expect(diff).toBeDefined();
-		expect(diff.originalContent).toBe('unchanged body');
-		expect(diff.proposedContent).toBe('unchanged body');
-	});
-
-	it('returns undefined when neither content nor description provided', async () => {
-		const tool = { name: 'edit_skill' } as any;
-		const params = { name: 'My-Skill' };
-
-		const diff = await (engine as any).buildDiffContext(tool, params);
-
-		expect(diff).toBeUndefined();
-	});
-
-	it('uses empty string when skillManager.loadSkill returns null', async () => {
-		plugin.skillManager.loadSkill.mockResolvedValue(null);
-
-		const tool = { name: 'edit_skill' } as any;
-		const params = { name: 'My-Skill', content: 'new content' };
-
-		const diff = await (engine as any).buildDiffContext(tool, params);
-
-		expect(diff).toBeDefined();
-		expect(diff.originalContent).toBe('');
-		expect(diff.proposedContent).toBe('new content');
-	});
-
-	it('uses empty string when skillManager is not available', async () => {
-		plugin.skillManager = undefined;
-
-		const tool = { name: 'edit_skill' } as any;
-		const params = { name: 'My-Skill', content: 'new content' };
-
-		// Re-create engine with updated plugin
-		engine = new ToolExecutionEngine(plugin, registry);
-
-		const diff = await (engine as any).buildDiffContext(tool, params);
-
-		expect(diff).toBeDefined();
-		expect(diff.originalContent).toBe('');
-		expect(diff.filePath).toBe('gemini-scribe/Skills/my-skill/SKILL.md');
+		expect(applyConfirmedEdit).not.toHaveBeenCalled();
 	});
 });
 
@@ -1349,27 +1118,10 @@ describe('ToolExecutionEngine - Confirmation Flow', () => {
 		expect(confirmProvider.allowToolWithoutConfirmation).toHaveBeenCalledWith('write_file');
 	});
 
-	it('sets _replaceFullContent on append_content when user edits the diff', async () => {
-		// Register a fake append_content tool so executeTool doesn't fail
-		const appendTool = {
-			name: 'append_content',
-			description: 'Append content',
-			category: ToolCategory.VAULT_OPERATIONS,
-			classification: ToolClassification.WRITE,
-			requiresConfirmation: true,
-			parameters: {
-				type: 'object' as const,
-				properties: {
-					path: { type: 'string' as const, description: 'Path' },
-					content: { type: 'string' as const, description: 'Content' },
-				},
-				required: ['path', 'content'],
-			},
-			execute: vi.fn().mockImplementation(async (params: any) => {
-				// Capture the params to verify _replaceFullContent was set
-				return { success: true, data: { params } };
-			}),
-		};
+	it('flips append_content to a full overwrite when the user edits the diff', async () => {
+		// The append→overwrite flip now lives in AppendContentTool.applyConfirmedEdit;
+		// register the real tool so the engine exercises that hook end-to-end.
+		const appendTool = getExtendedVaultTools().find((tt) => tt.name === 'append_content')!;
 		registry.registerTool(appendTool);
 
 		const context = {
@@ -1388,8 +1140,10 @@ describe('ToolExecutionEngine - Confirmation Flow', () => {
 
 		const mockFile = new TFile();
 		(mockFile as any).path = 'doc.md';
+		(mockFile as any).extension = 'md';
 		plugin.app.vault.getAbstractFileByPath.mockReturnValue(mockFile);
 		plugin.app.vault.read.mockResolvedValue('original');
+		plugin.app.vault.modify = vi.fn().mockResolvedValue(undefined);
 
 		const confirmProvider: IConfirmationProvider = {
 			showConfirmationInChat: vi.fn().mockResolvedValue({
@@ -1410,11 +1164,14 @@ describe('ToolExecutionEngine - Confirmation Flow', () => {
 		);
 
 		expect(result.success).toBe(true);
-		// Verify the tool received the user-edited full content with _replaceFullContent flag
-		const calledArgs = appendTool.execute.mock.calls[0][0];
-		expect(calledArgs.content).toBe('full edited file');
-		expect(calledArgs._userEdited).toBe(true);
-		expect(calledArgs._replaceFullContent).toBe(true);
+		// A user edit means "replace the whole file", not "append the suffix":
+		// the tool overwrites with the edited content and reports a replace.
+		expect(result.data.action).toBe('replaced');
+		expect(result.data.userEdited).toBe(true);
+		expect(plugin.app.vault.modify).toHaveBeenCalledWith(
+			expect.objectContaining({ path: 'doc.md' }),
+			'full edited file'
+		);
 	});
 });
 

--- a/test/tools/skill-tools.test.ts
+++ b/test/tools/skill-tools.test.ts
@@ -11,6 +11,7 @@ const mockSkillManager = {
 	createSkill: vi.fn(),
 	updateSkill: vi.fn(),
 	validateSkillName: vi.fn(),
+	getSkillsFolderPath: vi.fn().mockReturnValue('gemini-scribe/Skills'),
 };
 
 const mockPlugin = {
@@ -249,6 +250,37 @@ describe('Skill Tools', () => {
 
 			expect(mockSkillManager.createSkill).toHaveBeenCalledWith('my-skill', 'desc', 'content');
 		});
+
+		describe('buildDiffContext', () => {
+			it('returns a new-file diff with empty original and trimmed proposed body at the SKILL.md path', async () => {
+				const diff = await tool.buildDiffContext({ name: 'My-Skill', content: '  skill body  ' }, mockContext);
+
+				expect(diff).toBeDefined();
+				expect(diff!.filePath).toBe('gemini-scribe/Skills/my-skill/SKILL.md');
+				expect(diff!.originalContent).toBe('');
+				expect(diff!.proposedContent).toBe('skill body');
+				expect(diff!.isNewFile).toBe(true);
+			});
+
+			it('returns undefined when content is missing', async () => {
+				const diff = await tool.buildDiffContext({ name: 'My-Skill' }, mockContext);
+				expect(diff).toBeUndefined();
+			});
+		});
+
+		describe('applyConfirmedEdit', () => {
+			it('replaces the body with the user-edited content', () => {
+				const params: Record<string, unknown> = { name: 'my-skill', content: 'ai body' };
+				tool.applyConfirmedEdit(params, {
+					confirmed: true,
+					allowWithoutConfirmation: false,
+					finalContent: 'user body',
+					userEdited: true,
+				});
+				expect(params.content).toBe('user body');
+				expect(params._userEdited).toBe(true);
+			});
+		});
 	});
 
 	describe('EditSkillTool', () => {
@@ -415,6 +447,57 @@ describe('Skill Tools', () => {
 			expect(result.success).toBe(false);
 			expect(result.error).toContain('At least one of description or content must be provided');
 			expect(mockSkillManager.updateSkill).not.toHaveBeenCalled();
+		});
+
+		describe('buildDiffContext', () => {
+			it('returns the current body vs the edited body for a content edit', async () => {
+				mockSkillManager.loadSkill.mockResolvedValue('original body');
+
+				const diff = await tool.buildDiffContext({ name: 'My-Skill', content: '  updated body  ' }, mockContext);
+
+				expect(diff).toBeDefined();
+				expect(diff!.filePath).toBe('gemini-scribe/Skills/my-skill/SKILL.md');
+				expect(diff!.originalContent).toBe('original body');
+				expect(diff!.proposedContent).toBe('updated body');
+				expect(diff!.isNewFile).toBe(false);
+			});
+
+			it('shows the body unchanged for a description-only edit', async () => {
+				mockSkillManager.loadSkill.mockResolvedValue('unchanged body');
+
+				const diff = await tool.buildDiffContext({ name: 'My-Skill', description: 'new desc' }, mockContext);
+
+				expect(diff!.originalContent).toBe('unchanged body');
+				expect(diff!.proposedContent).toBe('unchanged body');
+			});
+
+			it('returns undefined when neither content nor description is provided', async () => {
+				const diff = await tool.buildDiffContext({ name: 'My-Skill' }, mockContext);
+				expect(diff).toBeUndefined();
+			});
+
+			it('falls back to an empty original body when the skill body cannot be loaded', async () => {
+				mockSkillManager.loadSkill.mockResolvedValue(null);
+
+				const diff = await tool.buildDiffContext({ name: 'My-Skill', content: 'new content' }, mockContext);
+
+				expect(diff!.originalContent).toBe('');
+				expect(diff!.proposedContent).toBe('new content');
+			});
+		});
+
+		describe('applyConfirmedEdit', () => {
+			it('replaces the body with the user-edited content', () => {
+				const params: Record<string, unknown> = { name: 'my-skill', content: 'ai body' };
+				tool.applyConfirmedEdit(params, {
+					confirmed: true,
+					allowWithoutConfirmation: false,
+					finalContent: 'user body',
+					userEdited: true,
+				});
+				expect(params.content).toBe('user body');
+				expect(params._userEdited).toBe(true);
+			});
 		});
 	});
 

--- a/test/tools/vault-tools-extended.test.ts
+++ b/test/tools/vault-tools-extended.test.ts
@@ -1,16 +1,19 @@
 import { TFile } from 'obsidian';
 import { getExtendedVaultTools } from '../../src/tools/vault-tools-extended';
 import { Tool, ToolExecutionContext } from '../../src/tools/types';
-import { resolvePathToFile } from '../../src/tools/vault/utils';
+import { resolvePathToFile, safeReadFileForDiff } from '../../src/tools/vault/utils';
 
 // The two extended vault tools resolve paths through resolvePathToFile; mock it
-// so the tests exercise the tools' own branching (JSON parsing, newline handling,
-// replace-vs-append) without depending on the full vault-resolution machinery.
+// (and the diff-preview read helper) so the tests exercise the tools' own
+// branching (JSON parsing, newline handling, replace-vs-append, diff building)
+// without depending on the full vault-resolution machinery.
 vi.mock('../../src/tools/vault/utils', () => ({
 	resolvePathToFile: vi.fn(),
+	safeReadFileForDiff: vi.fn(),
 }));
 
 const mockResolvePathToFile = vi.mocked(resolvePathToFile);
+const mockSafeReadFileForDiff = vi.mocked(safeReadFileForDiff);
 
 // Captures the frontmatter object handed to the processFrontMatter callback so
 // tests can assert the native value that was written.
@@ -250,6 +253,82 @@ describe('vault-tools-extended', () => {
 			expect(result.error).toContain('File not found');
 			expect(mockVault.append).not.toHaveBeenCalled();
 			expect(mockVault.modify).not.toHaveBeenCalled();
+		});
+
+		describe('buildDiffContext', () => {
+			it('builds proposed = original + content, mirroring the newline insertion', async () => {
+				const file = makeFile('notes/log.md');
+				mockResolvePathToFile.mockReturnValue({ file });
+				mockSafeReadFileForDiff.mockResolvedValue('existing content');
+
+				const diff = await getTools().appendContent.buildDiffContext!(
+					{ path: 'notes/log', content: 'new line' },
+					mockContext
+				);
+
+				expect(diff).toBeDefined();
+				expect(diff!.filePath).toBe('notes/log.md');
+				expect(diff!.originalContent).toBe('existing content');
+				expect(diff!.proposedContent).toBe('existing content\nnew line');
+				expect(diff!.isNewFile).toBe(false);
+			});
+
+			it('does not insert a newline when the original already ends with one', async () => {
+				const file = makeFile('notes/log.md');
+				mockResolvePathToFile.mockReturnValue({ file });
+				mockSafeReadFileForDiff.mockResolvedValue('existing content\n');
+
+				const diff = await getTools().appendContent.buildDiffContext!(
+					{ path: 'notes/log', content: 'new line' },
+					mockContext
+				);
+
+				expect(diff!.proposedContent).toBe('existing content\nnew line');
+			});
+
+			it('returns undefined when the file cannot be resolved', async () => {
+				mockResolvePathToFile.mockReturnValue({ file: null });
+
+				const diff = await getTools().appendContent.buildDiffContext!(
+					{ path: 'missing', content: 'text' },
+					mockContext
+				);
+
+				expect(diff).toBeUndefined();
+			});
+
+			it('returns undefined when content is missing', async () => {
+				const diff = await getTools().appendContent.buildDiffContext!({ path: 'notes/log' }, mockContext);
+				expect(diff).toBeUndefined();
+			});
+		});
+
+		describe('applyConfirmedEdit', () => {
+			it('flips to full-overwrite mode when the user edited the diff', () => {
+				const params: Record<string, unknown> = { path: 'notes/log', content: 'suffix' };
+				getTools().appendContent.applyConfirmedEdit!(params, {
+					confirmed: true,
+					allowWithoutConfirmation: false,
+					finalContent: 'full edited body',
+					userEdited: true,
+				});
+				expect(params.content).toBe('full edited body');
+				expect(params._userEdited).toBe(true);
+				expect(params._replaceFullContent).toBe(true);
+			});
+
+			it('leaves params untouched when the user approved without editing', () => {
+				const params: Record<string, unknown> = { path: 'notes/log', content: 'suffix' };
+				getTools().appendContent.applyConfirmedEdit!(params, {
+					confirmed: true,
+					allowWithoutConfirmation: false,
+					finalContent: 'suffix',
+					userEdited: false,
+				});
+				expect(params.content).toBe('suffix');
+				expect(params._userEdited).toBeUndefined();
+				expect(params._replaceFullContent).toBeUndefined();
+			});
 		});
 	});
 });

--- a/test/tools/vault/write-file-tool.test.ts
+++ b/test/tools/vault/write-file-tool.test.ts
@@ -347,3 +347,70 @@ describe('WriteFileTool', () => {
 		expect(tool.getProgressDescription({ path: '' })).toBe('Writing file');
 	});
 });
+
+describe('WriteFileTool - buildDiffContext', () => {
+	let tool: WriteFileTool;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		tool = new WriteFileTool();
+	});
+
+	it('returns original + proposed content when the file exists', async () => {
+		mockVault.getAbstractFileByPath.mockReturnValue(mockFile);
+		mockVault.read.mockResolvedValue('original content');
+
+		const diff = await tool.buildDiffContext({ path: 'test.md', content: 'new content' }, mockContext);
+
+		expect(diff).toBeDefined();
+		expect(diff!.filePath).toBe('test.md');
+		expect(diff!.originalContent).toBe('original content');
+		expect(diff!.proposedContent).toBe('new content');
+		expect(diff!.isNewFile).toBe(false);
+	});
+
+	it('returns empty original and isNewFile=true when the file does not exist', async () => {
+		mockVault.getAbstractFileByPath.mockReturnValue(null);
+
+		const diff = await tool.buildDiffContext({ path: 'brand-new.md', content: 'new file content' }, mockContext);
+
+		expect(diff).toBeDefined();
+		expect(diff!.originalContent).toBe('');
+		expect(diff!.proposedContent).toBe('new file content');
+		expect(diff!.isNewFile).toBe(true);
+	});
+
+	it('returns undefined for a path inside the excluded state folder', async () => {
+		const diff = await tool.buildDiffContext(
+			{ path: 'test-history-folder/History/log.md', content: 'content' },
+			mockContext
+		);
+
+		expect(diff).toBeUndefined();
+	});
+
+	it('returns undefined when content is missing', async () => {
+		const diff = await tool.buildDiffContext({ path: 'test.md' }, mockContext);
+		expect(diff).toBeUndefined();
+	});
+});
+
+describe('WriteFileTool - applyConfirmedEdit', () => {
+	let tool: WriteFileTool;
+
+	beforeEach(() => {
+		tool = new WriteFileTool();
+	});
+
+	it('replaces content with the user-edited body and records the edit', () => {
+		const params: Record<string, unknown> = { path: 'test.md', content: 'ai content' };
+		tool.applyConfirmedEdit(params, {
+			confirmed: true,
+			allowWithoutConfirmation: false,
+			finalContent: 'user edited',
+			userEdited: true,
+		});
+		expect(params.content).toBe('user edited');
+		expect(params._userEdited).toBe(true);
+	});
+});


### PR DESCRIPTION
## Summary

`ToolExecutionEngine` was the generic engine for running any `Tool`, but it hardcoded the private write contract of four specific tools in two name-branching blocks:

1. `buildDiffContext()` switch-cased `write_file` / `append_content` / `create_skill` / `edit_skill`, rebuilding each tool's original-vs-proposed content (newline-insertion for append, SKILL.md name-normalization + path layout for skills, reading the current skill body via `skillManager`).
2. The post-confirmation re-apply block branched on the same names to fold user-edited diff content back into the arguments (including the `append_content` → `_replaceFullContent` overwrite flip).

Adding any new content-editing tool therefore meant editing the engine, and the diff-preview logic duplicated each tool's real `execute()` semantics with no shared source of truth (a comment in the engine even admitted it "mirror[s] the newline-insertion logic from AppendContentTool").

This PR pushes that per-tool knowledge behind two new **optional `Tool`-interface hooks**, mirroring the existing `confirmationMessage?` / `getProgressDescription?` pattern. The engine now dispatches polymorphically with a generic no-diff fallback, and each tool owns both its diff-preview construction and its post-confirmation re-apply. It is a pure relocation of behavior — no confirmation/diff UX change.

Fixes #1215

## Changes

- `src/tools/types.ts` — add two optional methods to `Tool`:
  - `buildDiffContext?(params, context): Promise<DiffContext | undefined>` — a diff-preview-capable tool returns its own original/proposed content.
  - `applyConfirmedEdit?(params, result): void` — a tool folds the user-edited diff content back into its own arguments.
- `src/tools/execution-engine.ts` — replace the name-branching in `buildDiffContext()` with `tool.buildDiffContext?.(params, context)`, and the re-apply branch with `tool.applyConfirmedEdit?.(args, result)`. The generic no-diff fallback, read-before-write ordering, and loop detection stay untouched. Removes the engine's now-dead `buildDiffContext` / `getSkillFilePath` / `safeReadFile` private methods (~150 lines).
- `src/tools/vault/write-file-tool.ts` — `WriteFileTool` gains `buildDiffContext` (current-file-or-empty original) and `applyConfirmedEdit`.
- `src/tools/vault-tools-extended.ts` — `AppendContentTool` gains `buildDiffContext` (newline-insertion) and `applyConfirmedEdit` (the `_replaceFullContent` overwrite flip), moved verbatim.
- `src/tools/skill-tools.ts` — `CreateSkillTool` and `EditSkillTool` gain `buildDiffContext` / `applyConfirmedEdit`; adds a shared module-level `skillFilePath` helper (the SKILL.md path layout that lived on the engine).
- `src/tools/vault/utils.ts` — new shared `safeReadFileForDiff` helper (read-swallowing for diff construction), consumed by write/append.
- Tests: per-tool `buildDiffContext` / `applyConfirmedEdit` coverage moves to the tools' own test files (`write-file-tool.test.ts`, `vault-tools-extended.test.ts`, `skill-tools.test.ts`); the engine test is reduced to asserting the generic hook dispatch + the no-diff fallback, plus an end-to-end append-flip check through the real tool.

## Screenshots / Screencast

N/A — internal refactor with no user-visible change (diff-preview and confirmation behavior are identical).

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer (#1215, plan approved via `auto:ready`)
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — also ran `npm run typecheck:test`, `npm run lint`, and `npm run lint:cycles` (0 cycles); full suite: 3484 tests green
- [x] I have tested this change on Desktop — N/A: behavior-preserving refactor, no runtime behavior change; verified via the full unit suite (the diff-preview and re-apply paths are covered end-to-end)
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A: no platform-specific code; pure relocation behind an interface
- [x] Documentation has been updated (if applicable) — N/A: no user-facing behavior or settings change
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude (auto-dev pipeline)
- [x] I have reviewed and understand all AI-generated code in this PR

<!-- auto-dev -->

This PR was produced by the auto-dev pipeline from the approved plan on #1215.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WVCnTKZXmRVL6iaJokiBb4)_