### PR TITLE
chore(daily): 2026-07-30 daily update

### DIFF
--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -233,7 +233,7 @@ See the [Custom Prompts Guide](/guide/custom-prompts) for detailed instructions.
 - **Setting**: `expandedSettingsSections`
 - **Type**: `string[]`
 - **Default**: `[]`
-- **Description**: Internal list of section ids that are currently expanded in the settings tab. Updated automatically when you toggle a section. Known ids: `ui`, `automation`, `rag`, `tool-permissions`, `mcp-servers`, `agent-config`, `debug`. (General is always open; it has no id and ignores this setting.)
+- **Description**: Internal list of section ids that are currently expanded in the settings tab. Updated automatically when you toggle a section. Known ids: `ui`, `automation`, `rag`, `tool-permissions`, `mcp-servers`, `agent-config`, `debug`, `per-feature-provider`. (General itself is always open and has no id; its **Per-feature provider** sub-section is separately collapsible and tracked as `per-feature-provider`.)
 - **Note**: Edit `data.json` directly to pre-expand sections (for example, on a new install) or restore a custom layout after migrating vaults.
 
 ## Automation Settings

--- a/planning/changelog/2026-07-29.md
+++ b/planning/changelog/2026-07-29.md
@@ -13,7 +13,7 @@ Quiet day — one real bug fix, two housekeeping refactors, and a translation sy
 
 ### [#1276 chore(daily): 2026-07-28 daily update](https://github.com/allenhutchison/obsidian-gemini/pull/1276)
 
-Automated daily housekeeping run bundling the 2026-07-28 changelog entry and a docs-drift fix: four places still described provider gating as "hidden when Ollama is active," left over from before per-use-case provider routing (#1266) landed. Corrected to describe the actual per-feature `isProviderActive()` / registration behavior. Issue triage found nothing to label.
+A documentation-drift fix: four places still described provider gating as "hidden when Ollama is active," left over from before per-use-case provider routing (#1266) landed. Corrected to describe the actual per-feature `isProviderActive()` / registration behavior.
 
 ### [#1273 refactor(ui): build the hook save payload once for create and update](https://github.com/allenhutchison/obsidian-gemini/pull/1273)
 

--- a/planning/changelog/2026-07-29.md
+++ b/planning/changelog/2026-07-29.md
@@ -1,0 +1,28 @@
+# Daily changelog — July 29, 2026
+
+**Date:** 2026-07-29
+**PRs merged:** 4
+
+---
+
+## Summary
+
+Quiet day — one real bug fix, two housekeeping refactors, and a translation sync. The notable item is a design-token fix for dark text landing on red buttons under light-accent themes, caught with measured `getComputedStyle` verification rather than a screenshot.
+
+## What shipped
+
+### [#1276 chore(daily): 2026-07-28 daily update](https://github.com/allenhutchison/obsidian-gemini/pull/1276)
+
+Automated daily housekeeping run bundling the 2026-07-28 changelog entry and a docs-drift fix: four places still described provider gating as "hidden when Ollama is active," left over from before per-use-case provider routing (#1266) landed. Corrected to describe the actual per-feature `isProviderActive()` / registration behavior. Issue triage found nothing to label.
+
+### [#1273 refactor(ui): build the hook save payload once for create and update](https://github.com/allenhutchison/obsidian-gemini/pull/1273)
+
+An architecture-audit finding: `handleSave` in `hook-management-modal.ts` spelled out the same 15 form fields twice, once for `updateHook` and once for `createHook`, with `slug` the only genuine difference. Consolidated into a single typed `params` object so a new field added to one branch can't silently be forgotten in the other. No behavior change.
+
+### [#1272 fix(styles): add --gs-on-error token, remove per-consumer color literals](https://github.com/allenhutchison/obsidian-gemini/pull/1272)
+
+Closes a design-token drift: eleven color literals in `styles.css`, and a real bug underneath two of them. The scheduler delete buttons and the agent stop button used `--gs-on-accent` for their text color, which aliases Obsidian's accent-hue token — under a light accent theme that resolves dark, putting dark text on a red error button. Adds a dedicated `--gs-on-error` token and points those three call sites at it. Also moves several `var(--gs-*, #literal)` fallbacks from call sites onto the token definitions themselves, after measuring (rather than assuming) that the fallbacks are still reachable when a theme omits the underlying Obsidian variable. Verified with computed-style comparisons across three theme configurations in headless Chromium; the visual pass on a live Obsidian vault was flagged as not done in the sandbox. Produced by the auto-dev pipeline from the plan on #1263.
+
+### [#1271 chore(i18n): Update UI translations](https://github.com/allenhutchison/obsidian-gemini/pull/1271)
+
+Automated retranslation of `src/i18n/` for English source strings that changed since the last sync.


### PR DESCRIPTION
## Summary

Automated daily housekeeping run (`daily-update` meta-skill via the `maintainerd` plugin marketplace) bundling `daily-changelog`, `audit-product-docs`, and `triage-issues` for 2026-07-29 (Pacific time, the retrospective day this run covers).

Fixes N/A — routine automated daily housekeeping run.

## Changes

- **daily-changelog**: wrote [`planning/changelog/2026-07-29.md`](https://github.com/allenhutchison/obsidian-gemini/blob/daily-update-2026-07-30/planning/changelog/2026-07-29.md) — 4 PRs merged on 2026-07-29, a quiet housekeeping day: the 2026-07-28 daily update PR (#1276), a hook-modal save-payload DRY refactor (#1273), a design-token fix for dark text landing on red buttons under light-accent themes (#1272), and an i18n translation sync (#1271).
- **audit-product-docs**: `docs/reference/settings.md`'s `expandedSettingsSections` entry was missing the `per-feature-provider` section id (the separately-collapsible sub-section added by the per-use-case provider routing UI in `src/ui/settings-general.ts`). Added it to the known-ids list and clarified the General/sub-section relationship. Re-checked specifically for the stale "hidden when Ollama is active" framing that a prior daily-update pass fixed on 2026-07-28 — no remaining instances found. No new docs were warranted; no other drift found.
- **triage-issues**: 0 unlabeled open issues — no-op.

This is a housekeeping-only PR — no `src/` behavior changes.

## Screenshots / Screencast

N/A — changelog and docs-only change, no UI change.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A; routine automated daily housekeeping run
- [x] All CI checks pass locally: `npm run format-check` clean, `npm run lint` 0 errors (39 pre-existing warnings, untouched), `npm run build` clean, `npm run typecheck:test` clean, `npm test` 3656 passed / 168 files
- [x] I have tested this change on Desktop — N/A, changelog/docs-only change; verified via local pre-flight checks
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A, no code change
- [x] Documentation has been updated (if applicable) — N/A, this PR's content is the documentation update itself
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_013qU5SDYuK3XYr6RWXamHDX)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated settings documentation for `expandedSettingsSections` with additional/changed known expanded section identifiers.
  * Clarified that the **General** section is always open, and its **Per-feature provider** subsection is tracked separately.

* **Changelog**
  * Updated the **2026-07-29** daily changelog entry text (adjusted the description for one listed item while keeping the overall structure the same).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->