### PR TITLE
refactor(settings): remove dead re-export of SettingsSectionContext

### DIFF
--- a/src/ui/settings.ts
+++ b/src/ui/settings.ts
@@ -9,7 +9,6 @@ import { renderMCPSettings } from './settings-mcp';
 import { renderRAGSettings } from './settings-rag';
 import { renderDebugSettings } from './settings-debug';
 
-export type { SettingsSectionContext } from './settings-helpers';
 import type { SettingsSectionContext } from './settings-helpers';
 
 export default class ObsidianGeminiSettingTab extends PluginSettingTab {


### PR DESCRIPTION
## Summary

audit-architecture nightly sweep flagged a **dead export**: `src/ui/settings.ts:12` re-exports the `SettingsSectionContext` type from `./settings-helpers`, but nothing imports that type *from* `settings.ts` — every consumer (`settings-general`, `settings-tools`, `settings-mcp`, `settings-rag`, `settings-agent-config`) imports it directly from `settings-helpers`. `npm run knip` reports it as the repo's only unused export. This removes the vestigial re-export; the separate local `import type` on the following line (used at `settings.ts:41`) is retained.

Type-only change with no bundle impact — `main.js` is unchanged by the build.

## Changes

- `src/ui/settings.ts` — delete the unused `export type { SettingsSectionContext } from './settings-helpers'` line; keep the local `import type`.

## Screenshots / Screencast

N/A — internal type-surface cleanup, no UI or behavior change.

## Checklist

### Required

- [x] I have read and agree to the Contributing Guidelines
- [x] I have read and agree to the AI Policy
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A; mechanical dead-export removal surfaced by the architecture audit, not a feature change.
- [x] All CI checks pass (`npm test` 3523 passed, `npm run build`, `npm run format-check`; also `npm run lint` 0 errors, `npm run typecheck:test`, `npm run lint:cycles` 0 cycles, `npm run knip` now 0 unused)
- [x] I have tested this change on Desktop — build + full test suite green; type-only change.
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — type-only removal, no runtime or platform-specific code touched.
- [x] Documentation has been updated (if applicable) — N/A; no user-facing behavior or settings changed.
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude (audit-architecture skill)
- [x] I have reviewed and understand all AI-generated code in this PR

---

_Filed by the `audit-architecture` skill._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014XY5o3YUMASfJTtUqya4NF

---
_Generated by [Claude Code](https://claude.ai/code/session_014XY5o3YUMASfJTtUqya4NF)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal type handling without changing the settings interface or rendering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->