### PR TITLE
chore(daily): 2026-07-26 daily update

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ Obsidian Gemini Scribe is an Obsidian plugin that integrates Google's Gemini AI 
 ## Project Structure & Module Organization
 
 - `src/` contains TypeScript plugin code; `src/main.ts` is the entry point with domain folders such as `agent/`, `api/`, `tools/`, `ui/`, and `services/`, plus shared utilities in `utils/`.
-- `docs/` hosts user and operator guides; `prompts/` ships default agent prompts; `test-scripts/` holds manual integration runners.
+- `docs/` hosts user and operator guides; `prompts/` ships default agent prompts; `evals/` holds the agent eval harness (task fixtures, runner, baselines).
 - Unit tests live in the `test/` directory mirroring `src/` structure as `*.test.ts`; generated artifacts (`main.js`, `manifest.json`, `styles.css`) stay in the repo root for Obsidian.
 
 ## Commands
@@ -35,7 +35,7 @@ npm run translate    # Regenerate AI translations in src/i18n/ (needs GOOGLE_API
 ### Testing
 
 - Run single test: `npm test -- path/to/test.ts`
-- Manual integration: `node test-scripts/test-sdk-tools.mjs` (and siblings) validate agent toolchains before shipping
+- Manual integration: `npm run eval` drives the eval harness against a real Obsidian instance to validate agent toolchains before shipping (see `evals/README.md` and the **eval-harness** skill)
 - **Typecheck test files before pushing test changes**: the CI lint job runs `npm run typecheck:test` (`tsc --project tsconfig.test.json`), which type-checks the `test/` tree and catches errors the production build misses — `npm run build` uses `tsc -skipLibCheck` and excludes tests. A green local `npm run build` does **not** guarantee CI passes; run `npm run typecheck:test` too. (Classic trap: an expression-bodied arrow like `(t) => arr.push(t)` returns `number`, not `void`, and only the test typecheck flags it.)
 
 ### Versioning & Releases

--- a/docs/guide/custom-prompts.md
+++ b/docs/guide/custom-prompts.md
@@ -163,8 +163,10 @@ When a custom prompt is active, you'll see a badge in the session header showing
 For advanced users who want complete control:
 
 1. Set `override_system_prompt: true` in your prompt file
-2. Enable "Allow system prompt override" in plugin settings
-3. Your prompt will completely replace the default system instructions
+2. Your prompt will completely replace the default system instructions
+
+The frontmatter field alone controls this — the "Allow system prompt override" toggle in
+plugin settings does not currently gate it.
 
 **Warning:** Use with caution as this removes built-in safety features and Obsidian-specific knowledge.
 

--- a/docs/guide/projects.md
+++ b/docs/guide/projects.md
@@ -127,13 +127,13 @@ When you create a **new** agent session, the plugin inspects the session's initi
 
 ### What Changes When a Project is Active
 
-| Feature               | Behavior                                                                                    |
-| --------------------- | ------------------------------------------------------------------------------------------- |
-| **System prompt**     | Project instructions are injected between the base prompt and tool instructions             |
-| **Tool discovery**    | `list_files`, `find_files_by_name`, and `find_files_by_content` scope to the project root   |
-| **Read/write access** | Unrestricted — the agent can still access files outside the project when you reference them |
-| **Skills**            | Only skills listed in the project's `skills` array are available (empty = all)              |
-| **Tool policy**       | The project's `toolPolicy` is layered on top of the global plugin tool policy               |
+| Feature               | Behavior                                                                                                           |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| **System prompt**     | Project instructions are injected between the base prompt and tool instructions                                    |
+| **Tool discovery**    | `list_files`, `find_files_by_name`, `find_files_by_content`, and `vault_semantic_search` scope to the project root |
+| **Read/write access** | Unrestricted — the agent can still access files outside the project when you reference them                        |
+| **Skills**            | Only skills listed in the project's `skills` array are available (empty = all)                                     |
+| **Tool policy**       | The project's `toolPolicy` is layered on top of the global plugin tool policy                                      |
 
 ### Tool Policy Resolution Order
 
@@ -146,7 +146,7 @@ When you create a **new** agent session, the plugin inspects the session's initi
 
 ### Switching Projects
 
-Click the **project badge** in the agent session header to open the project picker. You can also use the **"Switch project"** command from the command palette.
+Click the **project badge** in the agent session header to open the project picker. You can also use the **"Switch project"** command from the command palette, or **"Link project to agent session"** to jump straight to the picker without clicking the badge first.
 
 Select **"No project"** to unlink the session from any project and return to vault-wide scope.
 

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -166,6 +166,7 @@ Custom prompts allow you to create reusable AI instruction templates that modify
 - **Default**: `false`
 - **Description**: Allow custom prompts to completely replace the default system prompt
 - **Warning**: Enabling this may break expected functionality if custom prompts don't include essential instructions
+- **Note**: This toggle does not currently gate the override — any prompt with `override_system_prompt: true` in its frontmatter replaces the system prompt regardless of this setting
 
 ### Creating Custom Prompts
 

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -159,14 +159,13 @@ The active model list depends on the [`provider`](#provider) setting:
 
 Custom prompts allow you to create reusable AI instruction templates that modify how the AI behaves for specific sessions.
 
-### Allow System Prompt Override
+### Allow System Prompt Override (legacy, currently non-functional)
 
 - **Setting**: `allowSystemPromptOverride`
 - **Type**: Boolean
 - **Default**: `false`
-- **Description**: Allow custom prompts to completely replace the default system prompt
-- **Warning**: Enabling this may break expected functionality if custom prompts don't include essential instructions
-- **Note**: This toggle does not currently gate the override — any prompt with `override_system_prompt: true` in its frontmatter replaces the system prompt regardless of this setting
+- **Description**: Intended to gate whether custom prompts can completely replace the default system prompt. **Currently has no effect**: any prompt with `override_system_prompt: true` in its frontmatter replaces the system prompt regardless of this setting. Toggling it on or off does not change that behavior.
+- **Warning**: Because the frontmatter flag alone controls the override, a custom prompt with `override_system_prompt: true` can break expected functionality if it doesn't include essential instructions — this setting will not prevent that.
 
 ### Creating Custom Prompts
 

--- a/planning/changelog/2026-07-25.md
+++ b/planning/changelog/2026-07-25.md
@@ -1,0 +1,16 @@
+# Daily changelog — July 25, 2026
+
+**Date:** 2026-07-25
+**PRs merged:** 1
+
+---
+
+## Summary
+
+Quiet day — the only PR to merge was the prior day's own automated housekeeping run.
+
+## What shipped
+
+### [#1251 chore(daily): 2026-07-25 daily update](https://github.com/allenhutchison/obsidian-gemini/pull/1251)
+
+The automated daily housekeeping run for 2026-07-25: wrote that day's changelog (5 PRs merged on 2026-07-24 — mostly dependency bumps, including a security-relevant `fast-uri` patch), audited product docs and found no drift or missing coverage, and found no unlabeled issues to triage.


### PR DESCRIPTION
## Summary

Automated daily housekeeping run (`daily-update` meta-skill via the `maintainerd` plugin marketplace) bundling `daily-changelog`, `audit-product-docs`, and `triage-issues` for 2026-07-26.

Fixes N/A — routine automated daily housekeeping run.

## Changes

- **daily-changelog**: wrote [`planning/changelog/2026-07-25.md`](https://github.com/allenhutchison/obsidian-gemini/blob/daily-update-2026-07-26/planning/changelog/2026-07-25.md) — 1 PR merged on 2026-07-25 (#1251, the prior day's own automated daily-update PR). A quiet day.
- **audit-product-docs**: read every file under `docs/guide/`, `docs/reference/`, `README.md`, and `AGENTS.md` and cross-checked settings, commands, tool names, and behavior claims against `src/`. Found and fixed 4 drift items:
  - `docs/guide/custom-prompts.md` + `docs/reference/settings.md`: both documented a 2-step gate on `override_system_prompt` (frontmatter flag *and* the "Allow system prompt override" plugin setting), but `getSystemPromptWithCustom` (`src/prompts/gemini-prompts.ts`) only ever checks the frontmatter flag — the plugin setting is defined but never read in that path. Corrected both docs to describe actual behavior and flagged the toggle as currently inert.
  - `AGENTS.md` (2 spots): referenced the removed `test-scripts/` directory and `node test-scripts/test-sdk-tools.mjs`; updated to point at the current `evals/` eval harness (`npm run eval`).
  - `docs/guide/projects.md`: the "Tool discovery" table omitted `vault_semantic_search`, which also scopes to the project root; added it. Also added a mention of the `link-project` command alongside the existing "Switch project" reference.
  - No new docs were warranted — no load-bearing feature found with zero coverage.
- **triage-issues**: 0 unlabeled open issues (15 open issues checked, all already labeled) — no-op.

This is a housekeeping-only PR — no `src/` behavior changes.

## Screenshots / Screencast

N/A — docs and changelog only, no UI change.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A; routine automated daily housekeeping run
- [x] All CI checks pass (`npm test` — 3517 passing, `npm run build`, `npm run format-check`, `npm run lint`, `npm run typecheck:test`)
- [x] I have tested this change on Desktop — N/A, docs/changelog-only change; verified via local pre-flight checks
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A, no code change
- [x] Documentation has been updated (if applicable) — N/A, this PR's content is the doc/changelog updates themselves
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01SrwrUnnJnzThoyfU1C2zMu)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified custom prompts’ `override_system_prompt: true` behavior: system prompts are replaced regardless of the “Allow system prompt override” toggle.
  * Updated settings docs to state “Allow System Prompt Override” is legacy and currently non-functional, with warnings about required instructions.
  * Refreshed project guidance: tool discovery now includes semantic search, and added an alternative workflow to link a project to an agent session.
  * Updated repository/testing guidance to reflect `evals/` as the agent eval harness and documented the `npm run eval` workflow.
  * Added the daily changelog entry for 2026-07-25.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->