### PR TITLE
chore(daily): 2026-07-24 daily update

### DIFF
--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -20,10 +20,10 @@ The reference below groups settings by topic for lookup, which doesn't always ma
 - [Basic Settings](#basic-settings) (UI: _General_ — provider, API key, models, plugin state folder)
 - [Model Configuration](#model-configuration) (UI: _General_ — chat/summary/completion/image model selection)
 - [Custom Prompts](#custom-prompts) (UI: _Agent config_ — advanced)
-- [UI Settings](#ui-settings) (UI: _User experience_ — streaming, diff view, identity, frontmatter key, session history)
+- [UI Settings](#ui-settings) (UI: _User experience_ — streaming, tool execution logging, diff view, identity, frontmatter key, session history)
 - [Automation Settings](#automation-settings) (UI: _Automation_ — scheduled task catch-up, lifecycle hooks toggle)
 - [Context management](#context-management) (UI: _Agent config_ — advanced)
-- [Developer Settings](#developer-settings) (UI: split across _Agent config_, _Tool permissions_, _MCP servers_, _Debug_)
+- [Developer Settings](#developer-settings) (UI: split across _Agent config_, _Tool permissions_, _MCP servers_, _Debug_ — including token usage display)
 - [Session-Level Settings](#session-level-settings)
 
 UI sections without a dedicated topic in this reference: _Vault search index_ (covered in [Semantic Search](/guide/semantic-search)). The _Automation_ section's task and hook management UI is covered in the [Scheduled tasks](/guide/scheduled-tasks) and [Lifecycle Hooks](/guide/lifecycle-hooks) guides; the two persistent settings (`autoRunCatchUp`, `hooksEnabled`) are documented in [Automation Settings](#automation-settings) below.
@@ -185,6 +185,25 @@ See the [Custom Prompts Guide](/guide/custom-prompts) for detailed instructions.
 - **Description**: Enable streaming responses in the chat interface for a more interactive experience
 - **Note**: When disabled, full responses are displayed at once
 
+### Log Tool Execution to Session History
+
+- **Setting**: `logToolExecution`
+- **Type**: Boolean
+- **Default**: `true`
+- **Description**: Append a summary of each tool execution to the session history file for auditing
+- **Format**: Collapsible callout blocks showing tool name, key parameters, status, and duration
+- **Note**: Takes effect immediately when toggled — no plugin reload needed
+
+### Always Show Diff view for File Writes
+
+- **Setting**: `alwaysShowDiffView`
+- **Type**: Boolean
+- **Default**: `false`
+- **Description**: Automatically open a diff view when the agent proposes file changes, instead of requiring a button click
+- **When off**: The confirmation card shows a summary and a "View changes" button. Click it to open the diff view
+- **When on**: The diff view opens automatically alongside the confirmation card
+- **Note**: The diff view lets you edit the proposed content before approving. If you modify content, the tool result reports `userEdited: true` so the agent knows
+
 ### Expanded Settings Sections
 
 - **Setting**: `expandedSettingsSections`
@@ -242,6 +261,18 @@ Re-issuing a tool call brings the full output back if the agent needs it. The be
 
 Compaction isn't only checked before the initial request — `AgentLoop` re-checks after every tool batch, so a long tool chain (many iterations in a single turn) can be compacted mid-flight instead of only at the start of the next user turn. Mid-loop compaction never touches the current tool chain's own turns (the ones carrying the in-flight `functionCall`/`thoughtSignature` continuity) — only turns from before the chain started are eligible, so an in-progress multi-step tool sequence is never summarized out from under itself.
 
+## Developer Settings
+
+Advanced settings for developers and power users. Access by clicking "Show advanced settings" in the plugin settings.
+
+### Debug mode
+
+- **Setting**: `debugMode`
+- **Type**: Boolean
+- **Default**: `false`
+- **Description**: Enable detailed console logging for troubleshooting
+- **Use case**: Debugging API issues, tool execution problems, or unexpected behavior
+
 ### Show Token Usage
 
 - **Setting**: `showTokenUsage`
@@ -254,37 +285,6 @@ Compaction isn't only checked before the initial request — `AgentLoop` re-chec
   - Normal (muted text) — well under threshold
   - Yellow — approaching compaction threshold (≥80% of threshold)
   - Orange/red — at or above compaction threshold
-
-### Log Tool Execution to Session History
-
-- **Setting**: `logToolExecution`
-- **Type**: Boolean
-- **Default**: `true`
-- **Description**: Append a summary of each tool execution to the session history file for auditing
-- **Format**: Collapsible callout blocks showing tool name, key parameters, status, and duration
-- **Note**: Takes effect immediately when toggled — no plugin reload needed
-
-### Always Show Diff view for File Writes
-
-- **Setting**: `alwaysShowDiffView`
-- **Type**: Boolean
-- **Default**: `false`
-- **Description**: Automatically open a diff view when the agent proposes file changes, instead of requiring a button click
-- **When off**: The confirmation card shows a summary and a "View changes" button. Click it to open the diff view
-- **When on**: The diff view opens automatically alongside the confirmation card
-- **Note**: The diff view lets you edit the proposed content before approving. If you modify content, the tool result reports `userEdited: true` so the agent knows
-
-## Developer Settings
-
-Advanced settings for developers and power users. Access by clicking "Show advanced settings" in the plugin settings.
-
-### Debug mode
-
-- **Setting**: `debugMode`
-- **Type**: Boolean
-- **Default**: `false`
-- **Description**: Enable detailed console logging for troubleshooting
-- **Use case**: Debugging API issues, tool execution problems, or unexpected behavior
 
 ### Log to File
 

--- a/planning/changelog/2026-07-23.md
+++ b/planning/changelog/2026-07-23.md
@@ -1,0 +1,32 @@
+# Daily changelog — July 23, 2026
+
+**Date:** 2026-07-23
+**PRs merged:** 5
+
+---
+
+## Summary
+
+A refactor-heavy day driven by the auto-dev pipeline: three separate cleanups chipped away at duplicated logic in the tools, services, and session-manager layers, plus the prior day's automated housekeeping PR landed and a new regression suite closed a coverage gap in the agent view's tool-result renderer.
+
+## What shipped
+
+### [#1244 chore(daily): 2026-07-22 daily update](https://github.com/allenhutchison/obsidian-gemini/pull/1244)
+
+The automated daily housekeeping run for 2026-07-22: wrote that day's changelog (2 PRs merged, including a Gemini model-list update adding `gemini-3.5-flash-lite` and `gemini-3.6-flash`), audited product docs (no drift found), and found no unlabeled issues to triage.
+
+### [#1243 refactor(services): parameterize resolveFeatureToolPolicy over frontmatter keys](https://github.com/allenhutchison/obsidian-gemini/pull/1243)
+
+Unified two parallel implementations of "resolve a feature's tool policy from frontmatter" that differed only in key casing — `resolveFeatureToolPolicy` (camelCase `toolPolicy`/`enabledTools`, used by hooks and scheduled tasks) and `parseSessionToolPolicy` (snake_case `tool_policy`/`enabled_tools`, used by agent sessions). The shared resolver now takes an optional `{ policyKey, legacyKey }` argument so both dialects reach one implementation; behavior and on-disk frontmatter contracts are unchanged.
+
+### [#1241 refactor(tools): move per-tool diff/edit logic behind Tool interface hooks](https://github.com/allenhutchison/obsidian-gemini/pull/1241)
+
+`ToolExecutionEngine` previously hardcoded the diff-preview and re-apply logic for four specific tools (`write_file`, `append_content`, `create_skill`, `edit_skill`) in two name-branching blocks. This PR pushes that knowledge behind two new optional `Tool` interface hooks — `buildDiffContext` and `applyConfirmedEdit` — so each tool owns its own diff-preview construction and re-apply behavior, removing about 150 lines of per-tool branching from the engine. Pure relocation; no confirmation/diff UX change.
+
+### [#1240 test(agent-view): add regression coverage for tool-display result dispatch](https://github.com/allenhutchison/obsidian-gemini/pull/1240)
+
+Added the first regression suite for `agent-view-tool-display.ts`, which renders every tool-execution result but had zero test coverage despite three recent refactors landing without a safety net. The tests drive the module's private shape-guard dispatch (citation/search results, generated images, file content, truncatable code, arrays, and error branches) through the public `showToolResult` render path. Coverage-only — no renderer behavior change.
+
+### [#1245 refactor(services): extract FileBackedFeatureManager base for hook/task managers](https://github.com/allenhutchison/obsidian-gemini/pull/1245)
+
+`HookManager` and `ScheduledTaskManager` shared field-level frontmatter helpers already, but their outer manager skeleton — folder-path getters, the discover-and-purge loop, sidecar load/save, and delete — was still copy-pasted between the two. This extracts that shell into a new abstract `FileBackedFeatureManager<TDef, TEntryState>` base, parameterized by a config object and two subclass seams (`parseDefinitionFile`, plus overridable `seedDiscoveredState`/`onOrphanPurged`). Pure code motion; no behavior or on-disk format change.


### PR DESCRIPTION
## Summary

Automated daily housekeeping run (`daily-update` meta-skill via the `maintainerd` plugin marketplace) bundling `daily-changelog`, `audit-product-docs`, and `triage-issues` for 2026-07-24.

Fixes N/A — routine automated daily housekeeping run.

## Changes

- **daily-changelog**: wrote [`planning/changelog/2026-07-23.md`](https://github.com/allenhutchison/obsidian-gemini/blob/daily-update-2026-07-24/planning/changelog/2026-07-23.md) — 5 PRs merged on 2026-07-23: #1244 (prior day's automated daily-update PR), #1243 (parameterize `resolveFeatureToolPolicy` over frontmatter keys), #1241 (move per-tool diff/edit logic behind `Tool` interface hooks), #1240 (regression coverage for agent-view tool-display result dispatch), and #1245 (extract `FileBackedFeatureManager` base for hook/task managers). All auto-dev refactor/test PRs; no user-facing behavior changes.
- **audit-product-docs**: read all files under `config.paths.productDocs` (README.md, AGENTS.md, all of `docs/guide/`, all of `docs/reference/`) and cross-checked settings names/defaults, command IDs, tool names, state-folder paths, frontmatter fields, schedule syntax, permission tiers, and MCP config fields against `src/`. Found and fixed one drift item: `docs/reference/settings.md` documented `showTokenUsage`, `logToolExecution`, and `alwaysShowDiffView` under the wrong section headers (their detailed entries didn't match where they actually render in `src/ui/settings-debug.ts` and `src/ui/settings-ui.ts`, even though the doc's own intro paragraph already had the correct attribution). Moved all three entries to the correct sections and updated the Table of Contents annotations. No new docs were warranted — no user-visible feature found with zero coverage.
- **triage-issues**: no unlabeled open issues — no-op.

This is a housekeeping-only PR — no `src/` behavior changes.

## Screenshots / Screencast

N/A — changelog and docs-only change, no UI change.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A; routine automated daily housekeeping run
- [x] All CI checks pass (`npm test` — 3517 passing, `npm run build`, `npm run format-check`, `npm run lint`, `npm run typecheck:test`)
- [x] I have tested this change on Desktop — N/A, changelog/docs-only change; verified via local pre-flight checks
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A, no code change
- [x] Documentation has been updated (if applicable) — N/A, this PR's content is the changelog and a docs drift fix themselves
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01VuzqD6at5DaXeNh5rSY8Sg)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the settings reference with clearer organization of general, UI, and developer options.
  - Added guidance for logging tool executions, automatically opening file diffs, confirmation behavior, edit tracking, and Debug mode.
  - Corrected the table of contents and section placement for easier navigation.

- **Changelog**
  - Added the July 23, 2026 daily release summary, highlighting recently shipped improvements and fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->