### PR TITLE
fix(mobile): remove regex lookbehind that crashes plugin load on iOS < 16.4

### DIFF
--- a/src/services/ollama-models-service.ts
+++ b/src/services/ollama-models-service.ts
@@ -7,12 +7,18 @@ import { GeminiModel } from '../models';
  * known small models toward the completions role; everything else stays available
  * for chat / summary / rewrite. Patterns are matched with digit-aware boundaries
  * so e.g. `1b` does not bleed into `11b` and bias `llava:13b` toward completions.
+ *
+ * The leading (?:^|\D) consumes any preceding non-digit instead of using a
+ * negative lookbehind, which is only supported on iOS 16.4+ (see
+ * .claude/guidelines/coding.md) and would crash plugin load on older iOS.
+ * Consuming the boundary is safe here because these patterns feed `.test()`,
+ * so the extra matched character does not affect the boolean result.
  */
 const COMPLETION_NAME_HINT_PATTERNS = [
-	/(?<!\d)0\.5b(?!\d)/i,
-	/(?<!\d)1\.5b(?!\d)/i,
-	/(?<!\d)1b(?!\d)/i,
-	/(?<!\d)3b(?!\d)/i,
+	/(?:^|\D)0\.5b(?!\d)/i,
+	/(?:^|\D)1\.5b(?!\d)/i,
+	/(?:^|\D)1b(?!\d)/i,
+	/(?:^|\D)3b(?!\d)/i,
 	/\bmini\b/i,
 	/\btiny\b/i,
 	/\blite\b/i,

--- a/src/utils/markdown-formatting.ts
+++ b/src/utils/markdown-formatting.ts
@@ -104,8 +104,11 @@ export function unescapeWikiLinks(text: string): string {
 		let segment = parts[i];
 
 		// Strip single-backtick wrapping: `[[note]]` → [[note]]
-		// Negative lookbehind/lookahead prevent matching multi-backtick spans
-		segment = segment.replace(/(?<!`)`(\[\[[^\]]+\]\])`(?!`)/g, '$1');
+		// The leading (^|[^`]) group and the (?!`) lookahead prevent matching
+		// multi-backtick spans. A consuming group is used instead of a negative
+		// lookbehind because lookbehind is only supported on iOS 16.4+ (see
+		// .claude/guidelines/coding.md) and would crash plugin load on older iOS.
+		segment = segment.replace(/(^|[^`])`(\[\[[^\]]+\]\])`(?!`)/g, '$1$2');
 
 		// Fix fully backslash-escaped brackets: \[\[note\]\] → [[note]]
 		segment = segment.replace(/\\\[\\\[([^\]]+)\\\]\\\]/g, '[[$1]]');

--- a/test/services/ollama-models-service.test.ts
+++ b/test/services/ollama-models-service.test.ts
@@ -231,4 +231,33 @@ describe('OllamaModelsService', () => {
 			expect(showCallCount).toBe(2); // fresh probe after invalidate
 		});
 	});
+
+	describe('completions-role name-hint boundaries (#1242)', () => {
+		const roles = async (names: string[]): Promise<Record<string, string[] | undefined>> => {
+			mockEndpoints(
+				names.map((name) => ({ name })),
+				() => ({ capabilities: ['completion'] })
+			);
+			const svc = new OllamaModelsService(buildPlugin());
+			const models = await svc.getModels();
+			return Object.fromEntries(models.map((m) => [m.value, m.defaultForRoles]));
+		};
+
+		it('biases genuine small models toward completions', async () => {
+			const result = await roles(['qwen2.5:0.5b', 'qwen2.5:1.5b', 'gemma:1b', 'llama3.2:3b']);
+			expect(result['qwen2.5:0.5b']).toEqual(['completions']);
+			expect(result['qwen2.5:1.5b']).toEqual(['completions']);
+			expect(result['gemma:1b']).toEqual(['completions']);
+			expect(result['llama3.2:3b']).toEqual(['completions']);
+		});
+
+		it('does not bias larger models whose size digits merely contain a small-model substring', async () => {
+			// The digit-aware boundaries must survive the lookbehind→consuming-group
+			// rewrite: `13b`/`11b`/`23b` must not match `3b`/`1b`.
+			const result = await roles(['llava:13b', 'model:11b', 'model:23b']);
+			expect(result['llava:13b']).toBeUndefined();
+			expect(result['model:11b']).toBeUndefined();
+			expect(result['model:23b']).toBeUndefined();
+		});
+	});
 });

--- a/test/utils/markdown-formatting.test.ts
+++ b/test/utils/markdown-formatting.test.ts
@@ -156,4 +156,16 @@ describe('unescapeWikiLinks', () => {
 			unescapeWikiLinks('`[[2024-11-23 - Introducing Gemini Scribe Your AI Writing Assistant for Obsidian]]`')
 		).toBe('[[2024-11-23 - Introducing Gemini Scribe Your AI Writing Assistant for Obsidian]]');
 	});
+
+	// --- Lookbehind-free rewrite (#1242) ---
+	// The strip pattern uses a consuming (^|[^`]) group instead of a negative
+	// lookbehind (unsupported on iOS < 16.4). These assert the preceding character
+	// is preserved rather than consumed, and start-of-string is still handled.
+	it('preserves the character preceding a backtick-wrapped wikilink (no leading space)', () => {
+		expect(unescapeWikiLinks('see:`[[My Note]]`')).toBe('see:[[My Note]]');
+	});
+
+	it('strips a backtick-wrapped wikilink at the very start of the string', () => {
+		expect(unescapeWikiLinks('`[[My Note]]` follows')).toBe('[[My Note]] follows');
+	});
 });

--- a/test/utils/no-regex-lookbehind.test.ts
+++ b/test/utils/no-regex-lookbehind.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync, statSync } from 'fs';
+import { join } from 'path';
+
+/**
+ * Regression guard for #1242.
+ *
+ * `.claude/guidelines/coding.md` (Platform guards): regex lookbehind
+ * (`(?<=…)` / `(?<!…)`) is only supported on iOS 16.4+. The plugin declares
+ * mobile support (`manifest.json` sets `isDesktopOnly: false`), so a lookbehind
+ * in a bundled regex *literal* is a parse-time `SyntaxError` when the module is
+ * evaluated on older iOS — which aborts the whole `main.js` bundle and crashes
+ * plugin **load**, not just the affected feature.
+ *
+ * Rule: no source file under `src/` may contain a `(?<=` or `(?<!` regex
+ * assertion. Lookaheads (`(?=…)` / `(?!…)`) are fine — Safari has supported them
+ * for years; only lookbehind is the 16.4 gate.
+ */
+
+function collectTsFiles(dir: string, acc: string[] = []): string[] {
+	for (const entry of readdirSync(dir)) {
+		const full = join(dir, entry);
+		if (statSync(full).isDirectory()) {
+			collectTsFiles(full, acc);
+		} else if (entry.endsWith('.ts')) {
+			acc.push(full);
+		}
+	}
+	return acc;
+}
+
+describe('no regex lookbehind in mobile-loaded source (#1242)', () => {
+	// Matches either lookbehind assertion opener: `(?<=` or `(?<!`.
+	const lookbehind = /\(\?<[=!]/g;
+
+	const files = collectTsFiles(join(process.cwd(), 'src'));
+
+	it('scans a non-trivial number of source files', () => {
+		expect(files.length).toBeGreaterThan(50);
+	});
+
+	it('no source file uses a regex lookbehind assertion', () => {
+		const offenders: string[] = [];
+		for (const file of files) {
+			const src = readFileSync(file, 'utf8');
+			const lines = src.split('\n');
+			lines.forEach((line, i) => {
+				if (lookbehind.test(line)) {
+					offenders.push(`${file.replace(process.cwd() + '/', '')}:${i + 1}: ${line.trim()}`);
+				}
+				lookbehind.lastIndex = 0;
+			});
+		}
+		expect(
+			offenders,
+			`Regex lookbehind is iOS 16.4+ only and crashes plugin load on older iOS (#1242). Rewrite these to a lookbehind-free form (e.g. a consuming (^|[^x]) / (?:^|\\D) prefix group):\n${offenders.join('\n')}`
+		).toEqual([]);
+	});
+});


### PR DESCRIPTION
## Summary

`.claude/guidelines/coding.md` (Platform guards) requires fallbacks for regex lookbehind because it is only supported on **iOS 16.4+**, and `manifest.json` sets `isDesktopOnly: false` — the plugin loads on mobile. Three negative-lookbehind regex **literals** were bundled into `main.js`. On iOS < 16.4 an unsupported lookbehind in a literal is a parse-time `SyntaxError` when the module is evaluated, which aborts the whole bundle — so this crashes plugin **load**, not just the affected feature.

This PR rewrites the three sites to a lookbehind-free consuming-group form. Lookaheads are left intact (Safari has supported them for years; only lookbehind is the 16.4 gate), and a source-scan guard test prevents any lookbehind literal from silently returning.

Fixes #1242

Produced by the auto-dev pipeline from the approved plan on #1242 (`auto:ready`).

## Changes

- `src/utils/markdown-formatting.ts` — the backtick-wrapped-wikilink strip pattern now uses a leading `(^|[^`])` group with replacement `$1$2` instead of `(?<!`)`, preserving the "not preceded by a backtick" semantics. The `(?!`)` lookahead is kept.
- `src/services/ollama-models-service.ts` — the four small-model size-hint patterns (`0.5b`/`1.5b`/`1b`/`3b`) now use a `(?:^|\D)` prefix instead of `(?<!\d)`. Safe because these patterns feed `.test()` (`COMPLETION_NAME_HINT_PATTERNS.some((re) => re.test(lower))`), so consuming a preceding non-digit does not change the boolean result. The `(?!\d)` lookahead is kept, so `1b` still doesn't bleed into `11b` and `llava:13b` isn't biased toward completions.
- `test/utils/no-regex-lookbehind.test.ts` (new) — scans `src/**/*.ts` and fails on any `(?<=` / `(?<!` literal, enforcing the guideline's platform guard automatically (mirrors the existing `test/services/mobile-node-builtins.test.ts` source-scan guard pattern).
- `test/utils/markdown-formatting.test.ts` — added edge cases confirming the consuming group preserves the preceding character and still handles start-of-string.
- `test/services/ollama-models-service.test.ts` — added a boundary block asserting genuine small models (`0.5b`/`1.5b`/`1b`/`3b`) get the `completions` role while `13b`/`11b`/`23b` do not.

## Screenshots / Screencast

N/A — internal regex refactor, no UI surface.

## Verification

- **Pre-flight (all green):** `npm run format-check`, `npm run typecheck:test`, `npm run lint` (0 errors), `npm test` (3523 passed), `npm run build`, `npm run lint:cycles` (no circular deps).
- **Behavioral (semantics):** both changed code paths are exercised end-to-end by unit tests — the markdown formatter (backtick-wrapped wikilinks still stripped, multi-backtick spans untouched) and the ollama classifier (`getModels() → defaultForRoles`, small-model boundaries preserved, `13b`/`11b` excluded). The new guard test confirms zero lookbehind literals remain under `src/`.
- **Platform (iOS < 16.4 load):** the crash itself cannot be reproduced in the headless Node sandbox (no old-iOS device) — **behavioral verification not run in sandbox; needs a manual check on an iOS < 16.4 device** to confirm plugin load. The fix is structurally guaranteed by removing all lookbehind literals and enforced going forward by the new source-scan guard.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer (#1242, plan approved via `auto:ready`)
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`; also `npm run typecheck:test`, `npm run lint`, `npm run lint:cycles`)
- [ ] I have tested this change on Desktop — desktop is unaffected (lookbehind works on desktop Electron); the fix targets iOS < 16.4.
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — the change *is* the platform guard: it removes the unsupported syntax and adds a guard test. Semantics preserved via unit tests; live iOS < 16.4 load confirmation still needs a device (see Verification).
- [x] Documentation has been updated (if applicable) — N/A; the guard is already stated in `.claude/guidelines/coding.md` and the new test enforces it.
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude (auto-dev pipeline)
- [x] I have reviewed and understand all AI-generated code in this PR

<!-- auto-dev -->
This PR was produced by the auto-dev pipeline from the approved plan on #1242.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FwL6EPwB8Hw6a131XLXRFn)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model-name classification to prevent larger models from being incorrectly identified as small-model completions.
  * Fixed WikiLink formatting in edge cases, including links at the start of text and links without preceding spaces.
  * Improved compatibility with older iOS versions by removing unsupported regular-expression features.

* **Tests**
  * Added regression coverage for model-name matching, WikiLink formatting, and unsupported regular-expression patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->