### PR TITLE
test: cover headless confirmation provider and agent-view leaf helpers (#1262)

### DIFF
--- a/test/services/headless-confirmation-provider.test.ts
+++ b/test/services/headless-confirmation-provider.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from 'vitest';
+import { HeadlessConfirmationProvider } from '../../src/services/headless-confirmation-provider';
+import type { DiffContext, IConfirmationProvider, Tool } from '../../src/tools/types';
+
+// This provider is the auto-approve surface every unattended run goes through
+// (`HookRunner`, `ScheduledTaskRunner`, via `runHeadlessAgentTurn`). A regression
+// here silently changes what a scheduled task is permitted to do while nobody is
+// watching, so the assertions below are about the *decision* it returns, not about
+// any rendering — it has none.
+
+const tool = { name: 'write_file', description: 'write a file' } as unknown as Tool;
+
+const diffContext: DiffContext = {
+	filePath: 'notes/target.md',
+	originalContent: 'before',
+	proposedContent: 'after',
+	isNewFile: false,
+};
+
+describe('HeadlessConfirmationProvider', () => {
+	// Typing the binding as the interface (rather than the class) means a future
+	// widening of IConfirmationProvider fails `typecheck:test` here.
+	const provider: IConfirmationProvider = new HeadlessConfirmationProvider();
+
+	describe('showConfirmationInChat', () => {
+		it('auto-approves without granting a session-wide bypass', async () => {
+			await expect(provider.showConfirmationInChat(tool, {}, 'exec-1')).resolves.toEqual({
+				confirmed: true,
+				allowWithoutConfirmation: false,
+			});
+		});
+
+		// `allowWithoutConfirmation: true` is what the interactive UI returns when the
+		// user ticks "don't ask again"; it persists a bypass for the rest of the
+		// session. A headless run has no user to have ticked it, so this must stay
+		// false — the enabledTools allowlist is the only authority.
+		it('never returns allowWithoutConfirmation, whatever it is asked about', async () => {
+			const results = await Promise.all([
+				provider.showConfirmationInChat(tool, { path: 'a.md' }, 'exec-1'),
+				provider.showConfirmationInChat(tool, { path: 'b.md' }, 'exec-2', diffContext),
+				provider.showConfirmationInChat({ name: 'delete_file' } as unknown as Tool, {}, 'exec-3'),
+			]);
+
+			for (const result of results) {
+				expect(result.allowWithoutConfirmation).toBe(false);
+				expect(result.confirmed).toBe(true);
+			}
+		});
+
+		it('approves a destructive diff without surfacing edited content', async () => {
+			const result = await provider.showConfirmationInChat(tool, { path: 'notes/target.md' }, 'exec-4', diffContext);
+
+			// No user edited anything — the runner must write the model's proposed
+			// content, not a `finalContent` this provider invented.
+			expect(result.finalContent).toBeUndefined();
+			expect(result.userEdited).toBeUndefined();
+		});
+	});
+
+	describe('isToolAllowedWithoutConfirmation', () => {
+		// The provider is deliberately unconditional: ASK_USER-class tools are
+		// filtered out upstream by `toolRegistry.getAutoApprovedTools()` before the
+		// loop ever runs, so anything that reaches here is already APPROVE-class.
+		it.each(['read_file', 'write_file', 'delete_file', 'a_tool_that_does_not_exist', ''])(
+			'reports %o as allowed',
+			(toolName) => {
+				expect(provider.isToolAllowedWithoutConfirmation(toolName)).toBe(true);
+			}
+		);
+	});
+
+	describe('statelessness', () => {
+		it('is unaffected by allowToolWithoutConfirmation', () => {
+			const fresh: IConfirmationProvider = new HeadlessConfirmationProvider();
+
+			expect(() => fresh.allowToolWithoutConfirmation('delete_file')).not.toThrow();
+			// Same answer before and after — there is no accumulated grant state that a
+			// later run could inherit.
+			expect(fresh.isToolAllowedWithoutConfirmation('delete_file')).toBe(true);
+			expect(fresh.isToolAllowedWithoutConfirmation('some_other_tool')).toBe(true);
+		});
+
+		it('accepts progress updates as a no-op', () => {
+			expect(() => provider.updateProgress?.('Reading notes/target.md', 'running')).not.toThrow();
+		});
+
+		it('two instances answer identically', async () => {
+			const a: IConfirmationProvider = new HeadlessConfirmationProvider();
+			const b: IConfirmationProvider = new HeadlessConfirmationProvider();
+			a.allowToolWithoutConfirmation('write_file');
+
+			await expect(a.showConfirmationInChat(tool, {}, 'exec-a')).resolves.toEqual(
+				await b.showConfirmationInChat(tool, {}, 'exec-b')
+			);
+		});
+	});
+
+	describe('IConfirmationProvider contract', () => {
+		it('implements every member AgentLoop may call', () => {
+			const instance = new HeadlessConfirmationProvider();
+
+			expect(typeof instance.showConfirmationInChat).toBe('function');
+			expect(typeof instance.isToolAllowedWithoutConfirmation).toBe('function');
+			expect(typeof instance.allowToolWithoutConfirmation).toBe('function');
+			// Optional on the interface, but the headless runners rely on it existing.
+			expect(typeof instance.updateProgress).toBe('function');
+		});
+
+		it('resolves rather than returning a bare value', () => {
+			expect(new HeadlessConfirmationProvider().showConfirmationInChat(tool, {}, 'exec-1')).toBeInstanceOf(Promise);
+		});
+	});
+});

--- a/test/ui/agent-view/leaf-helpers.test.ts
+++ b/test/ui/agent-view/leaf-helpers.test.ts
@@ -1,0 +1,313 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { setIcon } from 'obsidian';
+import type { TFile } from 'obsidian';
+import {
+	setCollapsibleExpanded,
+	wireCollapsibleToggle,
+	type CollapsibleRefs,
+} from '../../../src/ui/agent-view/collapsible';
+import { buildCompactionEntry } from '../../../src/ui/agent-view/compaction-notice';
+import { TOOL_ICONS } from '../../../src/ui/agent-view/tool-icons';
+import { AgentViewContext } from '../../../src/ui/agent-view/agent-view-context';
+import type { ChatSession } from '../../../src/types/agent';
+
+// The four agent-view leaf modules covered here were each extracted as shared
+// helpers (#1227, #1213, #1214) precisely so two call sites could not drift
+// apart again. They are pure — no Obsidian lifecycle — so they share one fixture
+// file rather than one file each.
+
+const setIconMock = setIcon as unknown as ReturnType<typeof vi.fn>;
+
+function makeRefs(expandedClass = 'gemini-tool-group-expanded'): CollapsibleRefs {
+	const host = document.createElement('div');
+	const control = document.createElement('div');
+	const body = document.createElement('div');
+	const chevron = document.createElement('span');
+	host.append(control, body);
+	control.append(chevron);
+	return { control, body, chevron, host, expandedClass };
+}
+
+beforeEach(() => {
+	setIconMock.mockClear();
+});
+
+describe('collapsible', () => {
+	describe('setCollapsibleExpanded', () => {
+		it('applies the expanded state across all four refs', () => {
+			const refs = makeRefs();
+
+			setCollapsibleExpanded(refs, true);
+
+			expect(refs.body.style.display).toBe('block');
+			expect(refs.host.classList.contains('gemini-tool-group-expanded')).toBe(true);
+			expect(refs.control.getAttribute('aria-expanded')).toBe('true');
+			expect(setIconMock).toHaveBeenCalledWith(refs.chevron, 'chevron-down');
+		});
+
+		it('applies the collapsed state across all four refs', () => {
+			const refs = makeRefs();
+			setCollapsibleExpanded(refs, true);
+			setIconMock.mockClear();
+
+			setCollapsibleExpanded(refs, false);
+
+			expect(refs.body.style.display).toBe('none');
+			expect(refs.host.classList.contains('gemini-tool-group-expanded')).toBe(false);
+			expect(refs.control.getAttribute('aria-expanded')).toBe('false');
+			expect(setIconMock).toHaveBeenCalledWith(refs.chevron, 'chevron-right');
+		});
+
+		it('honours the caller-supplied expanded class', () => {
+			const refs = makeRefs('gemini-tool-row-expanded');
+
+			setCollapsibleExpanded(refs, true);
+
+			expect(refs.host.classList.contains('gemini-tool-row-expanded')).toBe(true);
+			expect(refs.host.classList.contains('gemini-tool-group-expanded')).toBe(false);
+		});
+	});
+
+	describe('wireCollapsibleToggle', () => {
+		it('expands on first click when aria-expanded was never set', () => {
+			// A freshly-built header has no aria-expanded attribute; the missing
+			// attribute must read as collapsed, so the first click opens it.
+			const refs = makeRefs();
+			wireCollapsibleToggle(refs);
+
+			refs.control.dispatchEvent(new MouseEvent('click'));
+
+			expect(refs.control.getAttribute('aria-expanded')).toBe('true');
+			expect(refs.body.style.display).toBe('block');
+		});
+
+		it('toggles back and forth on repeated clicks', () => {
+			const refs = makeRefs();
+			wireCollapsibleToggle(refs);
+
+			refs.control.dispatchEvent(new MouseEvent('click'));
+			refs.control.dispatchEvent(new MouseEvent('click'));
+
+			expect(refs.control.getAttribute('aria-expanded')).toBe('false');
+			expect(refs.body.style.display).toBe('none');
+		});
+
+		// State is read back off aria-expanded rather than kept in a closure, so
+		// programmatic expansion (auto-expand on tool error) and user clicks stay in
+		// sync — the next click must collapse, not re-expand.
+		it('picks up programmatic expansion instead of tracking its own state', () => {
+			const refs = makeRefs();
+			wireCollapsibleToggle(refs);
+
+			setCollapsibleExpanded(refs, true);
+			refs.control.dispatchEvent(new MouseEvent('click'));
+
+			expect(refs.control.getAttribute('aria-expanded')).toBe('false');
+		});
+
+		it.each([
+			['Enter', 'Enter'],
+			['Space', ' '],
+		])('toggles on %s and suppresses the default action', (_label, key) => {
+			const refs = makeRefs();
+			wireCollapsibleToggle(refs);
+			const event = new KeyboardEvent('keydown', { key, cancelable: true });
+
+			refs.control.dispatchEvent(event);
+
+			expect(refs.control.getAttribute('aria-expanded')).toBe('true');
+			// Space would otherwise scroll the tool activity block.
+			expect(event.defaultPrevented).toBe(true);
+		});
+
+		it('ignores unrelated keys', () => {
+			const refs = makeRefs();
+			wireCollapsibleToggle(refs);
+			const event = new KeyboardEvent('keydown', { key: 'a', cancelable: true });
+
+			refs.control.dispatchEvent(event);
+
+			expect(refs.control.getAttribute('aria-expanded')).toBeNull();
+			expect(event.defaultPrevented).toBe(false);
+		});
+	});
+});
+
+describe('buildCompactionEntry', () => {
+	it('builds a model entry carrying the summary below the notice callout', () => {
+		const entry = buildCompactionEntry('Earlier turns discussed the vault layout.', 'gemini-3-flash-preview');
+
+		expect(entry.role).toBe('model');
+		expect(entry.model).toBe('gemini-3-flash-preview');
+		expect(entry.notePath).toBe('');
+		expect(entry.created_at).toBeInstanceOf(Date);
+		expect(entry.message).toContain('Earlier turns discussed the vault layout.');
+	});
+
+	// The message is persisted into session markdown, so the callout marker is a
+	// file-format detail: it must stay an `[!info]` callout and stay English
+	// (never routed through `t()`) per the repo's i18n invariant.
+	it('serializes as an English [!info] callout', () => {
+		const entry = buildCompactionEntry('summary', 'gemini-3-flash-preview');
+
+		expect(entry.message.startsWith('> [!info] Context Compacted\n')).toBe(true);
+		expect(entry.message).toContain('> Older conversation turns have been summarized to maintain performance.');
+	});
+
+	// Both compaction paths (pre-turn in agent-view-send, mid-loop via
+	// onMidLoopCompaction — #662) call this helper so the two notices cannot drift.
+	it('produces an identical notice for identical inputs', () => {
+		const preTurn = buildCompactionEntry('same summary', 'gemini-3-pro-preview');
+		const midLoop = buildCompactionEntry('same summary', 'gemini-3-pro-preview');
+
+		expect(midLoop.message).toBe(preTurn.message);
+	});
+
+	it('keeps the callout intact for an empty summary', () => {
+		const entry = buildCompactionEntry('', 'gemini-3-flash-preview');
+
+		expect(entry.message.startsWith('> [!info] Context Compacted\n')).toBe(true);
+	});
+});
+
+describe('TOOL_ICONS', () => {
+	// These are the entries that had drifted between the two partial copies the
+	// map replaced, so they are the ones worth pinning by name.
+	it.each([
+		['read_file', 'file-text'],
+		['write_file', 'file-edit'],
+		['list_files', 'folder-open'],
+		['create_folder', 'folder-plus'],
+		['delete_file', 'trash-2'],
+		['move_file', 'file-symlink'],
+		['find_files_by_name', 'search'],
+		['find_files_by_content', 'search'],
+		['google_search', 'globe'],
+		['google_maps', 'map-pin'],
+		['fetch_url', 'link'],
+		['generate_image', 'image'],
+	])('maps %s to the %s icon', (toolName, icon) => {
+		expect(TOOL_ICONS[toolName]).toBe(icon);
+	});
+
+	it('leaves unmapped tool names undefined so callers apply their own fallback', () => {
+		expect(TOOL_ICONS['activate_skill']).toBeUndefined();
+		expect(TOOL_ICONS['some_mcp_tool']).toBeUndefined();
+	});
+
+	it('has a non-empty icon id for every entry', () => {
+		for (const [toolName, icon] of Object.entries(TOOL_ICONS)) {
+			expect(icon, `${toolName} has an empty icon id`).toBeTruthy();
+		}
+	});
+});
+
+describe('AgentViewContext', () => {
+	// The class only ever uses reference identity (includes/indexOf/push/splice),
+	// so plain stand-ins are enough and avoid depending on the TFile constructor.
+	const fileA = { path: 'notes/a.md' } as TFile;
+	const fileB = { path: 'notes/b.md' } as TFile;
+	const fileC = { path: 'notes/c.md' } as TFile;
+
+	let context: AgentViewContext;
+	let session: ChatSession;
+
+	function makeSession(contextFiles: TFile[] = []): ChatSession {
+		return { context: { contextFiles } } as unknown as ChatSession;
+	}
+
+	beforeEach(() => {
+		context = new AgentViewContext();
+		session = makeSession();
+	});
+
+	describe('addFileToContext', () => {
+		it('adds a file that is not present', () => {
+			context.addFileToContext(fileA, session);
+
+			expect(session.context.contextFiles).toEqual([fileA]);
+		});
+
+		it('does not add the same file twice', () => {
+			context.addFileToContext(fileA, session);
+			context.addFileToContext(fileA, session);
+
+			expect(session.context.contextFiles).toEqual([fileA]);
+		});
+
+		it('preserves insertion order across distinct files', () => {
+			context.addFileToContext(fileA, session);
+			context.addFileToContext(fileB, session);
+
+			expect(session.context.contextFiles).toEqual([fileA, fileB]);
+		});
+	});
+
+	describe('addFilesToContext', () => {
+		it('adds every file in the batch', () => {
+			context.addFilesToContext([fileA, fileB, fileC], session);
+
+			expect(session.context.contextFiles).toEqual([fileA, fileB, fileC]);
+		});
+
+		it('skips files already in the context', () => {
+			session = makeSession([fileB]);
+
+			context.addFilesToContext([fileA, fileB], session);
+
+			expect(session.context.contextFiles).toEqual([fileB, fileA]);
+		});
+
+		it('de-duplicates within a single batch', () => {
+			context.addFilesToContext([fileA, fileA], session);
+
+			expect(session.context.contextFiles).toEqual([fileA]);
+		});
+
+		it('accepts an empty batch', () => {
+			context.addFilesToContext([], session);
+
+			expect(session.context.contextFiles).toEqual([]);
+		});
+	});
+
+	describe('removeContextFile', () => {
+		it('removes the file and leaves the rest in order', () => {
+			session = makeSession([fileA, fileB, fileC]);
+
+			context.removeContextFile(fileB, session);
+
+			expect(session.context.contextFiles).toEqual([fileA, fileC]);
+		});
+
+		it('is a no-op for a file that is not in the context', () => {
+			session = makeSession([fileA]);
+
+			context.removeContextFile(fileB, session);
+
+			expect(session.context.contextFiles).toEqual([fileA]);
+		});
+
+		it('removes only one occurrence', () => {
+			// addFileToContext dedupes, but history restore can hand back a list that
+			// does not — removal must not clear both entries at once.
+			session = makeSession([fileA, fileA]);
+
+			context.removeContextFile(fileA, session);
+
+			expect(session.context.contextFiles).toEqual([fileA]);
+		});
+	});
+
+	// The agent view calls these before a session exists (drag-and-drop onto an
+	// empty view), so a null session must be tolerated rather than thrown on.
+	describe('with no active session', () => {
+		it.each([
+			['addFileToContext', (c: AgentViewContext) => c.addFileToContext(fileA, null)],
+			['addFilesToContext', (c: AgentViewContext) => c.addFilesToContext([fileA], null)],
+			['removeContextFile', (c: AgentViewContext) => c.removeContextFile(fileA, null)],
+		])('%s does not throw', (_label, call) => {
+			expect(() => call(context)).not.toThrow();
+		});
+	});
+});


### PR DESCRIPTION
<!-- auto-dev -->

## Summary

First slice of the #1262 umbrella (20 source modules, ~3.9k lines, with no direct test coverage). This covers the five modules that need no Obsidian lifecycle and therefore carry no jsdom risk: the one Priority-1 module that is pure policy (`headless-confirmation-provider.ts`) and the four Priority-3 agent-view leaves (`collapsible.ts`, `compaction-notice.ts`, `tool-icons.ts`, `agent-view-context.ts`).

Tests only — no source changes, so there is no behavior change to document.

Refs #1262

**Deliberate deviation, worth a look:** the auto-dev pipeline's default is to put `Fixes #<N>` in the body, but #1262 is an umbrella tracker and the approved plan says explicitly that this slice does not close it. `Fixes` would auto-close a 20-module tracker after covering 5, so this PR uses `Refs` instead. The remaining 15 modules stay on the umbrella. If you would rather the tracker close and the rest be re-filed, say so and it can be split.

## Changes

- `test/services/headless-confirmation-provider.test.ts` (new) — asserts the *decision surface* of `HeadlessConfirmationProvider`, not rendering; it has none. This is the auto-approve provider every unattended run passes through (`HookRunner`, `ScheduledTaskRunner`, via `runHeadlessAgentTurn`), so a regression here silently changes what a scheduled task may do while nobody is watching.
  - The load-bearing assertion is that `allowWithoutConfirmation` stays `false`. Returning `true` is what the interactive UI does when a user ticks "don't ask again", and it persists a session-wide bypass — which no headless run has a user to have consented to.
  - Also covers statelessness (`allowToolWithoutConfirmation` grants nothing; two instances answer identically) and the `IConfirmationProvider` contract. The binding is typed as the interface rather than the class, so a future widening of `IConfirmationProvider` fails `typecheck:test` here instead of passing silently.
  - Complements, rather than duplicates, the existing wiring test in `test/services/headless-agent-turn.test.ts` — that one asserts the provider reaches `AgentLoop`; this one asserts what the provider decides.
- `test/ui/agent-view/leaf-helpers.test.ts` (new) — all four P3 leaves in one file with a shared fixture, since they are pure functions extracted by #1227/#1213/#1214:
  - **collapsible** — expanded/collapsed state applied across all four refs, and that `wireCollapsibleToggle` derives state from `aria-expanded` rather than a closure, so programmatic auto-expand-on-error and user clicks stay in sync (the next click collapses, not re-expands). Enter/Space toggle and `preventDefault`; unrelated keys do nothing.
  - **compaction-notice** — the `[!info]` callout marker and English wording. These are a persisted session-markdown file format, not UI strings, so they must stay out of `t()` per the repo's i18n invariant. Also pins that both compaction paths (#662) produce an identical notice.
  - **tool-icons** — every mapping by name, since the map exists precisely to stop two partial copies drifting again, plus that unmapped names stay `undefined` so callers keep their own fallback.
  - **agent-view-context** — add/remove/dedupe, single-occurrence removal, and that a null session is tolerated (drag-and-drop onto an empty view).

## Screenshots / Screencast

N/A — no UI or user-visible behavior changes; this PR adds test files only.

## Testing

Full pre-flight, all green:

| Gate | Result |
| --- | --- |
| `npm run format-check` | clean |
| `npm run lint` | 0 errors (38 pre-existing warnings, none in the new files) |
| `npm run build` | clean |
| `npm run typecheck:test` | clean |
| `npm test` | 166 files, 3591 tests passing (53 new) |
| `npm run lint:cycles` | 0 circular imports |

`typecheck:test` matters here in particular — a tests-only PR is exactly the case a green `npm run build` would not catch, since the build excludes the `test/` tree.

**Mutation check.** New tests are only worth what they catch, so each of the five modules under test was mutated in turn and the suite re-run, then reverted:

| Mutation | Tests failed |
| --- | --- |
| `allowWithoutConfirmation: false` → `true` | 2 |
| `wireCollapsibleToggle` state read → hardcoded `true` | 5 |
| `[!info]` callout → `[!note]` | 2 |
| `write_file` icon → wrong icon | 1 |
| `splice(index, 1)` → `splice(index, 2)` | 2 |

All five were caught; the tree was verified clean afterwards and the suite returns to 53/53 passing.

**Not run:** behavioral verification against a live vault. This diff has no runnable surface — it adds no source code and changes no behavior — so there is nothing to exercise end-to-end beyond the suite itself.

## Documentation

None required. No user-facing behavior, settings, or public surface changes — this adds test files only.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer — plan approved on #1262
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [x] I have tested this change on Desktop — via the Vitest + jsdom suite; N/A beyond that, as the change adds no runtime code
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A, no runtime code and no platform-specific APIs
- [x] Documentation has been updated (if applicable) — N/A, see Documentation above
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

---

Produced by the auto-dev pipeline from the approved plan on #1262.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BTHoYjUvnpjRZA5UgkK3RF)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for headless confirmation behavior, including approval results, tool permissions, statelessness, and progress updates.
  * Added UI tests for collapsible controls, keyboard and mouse interactions, accessibility state, and icon mappings.
  * Added tests for compaction notices and agent context-file management, including ordering, deduplication, removal, and null-session handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->