### PR TITLE
refactor(ui): build the hook save payload once for create and update

### DIFF
--- a/src/ui/hook-management-modal.ts
+++ b/src/ui/hook-management-modal.ts
@@ -1,5 +1,5 @@
 import { Notice, Setting, setIcon } from 'obsidian';
-import type { Hook, HookAction, HookState, HookTrigger, HooksState } from '../services/hook-manager';
+import type { Hook, HookAction, HookCreateParams, HookState, HookTrigger, HooksState } from '../services/hook-manager';
 import type { FeatureToolPolicy } from '../types/tool-policy';
 import { DEFAULT_HEADLESS_MAX_ITERATIONS } from '../agent/agent-loop';
 import { ManagementModalBase } from './components/management-modal-base';
@@ -464,47 +464,34 @@ export class HookManagementModal extends ManagementModalBase<Hook, HookState> {
 			return;
 		}
 
+		// Create and update send the identical field set; only `slug` differs
+		// (it is immutable after creation). Built once so a new form field can't
+		// be added to one branch and forgotten in the other.
+		const params: Omit<HookCreateParams, 'slug'> = {
+			trigger: this.form.trigger,
+			action,
+			prompt: this.form.prompt,
+			pathGlob: this.form.pathGlob || undefined,
+			debounceMs: this.form.debounceMs,
+			cooldownMs: this.form.cooldownMs,
+			maxRunsPerHour: this.form.maxRunsPerHour > 0 ? this.form.maxRunsPerHour : undefined,
+			toolPolicy: this.form.toolPolicy,
+			enabledSkills: this.form.enabledSkills,
+			model: this.form.model || undefined,
+			maxIterations,
+			outputPath: this.form.outputPath || undefined,
+			enabled: this.form.enabled,
+			desktopOnly: this.form.desktopOnly,
+			commandId: this.form.commandId || undefined,
+			focusFile: this.form.focusFile === true ? true : undefined,
+		};
+
 		try {
 			if (isEdit && this.editingSlug) {
-				await manager.updateHook(this.editingSlug, {
-					trigger: this.form.trigger,
-					action,
-					pathGlob: this.form.pathGlob || undefined,
-					debounceMs: this.form.debounceMs,
-					cooldownMs: this.form.cooldownMs,
-					maxRunsPerHour: this.form.maxRunsPerHour > 0 ? this.form.maxRunsPerHour : undefined,
-					toolPolicy: this.form.toolPolicy,
-					enabledSkills: this.form.enabledSkills,
-					model: this.form.model || undefined,
-					maxIterations,
-					outputPath: this.form.outputPath || undefined,
-					enabled: this.form.enabled,
-					desktopOnly: this.form.desktopOnly,
-					prompt: this.form.prompt,
-					commandId: this.form.commandId || undefined,
-					focusFile: this.form.focusFile === true ? true : undefined,
-				});
+				await manager.updateHook(this.editingSlug, params);
 				new Notice(t('hooks.hookUpdated', { slug: this.editingSlug }));
 			} else {
-				await manager.createHook({
-					slug: this.form.slug,
-					trigger: this.form.trigger,
-					action,
-					prompt: this.form.prompt,
-					pathGlob: this.form.pathGlob || undefined,
-					debounceMs: this.form.debounceMs,
-					cooldownMs: this.form.cooldownMs,
-					maxRunsPerHour: this.form.maxRunsPerHour > 0 ? this.form.maxRunsPerHour : undefined,
-					toolPolicy: this.form.toolPolicy,
-					enabledSkills: this.form.enabledSkills,
-					model: this.form.model || undefined,
-					maxIterations,
-					outputPath: this.form.outputPath || undefined,
-					enabled: this.form.enabled,
-					desktopOnly: this.form.desktopOnly,
-					commandId: this.form.commandId || undefined,
-					focusFile: this.form.focusFile === true ? true : undefined,
-				});
+				await manager.createHook({ slug: this.form.slug, ...params });
 				new Notice(t('hooks.hookCreated', { slug: this.form.slug }));
 			}
 			this.view = 'list';


### PR DESCRIPTION
## Summary

`audit-architecture` nightly sweep flagged: **DRY violation** in `src/ui/hook-management-modal.ts`.

`handleSave` spelled out the same 15 form fields twice — once in the `updateHook` call and once in the `createHook` call — with `slug` the only genuine difference between them (it is immutable after creation). A duplicate-block scan over `src/` found exactly one clone in the whole tree, and this was it: `hook-management-modal.ts` [471:12–483:12] vs [493:30–505:15], 12 lines / 145 tokens.

The failure mode this invites is a new form field getting wired into one branch and forgotten in the other — silently working on create and silently dropped on edit, or vice versa. The fix builds the payload once as `Omit<HookCreateParams, 'slug'>` and spreads `slug` in on the create path. `HookUpdateParams` is already `Partial<Omit<HookCreateParams, 'slug'>>`, so the same object satisfies both call signatures without a cast.

No behavior change: both calls receive exactly the fields they received before, with the same values and the same `|| undefined` coercions. The two field lists were already identical modulo ordering, which does not matter for an object literal.

No issue link — this is an automated audit finding, filed directly as a PR because the fix is mechanical and confined to one function in one file.

## Changes

- `src/ui/hook-management-modal.ts` — extract the shared create/update payload in `handleSave` into a single `params` object typed `Omit<HookCreateParams, 'slug'>`; `updateHook` takes it directly, `createHook` takes `{ slug, ...params }`. Import `HookCreateParams` as a type.

## Screenshots / Screencast

N/A — no rendered output changed. This is a refactor of the save handler's argument construction; the modal's markup, fields, and validation are untouched.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — **N/A**: filed by the `audit-architecture` sweep, which opens mechanical fixes directly rather than routing them through an issue first.
- [x] All CI checks pass — verified locally: `npm run format-check` clean, `npm run lint` 0 errors (39 pre-existing warnings in `test/`, none from this diff), `npm run build` clean, `npm run typecheck:test` clean, `npm test` 168 files / 3656 tests passing.
- [ ] I have tested this change on Desktop — **not done**: no Obsidian runtime in the audit sandbox. The type system carries most of the weight here (`Omit<HookCreateParams, 'slug'>` makes `trigger`/`action`/`prompt` required, so a dropped field is a compile error), but the hook create/edit round-trip has no unit coverage — `src/ui/hook-management-modal.ts` is on the untested-modules list in #1262 — so a manual create-then-edit pass on a hook before merge is worth the minute it costs.
- [x] I have verified this change does not break Mobile — no platform APIs touched; pure object construction.
- [ ] Documentation has been updated — **N/A**: internal refactor with no user-visible behavior change.
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (`audit-architecture` skill)
- [x] I have reviewed and understand all AI-generated code in this PR

---

_Filed by the `audit-architecture` skill._

---
_Generated by [Claude Code](https://claude.ai/code/session_01KkJPomSF4hoApYg1LZuknr)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined hook creation and update handling without changing the user-visible behavior.
  * Improved internal type handling and reduced duplicated logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->