### PR TITLE
chore(daily): 2026-07-22 daily update

### DIFF
--- a/planning/changelog/2026-07-22.md
+++ b/planning/changelog/2026-07-22.md
@@ -1,0 +1,20 @@
+# Daily changelog — July 22, 2026
+
+**Date:** 2026-07-22
+**PRs merged:** 2
+
+---
+
+## Summary
+
+Quiet day — one routine daily-housekeeping PR and one automated model-list update, no manual feature work landed.
+
+## What shipped
+
+### [#1238 chore(daily): 2026-07-21 daily update](https://github.com/allenhutchison/obsidian-gemini/pull/1238)
+
+Automated daily housekeeping run bundling `daily-changelog`, `audit-product-docs`, and `triage-issues` for 2026-07-21. The changelog step wrote up the prior day's single PR (itself the 2026-07-20 daily update), the docs audit found no drift against `src/` and no new docs warranted, and issue triage found no unlabeled issues. No `src/` behavior changes.
+
+### [#1239 chore: Update available Gemini models](https://github.com/allenhutchison/obsidian-gemini/pull/1239)
+
+Automated model-list sync added two new models to `src/data/models.json`: `gemini-3.5-flash-lite` (Gemini 3.5 Flash Lite) and `gemini-3.6-flash` (Gemini 3.6 Flash), both detected from Google's API and merged after maintainer curation.


### PR DESCRIPTION
## Summary

Automated daily housekeeping run (`daily-update` meta-skill via the `maintainerd` plugin marketplace) bundling `daily-changelog`, `audit-product-docs`, and `triage-issues` for 2026-07-22.

Fixes N/A — routine automated daily housekeeping run.

## Changes

- **daily-changelog**: wrote [`planning/changelog/2026-07-22.md`](https://github.com/allenhutchison/obsidian-gemini/blob/daily-update-2026-07-23/planning/changelog/2026-07-22.md) — 2 PRs merged on 2026-07-22: #1238 (the prior day's automated daily-update PR) and #1239 (automated Gemini model-list update adding `gemini-3.5-flash-lite` and `gemini-3.6-flash`).
- **audit-product-docs**: read all files under `config.paths.productDocs` (README.md, all of `docs/guide/`, all of `docs/reference/`, AGENTS.md) and cross-checked settings names/defaults, tool names, command IDs, and model defaults against `src/`. The only `src/` change since the prior audit (2026-07-21) was the models.json update in #1239, and the settings docs already describe the model dropdown as a representative sample of an auto-refreshed list (`docs/reference/settings.md`) — no drift found, no new docs warranted.
- **triage-issues**: no unlabeled open issues — no-op.

This is a housekeeping-only PR — no `src/` behavior changes.

## Screenshots / Screencast

N/A — changelog-only change, no UI change.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A; routine automated daily housekeeping run
- [x] All CI checks pass (`npm test` — 3477 passing, `npm run build`, `npm run format-check`, `npm run lint`, `npm run typecheck:test`)
- [x] I have tested this change on Desktop — N/A, changelog-only change; verified via local pre-flight checks
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A, no code change
- [x] Documentation has been updated (if applicable) — N/A, this PR's content is the changelog itself; the docs audit found no drift to fix
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jm22TstmFQ3Sq7mE8b7d4n)_