### PR TITLE
fix(styles): add --gs-on-error token, remove per-consumer color literals

### DIFF
--- a/docs/contributing/design-system.md
+++ b/docs/contributing/design-system.md
@@ -30,6 +30,7 @@ writing or migrating styles.
 | Accent    | `--gs-accent`, `--gs-accent-hover`                                  | `--interactive-accent`, `--interactive-accent-hover`                            |
 | Brand     | `--gs-brand-gradient` (+ `--gs-brand-1/-2/-3`)                      | Gemini gradient — **primary action & brand only**                               |
 | Status    | `--gs-success`, `--gs-warning`, `--gs-error`, `--gs-info`           | `--color-green/-orange/-red/-blue`                                              |
+| On-status | `--gs-on-error`                                                     | near-white literal — text drawn **on** a `--gs-error` fill (see below)          |
 | Spacing   | `--gs-space-1..8`                                                   | 4 / 8 / 12 / 16 / 24 / 32 / 48 px                                               |
 | Radius    | `--gs-radius-sm/-md/-lg/-pill`                                      | `--radius-s/-m/-l`                                                              |
 | Elevation | `--gs-shadow-sm/-md/-lg`                                            | custom 3-step scale, theme-aware (dark override on `body.theme-dark`)           |
@@ -44,6 +45,17 @@ writing or migrating styles.
   only. Everyday interactive elements use `--gs-accent` (the user's theme accent).
 - **Status is semantic, not accent.** Use `--gs-success/-warning/-error/-info` for
   state; never repurpose the accent for meaning.
+- **Text on an error fill uses `--gs-on-error`, never `--gs-on-accent`.**
+  `--gs-on-accent` aliases `--text-on-accent`, which the theme computes for the
+  _accent_ hue — a light accent makes it dark, which is unreadable on red. Because
+  `--gs-error` is always a red, `--gs-on-error` is a near-white literal. That is the
+  one place a color literal is correct: the token layer.
+- **Fallbacks live on the token definition, never on the consumer.** A theme that
+  omits an Obsidian variable makes the alias guaranteed-invalid, and `var()` then
+  treats the token as undefined — so both `--gs-error: var(--color-red, #dc3545)`
+  and a consumer's `var(--gs-error, #dc3545)` do fire. Only the first is worth
+  writing: it covers every call site at once, and it keeps consumers free of color
+  literals. `--gs-on-accent`, `--gs-success`, and `--gs-error` carry such fallbacks.
 - **Stay on the scales.** Spacing, radius, and icon sizes come from tokens — no magic
   numbers. The `--gs-space-*` scale covers the 4px grid (4/8/12/16/24/32/48);
   sub-grid micro-spacing (Obsidian's 2px-based `--size-2-*`: 2/4/6px) has no token

--- a/styles.css
+++ b/styles.css
@@ -81,12 +81,24 @@ body {
 	/* Accent */
 	--gs-accent: var(--interactive-accent);
 	--gs-accent-hover: var(--interactive-accent-hover);
-	--gs-on-accent: var(--text-on-accent);
+	/* The literal fallbacks below are the ones that used to be repeated at each
+	 * call site. They belong here, not there: a custom theme that never defines
+	 * --text-on-accent / --color-green / --color-red makes the alias
+	 * guaranteed-invalid, and var() then treats the token as undefined — so a
+	 * fallback on the token definition still fires, while one on a consumer's
+	 * var(--gs-error, …) is the only thing that ever kept those sites styled. */
+	--gs-on-accent: var(--text-on-accent, #ffffff);
 
 	/* Semantic status — separate from the accent hue */
-	--gs-success: var(--color-green);
+	--gs-success: var(--color-green, #10b981);
 	--gs-warning: var(--color-orange);
-	--gs-error: var(--color-red);
+	--gs-error: var(--color-red, #dc3545);
+	/* Text drawn on a --gs-error surface. Deliberately NOT --gs-on-accent:
+	 * that aliases --text-on-accent, which the theme computes for the accent
+	 * hue, so a light accent yields dark text — unreadable on red. --gs-error
+	 * is always a red, so a near-white literal is correct here, and the token
+	 * layer is where literals belong. */
+	--gs-on-error: #fff;
 	--gs-info: var(--color-blue);
 }
 
@@ -1533,7 +1545,7 @@ body.theme-dark {
 }
 
 .gemini-agent-stop-btn svg {
-	fill: var(--gs-error, #dc3545);
+	fill: var(--gs-error);
 }
 
 .gemini-agent-send-btn:disabled {
@@ -1559,20 +1571,22 @@ body.theme-dark {
 }
 
 .gemini-agent-plan-decision-approve {
-	color: var(--gs-success, #10b981);
+	color: var(--gs-success);
 }
 
-/* Stop button styling - red/warning color scheme
- * Uses Obsidian's --color-red variable which adapts to light/dark themes
- * Fallback colors provided for custom themes that may not define these variables
+/* Stop button styling - red/warning color scheme.
+ * --gs-error tracks Obsidian's --color-red, which adapts to light/dark themes;
+ * --gs-on-error keeps the label readable on it regardless of the theme accent.
+ * Both tokens are defined unconditionally in the body block at the top of this
+ * file, so no per-consumer fallback is needed.
  */
 .gemini-agent-stop-btn {
-	background-color: var(--gs-error, #dc3545);
-	color: var(--gs-on-accent, #ffffff);
+	background-color: var(--gs-error);
+	color: var(--gs-on-error);
 }
 
 .gemini-agent-stop-btn:hover:not(:disabled) {
-	background-color: color-mix(in srgb, var(--gs-error, #dc3545) 85%, black);
+	background-color: color-mix(in srgb, var(--gs-error) 85%, #000);
 }
 
 /* Session Modal Styles */
@@ -5097,7 +5111,7 @@ body.theme-dark {
 .gemini-scheduler-modal .gemini-scheduler-action--delete {
 	background: var(--gs-error);
 	border-color: var(--gs-error);
-	color: #fff;
+	color: var(--gs-on-error);
 	font-weight: 600;
 }
 
@@ -5124,7 +5138,7 @@ body.theme-dark {
 	cursor: pointer;
 	border: 1px solid var(--gs-error);
 	background: var(--gs-error);
-	color: #fff;
+	color: var(--gs-on-error);
 	font-weight: 600;
 }
 


### PR DESCRIPTION
<!-- auto-dev -->

## Summary

Closes the design-token drift in `styles.css`: eleven color literals, and the missing `--gs-on-error` token that two of them needed.

The load-bearing case is text on an error fill. `--gs-on-accent` aliases Obsidian's `--text-on-accent`, which the theme computes for the **accent** hue — so under a light accent it resolves dark, putting dark text on a red button. This adds `--gs-on-error` (a near-white literal, correct because `--gs-error` is always a red, and the token layer is where literals belong) and points the two scheduler delete buttons and `.gemini-agent-stop-btn` at it.

Produced by the auto-dev pipeline from the approved plan on #1263.

Fixes #1263

## Changes

- `styles.css` — new `--gs-on-error` token in the `body { }` block, with a comment explaining why it is not `--text-on-accent`.
- `styles.css:5100`, `:5127` — scheduler delete / confirm-delete `color: #fff` → `var(--gs-on-error)` (the Group A rule violations).
- `styles.css:1571` — `.gemini-agent-stop-btn`'s `var(--gs-on-accent, #ffffff)` → `var(--gs-on-error)`; same latent bug, same fix. Stale "Fallback colors provided for custom themes…" comment rewritten.
- `styles.css:1536`, `:1562`, `:1570`, `:1575` — per-consumer `var(--gs-*, #literal)` fallbacks removed; **moved onto the token definitions** rather than deleted (see the deviation below).
- `styles.css:1575` — Group C: `black` → `#000`, matching the four `#000` operands at 5105/5106/5132/5133. No new token.
- `docs/contributing/design-system.md` — `--gs-on-error` added to the token table, plus two rules: error fills use `--gs-on-error`, and fallbacks live on the token definition rather than the consumer.

## Deviation from the approved plan — please read

The plan's default was to **delete** the Group B fallbacks, on the issue's premise that "the plugin defines every `--gs-*` unconditionally, so the fallback operand is unreachable." **That premise is wrong**, and deleting them would have been a silent regression.

When a theme omits `--color-red`, `--gs-error: var(--color-red)` is *guaranteed-invalid*, and `var()` treats a guaranteed-invalid custom property as **undefined** — so the consumer's `var(--gs-error, #dc3545)` fallback *did* fire. It was the only thing keeping those sites styled in exactly the "custom themes that may not define these variables" case the original comment described. Measured, not reasoned — see Case B below.

So I took the alternative the plan itself named: move the fallbacks to the token definitions (`--gs-error`, `--gs-success`, `--gs-on-accent`). That covers every call site at once, keeps consumers literal-free (the actual hygiene goal), and is behavior-preserving. Say the word if you'd rather they were dropped outright.

## Test plan

`npm run format-check`, `npm run build`, `npm run typecheck:test`, `npm test` (168 files / 3656 tests), `npm run lint` (0 errors) — all green.

**Behavioral verification — computed values, measured in headless Chromium.** Rather than eyeball the change, I built a probe page carrying the real token block plus old-vs-new declarations, and compared `getComputedStyle` across three theme configurations:

| Probe | A: vars present, default accent | B: theme omits `--color-red`/`--color-green` | C: vars present, **light accent** |
| --- | --- | --- | --- |
| `fill: --gs-error` | same | same | same |
| `color: --gs-success` | same | same | same |
| `background: --gs-error` | same | same | same |
| `color-mix` (`black` → `#000`) | same | same | same |
| stop-btn text | same | same | **`rgb(26,26,26)` → `rgb(255,255,255)`** |
| delete-btn text | same | same | same |

- **A / B all identical** — the value-preserving half is confirmed value-preserving, *including* the custom-theme case. (Against the plan's delete-the-fallbacks version, every Case B row read DIFF — that is how the premise error surfaced.)
- **C is the one intended difference**: dark-on-red `rgb(26,26,26)` → readable `rgb(255,255,255)`. Exactly the bug the issue describes, demonstrated fixed.

**What was *not* verified in the sandbox:** that these rules land on the intended DOM nodes inside a live Obsidian, and the visual pass on the scheduler delete buttons and agent stop button in light/dark. Both need a running vault, which this build sandbox has no runtime for — **`behavioral verification not run in sandbox for the visual/selector half; needs a manual check before merge`**. The PR is marked ready rather than held as a draft so CI and CodeRabbit can run; please do that visual pass as part of your merge decision.

## Follow-up observation (not fixed here — out of the approved scope)

The issue counted eleven literals, but six more exist that its sweep missed — `color: white` at `styles.css:2122/2128/2133` (`.gemini-tool-row-status-running/-success/-error`) and `:2247/2253/2258`. The `-error` ones carry the identical latent bug this PR fixes; the `--gs-info` / `--gs-success` ones would need `--gs-on-info` / `--gs-on-success` tokens to fix properly. Flagging rather than folding in — happy to file a follow-up issue on your say-so.

## Screenshots / Screencast

Not captured — no live Obsidian runtime in the build sandbox. The computed-value table above is the evidence that was obtainable here; the visual pass is the manual check noted above.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [ ] I have tested this change on Desktop — **not done**; needs the manual visual pass above
- [x] I have verified this change does not break Mobile (CSS-only, no platform APIs)
- [x] Documentation has been updated (`docs/contributing/design-system.md`)
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (auto-dev pipeline)
- [x] I have reviewed and understand all AI-generated code in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added design tokens for error-state text and colors, including reliable fallback values.
  * Updated stop and scheduler delete actions to use consistent error styling and readable text.

* **Documentation**
  * Clarified design-system guidance for error text colors and token fallback usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->