### PR TITLE
refactor(services): extract FileBackedFeatureManager base for hook/task managers

### DIFF
--- a/src/services/feature-definition.ts
+++ b/src/services/feature-definition.ts
@@ -5,13 +5,16 @@ import { FeatureToolPolicy, parseToolPolicyFrontmatter } from '../types/tool-pol
 import { migrateLegacyToolCategoryArray } from './feature-policy-yaml';
 
 /**
- * Shared scaffolding for the markdown-defined feature managers — HookManager
- * and ScheduledTaskManager. Both discover `<slug>.md` definition files under a
- * folder in the plugin state directory, parse YAML frontmatter into a typed
- * definition, and persist volatile per-entry runtime state to a JSON sidecar.
- * The helpers below are the parts of that pattern that are identical between
- * the two managers; the feature-specific frontmatter-field mapping stays in
- * each manager's own `parseHookFile` / `parseTaskFile`.
+ * Shared field-level scaffolding for the markdown-defined feature managers —
+ * HookManager and ScheduledTaskManager. Both discover `<slug>.md` definition
+ * files under a folder in the plugin state directory, parse YAML frontmatter
+ * into a typed definition, and persist volatile per-entry runtime state to a
+ * JSON sidecar. The helpers below are the field-mapping parts of that pattern
+ * that are identical between the two managers; the outer manager skeleton
+ * (folder getters, discover-and-purge loop, sidecar load/save, delete) lives in
+ * the `FileBackedFeatureManager` base (`./file-backed-feature-manager.ts`),
+ * which consumes these helpers. The feature-specific frontmatter-field mapping
+ * stays in each manager's own `parseDefinitionFile`.
  */
 
 /**

--- a/src/services/file-backed-feature-manager.ts
+++ b/src/services/file-backed-feature-manager.ts
@@ -1,0 +1,186 @@
+import { normalizePath, type TFile } from 'obsidian';
+import type { ObsidianGemini } from '../types/plugin';
+import { JsonSidecarStateStore, purgeOrphanState } from './feature-definition';
+
+/**
+ * Minimal shape every file-backed feature definition shares: a `slug` (its
+ * stable identifier, also the definition file's basename) and the `filePath`
+ * of its `<slug>.md` definition file. `HookManager`'s `Hook` and
+ * `ScheduledTaskManager`'s `ScheduledTask` both satisfy this.
+ */
+export interface FileBackedDefinition {
+	readonly slug: string;
+	readonly filePath: string;
+}
+
+/** Per-manager identity strings that parameterize the shared skeleton. */
+export interface FileBackedFeatureManagerConfig {
+	/** Folder name under the plugin state folder, e.g. `Hooks`. */
+	featureFolder: string;
+	/** Sidecar state file name, e.g. `hooks-state.json`. */
+	stateFileName: string;
+	/** Bracketed tag for log lines, e.g. `[HookManager]`. */
+	logPrefix: string;
+	/** Lowercase noun used in the parse-failure warning, e.g. `hook`. */
+	featureNoun: string;
+	/** Label used in the not-found error, e.g. `Hook` or `Scheduled task`. */
+	entityLabel: string;
+}
+
+/** Subfolder (inside the feature folder) that holds per-run output. */
+const RUNS_SUBFOLDER = 'Runs';
+
+/**
+ * Shared scaffold for the markdown-defined feature managers — `HookManager`
+ * and `ScheduledTaskManager`. Both are file-backed: they discover `<slug>.md`
+ * definition files under a folder in the plugin state directory, parse each
+ * into a typed definition, and persist volatile per-entry runtime state to a
+ * JSON sidecar. This base owns the parts of that outer skeleton that are
+ * identical between the two — the folder-path getters, the discover-and-purge
+ * template, the sidecar `loadState`/`saveState` wrappers, and the generic
+ * `delete` — parameterized by the feature's folder + a per-file parse callback.
+ *
+ * The genuinely divergent parts stay in each subclass: the in-memory map (via
+ * the {@link definitions} accessor), the per-file parse (via
+ * {@link parseDefinitionFile}), any per-definition state seeding on discovery
+ * (via {@link seedDiscoveredState}), and orphan-purge logging (via
+ * {@link onOrphanPurged}). The field-level helpers already extracted into
+ * `feature-definition.ts` (state store, `purgeOrphanState`, …) are consumed
+ * here rather than re-implemented.
+ *
+ * @typeParam TDef        The manager's definition type (must expose `slug`/`filePath`).
+ * @typeParam TEntryState The per-slug sidecar state value; the sidecar file is a
+ *                        `Record<slug, TEntryState>`.
+ */
+export abstract class FileBackedFeatureManager<TDef extends FileBackedDefinition, TEntryState> {
+	/** Live sidecar state map (slug → runtime state). Reassigned on load. */
+	protected state: Record<string, TEntryState> = {};
+	/** Persistence layer for {@link state}; the live object stays on this class. */
+	protected readonly stateStore: JsonSidecarStateStore<Record<string, TEntryState>>;
+
+	constructor(
+		protected readonly plugin: ObsidianGemini,
+		private readonly featureConfig: FileBackedFeatureManagerConfig
+	) {
+		// The sidecar path is resolved lazily on every load/save because it
+		// depends on `settings.historyFolder`, which can change at runtime.
+		this.stateStore = new JsonSidecarStateStore<Record<string, TEntryState>>(
+			plugin,
+			() => this.stateFilePath,
+			featureConfig.logPrefix
+		);
+	}
+
+	// ── Folder path helpers ──────────────────────────────────────────────────
+
+	/** Absolute path of the feature folder inside the plugin state folder. */
+	get featureFolderPath(): string {
+		return normalizePath(`${this.plugin.settings.historyFolder}/${this.featureConfig.featureFolder}`);
+	}
+
+	/** Absolute path of the per-run output subfolder. */
+	get runsFolder(): string {
+		return normalizePath(`${this.featureFolderPath}/${RUNS_SUBFOLDER}`);
+	}
+
+	/** Absolute path of the JSON sidecar state file. */
+	get stateFilePath(): string {
+		return normalizePath(`${this.featureFolderPath}/${this.featureConfig.stateFileName}`);
+	}
+
+	// ── Subclass-supplied seams ──────────────────────────────────────────────
+
+	/**
+	 * The subclass's in-memory definition map. Exposed as an accessor so each
+	 * manager keeps its own descriptively-named field (`hooks` / `tasks`) while
+	 * the base operates on the same instance.
+	 */
+	protected abstract get definitions(): Map<string, TDef>;
+
+	/** Parse a single definition file, or return `null` if it isn't valid. */
+	protected abstract parseDefinitionFile(file: TFile): Promise<TDef | null>;
+
+	/**
+	 * Seed sidecar state for a definition newly encountered during discovery.
+	 * Default: no-op (hooks don't seed). Scheduled tasks override this to seed a
+	 * `nextRunAt` so a freshly-discovered task is due immediately.
+	 */
+	protected seedDiscoveredState(_def: TDef): void {}
+
+	/**
+	 * Called once per orphan state slug removed during discovery. Default:
+	 * no-op (hooks purge silently). Scheduled tasks override this to log.
+	 */
+	protected onOrphanPurged(_slug: string): void {}
+
+	// ── Discovery ────────────────────────────────────────────────────────────
+
+	/**
+	 * Rebuild the in-memory map from the definition files directly inside the
+	 * feature folder (excluding the `Runs/` subtree), seed state for newly-seen
+	 * definitions, drop orphan state entries, and persist. Replaces the
+	 * copy-pasted `discoverHooks` / `discoverTasks` loops.
+	 */
+	protected async discoverDefinitions(): Promise<void> {
+		this.definitions.clear();
+
+		const prefix = this.featureFolderPath + '/';
+		const runsPrefix = this.runsFolder + '/';
+
+		const files = this.plugin.app.vault
+			.getMarkdownFiles()
+			.filter((f) => f.path.startsWith(prefix) && !f.path.startsWith(runsPrefix));
+
+		for (const file of files) {
+			try {
+				const def = await this.parseDefinitionFile(file);
+				if (!def) continue;
+				this.definitions.set(def.slug, def);
+				this.seedDiscoveredState(def);
+			} catch (err) {
+				this.plugin.logger.warn(
+					`${this.featureConfig.logPrefix} Failed to parse ${this.featureConfig.featureNoun} file ${file.path}:`,
+					err
+				);
+			}
+		}
+
+		// Drop state entries whose definition file is gone.
+		for (const slug of purgeOrphanState(this.state, (s) => this.definitions.has(s))) {
+			this.onOrphanPurged(slug);
+		}
+
+		await this.saveState();
+	}
+
+	// ── Delete ───────────────────────────────────────────────────────────────
+
+	/**
+	 * Delete a definition: trash its file, drop it from the in-memory map, and
+	 * clear its sidecar state entry. Replaces the near-identical `deleteHook` /
+	 * `deleteTask` bodies.
+	 */
+	protected async deleteDefinition(slug: string): Promise<void> {
+		const def = this.definitions.get(slug);
+		if (!def) throw new Error(`${this.featureConfig.entityLabel} "${slug}" not found`);
+
+		const file = this.plugin.app.vault.getAbstractFileByPath(def.filePath);
+		if (file) {
+			await this.plugin.app.fileManager.trashFile(file);
+		}
+
+		this.definitions.delete(slug);
+		delete this.state[slug];
+		await this.saveState();
+	}
+
+	// ── State persistence ────────────────────────────────────────────────────
+
+	protected async loadState(): Promise<void> {
+		this.state = await this.stateStore.load();
+	}
+
+	protected async saveState(): Promise<void> {
+		await this.stateStore.save(this.state);
+	}
+}

--- a/src/services/hook-manager.ts
+++ b/src/services/hook-manager.ts
@@ -13,20 +13,18 @@ import type {
 	HookUpdateParams,
 } from './hook-types';
 import {
-	JsonSidecarStateStore,
 	extractMarkdownBody,
 	migrateLegacyEnabledTools,
 	parseMaxIterations,
-	purgeOrphanState,
 	resolveFeatureToolPolicy,
 } from './feature-definition';
+import { FileBackedFeatureManager } from './file-backed-feature-manager';
 import { FailurePauseTracker, MAX_CONSECUTIVE_FAILURES } from './failure-pause-tracker';
 import { matchesFrontmatterFilter, matchesGlob } from './hook-matcher';
 
 // ─── Folder / file layout ─────────────────────────────────────────────────────
 
 const HOOKS_FOLDER = 'Hooks';
-const RUNS_SUBFOLDER = 'Runs';
 const STATE_FILE = 'hooks-state.json';
 
 /** Default per-(hook, file) debounce window (ms). Resets on every matching event. */
@@ -97,10 +95,8 @@ function validateSlug(raw: string): string {
  *
  * Hooks are skipped entirely when `settings.hooksEnabled` is false (default).
  */
-export class HookManager {
+export class HookManager extends FileBackedFeatureManager<Hook, HookState> {
 	private hooks = new Map<string, Hook>();
-	private state: HooksState = {};
-	private readonly stateStore: JsonSidecarStateStore<HooksState>;
 	private initialized = false;
 	/** Per-(hook, file) debounce timers, keyed by `${slug}::${filePath}`. */
 	private debounceTimers = new Map<string, number>();
@@ -111,8 +107,14 @@ export class HookManager {
 	/** Shared auto-pause-after-N-failures ladder over the per-hook sidecar state. */
 	private readonly failureTracker: FailurePauseTracker<HookState>;
 
-	constructor(private plugin: ObsidianGemini) {
-		this.stateStore = new JsonSidecarStateStore<HooksState>(plugin, () => this.stateFilePath, '[HookManager]');
+	constructor(plugin: ObsidianGemini) {
+		super(plugin, {
+			featureFolder: HOOKS_FOLDER,
+			stateFileName: STATE_FILE,
+			logPrefix: '[HookManager]',
+			featureNoun: 'hook',
+			entityLabel: 'Hook',
+		});
 		this.failureTracker = new FailurePauseTracker<HookState>({
 			getState: (slug) => this.state[slug],
 			setState: (slug, next) => {
@@ -128,16 +130,14 @@ export class HookManager {
 
 	// ── Folder path helpers ──────────────────────────────────────────────────
 
+	/** Public alias for the base's feature-folder path (kept for callers). */
 	get hooksFolder(): string {
-		return normalizePath(`${this.plugin.settings.historyFolder}/${HOOKS_FOLDER}`);
+		return this.featureFolderPath;
 	}
 
-	get runsFolder(): string {
-		return normalizePath(`${this.hooksFolder}/${RUNS_SUBFOLDER}`);
-	}
-
-	get stateFilePath(): string {
-		return normalizePath(`${this.hooksFolder}/${STATE_FILE}`);
+	/** The base operates on this map; `hooks` keeps its descriptive name. */
+	protected get definitions(): Map<string, Hook> {
+		return this.hooks;
 	}
 
 	// ── Lifecycle ────────────────────────────────────────────────────────────
@@ -169,7 +169,7 @@ export class HookManager {
 		await ensureFolderExists(this.plugin.app.vault, this.hooksFolder, 'hooks', this.plugin.logger);
 		await ensureFolderExists(this.plugin.app.vault, this.runsFolder, 'hook runs', this.plugin.logger);
 		await this.loadState();
-		await this.discoverHooks();
+		await this.discoverDefinitions();
 		this.registerEventHandlers();
 
 		this.initialized = true;
@@ -224,7 +224,7 @@ export class HookManager {
 		const filePath = normalizePath(`${this.hooksFolder}/${slug}.md`);
 		// Normalize at the write boundary so an invalid value from a programmatic
 		// caller can't be persisted or held in memory — matches the read-path
-		// contract (parseHookFile), where invalid values fall back to the default.
+		// contract (parseDefinitionFile), where invalid values fall back to the default.
 		const normalizedParams = { ...params, maxIterations: parseMaxIterations(params.maxIterations) };
 		const content = this.serializeHook({ ...normalizedParams, slug });
 		await this.plugin.app.vault.create(filePath, content);
@@ -265,7 +265,7 @@ export class HookManager {
 			model: params.model ?? hook.model ?? '',
 			// `in` check (not ??) so callers can clear back to the default by
 			// passing maxIterations: undefined explicitly. Normalize incoming
-			// values so an invalid number can't be persisted (matches parseHookFile).
+			// values so an invalid number can't be persisted (matches parseDefinitionFile).
 			maxIterations: 'maxIterations' in params ? parseMaxIterations(params.maxIterations) : hook.maxIterations,
 			outputPath: params.outputPath ?? hook.outputPath ?? '',
 			enabled: params.enabled ?? hook.enabled,
@@ -285,17 +285,7 @@ export class HookManager {
 	 * Delete a hook: remove the definition file and its state entry.
 	 */
 	async deleteHook(slug: string): Promise<void> {
-		const hook = this.hooks.get(slug);
-		if (!hook) throw new Error(`Hook "${slug}" not found`);
-
-		const file = this.plugin.app.vault.getAbstractFileByPath(hook.filePath);
-		if (file) {
-			await this.plugin.app.fileManager.trashFile(file);
-		}
-
-		this.hooks.delete(slug);
-		delete this.state[slug];
-		await this.saveState();
+		await this.deleteDefinition(slug);
 	}
 
 	/**
@@ -386,7 +376,7 @@ export class HookManager {
 		if (params.focusFile === true) lines.push('focusFile: true');
 
 		// `summarize` and `command` actions don't use the prompt body, but
-		// `parseHookFile` rejects empty bodies for `agent-task` and `rewrite`.
+		// `parseDefinitionFile` rejects empty bodies for `agent-task` and `rewrite`.
 		// Emit the body trimmed; for the prompt-less actions an empty body
 		// is fine because the parser doesn't enforce a non-empty body for them.
 		lines.push('---', '', params.prompt.trim(), '');
@@ -683,31 +673,7 @@ export class HookManager {
 
 	// ── Discovery / parsing ─────────────────────────────────────────────────
 
-	private async discoverHooks(): Promise<void> {
-		this.hooks.clear();
-
-		const prefix = this.hooksFolder + '/';
-		const runsPrefix = this.runsFolder + '/';
-
-		const files = this.plugin.app.vault
-			.getMarkdownFiles()
-			.filter((f) => f.path.startsWith(prefix) && !f.path.startsWith(runsPrefix));
-
-		for (const file of files) {
-			try {
-				const hook = await this.parseHookFile(file);
-				if (hook) this.hooks.set(hook.slug, hook);
-			} catch (err) {
-				this.plugin.logger.warn(`[HookManager] Failed to parse hook file ${file.path}:`, err);
-			}
-		}
-
-		// Drop state entries whose definition file is gone.
-		purgeOrphanState(this.state, (slug) => this.hooks.has(slug));
-		await this.saveState();
-	}
-
-	private async parseHookFile(file: TFile): Promise<Hook | null> {
+	protected async parseDefinitionFile(file: TFile): Promise<Hook | null> {
 		const frontmatter = this.plugin.app.metadataCache.getFileCache(file)?.frontmatter;
 		if (!frontmatter) return null;
 
@@ -805,15 +771,5 @@ export class HookManager {
 	private parseAction(value: unknown): HookAction | null {
 		if (value === 'agent-task' || value === 'summarize' || value === 'rewrite' || value === 'command') return value;
 		return null;
-	}
-
-	// ── State persistence ───────────────────────────────────────────────────
-
-	private async loadState(): Promise<void> {
-		this.state = await this.stateStore.load();
-	}
-
-	private async saveState(): Promise<void> {
-		await this.stateStore.save(this.state);
 	}
 }

--- a/src/services/scheduled-task-manager.ts
+++ b/src/services/scheduled-task-manager.ts
@@ -4,13 +4,12 @@ import { ensureFolderExists } from '../utils/file-utils';
 import { FeatureToolPolicy } from '../types/tool-policy';
 import { formatToolPolicyYaml } from './feature-policy-yaml';
 import {
-	JsonSidecarStateStore,
 	extractMarkdownBody,
 	migrateLegacyEnabledTools,
 	parseMaxIterations,
-	purgeOrphanState,
 	resolveFeatureToolPolicy,
 } from './feature-definition';
+import { FileBackedFeatureManager } from './file-backed-feature-manager';
 import { FailurePauseTracker, MAX_CONSECUTIVE_FAILURES } from './failure-pause-tracker';
 import { computeNextRunAt } from './scheduled-tasks/schedule';
 import { detectMissedRuns as detectMissedRunsInWindow } from './scheduled-tasks/missed-runs';
@@ -47,9 +46,8 @@ const TICK_INTERVAL_MS = 60_000;
  *   │       └── <date>.md               ← result output
  *   └── scheduled-tasks-state.json      ← volatile runtime state
  */
-export class ScheduledTaskManager {
+export class ScheduledTaskManager extends FileBackedFeatureManager<ScheduledTask, TaskState> {
 	private tasks = new Map<string, ScheduledTask>();
-	private state: ScheduledTasksState = {};
 	private tickIntervalId: number | null = null;
 	private initialized = false;
 	private metadataCacheHandler: ((...data: unknown[]) => unknown) | null = null;
@@ -70,18 +68,19 @@ export class ScheduledTaskManager {
 	private pendingDefers = new Set<number>();
 	/** Slugs reserved for catch-up approval — tick skips these until approved or skipped. */
 	private catchUpPending = new Set<string>();
-	private readonly stateStore: JsonSidecarStateStore<ScheduledTasksState>;
 	/** Shared auto-pause-after-N-failures ladder over the per-task sidecar state. */
 	private readonly failureTracker: FailurePauseTracker<TaskState>;
 	/** Dependencies handed to the execution-dispatch module (submit/execute/advance). */
 	private readonly execDeps: ExecutionDeps;
 
-	constructor(private plugin: ObsidianGemini) {
-		this.stateStore = new JsonSidecarStateStore<ScheduledTasksState>(
-			plugin,
-			() => this.stateFilePath,
-			'[ScheduledTaskManager]'
-		);
+	constructor(plugin: ObsidianGemini) {
+		super(plugin, {
+			featureFolder: SCHEDULED_TASKS_FOLDER,
+			stateFileName: STATE_FILE,
+			logPrefix: '[ScheduledTaskManager]',
+			featureNoun: 'task',
+			entityLabel: 'Scheduled task',
+		});
 		this.failureTracker = new FailurePauseTracker<TaskState>({
 			getState: (slug) => this.state[slug],
 			setState: (slug, next) => {
@@ -105,16 +104,14 @@ export class ScheduledTaskManager {
 
 	// ── Folder path helpers ──────────────────────────────────────────────────
 
+	/** Public alias for the base's feature-folder path (kept for callers). */
 	get scheduledTasksFolder(): string {
-		return normalizePath(`${this.plugin.settings.historyFolder}/${SCHEDULED_TASKS_FOLDER}`);
+		return this.featureFolderPath;
 	}
 
-	get runsFolder(): string {
-		return normalizePath(`${this.scheduledTasksFolder}/${RUNS_SUBFOLDER}`);
-	}
-
-	get stateFilePath(): string {
-		return normalizePath(`${this.scheduledTasksFolder}/${STATE_FILE}`);
+	/** The base operates on this map; `tasks` keeps its descriptive name. */
+	protected get definitions(): Map<string, ScheduledTask> {
+		return this.tasks;
 	}
 
 	// ── Lifecycle ────────────────────────────────────────────────────────────
@@ -156,7 +153,7 @@ export class ScheduledTaskManager {
 		await ensureFolderExists(this.plugin.app.vault, this.scheduledTasksFolder, 'scheduled tasks', this.plugin.logger);
 		await ensureFolderExists(this.plugin.app.vault, this.runsFolder, 'scheduled task runs', this.plugin.logger);
 		await this.loadState();
-		await this.discoverTasks();
+		await this.discoverDefinitions();
 
 		// Re-parse a task definition file whenever the metadata cache updates it
 		// (fires after Obsidian re-indexes the frontmatter, so values are current).
@@ -369,17 +366,7 @@ export class ScheduledTaskManager {
 	 * map once Obsidian indexes the deletion; the state cleanup happens immediately.
 	 */
 	async deleteTask(slug: string): Promise<void> {
-		const task = this.tasks.get(slug);
-		if (!task) throw new Error(`Scheduled task "${slug}" not found`);
-
-		const file = this.plugin.app.vault.getAbstractFileByPath(task.filePath);
-		if (file) {
-			await this.plugin.app.fileManager.trashFile(file);
-		}
-
-		this.tasks.delete(slug);
-		delete this.state[slug];
-		await this.saveState();
+		await this.deleteDefinition(slug);
 	}
 
 	/**
@@ -516,41 +503,28 @@ export class ScheduledTaskManager {
 
 	// ── Private ──────────────────────────────────────────────────────────────
 
-	private async discoverTasks(): Promise<void> {
-		this.tasks.clear();
+	protected parseDefinitionFile(file: TFile): Promise<ScheduledTask | null> {
+		return this.parseTaskFile(file);
+	}
 
-		const prefix = this.scheduledTasksFolder + '/';
-		const runsPrefix = this.runsFolder + '/';
-
-		// All markdown files directly inside Scheduled-Tasks/ (not in Runs/ or deeper)
-		const files = this.plugin.app.vault
-			.getMarkdownFiles()
-			.filter((f) => f.path.startsWith(prefix) && !f.path.startsWith(runsPrefix));
-
-		for (const file of files) {
-			try {
-				const task = await this.parseTaskFile(file);
-				if (!task) continue;
-
-				this.tasks.set(task.slug, task);
-
-				// Seed state entry for newly-discovered tasks: due immediately
-				if (!this.state[task.slug]) {
-					this.state[task.slug] = { nextRunAt: new Date().toISOString() };
-				}
-			} catch (error) {
-				this.plugin.logger.warn(`[ScheduledTaskManager] Failed to parse task file ${file.path}:`, error);
-			}
+	/**
+	 * Seed a newly-discovered task's state so it is due immediately. The tick
+	 * already tolerates a missing entry, but seeding keeps discovery and the
+	 * hot-reload paths consistent. Existing entries are preserved verbatim.
+	 */
+	protected seedDiscoveredState(task: ScheduledTask): void {
+		if (!this.state[task.slug]) {
+			this.state[task.slug] = { nextRunAt: new Date().toISOString() };
 		}
+	}
 
-		// Drop state entries for slugs whose definition file is gone. The tick
-		// already tolerates orphan state, but stripping it on init keeps the
-		// JSON tidy and prevents stale lastError messages from accumulating.
-		for (const slug of purgeOrphanState(this.state, (s) => this.tasks.has(s))) {
-			this.plugin.logger.log(`[ScheduledTaskManager] Purged orphan state entry for "${slug}" (no matching task file)`);
-		}
-
-		await this.saveState();
+	/**
+	 * Log each orphan state entry stripped on discovery. The tick already
+	 * tolerates orphan state, but stripping it keeps the JSON tidy and stops
+	 * stale lastError messages from accumulating.
+	 */
+	protected onOrphanPurged(slug: string): void {
+		this.plugin.logger.log(`[ScheduledTaskManager] Purged orphan state entry for "${slug}" (no matching task file)`);
 	}
 
 	private async parseTaskFile(file: TFile): Promise<ScheduledTask | null> {
@@ -634,13 +608,5 @@ export class ScheduledTaskManager {
 
 		lines.push('---', '', params.prompt.trim(), '');
 		return lines.join('\n');
-	}
-
-	private async loadState(): Promise<void> {
-		this.state = await this.stateStore.load();
-	}
-
-	private async saveState(): Promise<void> {
-		await this.stateStore.save(this.state);
 	}
 }

--- a/src/services/scheduled-task-manager.ts
+++ b/src/services/scheduled-task-manager.ts
@@ -534,7 +534,7 @@ export class ScheduledTaskManager extends FileBackedFeatureManager<ScheduledTask
 		if (!prompt) return null;
 
 		const slug = file.basename;
-		const defaultOutputPath = `${this.runsFolder}/${slug}/{date}.md`;
+		const defaultOutputPath = normalizePath(`${this.runsFolder}/${slug}/{date}.md`);
 
 		const task: ScheduledTask = {
 			slug,

--- a/src/services/scheduled-task-manager.ts
+++ b/src/services/scheduled-task-manager.ts
@@ -24,7 +24,6 @@ export { computeNextRunAt } from './scheduled-tasks/schedule';
 // ─── Folder / file layout ─────────────────────────────────────────────────────
 
 const SCHEDULED_TASKS_FOLDER = 'Scheduled-Tasks';
-const RUNS_SUBFOLDER = 'Runs';
 const STATE_FILE = 'scheduled-tasks-state.json';
 
 /** Milliseconds between scheduler ticks (60 s). Same cadence as ChatTimer. */
@@ -331,7 +330,7 @@ export class ScheduledTaskManager extends FileBackedFeatureManager<ScheduledTask
 		computeNextRunAt(params.schedule, new Date());
 
 		const filePath = normalizePath(`${this.scheduledTasksFolder}/${slug}.md`);
-		const defaultOutputPath = normalizePath(`${this.scheduledTasksFolder}/${RUNS_SUBFOLDER}/${slug}/{date}.md`);
+		const defaultOutputPath = normalizePath(`${this.runsFolder}/${slug}/{date}.md`);
 		// Normalize at the write boundary so an invalid value from a programmatic
 		// caller can't be persisted or held in memory — matches the read-path
 		// contract (parseTaskFile), where invalid values fall back to the default.
@@ -361,9 +360,9 @@ export class ScheduledTaskManager extends FileBackedFeatureManager<ScheduledTask
 	}
 
 	/**
-	 * Delete a scheduled task: remove the definition file and its state entry.
-	 * The metadata cache 'changed' handler will drop the task from the in-memory
-	 * map once Obsidian indexes the deletion; the state cleanup happens immediately.
+	 * Delete a scheduled task. Delegates to the base `deleteDefinition`, which
+	 * trashes the definition file and removes the task (and its sidecar state
+	 * entry) from the in-memory map synchronously in this call.
 	 */
 	async deleteTask(slug: string): Promise<void> {
 		await this.deleteDefinition(slug);
@@ -535,7 +534,7 @@ export class ScheduledTaskManager extends FileBackedFeatureManager<ScheduledTask
 		if (!prompt) return null;
 
 		const slug = file.basename;
-		const defaultOutputPath = `${this.scheduledTasksFolder}/${RUNS_SUBFOLDER}/${slug}/{date}.md`;
+		const defaultOutputPath = `${this.runsFolder}/${slug}/{date}.md`;
 
 		const task: ScheduledTask = {
 			slug,
@@ -587,8 +586,7 @@ export class ScheduledTaskManager extends FileBackedFeatureManager<ScheduledTask
 			lines.push(...policyLines);
 		}
 
-		const defaultOutputPath =
-			params.slug && normalizePath(`${this.scheduledTasksFolder}/${RUNS_SUBFOLDER}/${params.slug}/{date}.md`);
+		const defaultOutputPath = params.slug && normalizePath(`${this.runsFolder}/${params.slug}/{date}.md`);
 		if (params.outputPath && params.outputPath !== defaultOutputPath) {
 			lines.push(`outputPath: '${params.outputPath}'`);
 		}

--- a/test/services/file-backed-feature-manager.test.ts
+++ b/test/services/file-backed-feature-manager.test.ts
@@ -1,0 +1,254 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { TFile } from 'obsidian';
+import { FileBackedFeatureManager, type FileBackedDefinition } from '../../src/services/file-backed-feature-manager';
+
+// normalizePath is a no-op in tests; TFile is only used as a type here.
+vi.mock('obsidian', () => ({
+	normalizePath: (p: string) => p,
+	TFile: class {},
+}));
+
+// feature-definition pulls skill-manager for findFrontmatterEndOffset — stub it
+// so the base's dependency graph stays light in this unit test.
+vi.mock('../../src/services/skill-manager', () => ({
+	findFrontmatterEndOffset: vi.fn().mockReturnValue(undefined),
+}));
+
+// ─── Test doubles ───────────────────────────────────────────────────────────
+
+interface TestDef extends FileBackedDefinition {
+	readonly slug: string;
+	readonly filePath: string;
+}
+
+type TestEntryState = { seededAt?: string; note?: string };
+
+function createMockPlugin(): any {
+	const disk: Record<string, string> = {};
+	return {
+		logger: { log: vi.fn(), debug: vi.fn(), error: vi.fn(), warn: vi.fn() },
+		settings: { historyFolder: 'gemini-scribe' },
+		app: {
+			fileManager: { trashFile: vi.fn().mockResolvedValue(undefined) },
+			vault: {
+				getMarkdownFiles: vi.fn().mockReturnValue([]),
+				getAbstractFileByPath: vi.fn().mockReturnValue(null),
+				adapter: {
+					exists: vi.fn().mockImplementation(async (path: string) => path in disk),
+					read: vi.fn().mockImplementation(async (path: string) => disk[path] ?? '{}'),
+					write: vi.fn().mockImplementation(async (path: string, content: string) => {
+						disk[path] = content;
+					}),
+				},
+			},
+		},
+		_disk: disk,
+	};
+}
+
+/**
+ * Minimal concrete manager that exercises the base seams. `parseDefinitionFile`
+ * treats a file basename `bad-*` as a parse failure (throws) and `null-*` as a
+ * non-definition (returns null); everything else becomes a `{ slug, filePath }`.
+ */
+class TestManager extends FileBackedFeatureManager<TestDef, TestEntryState> {
+	readonly defs = new Map<string, TestDef>();
+	seedCalls: string[] = [];
+
+	constructor(plugin: any, seedOnDiscovery = false) {
+		super(plugin, {
+			featureFolder: 'Widgets',
+			stateFileName: 'widgets-state.json',
+			logPrefix: '[TestManager]',
+			featureNoun: 'widget',
+			entityLabel: 'Widget',
+		});
+		this.seedOnDiscovery = seedOnDiscovery;
+	}
+
+	private seedOnDiscovery: boolean;
+
+	protected get definitions(): Map<string, TestDef> {
+		return this.defs;
+	}
+
+	protected async parseDefinitionFile(file: TFile): Promise<TestDef | null> {
+		const basename = file.path.split('/').pop() ?? file.path;
+		if (basename.startsWith('bad-')) throw new Error('boom');
+		if (basename.startsWith('null-')) return null;
+		const slug = basename.replace(/\.md$/, '');
+		return { slug, filePath: file.path };
+	}
+
+	protected seedDiscoveredState(def: TestDef): void {
+		this.seedCalls.push(def.slug);
+		if (this.seedOnDiscovery && !this.state[def.slug]) {
+			this.state[def.slug] = { seededAt: 'now' };
+		}
+	}
+
+	protected onOrphanPurged(slug: string): void {
+		this.plugin.logger.log(`purged ${slug}`);
+	}
+
+	// Expose the protected seams for the test.
+	runDiscover() {
+		return this.discoverDefinitions();
+	}
+	runDelete(slug: string) {
+		return this.deleteDefinition(slug);
+	}
+	runLoad() {
+		return this.loadState();
+	}
+	runSave() {
+		return this.saveState();
+	}
+	getState() {
+		return this.state;
+	}
+	setState(next: Record<string, TestEntryState>) {
+		this.state = next;
+	}
+}
+
+function mkFile(path: string): TFile {
+	return { path } as unknown as TFile;
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe('FileBackedFeatureManager', () => {
+	let plugin: any;
+	let manager: TestManager;
+
+	beforeEach(() => {
+		plugin = createMockPlugin();
+		manager = new TestManager(plugin);
+	});
+
+	describe('folder path helpers', () => {
+		it('derives feature/runs/state paths from historyFolder + config', () => {
+			expect(manager.featureFolderPath).toBe('gemini-scribe/Widgets');
+			expect(manager.runsFolder).toBe('gemini-scribe/Widgets/Runs');
+			expect(manager.stateFilePath).toBe('gemini-scribe/Widgets/widgets-state.json');
+		});
+
+		it('reflects a runtime historyFolder change (lazy resolution)', () => {
+			plugin.settings.historyFolder = 'other-folder';
+			expect(manager.stateFilePath).toBe('other-folder/Widgets/widgets-state.json');
+		});
+	});
+
+	describe('discoverDefinitions', () => {
+		it('builds the map from files, excluding the Runs/ subtree', async () => {
+			plugin.app.vault.getMarkdownFiles.mockReturnValue([
+				mkFile('gemini-scribe/Widgets/a.md'),
+				mkFile('gemini-scribe/Widgets/b.md'),
+				mkFile('gemini-scribe/Widgets/Runs/a/2026-01-01.md'), // filtered out
+				mkFile('some-other-folder/c.md'), // outside feature folder
+			]);
+
+			await manager.runDiscover();
+
+			expect([...manager.defs.keys()].sort()).toEqual(['a', 'b']);
+		});
+
+		it('skips null parses and logs a warning on a throwing parse, then continues', async () => {
+			plugin.app.vault.getMarkdownFiles.mockReturnValue([
+				mkFile('gemini-scribe/Widgets/good.md'),
+				mkFile('gemini-scribe/Widgets/null-x.md'),
+				mkFile('gemini-scribe/Widgets/bad-y.md'),
+			]);
+
+			await manager.runDiscover();
+
+			expect([...manager.defs.keys()]).toEqual(['good']);
+			expect(plugin.logger.warn).toHaveBeenCalledWith(
+				'[TestManager] Failed to parse widget file gemini-scribe/Widgets/bad-y.md:',
+				expect.any(Error)
+			);
+		});
+
+		it('calls seedDiscoveredState for each discovered definition', async () => {
+			plugin.app.vault.getMarkdownFiles.mockReturnValue([
+				mkFile('gemini-scribe/Widgets/a.md'),
+				mkFile('gemini-scribe/Widgets/b.md'),
+			]);
+
+			await manager.runDiscover();
+
+			expect(manager.seedCalls.sort()).toEqual(['a', 'b']);
+		});
+
+		it('purges orphan state entries and reports them via onOrphanPurged, keeping live ones', async () => {
+			manager.setState({ live: { note: 'keep' }, orphan: { note: 'drop' } });
+			plugin.app.vault.getMarkdownFiles.mockReturnValue([mkFile('gemini-scribe/Widgets/live.md')]);
+
+			await manager.runDiscover();
+
+			expect(manager.getState()).toEqual({ live: { note: 'keep' } });
+			expect(plugin.logger.log).toHaveBeenCalledWith('purged orphan');
+			expect(plugin.logger.log).not.toHaveBeenCalledWith('purged live');
+		});
+
+		it('persists the state after discovery', async () => {
+			plugin.app.vault.getMarkdownFiles.mockReturnValue([mkFile('gemini-scribe/Widgets/a.md')]);
+			await manager.runDiscover();
+			expect(plugin.app.vault.adapter.write).toHaveBeenCalledWith(
+				'gemini-scribe/Widgets/widgets-state.json',
+				expect.any(String)
+			);
+		});
+
+		it('a subclass override can seed per-definition state on discovery', async () => {
+			const seeding = new TestManager(plugin, true);
+			plugin.app.vault.getMarkdownFiles.mockReturnValue([mkFile('gemini-scribe/Widgets/a.md')]);
+			await seeding.runDiscover();
+			expect(seeding.getState()).toEqual({ a: { seededAt: 'now' } });
+		});
+	});
+
+	describe('deleteDefinition', () => {
+		it('trashes the file, drops the map entry and state, and saves', async () => {
+			manager.defs.set('a', { slug: 'a', filePath: 'gemini-scribe/Widgets/a.md' });
+			manager.setState({ a: { note: 'x' } });
+			const fileObj = mkFile('gemini-scribe/Widgets/a.md');
+			plugin.app.vault.getAbstractFileByPath.mockReturnValue(fileObj);
+
+			await manager.runDelete('a');
+
+			expect(plugin.app.fileManager.trashFile).toHaveBeenCalledWith(fileObj);
+			expect(manager.defs.has('a')).toBe(false);
+			expect(manager.getState().a).toBeUndefined();
+			expect(plugin.app.vault.adapter.write).toHaveBeenCalled();
+		});
+
+		it('tolerates a file already gone from the vault', async () => {
+			manager.defs.set('a', { slug: 'a', filePath: 'gemini-scribe/Widgets/a.md' });
+			plugin.app.vault.getAbstractFileByPath.mockReturnValue(null);
+
+			await manager.runDelete('a');
+
+			expect(plugin.app.fileManager.trashFile).not.toHaveBeenCalled();
+			expect(manager.defs.has('a')).toBe(false);
+		});
+
+		it('throws a labelled not-found error for an unknown slug', async () => {
+			await expect(manager.runDelete('nope')).rejects.toThrow('Widget "nope" not found');
+		});
+	});
+
+	describe('state persistence', () => {
+		it('loadState reads the sidecar; saveState writes it back', async () => {
+			plugin._disk['gemini-scribe/Widgets/widgets-state.json'] = JSON.stringify({ a: { note: 'loaded' } });
+
+			await manager.runLoad();
+			expect(manager.getState()).toEqual({ a: { note: 'loaded' } });
+
+			manager.setState({ b: { note: 'saved' } });
+			await manager.runSave();
+			expect(JSON.parse(plugin._disk['gemini-scribe/Widgets/widgets-state.json'])).toEqual({ b: { note: 'saved' } });
+		});
+	});
+});


### PR DESCRIPTION
## Summary

`HookManager` and `ScheduledTaskManager` are sibling file-backed feature managers that already shared their *field-level* helpers via `src/services/feature-definition.ts`, but the *outer manager skeleton* — the folder-path getters, the discover-and-purge loop, the sidecar load/save wrappers, and the delete method — was still copy-pasted between the two, differing only in the folder constant, the map field name, and the per-file parse callback.

This extracts that shell into a new abstract `FileBackedFeatureManager<TDef, TEntryState>` base under `src/services/`, parameterized by a small config object and two subclass seams. It is the structural follow-on to the field-level extraction already in `feature-definition.ts` — **pure code motion, no behavior change, no on-disk format change**.

Fixes #1229

## Changes

- **`src/services/file-backed-feature-manager.ts` (new)** — abstract base owning:
  - the folder getters (`featureFolderPath` / `runsFolder` / `stateFilePath`), derived from a config `featureFolder` + `stateFileName`;
  - `discoverDefinitions()` — the `getMarkdownFiles().filter(startsWith(prefix) && !startsWith(runsPrefix))` → per-file parse → seed → `purgeOrphanState` → `saveState` template;
  - `deleteDefinition(slug)` — trash file → drop from map → drop state → save, with a config-driven not-found error label;
  - `loadState()` / `saveState()` over the injected `JsonSidecarStateStore`.
  - Subclass seams: `definitions` (map accessor), `parseDefinitionFile(file)`, plus overridable `seedDiscoveredState(def)` and `onOrphanPurged(slug)` (both default no-op).
- **`src/services/hook-manager.ts`** — `extends FileBackedFeatureManager<Hook, HookState>`; removed the duplicated getters, `discoverHooks`, `deleteHook` body, and state wrappers. Supplies its config, the `hooks` map via `definitions`, and `parseDefinitionFile`. Keeps the public `hooksFolder` getter as an alias. Hooks don't seed or log on purge, so both overridable hooks stay at their no-op defaults.
- **`src/services/scheduled-task-manager.ts`** — same removals; additionally overrides `seedDiscoveredState` to seed `nextRunAt` on newly-discovered tasks and `onOrphanPurged` to keep its per-orphan purge log. Keeps the public `scheduledTasksFolder` / `runsFolder` / `stateFilePath` getters (used by the scheduler UI + tests).
- **`src/services/feature-definition.ts`** — docstring updated to point at the new base as the home of the outer skeleton (leaf helpers unchanged; the base consumes them).
- **`test/services/file-backed-feature-manager.test.ts` (new)** — covers the base seams via a minimal concrete subclass: folder-path derivation (incl. lazy `historyFolder` change), discovery with `Runs/` exclusion + null/throwing parse handling, the seed hook, orphan purge + `onOrphanPurged`, delete (trash + state clear + already-gone file + labelled not-found error), and sidecar load/save round-trip.

Each manager keeps its descriptively-named `hooks` / `tasks` field (exposed to the base via the `definitions` accessor), so the existing suites' `(manager as any).hooks` / `.tasks` reassignments and the public folder getters continue to work unchanged.

## Screenshots / Screencast

N/A — internal refactor with no user-visible or UI change.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer (#1229, plan approved via `auto:ready`)
- [x] All CI checks pass (`npm test` — 3489 green, `npm run build`, `npm run format-check`) — also ran `npm run typecheck:test`, `npm run lint` (0 errors), and `npm run lint:cycles` (0 cycles)
- [x] I have tested this change on Desktop — N/A: behavior-preserving structural refactor with no runnable surface; verified via the full unit suite, which pins discovery (incl. `Runs/` exclusion), the task-only `nextRunAt` seed + orphan-purge log vs hooks' silent purge, delete, and folder-path behavior
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A: no platform-specific code; pure code motion behind an abstract base
- [x] Documentation has been updated (if applicable) — N/A: no user-facing behavior, settings, or file-format change; the `feature-definition.ts` module docstring was refreshed to reference the new base

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude (auto-dev pipeline)
- [x] I have reviewed and understand all AI-generated code in this PR

---

This PR was produced by the auto-dev pipeline from the approved plan on #1229.

Behavioral verification: this is a pure internal refactor with no runnable surface (no CLI, endpoint, UI, or observable side effect) — the behavioral gate is the unit suite, which pins both managers' discovery, seeding, orphan-purge, and delete behavior byte-for-byte.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAKcZ742cEJUJdiwksujxQ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Added a shared manager backbone for file-backed markdown feature handling, including standardized discovery, deletion, and sidecar state persistence.
  * Hook and scheduled task managers now use the shared lifecycle for consistent definition/state management.
  * Scheduled task output paths now reliably derive from the runs folder.
* **Bug Fixes**
  * Invalid definitions are skipped with warnings; stale/orphan state entries are purged.
  * Safer deletion behavior when definition files are missing.
* **Tests**
  * Added unit tests covering discovery, purge, deletion, and sidecar save/load behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->