### PR TITLE
fix(gemini): capture thought_signature deltas on the Interactions stream

### DIFF
--- a/src/api/providers/gemini/interactions-mapper.ts
+++ b/src/api/providers/gemini/interactions-mapper.ts
@@ -287,11 +287,17 @@ interface PendingToolCall {
  * Accumulates Interactions streaming events into a final `ModelResponse`.
  *
  * The step-based stream interleaves: `step.start` (carries the full `Step`, so a
- * `function_call` step's id/name/signature land here), `step.delta` (incremental
- * `text`, `thought_summary`, or `arguments_delta`), `step.stop` (finalizes a
- * step), and `interaction.completed` (final `usage`). Function-call arguments
- * arrive as `arguments_delta` string fragments keyed by step `index` and are
- * JSON-parsed once the step stops.
+ * `function_call` step's id/name land here), `step.delta` (incremental `text`,
+ * `thought_summary`, `thought_signature`, or `arguments_delta`), `step.stop`
+ * (finalizes a step), and `interaction.completed` (final `usage`). Function-call
+ * arguments arrive as `arguments_delta` string fragments keyed by step `index`
+ * and are JSON-parsed once the step stops.
+ *
+ * Thought signatures are *not* carried on the `function_call` step. They stream
+ * as a `thought_signature` delta on the preceding `thought` step, and Gemini
+ * thinking models reject a replayed tool turn whose `functionCall` lacks one
+ * (an opaque 400). So the signature is buffered when it arrives and attached to
+ * the next function call that finalizes — see {@link takeSignature}.
  *
  * Kept free of SDK/DOM dependencies so it is unit-testable with plain event
  * objects. `handleEvent` returns the chunk to emit (or null); `finalize` builds
@@ -304,6 +310,8 @@ export class InteractionStreamAccumulator {
 	private readonly pending = new Map<number, PendingToolCall>();
 	private readonly toolCalls: ToolCall[] = [];
 	private readonly sources = new Map<string, GroundingSource>();
+	/** Latest `thought_signature` delta, awaiting the function call it belongs to. */
+	private unclaimedSignature: string | undefined;
 
 	/** Process one streamed event; returns a chunk to emit, or null if nothing to surface. */
 	handleEvent(event: InteractionStreamEvent): InteractionStreamChunk | null {
@@ -371,6 +379,14 @@ export class InteractionStreamAccumulator {
 				}
 				return null;
 			}
+			case 'thought_signature': {
+				// Arrives on the `thought` step, not the `function_call` step it
+				// authorizes, so it can't be keyed by `event.index` into `pending`.
+				if (typeof delta.signature === 'string' && delta.signature) {
+					this.unclaimedSignature = delta.signature;
+				}
+				return null;
+			}
 			case 'text_annotation_delta': {
 				// Grounding sources stream as url_citation annotations (#1016).
 				collectUrlCitations(delta.annotations, this.sources);
@@ -400,8 +416,20 @@ export class InteractionStreamAccumulator {
 			name: pending.name,
 			arguments: args,
 			id: pending.id,
-			thoughtSignature: pending.signature,
+			thoughtSignature: pending.signature ?? this.takeSignature(),
 		});
+	}
+
+	/**
+	 * Claim the buffered thought signature for one function call, clearing it so a
+	 * later call doesn't reuse it. A parallel tool batch is preceded by a single
+	 * thought step, so only the first call in the batch carries a signature —
+	 * matching what the `generateContent` path produces (and what the API accepts).
+	 */
+	private takeSignature(): string | undefined {
+		const signature = this.unclaimedSignature;
+		this.unclaimedSignature = undefined;
+		return signature;
 	}
 
 	/** Build the final response once the stream is exhausted (flushing any unstopped steps). */

--- a/src/api/providers/gemini/interactions-mapper.ts
+++ b/src/api/providers/gemini/interactions-mapper.ts
@@ -402,6 +402,10 @@ export class InteractionStreamAccumulator {
 		const pending = this.pending.get(index);
 		if (!pending) return;
 		this.pending.delete(index);
+		// Claim unconditionally: a step-level signature takes precedence below, but
+		// the buffered one is still spent here so it can't leak to a later call.
+		// (Non-function_call steps return above, so a thought step's own stop is a no-op.)
+		const bufferedSignature = this.takeSignature();
 
 		let args: Record<string, unknown> = pending.seedArgs ?? {};
 		if (pending.argsBuffer) {
@@ -416,7 +420,7 @@ export class InteractionStreamAccumulator {
 			name: pending.name,
 			arguments: args,
 			id: pending.id,
-			thoughtSignature: pending.signature ?? this.takeSignature(),
+			thoughtSignature: pending.signature ?? bufferedSignature,
 		});
 	}
 

--- a/test/api/providers/gemini/interactions-mapper.test.ts
+++ b/test/api/providers/gemini/interactions-mapper.test.ts
@@ -186,9 +186,25 @@ describe('InteractionStreamAccumulator', () => {
 				step: { type: 'function_call', id: 'c1', name: 'read_file', signature: 'on-step' },
 			},
 			{ event_type: 'step.stop', index: 1 },
+			// The step-level signature wins, but the buffered one is spent rather than
+			// left behind — otherwise this next unsigned call inherits a stale signature.
+			{ event_type: 'step.start', index: 2, step: { type: 'function_call', id: 'c2', name: 'list_files' } },
+			{ event_type: 'step.stop', index: 2 },
 		]);
 
-		expect(response.toolCalls?.[0].thoughtSignature).toBe('on-step');
+		expect(response.toolCalls?.map((c) => c.thoughtSignature)).toEqual(['on-step', undefined]);
+	});
+
+	test('a thought step stopping does not consume the signature meant for the call after it', () => {
+		const { response } = run([
+			{ event_type: 'step.start', index: 0, step: { type: 'thought' } },
+			{ event_type: 'step.delta', index: 0, delta: { type: 'thought_signature', signature: 'sig-abc' } },
+			{ event_type: 'step.stop', index: 0 },
+			{ event_type: 'step.start', index: 1, step: { type: 'function_call', id: 'c1', name: 'read_file' } },
+			{ event_type: 'step.stop', index: 1 },
+		]);
+
+		expect(response.toolCalls?.[0].thoughtSignature).toBe('sig-abc');
 	});
 });
 

--- a/test/api/providers/gemini/interactions-mapper.test.ts
+++ b/test/api/providers/gemini/interactions-mapper.test.ts
@@ -143,6 +143,53 @@ describe('InteractionStreamAccumulator', () => {
 			{ name: 'list_files', arguments: { dir: '.' }, id: 'b', thoughtSignature: undefined },
 		]);
 	});
+
+	// The event order below mirrors a real gemini-3.x stream: the signature arrives
+	// as a `thought_signature` delta on the *thought* step, and the `function_call`
+	// step.start carries none. Dropping it made the replayed tool turn fail with an
+	// opaque 400 for every agent turn that called a tool.
+	test('claims a thought_signature delta from the thought step for the following tool call', () => {
+		const { response } = run([
+			{ event_type: 'step.start', index: 0, step: { type: 'thought' } },
+			{ event_type: 'step.delta', index: 0, delta: { type: 'thought_signature', signature: 'sig-abc' } },
+			{ event_type: 'step.stop', index: 0 },
+			{ event_type: 'step.start', index: 1, step: { type: 'function_call', id: 'c1', name: 'read_file' } },
+			{ event_type: 'step.delta', index: 1, delta: { type: 'arguments_delta', arguments: '{"path":"a.md"}' } },
+			{ event_type: 'step.stop', index: 1 },
+		]);
+
+		expect(response.toolCalls).toEqual([
+			{ name: 'read_file', arguments: { path: 'a.md' }, id: 'c1', thoughtSignature: 'sig-abc' },
+		]);
+	});
+
+	test('a signature is claimed by only the first call of a parallel batch', () => {
+		const { response } = run([
+			{ event_type: 'step.start', index: 0, step: { type: 'thought' } },
+			{ event_type: 'step.delta', index: 0, delta: { type: 'thought_signature', signature: 'sig-abc' } },
+			{ event_type: 'step.stop', index: 0 },
+			{ event_type: 'step.start', index: 1, step: { type: 'function_call', id: 'a', name: 'read_file' } },
+			{ event_type: 'step.start', index: 2, step: { type: 'function_call', id: 'b', name: 'list_files' } },
+			{ event_type: 'step.stop', index: 1 },
+			{ event_type: 'step.stop', index: 2 },
+		]);
+
+		expect(response.toolCalls?.map((c) => c.thoughtSignature)).toEqual(['sig-abc', undefined]);
+	});
+
+	test('a signature on the function_call step itself still wins over a buffered one', () => {
+		const { response } = run([
+			{ event_type: 'step.delta', index: 0, delta: { type: 'thought_signature', signature: 'buffered' } },
+			{
+				event_type: 'step.start',
+				index: 1,
+				step: { type: 'function_call', id: 'c1', name: 'read_file', signature: 'on-step' },
+			},
+			{ event_type: 'step.stop', index: 1 },
+		]);
+
+		expect(response.toolCalls?.[0].thoughtSignature).toBe('on-step');
+	});
 });
 
 describe('grounding sources (rendered)', () => {


### PR DESCRIPTION
## Summary

Every agent turn that called a tool was failing with an opaque `400 API error occurred: {"httpMeta":{"response":{},"request":{}}}` on the follow-up request. The Interactions streaming path never captured thought signatures, so the replayed `functionCall` went back to the model without one — which Gemini thinking models reject.

This surfaced now because #1191 defaulted the Interactions transport on; the `generateContent` path reads the signature correctly, which is why the same vault worked earlier on the legacy path.

## Root cause

`InteractionStreamAccumulator` only read a signature from `step.start`'s `step.signature`. That is not where the API puts it. Probing a live `gemini-3.6-flash` stream:

```
step.start   idx=0 type=thought        signature=absent
step.delta   idx=0 delta.type=thought_signature  signature=PRESENT(340)
step.stop    idx=0
step.start   idx=1 type=function_call name=get_weather  signature=absent
step.delta   idx=1 delta.type=arguments_delta
```

The `function_call` step carries no signature; it streams as a `thought_signature` delta on the *preceding* `thought` step. `handleDelta` had no case for that type, so it fell through to `default: return null` and was discarded.

The replay side needed no change — `contentToSteps` already puts `signature` on the `function_call` step.

## Changes

- `handleDelta`: handle the `thought_signature` delta, buffering the signature.
- `finalizeStep`: claim the buffered signature via a new `takeSignature()`. It can't be keyed by `event.index` into `pending`, since it arrives on a different step than the call it authorizes.
- Three regression tests built from the real event ordering above.
- Corrected the class doc comment, which asserted that a `function_call` step's signature "lands here" on `step.start`.

## Reviewer notes

**`takeSignature()` consumes the signature**, so a parallel tool batch puts a signature on only the *first* call. That deliberately mirrors what the working `generateContent` path produced — logs from the legacy path show `3 calls, 1 with signatures` and `4 calls, 1 with signatures` succeeding. Attaching the same signature to all N calls is the plausible-looking alternative and is **not** verified against the server.

The existing tests didn't catch this because every fixture hand-models `step.start`/`step.stop` with no `thought_signature` delta — the assumption under test was the same one that was wrong.

## Verification

Bundled the modified source and ran a real round trip against the live API:

```
turn 1: thoughtSignature=CAPTURED(340)
replay steps: user_input -> function_call -> function_result
replay function_call carries signature: true
>>> follow-up ACCEPTED: "The weather in Paris right now is 18°C and cloudy..."
```

The identical request with the signature omitted reproduces the exact 400, so this is causal rather than correlated.

- `npm test` — 3519 passed (163 files)
- `npm run typecheck:test` — clean
- `npm run lint` — 0 errors
- `npm run build` — succeeds
- `npm run format-check` — clean
- Tested on Desktop in a live vault (plugin reloads clean; agent tool turns no longer 400)

No mobile-specific surface is touched — this is transport-layer response parsing with no platform APIs involved.

## Screenshots / Screencast

N/A — internal transport fix, no UI surface.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — **no issue filed; found while debugging a live vault failure. Authored by the maintainer.**
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop
- [x] I have verified this change does not break Mobile (no platform-specific code involved)
- [x] Documentation has been updated (if applicable) — n/a, no user-facing surface change
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Gemini streaming so `thought_signature` deltas are buffered and correctly attached to the next `function_call` tool call.
  - Fixed parallel tool-call handling so only the intended call receives the buffered signature.
  - Ensured a signature provided on a `function_call` step overrides any previously buffered value.

- **Tests**
  - Expanded coverage for buffering behavior, parallel association rules, precedence when signatures arrive on tool calls, and correct behavior when stopping a thought step.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->