### PR TITLE
refactor(services): extract shared headless agent-turn driver (#1261)

### DIFF
--- a/src/services/headless-agent-turn.ts
+++ b/src/services/headless-agent-turn.ts
@@ -1,0 +1,167 @@
+import { getActiveChatModel } from '../models';
+import type { ObsidianGemini } from '../types/plugin';
+import type { FeatureToolPolicy } from '../types/tool-policy';
+import { DestructiveAction } from '../types/agent';
+import { ToolExecutionContext } from '../tools/types';
+import { ModelClientFactory } from '../api';
+import { ExtendedModelRequest } from '../api/interfaces/model-api';
+import { formatLocalTimestamp } from '../utils/format-utils';
+import { buildTurnPreamble } from '../utils/turn-preamble';
+import { AgentLoop, DEFAULT_HEADLESS_MAX_ITERATIONS } from '../agent/agent-loop';
+import { HeadlessConfirmationProvider } from './headless-confirmation-provider';
+
+/**
+ * Shared driver for a single headless agent turn, used by both
+ * `ScheduledTaskRunner` and `HookRunner`.
+ *
+ * Both callers need exactly the same thing — create a temporary session under a
+ * feature tool policy, send one non-streaming request, hand any tool calls to
+ * `AgentLoop`, and come back with the final text — and the two copies had
+ * already drifted in wording. Keeping the whole span here means a change to
+ * headless turn semantics (a new `ExtendedModelRequest` field, a different
+ * tool-exposure rule, a cancellation-check placement) is made once.
+ *
+ * What deliberately stays with the callers: the output write. The scheduled task
+ * always writes its result and treats empty output as a failure; a hook writes
+ * only when `outputPath` is set and treats empty output as a silent no-op. Those
+ * differences are real, and `headless-run-output.ts` already shares the
+ * mechanical parts.
+ *
+ * This is a leaf module: it imports the session/factory/loop layers and nothing
+ * imports the runners back, per the shared-leaf-helper rule in `coding.md`.
+ */
+export interface HeadlessAgentTurnSpec {
+	/** Session title, e.g. `Scheduled: my-task` or `Hook: my-hook`. */
+	sessionLabel: string;
+	/** Log/error prefix identifying the caller, e.g. `[ScheduledTaskRunner]`. */
+	logPrefix: string;
+	/** Noun used in the exhaustion error, e.g. `Task` or `Hook`. */
+	subjectNoun: string;
+	/** Human-readable identifier of the unit of work, used in error messages. */
+	subjectName: string;
+	/** The prompt to send. Callers render any templates before handing it over. */
+	prompt: string;
+	/** Per-feature tool policy; when unset the session inherits the global policy. */
+	toolPolicy?: FeatureToolPolicy;
+	/** Model override; falls back to the active chat model. */
+	model?: string;
+	/** Tool-iteration cap; falls back to `DEFAULT_HEADLESS_MAX_ITERATIONS`. */
+	maxIterations?: number;
+	/**
+	 * Skill include-list passed through to the model API. An empty or absent
+	 * list means "no filter" — the run sees every available skill.
+	 */
+	projectSkills?: string[];
+}
+
+/**
+ * Drive one headless agent turn to completion.
+ *
+ * @returns the final response text, or `undefined` if the run was cancelled.
+ * @throws if agent services are not initialised, or if the tool-iteration
+ *         budget is exhausted without producing a response.
+ */
+export async function runHeadlessAgentTurn(
+	plugin: ObsidianGemini,
+	spec: HeadlessAgentTurnSpec,
+	isCancelled: () => boolean
+): Promise<string | undefined> {
+	if (!plugin.sessionManager || !plugin.toolRegistry || !plugin.toolExecutionEngine) {
+		throw new Error(`${spec.logPrefix} Agent services not initialised`);
+	}
+
+	// Create a headless session bound to the caller's tool policy. When there is
+	// no policy, the session inherits the global plugin policy — the registry
+	// filter is permission-driven, so a run without a policy sees the same tools
+	// as an interactive agent session.
+	const session = await plugin.sessionManager.createAgentSession(spec.sessionLabel, {
+		toolPolicy: spec.toolPolicy,
+		requireConfirmation: [] as DestructiveAction[],
+	});
+
+	// Propagate the per-run model override so follow-up requests also use the
+	// right model via session.modelConfig.
+	if (spec.model) {
+		session.modelConfig = { model: spec.model };
+	}
+
+	const toolContext: ToolExecutionContext = {
+		plugin,
+		session,
+		featureToolPolicy: spec.toolPolicy,
+	};
+	const modelApi = ModelClientFactory.createChatModel(plugin);
+	// Headless runs auto-approve confirmations, so only expose tools the user
+	// explicitly opted into (APPROVE under the layered policy). ASK_USER tools
+	// are excluded — exposing them would silently bypass the user's "ask first"
+	// intent because there's no UI to ask on. To allow an ASK_USER tool in a
+	// headless run, the run's toolPolicy must explicitly upgrade it (preset or
+	// per-tool override).
+	const availableTools = plugin.toolRegistry.getAutoApprovedTools(toolContext);
+
+	// Prepend a turn preamble so the model has accurate "now" awareness.
+	const startedAt = formatLocalTimestamp(session.created);
+	const userMessage = buildTurnPreamble(formatLocalTimestamp(new Date())) + spec.prompt;
+	const model = spec.model ?? getActiveChatModel(plugin.settings);
+
+	const initialRequest: ExtendedModelRequest = {
+		kind: 'extended',
+		userMessage,
+		conversationHistory: [],
+		model,
+		temperature: plugin.settings.temperature,
+		topP: plugin.settings.topP,
+		prompt: '',
+		availableTools,
+		renderContent: false,
+		sessionStartedAt: startedAt,
+		// The model API uses projectSkills as its include-list when filtering the
+		// registered skill set. Empty list ⇒ no filter, so the run sees every
+		// available skill (matches the documented "leave blank to inherit"
+		// semantics).
+		projectSkills: spec.projectSkills?.length ? spec.projectSkills : undefined,
+	};
+
+	if (isCancelled()) return undefined;
+	const initialResponse = await modelApi.generateModelResponse(initialRequest);
+	if (isCancelled()) return undefined;
+
+	if (!initialResponse.toolCalls?.length) {
+		return initialResponse.markdown ?? '';
+	}
+
+	// Per-run override falls back to the shared headless default when unset.
+	const maxIterations = spec.maxIterations ?? DEFAULT_HEADLESS_MAX_ITERATIONS;
+	// Hand off to AgentLoop — handles thoughtSignature propagation, history
+	// construction, follow-up requests, empty-response retry, and agentEventBus
+	// events without any UI coupling.
+	const loop = new AgentLoop();
+	const result = await loop.run({
+		initialResponse,
+		initialUserMessage: userMessage,
+		initialHistory: [],
+		options: {
+			plugin,
+			session,
+			isCancelled,
+			confirmationProvider: new HeadlessConfirmationProvider(),
+			maxIterations,
+			featureToolPolicy: spec.toolPolicy,
+			headless: true,
+		},
+	});
+
+	if (result.cancelled) return undefined;
+
+	if (result.exhausted) {
+		// Exhaustion fires only after the soft budget's one-shot extension was
+		// also spent, so the actual iteration count exceeds the configured cap —
+		// report both.
+		throw new Error(
+			`${spec.logPrefix} ${spec.subjectNoun} "${spec.subjectName}" exhausted its tool-iteration budget ` +
+				`(cap ${maxIterations}, ran ${result.iterations}) without producing a response`
+		);
+	}
+
+	return result.markdown;
+}

--- a/src/services/hook-runner.ts
+++ b/src/services/hook-runner.ts
@@ -1,27 +1,20 @@
 import { App, TFile } from 'obsidian';
-import { getActiveChatModel } from '../models';
 import type { ObsidianGemini } from '../types/plugin';
-import { DestructiveAction } from '../types/agent';
-import { ToolExecutionContext } from '../tools/types';
-import { ModelClientFactory } from '../api';
-import { ExtendedModelRequest } from '../api/interfaces/model-api';
 import { resolveOutputPath, writeHeadlessOutput } from './headless-run-output';
-import { formatLocalDate, formatLocalTimestamp } from '../utils/format-utils';
-import { buildTurnPreamble } from '../utils/turn-preamble';
-import { AgentLoop, DEFAULT_HEADLESS_MAX_ITERATIONS } from '../agent/agent-loop';
+import { formatLocalDate } from '../utils/format-utils';
 import { GeminiSummary } from '../summary';
 import { SelectionRewriter } from '../rewrite-selection';
 import { renderPrompt } from './hook-types';
 import type { HookFireContext } from './hook-types';
-import { HeadlessConfirmationProvider } from './headless-confirmation-provider';
+import { runHeadlessAgentTurn } from './headless-agent-turn';
 
 /**
  * Runs a single hook fire headlessly:
  *  1. Renders the prompt template with the trigger context
- *  2. Creates a temporary agent session scoped to the hook's tool/skill list
- *  3. Sends the rendered prompt to the model
- *  4. Hands off any tool calls to AgentLoop
- *  5. Optionally writes the final response to the resolved outputPath
+ *  2. Drives one headless agent turn via `runHeadlessAgentTurn` (temporary
+ *     session scoped to the hook's tool/skill list, one model request, and the
+ *     AgentLoop tool-execution loop)
+ *  3. Optionally writes the final response to the resolved outputPath
  */
 export class HookRunner {
 	constructor(
@@ -50,93 +43,29 @@ export class HookRunner {
 	// ── agent-task action ────────────────────────────────────────────────────
 
 	private async runAgentTask(isCancelled: () => boolean): Promise<string | undefined> {
-		if (!this.plugin.sessionManager || !this.plugin.toolRegistry || !this.plugin.toolExecutionEngine) {
-			throw new Error('[HookRunner] Agent services not initialised');
-		}
-
 		const { hook } = this.ctx;
 
-		const session = await this.plugin.sessionManager.createAgentSession(`Hook: ${hook.slug}`, {
-			toolPolicy: hook.toolPolicy,
-			requireConfirmation: [] as DestructiveAction[],
-		});
+		const finalText = await runHeadlessAgentTurn(
+			this.plugin,
+			{
+				sessionLabel: `Hook: ${hook.slug}`,
+				logPrefix: '[HookRunner]',
+				subjectNoun: 'Hook',
+				subjectName: hook.slug,
+				// The hook's prompt is a template — render it against the trigger
+				// context before the shared driver sends it.
+				prompt: renderPrompt(hook.prompt, this.promptVars()),
+				toolPolicy: hook.toolPolicy,
+				model: hook.model,
+				maxIterations: hook.maxIterations,
+				// Apply the hook's enabledSkills as a skill filter.
+				projectSkills: hook.enabledSkills,
+			},
+			isCancelled
+		);
 
-		if (hook.model) {
-			session.modelConfig = { model: hook.model };
-		}
-
-		const toolContext: ToolExecutionContext = {
-			plugin: this.plugin,
-			session,
-			featureToolPolicy: hook.toolPolicy,
-		};
-		const modelApi = ModelClientFactory.createChatModel(this.plugin);
-		// Headless hook fires auto-approve confirmations, so only expose
-		// APPROVE tools — ASK_USER tools would otherwise execute unattended.
-		// To allow an ASK_USER tool in a hook, the hook's toolPolicy must
-		// explicitly upgrade it (preset or per-tool override).
-		const availableTools = this.plugin.toolRegistry.getAutoApprovedTools(toolContext);
-
-		const renderedPrompt = renderPrompt(hook.prompt, this.promptVars());
-		const startedAt = formatLocalTimestamp(session.created);
-		const userMessage = buildTurnPreamble(formatLocalTimestamp(new Date())) + renderedPrompt;
-		const model = hook.model ?? getActiveChatModel(this.plugin.settings);
-
-		const initialRequest: ExtendedModelRequest = {
-			kind: 'extended',
-			userMessage,
-			conversationHistory: [],
-			model,
-			temperature: this.plugin.settings.temperature,
-			topP: this.plugin.settings.topP,
-			prompt: '',
-			availableTools,
-			renderContent: false,
-			sessionStartedAt: startedAt,
-			// Apply the hook's enabledSkills as a skill filter — the model API
-			// uses projectSkills as its include-list when filtering the registered
-			// skill set. Empty list ⇒ no filter, so the hook sees every available
-			// skill (matches the documented "leave blank to inherit" semantics).
-			projectSkills: hook.enabledSkills.length > 0 ? hook.enabledSkills : undefined,
-		};
-
-		if (isCancelled()) return undefined;
-		const initialResponse = await modelApi.generateModelResponse(initialRequest);
-		if (isCancelled()) return undefined;
-
-		let finalText: string;
-		if (initialResponse.toolCalls?.length) {
-			// Per-hook override falls back to the shared headless default when unset.
-			const maxIterations = hook.maxIterations ?? DEFAULT_HEADLESS_MAX_ITERATIONS;
-			const loop = new AgentLoop();
-			const result = await loop.run({
-				initialResponse,
-				initialUserMessage: userMessage,
-				initialHistory: [],
-				options: {
-					plugin: this.plugin,
-					session,
-					isCancelled,
-					confirmationProvider: new HeadlessConfirmationProvider(),
-					maxIterations,
-					featureToolPolicy: hook.toolPolicy,
-					headless: true,
-				},
-			});
-			if (result.cancelled) return undefined;
-			if (result.exhausted) {
-				// Exhaustion now fires only after the soft budget's one-shot
-				// extension was also spent, so the actual iteration count exceeds
-				// the configured cap — report both.
-				throw new Error(
-					`[HookRunner] Hook "${hook.slug}" exhausted its tool-iteration budget ` +
-						`(cap ${maxIterations}, ran ${result.iterations}) without producing a response`
-				);
-			}
-			finalText = result.markdown;
-		} else {
-			finalText = initialResponse.markdown ?? '';
-		}
+		// `undefined` means the run was cancelled mid-turn — nothing to write.
+		if (finalText === undefined) return undefined;
 
 		if (isCancelled()) return undefined;
 		if (!hook.outputPath) return undefined;

--- a/src/services/scheduled-task-runner.ts
+++ b/src/services/scheduled-task-runner.ts
@@ -1,25 +1,16 @@
-import { getActiveChatModel } from '../models';
 import type { ObsidianGemini } from '../types/plugin';
 import type { ScheduledTask } from './scheduled-tasks/types';
-import { DestructiveAction } from '../types/agent';
-import { ToolExecutionContext } from '../tools/types';
-import { ModelClientFactory } from '../api';
-import { ExtendedModelRequest } from '../api/interfaces/model-api';
 import { resolveOutputPath, writeHeadlessOutput } from './headless-run-output';
-import { formatLocalDate, formatLocalTimestamp } from '../utils/format-utils';
-import { buildTurnPreamble } from '../utils/turn-preamble';
-import { AgentLoop, DEFAULT_HEADLESS_MAX_ITERATIONS } from '../agent/agent-loop';
-import { HeadlessConfirmationProvider } from './headless-confirmation-provider';
+import { formatLocalDate } from '../utils/format-utils';
+import { runHeadlessAgentTurn } from './headless-agent-turn';
 
 /**
  * Runs a single scheduled task headlessly:
- *  1. Creates a temporary agent session with the task's tool configuration
- *  2. Sends the task prompt to the model (non-streaming)
- *  3. Delegates tool-execution loop to AgentLoop (inherits thoughtSignature
- *     propagation, empty-response retry, agentEventBus events, and hook-failure
- *     isolation for free)
- *  4. Writes the final response text to the resolved outputPath
- *  5. Returns the vault path so BackgroundTaskManager can surface an "Open result" link
+ *  1. Drives one headless agent turn via `runHeadlessAgentTurn` (temporary
+ *     session under the task's tool policy, one model request, and the
+ *     AgentLoop tool-execution loop)
+ *  2. Writes the final response text to the resolved outputPath
+ *  3. Returns the vault path so BackgroundTaskManager can surface an "Open result" link
  */
 export class ScheduledTaskRunner {
 	constructor(
@@ -28,99 +19,23 @@ export class ScheduledTaskRunner {
 	) {}
 
 	async run(isCancelled: () => boolean): Promise<string | undefined> {
-		if (!this.plugin.sessionManager || !this.plugin.toolRegistry || !this.plugin.toolExecutionEngine) {
-			throw new Error('[ScheduledTaskRunner] Agent services not initialised');
-		}
+		const finalText = await runHeadlessAgentTurn(
+			this.plugin,
+			{
+				sessionLabel: `Scheduled: ${this.task.slug}`,
+				logPrefix: '[ScheduledTaskRunner]',
+				subjectNoun: 'Task',
+				subjectName: this.task.slug,
+				prompt: this.task.prompt,
+				toolPolicy: this.task.toolPolicy,
+				model: this.task.model,
+				maxIterations: this.task.maxIterations,
+			},
+			isCancelled
+		);
 
-		// Create a headless session bound to this task's tool policy. When the
-		// task has no toolPolicy, the session inherits the global plugin policy
-		// — the registry filter is permission-driven so a task without a policy
-		// sees the same tools as an interactive agent session.
-		const session = await this.plugin.sessionManager.createAgentSession(`Scheduled: ${this.task.slug}`, {
-			toolPolicy: this.task.toolPolicy,
-			requireConfirmation: [] as DestructiveAction[],
-		});
-
-		// Propagate the per-task model override so follow-up requests also use
-		// the right model via session.modelConfig.
-		if (this.task.model) {
-			session.modelConfig = { model: this.task.model };
-		}
-
-		const toolContext: ToolExecutionContext = {
-			plugin: this.plugin,
-			session,
-			featureToolPolicy: this.task.toolPolicy,
-		};
-		const modelApi = ModelClientFactory.createChatModel(this.plugin);
-		// Headless runs auto-approve confirmations, so only expose tools the
-		// user explicitly opted into (APPROVE under the layered policy).
-		// ASK_USER tools are excluded — exposing them would silently bypass
-		// the user's "ask first" intent because there's no UI to ask on.
-		const availableTools = this.plugin.toolRegistry.getAutoApprovedTools(toolContext);
-
-		// Prepend a turn preamble so the model has accurate "now" awareness.
-		const startedAt = formatLocalTimestamp(session.created);
-		const userMessage = buildTurnPreamble(formatLocalTimestamp(new Date())) + this.task.prompt;
-		const model = this.task.model ?? getActiveChatModel(this.plugin.settings);
-
-		const initialRequest: ExtendedModelRequest = {
-			kind: 'extended',
-			userMessage,
-			conversationHistory: [],
-			model,
-			temperature: this.plugin.settings.temperature,
-			topP: this.plugin.settings.topP,
-			prompt: '',
-			availableTools,
-			renderContent: false,
-			sessionStartedAt: startedAt,
-		};
-
-		if (isCancelled()) return undefined;
-		const initialResponse = await modelApi.generateModelResponse(initialRequest);
-		if (isCancelled()) return undefined;
-
-		let finalText: string;
-
-		if (initialResponse.toolCalls?.length) {
-			// Per-task override falls back to the shared default when unset.
-			const maxIterations = this.task.maxIterations ?? DEFAULT_HEADLESS_MAX_ITERATIONS;
-			// Hand off to AgentLoop — handles thoughtSignature propagation,
-			// history construction, follow-up requests, empty-response retry,
-			// and agentEventBus events without any UI coupling.
-			const loop = new AgentLoop();
-			const result = await loop.run({
-				initialResponse,
-				initialUserMessage: userMessage,
-				initialHistory: [],
-				options: {
-					plugin: this.plugin,
-					session,
-					isCancelled,
-					confirmationProvider: new HeadlessConfirmationProvider(),
-					maxIterations,
-					featureToolPolicy: this.task.toolPolicy,
-					headless: true,
-				},
-			});
-
-			if (result.cancelled) return undefined;
-
-			if (result.exhausted) {
-				// Exhaustion now fires only after the soft budget's one-shot
-				// extension was also spent, so the actual iteration count exceeds
-				// the configured cap — report both.
-				throw new Error(
-					`[ScheduledTaskRunner] Task "${this.task.slug}" exhausted its tool-iteration budget ` +
-						`(cap ${maxIterations}, ran ${result.iterations}) without producing a response`
-				);
-			}
-
-			finalText = result.markdown;
-		} else {
-			finalText = initialResponse.markdown ?? '';
-		}
+		// `undefined` means the run was cancelled mid-turn — nothing to write.
+		if (finalText === undefined) return undefined;
 
 		if (isCancelled()) return undefined;
 

--- a/test/services/headless-agent-turn.test.ts
+++ b/test/services/headless-agent-turn.test.ts
@@ -1,0 +1,393 @@
+import type { Mock } from 'vitest';
+import { runHeadlessAgentTurn } from '../../src/services/headless-agent-turn';
+import type { HeadlessAgentTurnSpec } from '../../src/services/headless-agent-turn';
+import type { AgentLoopResult } from '../../src/agent/agent-loop';
+import { PolicyPreset } from '../../src/types/tool-policy';
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+vi.mock('obsidian', () => ({
+	normalizePath: (p: string) => p,
+	TFile: class {},
+}));
+
+vi.mock('../../src/utils/format-utils', () => ({
+	formatLocalDate: vi.fn().mockReturnValue('2026-07-28'),
+	formatLocalTimestamp: vi.fn().mockReturnValue('2026-07-28 08:00'),
+}));
+
+vi.mock('../../src/utils/turn-preamble', () => ({
+	buildTurnPreamble: vi.fn().mockReturnValue('[preamble] '),
+}));
+
+vi.mock('../../src/api', () => ({
+	ModelClientFactory: {
+		createChatModel: vi.fn(),
+	},
+}));
+
+/** Mock AgentLoop so tests don't pull in the real agent infrastructure. */
+const mockAgentLoopRun = vi.fn();
+vi.mock('../../src/agent/agent-loop', () => ({
+	AgentLoop: vi.fn().mockImplementation(function () {
+		return { run: mockAgentLoopRun };
+	}),
+	DEFAULT_HEADLESS_MAX_ITERATIONS: 20,
+}));
+
+import { ModelClientFactory } from '../../src/api';
+
+function createMockModelApi(responseText = 'Model answer.', toolCalls: any[] = []) {
+	return {
+		generateModelResponse: vi.fn().mockResolvedValue({
+			markdown: responseText,
+			toolCalls,
+		}),
+	};
+}
+
+function successfulLoopResult(markdown = 'Tool result text.'): AgentLoopResult {
+	return {
+		markdown,
+		history: [],
+		cancelled: false,
+		retried: false,
+		fellBack: false,
+		exhausted: false,
+		loopAborted: false,
+		iterations: 1,
+	};
+}
+
+/** The auto-approved subset the registry is expected to hand to the request. */
+const AUTO_APPROVED_TOOLS = [{ name: 'read_file' }];
+/** The full registry, which must NOT reach the request in a headless run. */
+const ALL_ENABLED_TOOLS = [{ name: 'read_file' }, { name: 'ask_user' }];
+
+function createMockPlugin(): any {
+	return {
+		logger: { log: vi.fn(), debug: vi.fn(), error: vi.fn(), warn: vi.fn() },
+		settings: {
+			chatModelName: 'plugin-default-model',
+			temperature: 1,
+			topP: 0.95,
+		},
+		sessionManager: {
+			createAgentSession: vi.fn().mockResolvedValue({
+				id: 'session-1',
+				title: 'Headless: test',
+				created: new Date(),
+				context: { enabledTools: [], requireConfirmation: [] },
+				modelConfig: {},
+			}),
+		},
+		toolRegistry: {
+			getEnabledTools: vi.fn().mockReturnValue(ALL_ENABLED_TOOLS),
+			getAutoApprovedTools: vi.fn().mockReturnValue(AUTO_APPROVED_TOOLS),
+		},
+		toolExecutionEngine: {
+			executeTool: vi.fn().mockResolvedValue({ success: true, output: 'ok' }),
+		},
+		app: { vault: {} },
+	};
+}
+
+function makeSpec(overrides: Partial<HeadlessAgentTurnSpec> = {}): HeadlessAgentTurnSpec {
+	return {
+		sessionLabel: 'Scheduled: test-task',
+		logPrefix: '[TestRunner]',
+		subjectNoun: 'Task',
+		subjectName: 'test-task',
+		prompt: 'Write a daily summary.',
+		...overrides,
+	};
+}
+
+/** The request object handed to the (mocked) model API. */
+function lastRequest(): any {
+	return ((ModelClientFactory.createChatModel as Mock).mock.results[0].value.generateModelResponse as Mock).mock
+		.calls[0][0];
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('runHeadlessAgentTurn', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		(ModelClientFactory.createChatModel as Mock).mockReturnValue(createMockModelApi());
+		mockAgentLoopRun.mockResolvedValue(successfulLoopResult());
+	});
+
+	describe('missing agent services', () => {
+		// Each of the three handles is checked, so a partially-initialised plugin
+		// can't slip a headless run past the guard.
+		it.each(['sessionManager', 'toolRegistry', 'toolExecutionEngine'])(
+			'throws when %s is not initialised',
+			async (service) => {
+				const plugin = createMockPlugin();
+				plugin[service] = null;
+
+				await expect(runHeadlessAgentTurn(plugin, makeSpec(), () => false)).rejects.toThrow(
+					'[TestRunner] Agent services not initialised'
+				);
+			}
+		);
+	});
+
+	describe('cancellation', () => {
+		it('returns undefined and never calls the model when cancelled up front', async () => {
+			const plugin = createMockPlugin();
+
+			const result = await runHeadlessAgentTurn(plugin, makeSpec(), () => true);
+
+			expect(result).toBeUndefined();
+			expect(
+				(ModelClientFactory.createChatModel as Mock).mock.results[0].value.generateModelResponse
+			).not.toHaveBeenCalled();
+		});
+
+		it('returns undefined when cancellation flips true during the model call', async () => {
+			const plugin = createMockPlugin();
+			// False for the pre-call check, true for the post-call check.
+			let calls = 0;
+			const isCancelled = () => calls++ > 0;
+
+			const result = await runHeadlessAgentTurn(plugin, makeSpec(), isCancelled);
+
+			expect(result).toBeUndefined();
+			// The model was reached, but its answer is discarded.
+			expect(
+				(ModelClientFactory.createChatModel as Mock).mock.results[0].value.generateModelResponse
+			).toHaveBeenCalled();
+		});
+
+		it('returns undefined when AgentLoop reports cancellation', async () => {
+			(ModelClientFactory.createChatModel as Mock).mockReturnValue(
+				createMockModelApi('', [{ name: 'list_files', arguments: {} }])
+			);
+			mockAgentLoopRun.mockResolvedValue({ ...successfulLoopResult(), cancelled: true, markdown: '' });
+
+			const result = await runHeadlessAgentTurn(createMockPlugin(), makeSpec(), () => false);
+
+			expect(result).toBeUndefined();
+		});
+	});
+
+	describe('no tool calls', () => {
+		it('returns the initial response markdown without invoking AgentLoop', async () => {
+			(ModelClientFactory.createChatModel as Mock).mockReturnValue(createMockModelApi('Straight answer.'));
+
+			const result = await runHeadlessAgentTurn(createMockPlugin(), makeSpec(), () => false);
+
+			expect(result).toBe('Straight answer.');
+			expect(mockAgentLoopRun).not.toHaveBeenCalled();
+		});
+
+		it('falls back to an empty string when the model returns null markdown', async () => {
+			(ModelClientFactory.createChatModel as Mock).mockReturnValue({
+				generateModelResponse: vi.fn().mockResolvedValue({ markdown: null, toolCalls: [] }),
+			});
+
+			const result = await runHeadlessAgentTurn(createMockPlugin(), makeSpec(), () => false);
+
+			// Empty string, not undefined — callers distinguish "cancelled"
+			// (undefined) from "ran but produced nothing" (empty).
+			expect(result).toBe('');
+		});
+	});
+
+	describe('tool-call path', () => {
+		beforeEach(() => {
+			(ModelClientFactory.createChatModel as Mock).mockReturnValue(
+				createMockModelApi('', [{ name: 'list_files', arguments: { path: '/' } }])
+			);
+		});
+
+		it('hands off to AgentLoop and returns its markdown', async () => {
+			mockAgentLoopRun.mockResolvedValue(successfulLoopResult('Loop answer.'));
+			const plugin = createMockPlugin();
+
+			const result = await runHeadlessAgentTurn(plugin, makeSpec(), () => false);
+
+			expect(result).toBe('Loop answer.');
+			expect(mockAgentLoopRun).toHaveBeenCalledWith(
+				expect.objectContaining({
+					initialUserMessage: '[preamble] Write a daily summary.',
+					initialHistory: [],
+					options: expect.objectContaining({
+						plugin,
+						headless: true,
+						isCancelled: expect.any(Function),
+						maxIterations: 20,
+						// Regression guard: headless runs must supply their own
+						// confirmation provider so AgentLoop never has to fall back.
+						confirmationProvider: expect.objectContaining({
+							showConfirmationInChat: expect.any(Function),
+							isToolAllowedWithoutConfirmation: expect.any(Function),
+							allowToolWithoutConfirmation: expect.any(Function),
+						}),
+					}),
+				})
+			);
+		});
+
+		it('forwards a per-run maxIterations override', async () => {
+			await runHeadlessAgentTurn(createMockPlugin(), makeSpec({ maxIterations: 50 }), () => false);
+
+			expect(mockAgentLoopRun).toHaveBeenCalledWith(
+				expect.objectContaining({ options: expect.objectContaining({ maxIterations: 50 }) })
+			);
+		});
+
+		it('throws on exhaustion, naming the caller, subject, cap and actual count', async () => {
+			mockAgentLoopRun.mockResolvedValue({
+				...successfulLoopResult(),
+				exhausted: true,
+				iterations: 21,
+				markdown: '',
+			});
+
+			await expect(
+				runHeadlessAgentTurn(createMockPlugin(), makeSpec({ maxIterations: 20 }), () => false)
+			).rejects.toThrow(
+				'[TestRunner] Task "test-task" exhausted its tool-iteration budget (cap 20, ran 21) without producing a response'
+			);
+		});
+
+		it('uses the caller-supplied subject noun in the exhaustion message', async () => {
+			mockAgentLoopRun.mockResolvedValue({ ...successfulLoopResult(), exhausted: true, markdown: '' });
+
+			await expect(
+				runHeadlessAgentTurn(
+					createMockPlugin(),
+					makeSpec({ logPrefix: '[HookRunner]', subjectNoun: 'Hook', subjectName: 'my-hook' }),
+					() => false
+				)
+			).rejects.toThrow('[HookRunner] Hook "my-hook" exhausted');
+		});
+	});
+
+	describe('tool exposure', () => {
+		// The headless invariant: only APPROVE-class tools reach the request.
+		// Exposing ASK_USER tools would silently bypass the user's "ask first"
+		// intent, because there is no UI to ask on.
+		it('sends the auto-approved subset, not the full enabled registry', async () => {
+			const plugin = createMockPlugin();
+
+			await runHeadlessAgentTurn(plugin, makeSpec(), () => false);
+
+			expect(plugin.toolRegistry.getAutoApprovedTools).toHaveBeenCalled();
+			expect(plugin.toolRegistry.getEnabledTools).not.toHaveBeenCalled();
+			expect(lastRequest().availableTools).toBe(AUTO_APPROVED_TOOLS);
+		});
+
+		it('builds the tool context with the spec tool policy', async () => {
+			const plugin = createMockPlugin();
+			const toolPolicy = { preset: PolicyPreset.READ_ONLY };
+
+			await runHeadlessAgentTurn(plugin, makeSpec({ toolPolicy }), () => false);
+
+			expect(plugin.toolRegistry.getAutoApprovedTools).toHaveBeenCalledWith(
+				expect.objectContaining({ plugin, featureToolPolicy: toolPolicy })
+			);
+		});
+	});
+
+	describe('session and request construction', () => {
+		it('creates the session with the spec label and tool policy', async () => {
+			const plugin = createMockPlugin();
+			const toolPolicy = { preset: PolicyPreset.READ_ONLY };
+
+			await runHeadlessAgentTurn(plugin, makeSpec({ sessionLabel: 'Hook: my-hook', toolPolicy }), () => false);
+
+			expect(plugin.sessionManager.createAgentSession).toHaveBeenCalledWith(
+				'Hook: my-hook',
+				expect.objectContaining({ toolPolicy, requireConfirmation: [] })
+			);
+		});
+
+		it('passes toolPolicy: undefined so the session inherits the global policy', async () => {
+			const plugin = createMockPlugin();
+
+			await runHeadlessAgentTurn(plugin, makeSpec({ toolPolicy: undefined }), () => false);
+
+			expect(plugin.sessionManager.createAgentSession).toHaveBeenCalledWith(
+				expect.any(String),
+				expect.objectContaining({ toolPolicy: undefined })
+			);
+		});
+
+		it('applies a model override to both the session and the request', async () => {
+			const plugin = createMockPlugin();
+			const session = { modelConfig: {} as any, created: new Date() };
+			plugin.sessionManager.createAgentSession = vi.fn().mockResolvedValue(session);
+
+			await runHeadlessAgentTurn(plugin, makeSpec({ model: 'override-model' }), () => false);
+
+			expect(session.modelConfig).toEqual({ model: 'override-model' });
+			expect(lastRequest().model).toBe('override-model');
+		});
+
+		it('falls back to the plugin chat model when no override is given', async () => {
+			await runHeadlessAgentTurn(createMockPlugin(), makeSpec(), () => false);
+
+			expect(lastRequest().model).toBe('plugin-default-model');
+		});
+
+		it('prepends the turn preamble to the caller-rendered prompt', async () => {
+			await runHeadlessAgentTurn(createMockPlugin(), makeSpec({ prompt: 'Do the thing.' }), () => false);
+
+			expect(lastRequest().userMessage).toBe('[preamble] Do the thing.');
+		});
+
+		it('sends a non-rendering, history-free extended request with plugin sampling settings', async () => {
+			await runHeadlessAgentTurn(createMockPlugin(), makeSpec(), () => false);
+
+			expect(lastRequest()).toMatchObject({
+				kind: 'extended',
+				conversationHistory: [],
+				prompt: '',
+				renderContent: false,
+				temperature: 1,
+				topP: 0.95,
+			});
+		});
+
+		it('forwards a non-empty projectSkills list as the skill include-list', async () => {
+			await runHeadlessAgentTurn(createMockPlugin(), makeSpec({ projectSkills: ['research'] }), () => false);
+
+			expect(lastRequest().projectSkills).toEqual(['research']);
+		});
+
+		it.each([
+			['an empty list', [] as string[]],
+			['an absent list', undefined],
+		])('omits projectSkills for %s (inherit-all default)', async (_label, projectSkills) => {
+			await runHeadlessAgentTurn(createMockPlugin(), makeSpec({ projectSkills }), () => false);
+
+			expect(lastRequest().projectSkills).toBeUndefined();
+		});
+	});
+
+	describe('HeadlessConfirmationProvider wiring', () => {
+		it('auto-approves confirmations and reports all tools allowed', async () => {
+			(ModelClientFactory.createChatModel as Mock).mockReturnValue(
+				createMockModelApi('', [{ name: 'list_files', arguments: {} }])
+			);
+			mockAgentLoopRun.mockResolvedValue(successfulLoopResult('Tool output.'));
+
+			await runHeadlessAgentTurn(createMockPlugin(), makeSpec(), () => false);
+
+			const provider = mockAgentLoopRun.mock.calls[0][0].options.confirmationProvider;
+
+			await expect(provider.showConfirmationInChat({}, {}, 'exec-1')).resolves.toEqual({
+				confirmed: true,
+				allowWithoutConfirmation: false,
+			});
+			expect(provider.isToolAllowedWithoutConfirmation('any_tool')).toBe(true);
+			// No-ops; just verify they don't throw.
+			provider.allowToolWithoutConfirmation('any_tool');
+			provider.updateProgress('msg', 'status');
+		});
+	});
+});

--- a/test/services/headless-agent-turn.test.ts
+++ b/test/services/headless-agent-turn.test.ts
@@ -26,16 +26,25 @@ vi.mock('../../src/api', () => ({
 	},
 }));
 
-/** Mock AgentLoop so tests don't pull in the real agent infrastructure. */
+/**
+ * Stub out `AgentLoop` so tests don't pull in the real agent infrastructure,
+ * but keep every other export — notably `DEFAULT_HEADLESS_MAX_ITERATIONS` —
+ * pointing at the real module. Hard-coding the default here would let the
+ * driver's actual default drift while the assertions below still passed.
+ */
 const mockAgentLoopRun = vi.fn();
-vi.mock('../../src/agent/agent-loop', () => ({
-	AgentLoop: vi.fn().mockImplementation(function () {
-		return { run: mockAgentLoopRun };
-	}),
-	DEFAULT_HEADLESS_MAX_ITERATIONS: 20,
-}));
+vi.mock('../../src/agent/agent-loop', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('../../src/agent/agent-loop')>();
+	return {
+		...actual,
+		AgentLoop: vi.fn().mockImplementation(function () {
+			return { run: mockAgentLoopRun };
+		}),
+	};
+});
 
 import { ModelClientFactory } from '../../src/api';
+import { DEFAULT_HEADLESS_MAX_ITERATIONS } from '../../src/agent/agent-loop';
 
 function createMockModelApi(responseText = 'Model answer.', toolCalls: any[] = []) {
 	return {
@@ -218,7 +227,7 @@ describe('runHeadlessAgentTurn', () => {
 						plugin,
 						headless: true,
 						isCancelled: expect.any(Function),
-						maxIterations: 20,
+						maxIterations: DEFAULT_HEADLESS_MAX_ITERATIONS,
 						// Regression guard: headless runs must supply their own
 						// confirmation provider so AgentLoop never has to fall back.
 						confirmationProvider: expect.objectContaining({
@@ -243,14 +252,17 @@ describe('runHeadlessAgentTurn', () => {
 			mockAgentLoopRun.mockResolvedValue({
 				...successfulLoopResult(),
 				exhausted: true,
-				iterations: 21,
+				iterations: 8,
 				markdown: '',
 			});
 
+			// A deliberately non-default cap, so the message is proven to report
+			// the *configured* value rather than coincidentally matching the
+			// shared default.
 			await expect(
-				runHeadlessAgentTurn(createMockPlugin(), makeSpec({ maxIterations: 20 }), () => false)
+				runHeadlessAgentTurn(createMockPlugin(), makeSpec({ maxIterations: 7 }), () => false)
 			).rejects.toThrow(
-				'[TestRunner] Task "test-task" exhausted its tool-iteration budget (cap 20, ran 21) without producing a response'
+				'[TestRunner] Task "test-task" exhausted its tool-iteration budget (cap 7, ran 8) without producing a response'
 			);
 		});
 

--- a/test/services/hook-runner.test.ts
+++ b/test/services/hook-runner.test.ts
@@ -690,23 +690,9 @@ describe('HookRunner agent-task: exhausted iterations', () => {
 		);
 	});
 
-	it('exhausted error message reflects the per-hook maxIterations', async () => {
-		const generateModelResponse = vi.fn().mockResolvedValue({
-			markdown: '',
-			toolCalls: [{ name: 'some_tool', arguments: {} }],
-		});
-		(ModelClientFactory.createChatModel as any).mockReturnValue({ generateModelResponse });
-		mockAgentLoopRun.mockResolvedValue({
-			...successfulLoopResult(),
-			exhausted: true,
-			markdown: '',
-		});
-
-		const plugin = createMockPlugin();
-		const runner = new HookRunner(plugin as any, makeContext(makeHook({ maxIterations: 50 })));
-
-		await expect(runner.run()).rejects.toThrow(/exhausted its tool-iteration budget \(cap 50, ran \d+\)/);
-	});
+	// The exhaustion-message *format* (prefix, subject noun, cap vs actual) is
+	// asserted once in `headless-agent-turn.test.ts`; what matters here is that
+	// this runner's own `maxIterations` reaches the shared driver, covered above.
 });
 
 // ─── Rewrite non-markdown skip ───────────────────────────────────────────────

--- a/test/services/scheduled-task-runner.test.ts
+++ b/test/services/scheduled-task-runner.test.ts
@@ -239,21 +239,6 @@ describe('ScheduledTaskRunner', () => {
 		);
 	});
 
-	it('exhausted error message reflects the per-task maxIterations', async () => {
-		const toolCalls = [{ name: 'list_files', arguments: { path: '/' } }];
-		(ModelClientFactory.createChatModel as Mock).mockReturnValue(createMockModelApi('', toolCalls));
-		mockAgentLoopRun.mockResolvedValue({
-			...successfulLoopResult(),
-			exhausted: true,
-			markdown: '',
-		});
-
-		const plugin = createMockPlugin();
-		const runner = new ScheduledTaskRunner(plugin, makeTask({ maxIterations: 50 }));
-
-		await expect(runner.run(() => false)).rejects.toThrow(/exhausted its tool-iteration budget \(cap 50, ran \d+\)/);
-	});
-
 	it('returns undefined when AgentLoop reports cancellation', async () => {
 		const toolCalls = [{ name: 'list_files', arguments: { path: '/' } }];
 		(ModelClientFactory.createChatModel as Mock).mockReturnValue(createMockModelApi('', toolCalls));
@@ -351,56 +336,11 @@ describe('ScheduledTaskRunner', () => {
 		});
 	});
 
-	describe('HeadlessConfirmationProvider', () => {
-		it('auto-approves confirmations and reports all tools allowed', async () => {
-			const plugin = createMockPlugin();
-			// Trigger the tool-call path so the runner constructs a HeadlessConfirmationProvider
-			const toolCalls = [{ name: 'list_files', arguments: { path: '/' } }];
-			(ModelClientFactory.createChatModel as Mock).mockReturnValue(createMockModelApi('', toolCalls));
-			mockAgentLoopRun.mockResolvedValue(successfulLoopResult('Tool output.'));
-
-			const runner = new ScheduledTaskRunner(plugin, makeTask());
-			await runner.run(() => false);
-
-			// Extract the confirmationProvider from the AgentLoop.run call
-			const options = mockAgentLoopRun.mock.calls[0][0].options;
-			const provider = options.confirmationProvider;
-
-			// Exercise the HeadlessConfirmationProvider methods (lines 30-33)
-			const confirmation = await provider.showConfirmationInChat({}, {}, 'exec-1');
-			expect(confirmation).toEqual({ confirmed: true, allowWithoutConfirmation: false });
-			expect(provider.isToolAllowedWithoutConfirmation('any_tool')).toBe(true);
-			// These are no-ops; just verify they don't throw
-			provider.allowToolWithoutConfirmation('any_tool');
-			provider.updateProgress('msg', 'status');
-		});
-	});
-
-	describe('missing agent services', () => {
-		it('throws when sessionManager is not initialised', async () => {
-			const plugin = createMockPlugin();
-			plugin.sessionManager = null;
-
-			const runner = new ScheduledTaskRunner(plugin, makeTask());
-			await expect(runner.run(() => false)).rejects.toThrow('Agent services not initialised');
-		});
-
-		it('throws when toolRegistry is not initialised', async () => {
-			const plugin = createMockPlugin();
-			plugin.toolRegistry = null;
-
-			const runner = new ScheduledTaskRunner(plugin, makeTask());
-			await expect(runner.run(() => false)).rejects.toThrow('Agent services not initialised');
-		});
-
-		it('throws when toolExecutionEngine is not initialised', async () => {
-			const plugin = createMockPlugin();
-			plugin.toolExecutionEngine = null;
-
-			const runner = new ScheduledTaskRunner(plugin, makeTask());
-			await expect(runner.run(() => false)).rejects.toThrow('Agent services not initialised');
-		});
-	});
+	// The headless-turn mechanics this runner delegates — the agent-services
+	// guard, HeadlessConfirmationProvider wiring, tool exposure, and the
+	// exhaustion-message format — are covered once in
+	// `headless-agent-turn.test.ts`. What stays here is this runner's own
+	// mapping and output-writing behavior.
 
 	describe('resolveUniquePath — Date.now() fallback', () => {
 		it('falls back to a timestamp suffix when all numeric suffixes 1-99 are taken', async () => {


### PR DESCRIPTION
<!-- auto-dev -->

## Summary

`ScheduledTaskRunner.run()` and `HookRunner.runAgentTask()` were two near-verbatim implementations of the same thing — "drive one headless agent turn." Both already delegated the tool loop to `AgentLoop`, but the ~65 lines *around* that call were written twice: the agent-services guard, `createAgentSession` with the feature's `toolPolicy`, the `session.modelConfig` override, `ToolExecutionContext` construction, `ModelClientFactory.createChatModel`, `getAutoApprovedTools` (with the same rationale comment in both), the turn preamble, the whole `ExtendedModelRequest` literal, the pre/post-call cancellation checks, the `AgentLoop.run` options, and the `cancelled` / `exhausted` / `finalText` handling.

The duplication had already started to cost: the exhaustion error message was maintained in two places, and there was no test that would have caught the two copies diverging.

This extracts the whole span into a new leaf module, `src/services/headless-agent-turn.ts`, exporting a single `runHeadlessAgentTurn()`. The four real differences become a spec parameter object. Both callers keep only their own output-writing behavior — which genuinely differs and should stay split: the scheduled task always writes its result and treats empty output as a *failure*; a hook writes only when `outputPath` is set and treats empty output as a silent no-op.

This is the second extraction from this same file pair — #997 split out `HeadlessConfirmationProvider`, and the setup around it never followed. The `headless: true` + `HeadlessConfirmationProvider` wiring now lives inside the helper, so the "headless never surfaces ASK_USER tools" invariant has exactly one enforcement site.

Produced by the auto-dev pipeline from the plan approved on the issue.

Fixes #1261

## Changes

- **`src/services/headless-agent-turn.ts` (new, 167 lines)** — `runHeadlessAgentTurn(plugin, spec, isCancelled)`. Owns the entire duplicated span; returns `finalText`, or `undefined` when cancelled. Leaf module (imports the session/factory/loop layers; nothing imports the runners back), per the shared-leaf-helper rule in `coding.md`.
- **`HeadlessAgentTurnSpec`** — `sessionLabel`, `logPrefix`, `subjectNoun` + `subjectName` (so the exhaustion message has one source instead of two drifting copies), `prompt` (callers render templates first), `toolPolicy`, `model`, `maxIterations`, `projectSkills`.
- **`src/services/scheduled-task-runner.ts`** — 133 lines lighter; `run()` now builds the spec, calls the helper, and does only its `resolveOutputPath` + frontmatter header + `writeHeadlessOutput`.
- **`src/services/hook-runner.ts`** — 123 lines lighter; `runAgentTask()` now renders the prompt, builds the spec (passing `hook.enabledSkills` as `projectSkills`), calls the helper, and does only its conditional output write.
- **`test/services/headless-agent-turn.test.ts` (new, 24 tests)** — covers the shared path once.
- **`test/services/{scheduled-task-runner,hook-runner}.test.ts`** — trimmed the assertions that are now shared-path assertions, so they live in exactly one place. Each caller's own mapping and output-writing tests stay.

### Behavior-equivalence notes

Two places where the code motion could have changed behavior, both checked:

- **`projectSkills` on the scheduled-task request.** The scheduled path previously omitted the key entirely; it now passes `projectSkills: undefined`. Consumption is by truthiness (`src/prompts/gemini-prompts.ts:212` — `if (request.projectSkills && request.projectSkills.length > 0)`), never by key presence, so explicit-`undefined` and absent are equivalent.
- **Hook guard ordering.** `renderPrompt()` now runs before the agent-services guard (the guard moved inside the helper). `renderPrompt` is pure string substitution with no failure mode, and the thrown message is byte-identical (`[HookRunner] Agent services not initialised`).

## Screenshots / Screencast

N/A — no UI surface. Pure internal code motion.

## Testing

**Automated — full pre-flight green:**

- `npm test` — **164 files, 3534 tests passing**
- `npm run build`, `npm run typecheck:test`, `npm run format-check` — clean
- `npm run lint` — 0 errors (38 pre-existing warnings, none in touched files)
- `npm run lint:cycles` — **no circular dependency**, confirming the new module is a true leaf
- `npm run knip` — clean

**The strongest evidence this is behavior-preserving:** the pre-existing `scheduled-task-runner` and `hook-runner` suites — **56 tests** — passed **unmodified** against the refactored code, before any test was trimmed. The trim came afterward and only removed assertions that the new shared suite now makes.

**New coverage** (`test/services/headless-agent-turn.test.ts`, 24 tests): the services guard for each of the three handles; cancellation before the call, during the call, and reported by `AgentLoop`; the no-tool-calls fallback to `initialResponse.markdown` (including the null → `''` case, which is what lets callers distinguish "cancelled" from "ran but produced nothing"); the exhaustion message with its caller prefix, subject noun, cap and actual count; `maxIterations` forwarding; session/model/preamble/request construction; `projectSkills` include-list semantics; `HeadlessConfirmationProvider` wiring; and a direct guard that `getAutoApprovedTools` — **not** `getEnabledTools` — is what reaches `availableTools`.

**Behavioral verification not run in sandbox — needs a manual check.** Firing a real scheduled task or hook end-to-end needs a live Obsidian vault and a Gemini API key, neither of which this sandbox has. The change is pure code motion with no runnable-surface change, and the unmodified-suite result above is the substitute evidence, but no scheduled task or hook was actually fired.

**Mobile** — no platform-specific APIs added or moved; the code is provider/session plumbing only.

## Documentation

No documentation updates. This changes no user-facing behavior, setting, command, or public surface — it is internal code motion between two service modules. Flagging explicitly given the repo's mandatory-docs policy: this is the documented "N/A, and here's why" case, and the approved plan called it out the same way.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [ ] I have tested this change on Desktop — **not done**: no live vault in the sandbox (see Testing)
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards)
- [x] Documentation has been updated (if applicable) — N/A, rationale above
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (auto-dev pipeline)
- [x] I have reviewed and understand all AI-generated code in this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_015bZrjuRSZAniKh3UJntxRo)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a shared headless agent execution driver used by scheduled tasks and automated hooks.
  * Supports per-run model overrides, tool policy, project skill constraints, iteration limits, and headless auto-confirmations.

* **Bug Fixes**
  * Canceled automated runs now stop cleanly without writing output.

* **Tests**
  * Added comprehensive coverage for the shared headless execution flow (cancellation, tool handling, model selection, and exhaustion errors).
  * Reduced/relocated overlapping runner test assertions to avoid duplication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->