### PR TITLE
fix(agent-view): make history tool blocks actually collapse

### DIFF
--- a/src/ui/agent-view/agent-view-messages.ts
+++ b/src/ui/agent-view/agent-view-messages.ts
@@ -157,6 +157,9 @@ export class AgentViewMessages {
 					// Create collapsible tool execution block
 					const toolDiv = content.createDiv({ cls: 'gemini-agent-tool-execution' });
 					const toolHeader = toolDiv.createDiv({ cls: 'gemini-agent-tool-header' });
+					toolHeader.setAttribute('role', 'button');
+					toolHeader.setAttribute('tabindex', '0');
+					toolHeader.setAttribute('aria-expanded', 'false');
 
 					// Add expand/collapse icon
 					const icon = toolHeader.createSpan({ cls: 'gemini-agent-tool-icon' });
@@ -181,24 +184,21 @@ export class AgentViewMessages {
 						});
 					}
 
-					// Tool content (initially hidden)
-					const toolContentDiv = toolDiv.createDiv({
-						cls: 'gemini-agent-tool-content gemini-agent-tool-content-collapsed',
-					});
+					// Tool content (collapsed until the header is toggled)
+					const toolContentDiv = toolDiv.createDiv({ cls: 'gemini-agent-tool-content' });
+					toolContentDiv.hide();
 
 					// Render the tool content
 					await MarkdownRenderer.render(this.app, toolContent, toolContentDiv, sourcePath, this.viewContext);
 
-					// Toggle handler
-					toolHeader.addEventListener('click', () => {
-						const isCollapsed = toolContentDiv.hasClass('gemini-agent-tool-content-collapsed');
-						if (isCollapsed) {
-							toolContentDiv.removeClass('gemini-agent-tool-content-collapsed');
-							setIcon(icon, 'chevron-down');
-						} else {
-							toolContentDiv.addClass('gemini-agent-tool-content-collapsed');
-							setIcon(icon, 'chevron-right');
-						}
+					// Share the collapsible wiring used by tool rows and reasoning rows so
+					// keyboard toggling and aria-expanded stay consistent across surfaces.
+					wireCollapsibleToggle({
+						control: toolHeader,
+						body: toolContentDiv,
+						chevron: icon,
+						host: toolDiv,
+						expandedClass: 'gemini-agent-tool-execution-expanded',
 					});
 				}
 			} else {


### PR DESCRIPTION
## Summary

`audit-architecture` nightly sweep flagged: **DRY violation / dead surface** in `src/ui/agent-view/agent-view-messages.ts`.

When a past session is reloaded, persisted `Tool Execution Results:` messages are rendered as collapsible blocks. That block hand-rolled its own toggle instead of using `wireCollapsibleToggle` from the sibling leaf module `./collapsible`, which every other collapsible surface in the agent view already uses (`agent-view-tool-display.ts:202`, `:355`, and the reasoning row at `agent-view-messages.ts:312`).

The hand-rolled version hid content by toggling the class `gemini-agent-tool-content-collapsed`. That class has **no rule in `styles.css`** — `grep -n 'tool-content' styles.css` returns nothing — so the block rendered fully expanded on load, and clicking the header only swapped the chevron icon while the content stayed visible. `docs/guide/agent-mode.md:196` documents these as collapsible, so this restores documented behavior rather than changing it.

Routing this as a PR rather than an issue: one file, 14 lines changed, and the correct fix is to call the helper that already exists for exactly this.

## Changes

- `src/ui/agent-view/agent-view-messages.ts` — replace the hand-rolled click handler with `wireCollapsibleToggle`; hide the content div via `.hide()` (inline `display`) rather than a class with no CSS behind it; drop the orphaned `gemini-agent-tool-content-collapsed` class, the codebase's only reference to it.
- Same file — add `role="button"`, `tabindex="0"`, and `aria-expanded="false"` to the block header, matching the tool rows and reasoning rows. The shared helper keeps `aria-expanded` in sync and adds Enter/Space toggling, so the block is now keyboard-operable.

Behavior change is limited to what is claimed: the block now starts collapsed and actually collapses/expands, and responds to the keyboard. Nothing about parsing, rendering, or persistence is touched.

## Screenshots / Screencast

Not attached — this run is unattended with no live Obsidian instance to capture from. The change is verifiable by reloading a session containing tool-execution history: the tool blocks should start collapsed and toggle on click or Enter/Space.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: filed directly by the `audit-architecture` sweep, which opens focused PRs for mechanical findings and issues for anything needing design discussion.
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — verified locally: `npm run format-check` clean, `npm run lint` 0 errors (39 pre-existing warnings, none in the touched file), `npm run build` clean, `npm run typecheck:test` clean, `npm test` 168 files / 3656 tests passing.
- [ ] I have tested this change on Desktop — not done: unattended run, no Obsidian instance available. Needs a manual pass before merge.
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — no platform-specific API is introduced; `wireCollapsibleToggle` and `HTMLElement.hide()` are already used on the same surfaces on both platforms.
- [ ] Documentation has been updated (if applicable) — N/A: `docs/guide/agent-mode.md` already describes these blocks as collapsible; this makes the code match the docs.
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (`audit-architecture` skill)
- [x] I have reviewed and understand all AI-generated code in this PR

---

_Filed by the `audit-architecture` skill._

---
_Generated by [Claude Code](https://claude.ai/code/session_01UB2xmeXd8XqhZXVeFhSAqn)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved keyboard and assistive-technology support for expanding and collapsing tool-execution messages.
  * Added clear expanded-state information to tool message headers.

* **Bug Fixes**
  * Improved the reliability and consistency of tool-content expand/collapse behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->