### PR TITLE
chore(daily): 2026-07-28 daily update

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,7 @@ repo-specific release gates live in `.claude/guidelines/release.md`).
 src/main.ts → ModelClientFactory.createFromPlugin() → GeminiClient | OllamaClient → RetryDecorator → ModelApi
 ```
 
-The plugin uses a factory pattern (`ModelClientFactory` in `src/api/factory.ts`) to create model API clients, wrapped with a retry decorator (`RetryDecorator`) for resilience. The factory branches on `settings.provider` to instantiate either a `GeminiClient` or an `OllamaClient`. All API implementations follow the `ModelApi` interface. The factory supports different use cases (chat, summary, completions, rewrite) and provides retry logic with exponential backoff for handling transient API failures. Each provider lives in its own package under `src/api/providers/{gemini,ollama}/`.
+The plugin uses a factory pattern (`ModelClientFactory` in `src/api/factory.ts`) to create model API clients, wrapped with a retry decorator (`RetryDecorator`) for resilience. Since per-use-case provider selection (#704), the factory resolves each call's provider independently — via `resolveProviderOrDefault(settings, useCase)` in `src/api/provider-routing.ts`, which checks `settings.providerOverrides[useCase]` before falling back to the primary `settings.provider` — then instantiates the matching `GeminiClient` or `OllamaClient`. All API implementations follow the `ModelApi` interface. The factory supports different use cases (chat, summary, completions, rewrite) and provides retry logic with exponential backoff for handling transient API failures. Each provider lives in its own package under `src/api/providers/{gemini,ollama}/`; the capability matrix and routing helpers live in the leaf modules `src/api/providers/registry.ts` and `src/api/provider-routing.ts`.
 
 ### Key Components
 

--- a/docs/guide/agent-mode.md
+++ b/docs/guide/agent-mode.md
@@ -371,7 +371,7 @@ What do you remember about my vault?
 
 ### Web & Research Operations
 
-> All four tools in this section (`google_search`, `google_maps`, `fetch_url`, `deep_research`) are available on the Gemini provider only — they're hidden when Ollama is the active provider. See the [Provider Capabilities reference](/reference/provider-capabilities) for the full matrix.
+> All four tools in this section (`google_search`, `google_maps`, `fetch_url`, `deep_research`) require Gemini — they're registered only when the **Web and search** feature (Settings → Gemini Scribe → Per-feature provider) resolves to Gemini, whether that's your default provider or a per-feature override on an otherwise-Ollama setup. See the [Provider Capabilities reference](/reference/provider-capabilities) for the full matrix.
 
 #### google_search
 
@@ -411,7 +411,7 @@ Research the latest developments in quantum error correction and save it to Rese
 
 #### generate_image
 
-Generate an image from a prompt and save it to your vault. The agent picks a default attachment path if you don't specify one. Like `deep_research`, it defaults to running as a background task — the agent only generates inline when the image needs to appear in the same turn. Available on the Gemini provider only.
+Generate an image from a prompt and save it to your vault. The agent picks a default attachment path if you don't specify one. Like `deep_research`, it defaults to running as a background task — the agent only generates inline when the image needs to appear in the same turn. Requires the **Image generation** feature to be routed to Gemini (the only provider that supports it today).
 
 ```text
 Generate a watercolor diagram of a Zettelkasten workflow and embed it in my notes

--- a/docs/reference/advanced-settings.md
+++ b/docs/reference/advanced-settings.md
@@ -59,7 +59,7 @@ Route Gemini requests through Google's newer [Interactions API](https://ai.googl
 
 - **Setting name**: Use Interactions API
 - **Default**: on. Existing installs are migrated to the Interactions API automatically on upgrade — a one-time flip you can reverse by turning the toggle off, which is then respected on future launches.
-- **Scope**: Gemini provider only — the toggle is hidden when the provider is Ollama.
+- **Scope**: Gemini transport only — the toggle is shown whenever Gemini serves at least one use case (chat, summary, completions, etc.), and hidden only in a fully local, all-Ollama setup.
 - **Privacy**: The plugin runs the Interactions API **statelessly** (`store: false`). Conversation history is replayed with each request, and the plugin does not persist Interactions state on Google's side between turns. (Requests are still sent to Google to generate each response, subject to Google's standard API data-handling terms.)
 - **Status**: Default transport. If you hit problems, turn it off to fall back to the proven `generateContent` path. Responses stream incrementally, including reasoning and tool calls.
 - **Interactions-only models**: Some models (e.g. Gemini Omni Flash Preview, an image-generation model) are only served by the Interactions API — `generateContent` rejects them outright. Requests to these models always use the Interactions API, even when this toggle is off; that includes image generation when an interactions-only model is selected as the image model. Features that still run on `generateContent` (Google Search grounding, web fetch, RAG semantic search) substitute the default chat model if an interactions-only model ever ends up configured as the chat model.

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -331,7 +331,7 @@ Advanced settings for developers and power users. Access by clicking "Show advan
 - **Setting**: `useInteractionsApi`
 - **Type**: Boolean
 - **Default**: `true`
-- **Only applies when**: Provider is `gemini`
+- **Only applies when**: Gemini serves at least one use case (the toggle is hidden in an all-Ollama setup, shown whenever chat, summary, or any other feature is routed to Gemini)
 - **Description**: Routes Gemini requests through Google's GA [Interactions API](https://ai.google.dev/gemini-api/docs/interactions) (`interactions.create`) instead of the legacy `generateContent` API. This is now the default transport; existing installs are migrated to it automatically (a one-time flip you can reverse by turning the toggle off).
 - **Privacy**: Runs statelessly (`store: false`) — conversation history is replayed with each request, and the plugin does not persist Interactions state on Google's side between turns. (Requests are still sent to Google to generate each response, subject to Google's standard API data-handling terms.)
 - **Status**: Default-on. Responses stream incrementally (text, reasoning, and tool calls); turn it off to fall back to the legacy `generateContent` path if you hit issues.
@@ -343,7 +343,7 @@ Advanced settings for developers and power users. Access by clicking "Show advan
 - **Setting**: `customBaseUrl`
 - **Type**: String
 - **Default**: `""` (empty)
-- **Only applies when**: Provider is `gemini`
+- **Only applies when**: Gemini serves at least one use case (Ollama has its own `ollamaBaseUrl` setting and ignores this value; the field is hidden in an all-Ollama setup)
 - **Description**: Overrides the default Google API base URL for all SDK calls. Use this to route requests through a corporate proxy, local gateway, or regional mirror.
 - **Example**: `https://my-proxy.example.com`
 - **Scope**: Applies to every Google API call site in the plugin (chat, streaming, image generation, web fetch, Google Search/Maps grounding, RAG indexing, deep research, context management).

--- a/planning/changelog/2026-07-28.md
+++ b/planning/changelog/2026-07-28.md
@@ -7,7 +7,7 @@
 
 ## Summary
 
-Feature-heavy day. The headline is per-use-case provider routing, letting chat run on a local Ollama model while cloud-only features (search, RAG, image generation) stay on Gemini. Alongside it: a real bug fix for a `400` error on tool-calling turns over the Interactions stream, two DRY refactors surfaced by the architecture audit, a first slice of test coverage for previously-untested headless/agent-view modules, and the previous day's automated daily-update landing after review.
+Feature-heavy day. The headline is per-use-case provider routing, letting chat run on a local Ollama model while cloud-only features (search, RAG, image generation) stay on Gemini. Alongside it: a real bug fix for a `400` error on tool-calling turns over the Interactions stream, two DRY refactors surfaced by the architecture audit, and a first slice of test coverage for previously-untested headless/agent-view modules.
 
 ## What shipped
 
@@ -21,7 +21,7 @@ An architecture-audit finding: all four agent-event-bus subscribers each declare
 
 ### [#1265 chore(daily): 2026-07-28 daily update](https://github.com/allenhutchison/obsidian-gemini/pull/1265)
 
-The previous day's automated housekeeping run landing after review: wrote the 2026-07-27 changelog, confirmed no documentation drift across `docs/`, `README.md`, and `AGENTS.md` (re-verifying three previously-fixed drift items held), and found no unlabeled issues to triage.
+Wrote the 2026-07-27 daily changelog entry.
 
 ### [#1269 fix(gemini): capture thought_signature deltas on the Interactions stream](https://github.com/allenhutchison/obsidian-gemini/pull/1269)
 

--- a/planning/changelog/2026-07-28.md
+++ b/planning/changelog/2026-07-28.md
@@ -1,0 +1,40 @@
+# Daily changelog — July 28, 2026
+
+**Date:** 2026-07-28
+**PRs merged:** 7
+
+---
+
+## Summary
+
+Feature-heavy day. The headline is per-use-case provider routing, letting chat run on a local Ollama model while cloud-only features (search, RAG, image generation) stay on Gemini. Alongside it: a real bug fix for a `400` error on tool-calling turns over the Interactions stream, two DRY refactors surfaced by the architecture audit, a first slice of test coverage for previously-untested headless/agent-view modules, and the previous day's automated daily-update landing after review.
+
+## What shipped
+
+### [#1256 refactor(gemini): remove obsolete Interactions API requestUrl CORS shim](https://github.com/allenhutchison/obsidian-gemini/pull/1256)
+
+The Interactions (Next-Gen) `@google/genai` client used to send an `Api-Revision` header that triggered a CORS preflight Google's API rejected, so the client was routed through Obsidian's `requestUrl` to bypass it. Upstream `js-genai` fixed the header issue (merged 2026-07-08), so the pinned SDK version no longer emits it and the shim is unnecessary. Removing it also drops the response buffering the shim imposed — streamed interactions can now resolve token-by-token instead of all-at-once. Produced by the auto-dev pipeline from the plan on #1023, gated on a live end-to-end check before merge.
+
+### [#1260 refactor(subscribers): extract shared EventBusSubscriber base for teardown](https://github.com/allenhutchison/obsidian-gemini/pull/1260)
+
+An architecture-audit finding: all four agent-event-bus subscribers each declared an identical `unsubscribers` field and `destroy()` teardown loop. Extracted into a shared abstract `EventBusSubscriber` base class; pure code motion, net −24 lines of duplication. `ToolExecutionLogger` overrides `destroy()` to also clear its unflushed log queue.
+
+### [#1265 chore(daily): 2026-07-28 daily update](https://github.com/allenhutchison/obsidian-gemini/pull/1265)
+
+The previous day's automated housekeeping run landing after review: wrote the 2026-07-27 changelog, confirmed no documentation drift across `docs/`, `README.md`, and `AGENTS.md` (re-verifying three previously-fixed drift items held), and found no unlabeled issues to triage.
+
+### [#1269 fix(gemini): capture thought_signature deltas on the Interactions stream](https://github.com/allenhutchison/obsidian-gemini/pull/1269)
+
+Every agent turn that called a tool over the Interactions stream was failing with an opaque `400` error on the follow-up request, because the streaming accumulator never captured the tool call's thought signature — Gemini thinking models reject a replayed `functionCall` without one. The signature actually arrives as a `thought_signature` delta on the _preceding_ thought step, not on the function-call step's `step.start` as the code assumed. This surfaced now because #1191 defaulted the Interactions transport on. Verified with a real round trip against the live API, plus three regression tests built from the observed event ordering.
+
+### [#1267 refactor(services): extract shared headless agent-turn driver (#1261)](https://github.com/allenhutchison/obsidian-gemini/pull/1267)
+
+`ScheduledTaskRunner.run()` and `HookRunner.runAgentTask()` had grown into two near-verbatim ~65-line implementations of "drive one headless agent turn" — session creation, tool-policy wiring, `ExtendedModelRequest` construction, cancellation checks, and result handling, all duplicated. Extracted into a new `runHeadlessAgentTurn()` helper in `src/services/headless-agent-turn.ts`, with the four real differences between the two callers expressed as a spec parameter object. Each caller keeps only its own output-writing behavior, which genuinely differs. Produced by the auto-dev pipeline from the plan on #1261.
+
+### [#1270 test: cover headless confirmation provider and agent-view leaf helpers (#1262)](https://github.com/allenhutchison/obsidian-gemini/pull/1270)
+
+First slice of the #1262 umbrella tracking 20 untested source modules. Covers five modules with no Obsidian lifecycle dependency: `HeadlessConfirmationProvider` (the auto-approve provider every unattended run passes through — its load-bearing assertion is that `allowWithoutConfirmation` stays `false`) and four pure-function agent-view leaves (`collapsible`, `compaction-notice`, `tool-icons`, `agent-view-context`). Uses `Refs #1262` rather than `Fixes`, since this slice intentionally leaves the other 15 modules on the umbrella. Produced by the auto-dev pipeline.
+
+### [#1266 feat(providers): per-use-case provider selection (chat/summary/RAG/image independently)](https://github.com/allenhutchison/obsidian-gemini/pull/1266)
+
+Replaces the single global `settings.provider` gate with per-use-case routing: a primary provider plus a sparse `providerOverrides` map. Chat can now run on a local Ollama model while summaries, web search, or image generation run on Gemini — the cloud-only tools were never technically bound to the chat provider, just gated by a blanket policy check. Privacy is preserved by construction: `resolveProvider` returns `null` (and the feature stays off) rather than ever silently substituting a cloud provider for a capability the local one lacks; enabling a cloud feature is always an explicit per-feature choice. Migration is a no-op for existing installs, verified against a live vault's `data.json`. Closes the first sub-task of the #703 epic.


### PR DESCRIPTION
## Summary

Automated daily housekeeping run (`daily-update` meta-skill via the `maintainerd` plugin marketplace) bundling `daily-changelog`, `audit-product-docs`, and `triage-issues` for 2026-07-28.

Fixes N/A — routine automated daily housekeeping run.

## Changes

- **daily-changelog**: wrote [`planning/changelog/2026-07-28.md`](https://github.com/allenhutchison/obsidian-gemini/blob/daily-update-2026-07-29/planning/changelog/2026-07-28.md) — 7 PRs merged on 2026-07-28 (Pacific time), headlined by per-use-case provider selection (#1266, chat can run on local Ollama while cloud-only features stay on Gemini) and a fix for a `400` error on tool-calling turns over the Interactions stream (#1269), plus two architecture-audit DRY refactors (#1260, #1267), a first slice of new test coverage (#1270), a CORS-shim removal (#1256), and the prior day's automated daily-update landing after review (#1265).
- **audit-product-docs**: found a consistent pattern of stale "hidden when Ollama is the active provider" framing left over from before per-use-case provider routing (#1266) landed, and fixed it in four places:
  - `docs/reference/settings.md` — the `useInteractionsApi` and `customBaseUrl` entries said "Only applies when: Provider is `gemini`"; corrected to describe the actual per-use-case `isProviderActive()` gating (verified against `src/ui/settings-agent-config.ts:65,80`).
  - `docs/reference/advanced-settings.md` — same drift for the Interactions API toggle's scope note.
  - `docs/guide/agent-mode.md` — the Web & Research Operations blockquote said `google_search`/`google_maps`/`fetch_url`/`deep_research` "are hidden when Ollama is the active provider"; corrected to describe registration keyed off the **Web and search** use case resolving to Gemini, which can be true even under an Ollama primary via a per-feature override (verified against `src/services/tool-registrar.ts`). Same fix for `generate_image`'s description.
  - `AGENTS.md` (conceptual drift) — the Architecture section still said "The factory branches on `settings.provider`"; this is no longer accurate post-#1266. Updated to describe `ModelClientFactory.createFromPlugin`'s per-use-case resolution via `resolveProviderOrDefault()` (verified against `src/api/factory.ts`), and named the new leaf modules `src/api/providers/registry.ts` and `src/api/provider-routing.ts`.
  - `docs/reference/provider-capabilities.md` and `docs/guide/ollama-setup.md` were already correctly updated for the new routing model — no changes needed there. No zero-documentation user-visible features were found.
- **triage-issues**: 0 unlabeled open issues — no-op.

This is a housekeeping-only PR — no `src/` behavior changes.

## Screenshots / Screencast

N/A — changelog and docs-only change, no UI change.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A; routine automated daily housekeeping run
- [x] All CI checks pass locally: `npm run format-check` clean, `npm run lint` 0 errors (39 pre-existing warnings, untouched), `npm run build` clean, `npm run typecheck:test` clean, `npm test` 3656 passed / 168 files, `npm run lint:cycles` 0 cycles
- [x] I have tested this change on Desktop — N/A, changelog/docs-only change; verified via local pre-flight checks
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A, no code change
- [x] Documentation has been updated (if applicable) — N/A, this PR's content is the documentation update itself
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_015t5aP8JYjo9wj6fwGwjxEb)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified how provider routing works for specific features, including per-use-case provider overrides and how this affects which tools are available.
  * Updated tool availability guidance for web/research and image generation based on Gemini routing.
  * Refined the “Use Interactions API” and Gemini-only settings conditions to reflect Gemini being used for at least one use case.
* **Chores**
  * Added the daily changelog entry for 2026-07-28 with a summary of recent shipped improvements and fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->