### PR TITLE
refactor(subscribers): extract shared EventBusSubscriber base for teardown

### DIFF
--- a/src/subscribers/accessed-files-subscriber.ts
+++ b/src/subscribers/accessed-files-subscriber.ts
@@ -1,16 +1,16 @@
 import type { ObsidianGemini } from '../types/plugin';
 import { HandlerPriority } from '../types/agent-events';
 import { extractAccessedPaths } from '../utils/accessed-files';
+import { EventBusSubscriber } from './event-bus-subscriber';
 
 /**
  * Subscribes to toolChainComplete to track which files the agent
  * accessed during tool execution. Updates session.accessedFiles
  * and persists to frontmatter.
  */
-export class AccessedFilesSubscriber {
-	private unsubscribers: (() => void)[] = [];
-
+export class AccessedFilesSubscriber extends EventBusSubscriber {
 	constructor(plugin: ObsidianGemini) {
+		super();
 		this.unsubscribers.push(
 			plugin.agentEventBus.on(
 				'toolChainComplete',
@@ -40,12 +40,5 @@ export class AccessedFilesSubscriber {
 				HandlerPriority.INTERNAL
 			)
 		);
-	}
-
-	destroy(): void {
-		for (const unsub of this.unsubscribers) {
-			unsub();
-		}
-		this.unsubscribers = [];
 	}
 }

--- a/src/subscribers/context-tracking-subscriber.ts
+++ b/src/subscribers/context-tracking-subscriber.ts
@@ -1,5 +1,6 @@
 import type { ObsidianGemini } from '../types/plugin';
 import { HandlerPriority } from '../types/agent-events';
+import { EventBusSubscriber } from './event-bus-subscriber';
 
 /**
  * Subscribes to agent lifecycle events to manage context tracking:
@@ -7,10 +8,9 @@ import { HandlerPriority } from '../types/agent-events';
  * - Updates usage metadata from API responses
  * - Resets context manager on session changes
  */
-export class ContextTrackingSubscriber {
-	private unsubscribers: (() => void)[] = [];
-
+export class ContextTrackingSubscriber extends EventBusSubscriber {
 	constructor(plugin: ObsidianGemini) {
+		super();
 		this.unsubscribers.push(
 			plugin.agentEventBus.on(
 				'turnStart',
@@ -40,12 +40,5 @@ export class ContextTrackingSubscriber {
 		this.unsubscribers.push(plugin.agentEventBus.on('sessionCreated', resetContext, HandlerPriority.INTERNAL));
 
 		this.unsubscribers.push(plugin.agentEventBus.on('sessionLoaded', resetContext, HandlerPriority.INTERNAL));
-	}
-
-	destroy(): void {
-		for (const unsub of this.unsubscribers) {
-			unsub();
-		}
-		this.unsubscribers = [];
 	}
 }

--- a/src/subscribers/event-bus-subscriber.ts
+++ b/src/subscribers/event-bus-subscriber.ts
@@ -1,0 +1,23 @@
+/**
+ * Base class for agent-event-bus subscribers.
+ *
+ * Every subscriber in this directory registers one or more handlers on
+ * `plugin.agentEventBus` in its constructor, keeps the returned unsubscribe
+ * callbacks, and tears them all down in `destroy()`. That teardown was
+ * repeated verbatim in each subscriber; it lives here once instead.
+ *
+ * Subclasses push their unsubscribe callbacks onto {@link unsubscribers} and
+ * override `destroy()` only when they own additional state to release (calling
+ * `super.destroy()` first).
+ */
+export abstract class EventBusSubscriber {
+	protected unsubscribers: (() => void)[] = [];
+
+	/** Unsubscribe from every registered event-bus handler. */
+	destroy(): void {
+		for (const unsub of this.unsubscribers) {
+			unsub();
+		}
+		this.unsubscribers = [];
+	}
+}

--- a/src/subscribers/project-activation-subscriber.ts
+++ b/src/subscribers/project-activation-subscriber.ts
@@ -1,5 +1,6 @@
 import type { ObsidianGemini } from '../types/plugin';
 import { HandlerPriority } from '../types/agent-events';
+import { EventBusSubscriber } from './event-bus-subscriber';
 
 /**
  * Subscribes to session lifecycle events to auto-detect and link projects.
@@ -9,10 +10,9 @@ import { HandlerPriority } from '../types/agent-events';
  *
  * On sessionLoaded: verify the linked project still exists.
  */
-export class ProjectActivationSubscriber {
-	private unsubscribers: (() => void)[] = [];
-
+export class ProjectActivationSubscriber extends EventBusSubscriber {
 	constructor(plugin: ObsidianGemini) {
+		super();
 		this.unsubscribers.push(
 			plugin.agentEventBus.on(
 				'sessionCreated',
@@ -62,12 +62,5 @@ export class ProjectActivationSubscriber {
 				HandlerPriority.INTERNAL
 			)
 		);
-	}
-
-	destroy(): void {
-		for (const unsub of this.unsubscribers) {
-			unsub();
-		}
-		this.unsubscribers = [];
 	}
 }

--- a/src/subscribers/tool-execution-logger.ts
+++ b/src/subscribers/tool-execution-logger.ts
@@ -3,6 +3,7 @@ import type { ObsidianGemini } from '../types/plugin';
 import { HandlerPriority } from '../types/agent-events';
 import { ToolResult } from '../tools/types';
 import { ChatSession } from '../types/agent';
+import { EventBusSubscriber } from './event-bus-subscriber';
 
 /** Map tool names to the key parameter to display in summaries. undefined = no args to display. */
 const KEY_PARAM_MAP: Record<string, string | undefined> = {
@@ -38,12 +39,12 @@ interface ToolLogEntry {
  * Subscribes to agent event bus hooks and logs tool execution summaries
  * to session history files as collapsible callout blocks.
  */
-export class ToolExecutionLogger {
+export class ToolExecutionLogger extends EventBusSubscriber {
 	private plugin: ObsidianGemini;
 	private pendingLogs: ToolLogEntry[] = [];
-	private unsubscribers: (() => void)[] = [];
 
 	constructor(plugin: ObsidianGemini) {
+		super();
 		this.plugin = plugin;
 
 		this.unsubscribers.push(
@@ -89,13 +90,11 @@ export class ToolExecutionLogger {
 	}
 
 	/**
-	 * Unsubscribe from event bus.
+	 * Unsubscribe from the event bus and drop any tool entries that were queued
+	 * but never flushed to a history file.
 	 */
-	destroy(): void {
-		for (const unsub of this.unsubscribers) {
-			unsub();
-		}
-		this.unsubscribers = [];
+	override destroy(): void {
+		super.destroy();
 		this.pendingLogs = [];
 	}
 


### PR DESCRIPTION
## Summary

`audit-architecture` nightly sweep flagged a **DRY violation** in `src/subscribers/`.

All four agent-event-bus subscribers (`AccessedFilesSubscriber`, `ContextTrackingSubscriber`, `ProjectActivationSubscriber`, `ToolExecutionLogger`) each declared an identical `private unsubscribers: (() => void)[] = []` field and an identical `destroy()` that walked and cleared it. This extracts both into a small abstract base class the four subscribers extend. It is pure code motion — no behavior change, no new abstraction beyond the teardown that was already written four times.

`ToolExecutionLogger` is the only subscriber with extra teardown state (its unflushed `pendingLogs` queue); it overrides `destroy()` to call `super.destroy()` and then clear that queue, preserving the previous ordering and effect.

No linked issue — this is an automated architecture-audit finding rather than a maintainer-approved feature.

## Changes

- `src/subscribers/event-bus-subscriber.ts` (new) — abstract `EventBusSubscriber` holding the `unsubscribers` list and the shared `destroy()`.
- `src/subscribers/accessed-files-subscriber.ts` — extend the base; drop the duplicated field and `destroy()`.
- `src/subscribers/context-tracking-subscriber.ts` — same.
- `src/subscribers/project-activation-subscriber.ts` — same.
- `src/subscribers/tool-execution-logger.ts` — extend the base; `override destroy()` now calls `super.destroy()` then clears `pendingLogs`.

Net −24 lines of duplicated teardown.

## Screenshots / Screencast

N/A — internal refactor, no UI surface.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A; filed directly by the `audit-architecture` sweep. Close it if the extraction isn't wanted.
- [x] All CI checks pass — locally: `npm run format-check` clean, `npm run lint` 0 errors (38 pre-existing warnings in `test/`, untouched), `npm run build` clean, `npm run typecheck:test` clean, `npm test` 3523 passed / 164 files, `npm run lint:cycles` 0 cycles.
- [ ] I have tested this change on Desktop — not run; no live Obsidian instance in the audit sandbox. The change is code motion covered by the existing per-subscriber `destroy()` unit tests (`test/subscribers/*.test.ts`), each of which asserts handlers stop firing after teardown.
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — no platform-specific API introduced or touched.
- [x] Documentation has been updated (if applicable) — N/A; no user-facing behavior, settings, or public surface changed.
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude (`audit-architecture` skill)
- [x] I have reviewed and understand all AI-generated code in this PR

---

_Filed by the `audit-architecture` skill._

---
_Generated by [Claude Code](https://claude.ai/code/session_01L6gs5Rw9tfaj3jYcPuKVfX)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized event subscription cleanup across session, project, file-access, context-tracking, and tool-logging components.
  * Improved lifecycle management to ensure event listeners are consistently removed.
  * Preserved existing behavior for tracking accessed files, project activation, context usage, and tool execution logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->