### PR TITLE
chore(daily): 2026-07-25 daily update

### DIFF
--- a/planning/changelog/2026-07-24.md
+++ b/planning/changelog/2026-07-24.md
@@ -1,0 +1,32 @@
+# Daily changelog — July 24, 2026
+
+**Date:** 2026-07-24
+**PRs merged:** 5
+
+---
+
+## Summary
+
+A quiet, mostly-automated day: the prior day's housekeeping PR landed with a docs drift fix, and the rest of the day was dependency bumps — a security-relevant `fast-uri` patch plus routine `hono` and `postcss` upgrades.
+
+## What shipped
+
+### [#1247 chore(daily): 2026-07-23 daily update](https://github.com/allenhutchison/obsidian-gemini/pull/1247)
+
+The automated daily housekeeping run for 2026-07-23: wrote that day's changelog (5 PRs merged, a refactor-heavy day around tool policy resolution, per-tool diff/edit hooks, and a new `FileBackedFeatureManager` base), audited product docs and fixed one drift item (`docs/reference/settings.md` documented `showTokenUsage`, `logToolExecution`, and `alwaysShowDiffView` under the wrong section headers relative to where they actually render), and found no unlabeled issues to triage.
+
+### [#1246 chore(deps): bump hono from 4.12.26 to 4.12.31](https://github.com/allenhutchison/obsidian-gemini/pull/1246)
+
+Routine dependency bump picking up five patch releases' worth of `hono` fixes (form-data caching, multipart boundary handling, SSE retry field emission) and test/refactor cleanup upstream. No source changes on this side.
+
+### [#1250 chore(deps): bump fast-uri from 3.1.2 to 3.1.4](https://github.com/allenhutchison/obsidian-gemini/pull/1250)
+
+Security-relevant dependency bump: `fast-uri` 3.1.3 and 3.1.4 each fix a distinct advisory (URI authority parsing and a related fix), so this pulls in two security releases at once.
+
+### [#1249 chore(deps): bump hono from 4.12.31 to 4.12.32](https://github.com/allenhutchison/obsidian-gemini/pull/1249)
+
+A second same-day `hono` bump landing right behind #1246, picking up a further patch release (Lambda authorizer types, SSE `Last-Event-ID` reset, secure-headers CSP scoping fix).
+
+### [#1248 chore(deps-dev): bump postcss from 8.5.15 to 8.5.17](https://github.com/allenhutchison/obsidian-gemini/pull/1248)
+
+Dev-dependency bump for `postcss`, picking up fixes for a stack-overflow in deeply nested ASTs and several `Input#origin()`/`rangeBy()` position-computation bugs.


### PR DESCRIPTION
## Summary

Automated daily housekeeping run (`daily-update` meta-skill via the `maintainerd` plugin marketplace) bundling `daily-changelog`, `audit-product-docs`, and `triage-issues` for 2026-07-25.

Fixes N/A — routine automated daily housekeeping run.

## Changes

- **daily-changelog**: wrote [`planning/changelog/2026-07-24.md`](https://github.com/allenhutchison/obsidian-gemini/blob/daily-update-2026-07-25/planning/changelog/2026-07-24.md) — 5 PRs merged on 2026-07-24: #1247 (prior day's automated daily-update PR, which fixed a docs drift item), #1246 and #1249 (two same-day `hono` patch bumps), #1250 (`fast-uri` bump covering two security advisories), and #1248 (`postcss` dev-dependency bump). Mostly dependency-bump day; no `src/` changes.
- **audit-product-docs**: read every file under `docs/guide/`, `docs/reference/`, `README.md`, and `AGENTS.md` and cross-checked settings names/defaults, command IDs, tool names, MCP config fields, turn-budget/compaction/hook/RAG constants, and enumerated lists (agent tools, i18n languages, eval suite) against `src/`. No drift found and no user-visible feature with zero documentation coverage — no doc edits made.
- **triage-issues**: 0 unlabeled open issues (14 open issues checked, all already labeled) — no-op.

This is a housekeeping-only PR — no `src/` behavior changes.

## Screenshots / Screencast

N/A — changelog-only change, no UI change.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A; routine automated daily housekeeping run
- [x] All CI checks pass (`npm test` — 3517 passing, `npm run build`, `npm run format-check`, `npm run lint`, `npm run typecheck:test`)
- [x] I have tested this change on Desktop — N/A, changelog-only change; verified via local pre-flight checks
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A, no code change
- [x] Documentation has been updated (if applicable) — N/A, this PR's content is the changelog itself; the docs audit found nothing to fix
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01WVuC24HALakFtREvTu5e5F)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added the daily changelog for July 24, 2026.
  - Documented five recently shipped updates, including routine maintenance, dependency updates, and a security-related patch.
  - Improved release-history visibility by recording merged changes and brief descriptions in one place.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->