### PR TITLE
refactor(services): parameterize resolveFeatureToolPolicy over frontmatter keys

### DIFF
--- a/src/agent/session-manager.ts
+++ b/src/agent/session-manager.ts
@@ -11,8 +11,8 @@ import {
 import type { ObsidianGemini } from '../types/plugin';
 import { sanitizeFileName } from '../utils/file-utils';
 import { formatLocalDate } from '../utils/format-utils';
-import { FeatureToolPolicy, parseToolPolicyFrontmatter, clonePolicy } from '../types/tool-policy';
-import { migrateLegacyToolCategoryArray } from '../services/feature-policy-yaml';
+import { FeatureToolPolicy, clonePolicy } from '../types/tool-policy';
+import { resolveFeatureToolPolicy } from '../services/feature-definition';
 import { asRecord } from '../utils/error-utils';
 
 /** Read a frontmatter field as a non-empty string, or `undefined`. */
@@ -26,19 +26,20 @@ function frontmatterDate(value: unknown, fallbackMs: number): Date {
 }
 
 /**
- * Parse a session's tool policy from frontmatter. Prefers the new
- * `tool_policy:` block; falls back to the legacy `enabled_tools` array
- * (via the shared category-array migrator); falls back to the supplied default.
+ * Parse a session's tool policy from frontmatter. Delegates the preference
+ * ladder (canonical `tool_policy:` block → legacy `enabled_tools` array) to the
+ * shared {@link resolveFeatureToolPolicy}, passing the session's snake_case key
+ * dialect; the session-specific `clonePolicy(fallback)` default is layered here
+ * because inheriting the supplied fallback is unique to sessions.
  */
 function parseSessionToolPolicy(
 	frontmatter: Record<string, unknown> | undefined,
 	fallback: FeatureToolPolicy | undefined
 ): FeatureToolPolicy | undefined {
-	const fromNewShape = parseToolPolicyFrontmatter(frontmatter?.tool_policy);
-	if (fromNewShape) return fromNewShape;
-	const fromLegacy = migrateLegacyToolCategoryArray(frontmatter?.enabled_tools);
-	if (fromLegacy !== undefined) return fromLegacy;
-	return clonePolicy(fallback);
+	return (
+		resolveFeatureToolPolicy(frontmatter ?? {}, { policyKey: 'tool_policy', legacyKey: 'enabled_tools' }) ??
+		clonePolicy(fallback)
+	);
 }
 
 /**

--- a/src/services/feature-definition.ts
+++ b/src/services/feature-definition.ts
@@ -95,11 +95,20 @@ export function parseMaxIterations(raw: unknown): number | undefined {
 
 /**
  * Resolve the tool policy for a feature definition from its frontmatter:
- * prefer the canonical `toolPolicy:` block, falling back to the legacy
- * `enabledTools:` category array. `undefined` means "inherit the global policy".
+ * prefer the canonical policy block, falling back to the legacy category
+ * array. `undefined` means "inherit the global policy".
+ *
+ * The frontmatter key names are parameterized so callers with a different
+ * on-disk dialect can reach this one implementation instead of forking the
+ * whole resolver: hooks and scheduled tasks use the camelCase defaults
+ * (`toolPolicy` / `enabledTools`), while agent sessions pass their snake_case
+ * keys (`tool_policy` / `enabled_tools`).
  */
-export function resolveFeatureToolPolicy(frontmatter: Record<string, unknown>): FeatureToolPolicy | undefined {
-	return parseToolPolicyFrontmatter(frontmatter.toolPolicy) ?? migrateLegacyToolCategoryArray(frontmatter.enabledTools);
+export function resolveFeatureToolPolicy(
+	frontmatter: Record<string, unknown>,
+	{ policyKey = 'toolPolicy', legacyKey = 'enabledTools' }: { policyKey?: string; legacyKey?: string } = {}
+): FeatureToolPolicy | undefined {
+	return parseToolPolicyFrontmatter(frontmatter[policyKey]) ?? migrateLegacyToolCategoryArray(frontmatter[legacyKey]);
 }
 
 /**

--- a/test/agent/session-manager.test.ts
+++ b/test/agent/session-manager.test.ts
@@ -1,5 +1,6 @@
 import { SessionManager } from '../../src/agent/session-manager';
 import { SessionType } from '../../src/types/agent';
+import { PolicyPreset } from '../../src/types/tool-policy';
 
 // Import the mocked TFile class
 import { TFile } from 'obsidian';
@@ -135,6 +136,35 @@ describe('SessionManager', () => {
 			expect(mockPlugin.app.vault.getAbstractFileByPath).toHaveBeenCalledWith(
 				expect.stringContaining('Test-File Chat.md')
 			);
+		});
+	});
+
+	describe('parseContextFromFrontmatter tool policy', () => {
+		// parseContextFromFrontmatter resolves the session tool policy via the shared
+		// resolveFeatureToolPolicy using the session's snake_case key dialect, layering
+		// the NOTE_CHAT read-only default (cloned) when no policy keys are present.
+		const parse = (frontmatter: Record<string, unknown> | undefined) =>
+			(sessionManager as any).parseContextFromFrontmatter(frontmatter).toolPolicy;
+
+		it('parses the canonical snake_case tool_policy block', () => {
+			expect(parse({ tool_policy: { preset: 'edit_mode' } })).toEqual({ preset: PolicyPreset.EDIT_MODE });
+		});
+
+		it('falls back to the legacy snake_case enabled_tools array', () => {
+			expect(parse({ enabled_tools: ['read_only'] })).toEqual({ preset: PolicyPreset.READ_ONLY });
+		});
+
+		it('falls back to a clone of the NOTE_CHAT default when no policy keys are present', () => {
+			// The read-only default is the note-chat fallback; the result must equal it
+			// but be a distinct object so per-session mutations never leak into the shared default.
+			const defaultPolicy = { preset: PolicyPreset.READ_ONLY };
+			const resolved = parse({ session_id: 'x' });
+			expect(resolved).toEqual(defaultPolicy);
+			expect(resolved).not.toBe(defaultPolicy);
+		});
+
+		it('falls back to the clone default when frontmatter is undefined', () => {
+			expect(parse(undefined)).toEqual({ preset: PolicyPreset.READ_ONLY });
 		});
 	});
 

--- a/test/agent/session-manager.test.ts
+++ b/test/agent/session-manager.test.ts
@@ -155,15 +155,21 @@ describe('SessionManager', () => {
 		});
 
 		it('falls back to a clone of the NOTE_CHAT default when no policy keys are present', () => {
-			// The read-only default is the note-chat fallback; the result must equal it
-			// but be a distinct object so per-session mutations never leak into the shared default.
-			const defaultPolicy = { preset: PolicyPreset.READ_ONLY };
-			const resolved = parse({ session_id: 'x' });
-			expect(resolved).toEqual(defaultPolicy);
-			expect(resolved).not.toBe(defaultPolicy);
+			// The read-only default is the note-chat fallback; each resolution must return a
+			// distinct object (a fresh clone) so per-session mutations never leak into the shared
+			// default. Comparing two resolutions — rather than a locally-built object — is what
+			// actually proves the clone: a locally-allocated object is trivially reference-distinct.
+			const first = parse({ session_id: 'x' });
+			const second = parse({ session_id: 'x' });
+			expect(first).toEqual({ preset: PolicyPreset.READ_ONLY });
+			expect(first).not.toBe(second);
 		});
 
-		it('falls back to the clone default when frontmatter is undefined', () => {
+		it('returns the read-only default when frontmatter is undefined', () => {
+			// Undefined frontmatter short-circuits to the shared DEFAULT_CONTEXTS.NOTE_CHAT via an
+			// early return that predates this change and does not route through the clone path, so
+			// only the resolved value is asserted here — not clone identity (two calls share the
+			// same reference on this path).
 			expect(parse(undefined)).toEqual({ preset: PolicyPreset.READ_ONLY });
 		});
 	});

--- a/test/services/feature-definition.test.ts
+++ b/test/services/feature-definition.test.ts
@@ -147,6 +147,39 @@ describe('resolveFeatureToolPolicy', () => {
 			preset: PolicyPreset.EDIT_MODE,
 		});
 	});
+
+	describe('with a custom key dialect (e.g. sessions use snake_case)', () => {
+		const keys = { policyKey: 'tool_policy', legacyKey: 'enabled_tools' };
+
+		it('returns undefined when neither dialect key is present', () => {
+			expect(resolveFeatureToolPolicy({ schedule: 'daily' }, keys)).toBeUndefined();
+		});
+
+		it('ignores the default camelCase keys when a custom dialect is given', () => {
+			// The camelCase keys must not be read once snake_case keys are requested.
+			expect(resolveFeatureToolPolicy({ toolPolicy: { preset: 'edit_mode' } }, keys)).toBeUndefined();
+		});
+
+		it('parses the canonical block under the custom policy key', () => {
+			expect(resolveFeatureToolPolicy({ tool_policy: { preset: 'read_only' } }, keys)).toEqual({
+				preset: PolicyPreset.READ_ONLY,
+			});
+		});
+
+		it('falls back to the legacy array under the custom legacy key', () => {
+			expect(resolveFeatureToolPolicy({ enabled_tools: ['read_only'] }, keys)).toEqual({
+				preset: PolicyPreset.READ_ONLY,
+			});
+		});
+
+		it('prefers the canonical block over the legacy array under the custom keys', () => {
+			expect(
+				resolveFeatureToolPolicy({ tool_policy: { preset: 'edit_mode' }, enabled_tools: ['read_only'] }, keys)
+			).toEqual({
+				preset: PolicyPreset.EDIT_MODE,
+			});
+		});
+	});
 });
 
 // ─── migrateLegacyEnabledTools ───────────────────────────────────────────────


### PR DESCRIPTION
## Summary

There were two parallel implementations of the same "resolve a feature's tool policy from frontmatter" logic, split only by frontmatter key casing:

- `resolveFeatureToolPolicy(frontmatter)` in `src/services/feature-definition.ts` — used by **hooks** and **scheduled tasks**, hardcoded the camelCase keys `toolPolicy` / `enabledTools`.
- `parseSessionToolPolicy(frontmatter, fallback)` in `src/agent/session-manager.ts` — used by **agent sessions**, re-implemented the same `parseToolPolicyFrontmatter(...) ?? migrateLegacy(...)` ladder over the snake_case keys `tool_policy` / `enabled_tools`, plus a session-only `clonePolicy(fallback)` default arm.

Because the shared helper hardcoded its key names, any consumer with a different frontmatter dialect had to fork the whole resolver rather than just supply its keys. This PR parameterizes the shared resolver over its key names so both dialects reach one implementation.

This is the follow-up to #1218 (which removed the byte-identical `migrateLegacyEnabledTools` mapper copy); on `master` today `session-manager.ts` already consumes the shared `migrateLegacyToolCategoryArray`, so there is no ordering dependency.

Fixes #1219

## Changes

- `src/services/feature-definition.ts` — `resolveFeatureToolPolicy` now takes an optional `{ policyKey = 'toolPolicy', legacyKey = 'enabledTools' }` argument and reads `frontmatter[policyKey]` / `frontmatter[legacyKey]`. The hooks/tasks callers keep working unchanged via the defaults.
- `src/agent/session-manager.ts` — `parseSessionToolPolicy` now delegates the preference ladder to `resolveFeatureToolPolicy(frontmatter ?? {}, { policyKey: 'tool_policy', legacyKey: 'enabled_tools' })` and layers the session-specific `?? clonePolicy(fallback)` default at the call site. The duplicated ladder and the now-unused `parseToolPolicyFrontmatter` / `migrateLegacyToolCategoryArray` imports are removed.
- `test/services/feature-definition.test.ts` — adds a "custom key dialect" describe covering the snake_case keys for the canonical-block, legacy-array, neither-present, and precedence cases, plus a guard that the default camelCase keys are not read once a custom dialect is requested.
- `test/agent/session-manager.test.ts` — adds coverage that `parseContextFromFrontmatter` resolves the snake_case `tool_policy` block and legacy `enabled_tools` array, and that the no-policy-keys path returns a **clone** of the NOTE_CHAT read-only default (equal value, distinct object).

**Behavior is unchanged.** Both leaf helpers (`parseToolPolicyFrontmatter`, `migrateLegacyToolCategoryArray`) return `FeatureToolPolicy | undefined` (never `null`), so the shared `??` ladder is equivalent to the previous `if (x !== undefined)` checks in the session resolver. The on-disk frontmatter contracts (snake_case for sessions, camelCase for hooks/tasks) are untouched — only the parsing code is unified.

## Screenshots / Screencast

N/A — internal refactor with no user-visible or UI change.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer (#1219, plan approved via `auto:ready`)
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — also ran `npm run typecheck:test`, `npm run lint` (0 errors), and `npm run lint:cycles` (0 cycles); full suite: 3486 tests green
- [x] I have tested this change on Desktop — N/A: behavior-preserving refactor with no runnable surface; verified via the full unit suite, which covers both frontmatter dialects and the session fallback-clone path
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A: no platform-specific code; pure parsing-code consolidation
- [x] Documentation has been updated (if applicable) — N/A: no user-facing behavior, settings, or file-format change
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude (auto-dev pipeline)
- [x] I have reviewed and understand all AI-generated code in this PR

---

This PR was produced by the auto-dev pipeline from the approved plan on #1219.

Behavioral verification: this is a pure internal refactor with no runnable surface (no CLI, endpoint, UI, or observable side effect) — the behavioral gate is the unit suite, which pins both key dialects and the session fallback-clone path.

---
_Generated by [Claude Code](https://claude.ai/code/session_0141Sjn3EuVArpz4W6hkqrj7)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved session tool-policy handling for configurations using `tool_policy` and legacy `enabled_tools` keys.
  - Added support for migrating legacy read-only tool settings to the appropriate policy preset.
  - Ensured sessions consistently apply the default read-only policy when no tool policy is configured.
  - Standardized policy resolution across supported configuration formats while preserving precedence for canonical policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->