### PR TITLE
refactor(api): drop dead imageAttachments compat alias

### DIFF
--- a/src/api/interfaces/model-api.ts
+++ b/src/api/interfaces/model-api.ts
@@ -80,7 +80,6 @@ export interface InlineDataPart {
  * @property projectInstructions - Optional project-scoped instructions injected into the system prompt
  * @property availableTools - Optional array of tool definitions for function calling
  * @property inlineAttachments - Optional array of inline data attachments for multimodal input
- * @property imageAttachments - Deprecated alias for inlineAttachments
  */
 export interface ExtendedModelRequest extends Omit<BaseModelRequest, 'kind'> {
 	/** Discriminant for the request union. `'extended'` marks a chat-style request. */
@@ -104,8 +103,6 @@ export interface ExtendedModelRequest extends Omit<BaseModelRequest, 'kind'> {
 	 */
 	sessionStartedAt?: string;
 	inlineAttachments?: InlineDataPart[];
-	/** @deprecated Use inlineAttachments instead */
-	imageAttachments?: InlineDataPart[];
 }
 
 /**

--- a/src/api/providers/gemini/client.ts
+++ b/src/api/providers/gemini/client.ts
@@ -327,11 +327,7 @@ export class GeminiClient implements ModelApi {
 			if (content) steps.push(...contentToSteps(content));
 		}
 
-		// `imageAttachments` is the deprecated alias for `inlineAttachments`; still read here so
-		// callers passing the legacy field keep working (backward-compat merge). Remove once no
-		// caller populates it. See ExtendedModelRequest.imageAttachments (#1040).
-		// eslint-disable-next-line @typescript-eslint/no-deprecated -- deprecated imageAttachments alias merged for backward-compat (#1040)
-		const attachments = [...(request.inlineAttachments || []), ...(request.imageAttachments || [])];
+		const attachments = request.inlineAttachments ?? [];
 		const userStep = buildUserInputStep(request.userMessage, request.perTurnContext, attachments);
 		if (userStep) steps.push(userStep);
 
@@ -590,10 +586,7 @@ export class GeminiClient implements ModelApi {
 		}
 
 		// Add inline data attachments (images, audio, video, PDF)
-		// `imageAttachments` is the deprecated alias for `inlineAttachments`; still merged here for
-		// backward-compat with callers passing the legacy field (#1040).
-		// eslint-disable-next-line @typescript-eslint/no-deprecated -- deprecated imageAttachments alias merged for backward-compat (#1040)
-		const allAttachments = [...(extReq.inlineAttachments || []), ...(extReq.imageAttachments || [])];
+		const allAttachments = extReq.inlineAttachments ?? [];
 		for (const attachment of allAttachments) {
 			userParts.push({
 				inlineData: {

--- a/src/api/providers/ollama/client.ts
+++ b/src/api/providers/ollama/client.ts
@@ -252,13 +252,7 @@ export class OllamaClient implements ModelApi {
 		if (request.perTurnContext && request.perTurnContext.trim()) {
 			userParts.push(request.perTurnContext);
 		}
-		const allAttachments: InlineDataPart[] = [
-			...(request.inlineAttachments || []),
-			// `imageAttachments` is the deprecated alias for `inlineAttachments`; still merged here for
-			// backward-compat with callers passing the legacy field (#1040).
-			// eslint-disable-next-line @typescript-eslint/no-deprecated -- deprecated imageAttachments alias merged for backward-compat (#1040)
-			...(request.imageAttachments || []),
-		];
+		const allAttachments: InlineDataPart[] = request.inlineAttachments ?? [];
 		for (const att of allAttachments) {
 			if (att.mimeType.startsWith('image/')) {
 				userImages.push(att.base64);

--- a/test/api/providers/gemini/client.test.ts
+++ b/test/api/providers/gemini/client.test.ts
@@ -1223,6 +1223,28 @@ describe('GeminiClient', () => {
 			]);
 		});
 
+		test('maps multiple inline attachments in order', async () => {
+			const client = makeInteractionsClient();
+			await client.generateModelResponse({
+				prompt: '',
+				userMessage: 'what are these?',
+				kind: 'extended',
+				conversationHistory: [],
+				inlineAttachments: [
+					{ base64: 'AAAA', mimeType: 'image/png' },
+					{ base64: 'BBBB', mimeType: 'image/gif' },
+				],
+			});
+
+			const params = interactionsCreateMock.mock.calls[0][0];
+			const lastStep = params.input[params.input.length - 1];
+			expect(lastStep.content).toEqual([
+				{ type: 'text', text: 'what are these?' },
+				{ type: 'image', data: 'AAAA', mime_type: 'image/png' },
+				{ type: 'image', data: 'BBBB', mime_type: 'image/gif' },
+			]);
+		});
+
 		test('extracts tool calls, thoughts, and usage from the interaction', async () => {
 			interactionsCreateMock.mockResolvedValue({
 				id: 'int_2',

--- a/test/api/providers/gemini/client.test.ts
+++ b/test/api/providers/gemini/client.test.ts
@@ -928,21 +928,26 @@ describe('GeminiClient', () => {
 			);
 		});
 
-		test('both inlineAttachments and imageAttachments merged', async () => {
+		test('multiple inlineAttachments all reach the request', async () => {
 			await client.generateModelResponse({
 				prompt: '',
 				userMessage: 'see these',
 				kind: 'extended',
 				conversationHistory: [],
-				inlineAttachments: [{ base64: 'inline1', mimeType: 'image/jpeg' }],
-				imageAttachments: [{ base64: 'img1', mimeType: 'image/gif' }],
+				inlineAttachments: [
+					{ base64: 'inline1', mimeType: 'image/jpeg' },
+					{ base64: 'inline2', mimeType: 'image/gif' },
+				],
 			});
 
 			const params = (generateContentMock as Mock).mock.calls[0][0];
 			const lastContent = params.contents[params.contents.length - 1];
 			// Should have text + 2 inlineData parts
 			const inlineDataParts = lastContent.parts.filter((p: any) => 'inlineData' in p);
-			expect(inlineDataParts).toHaveLength(2);
+			expect(inlineDataParts).toEqual([
+				{ inlineData: { mimeType: 'image/jpeg', data: 'inline1' } },
+				{ inlineData: { mimeType: 'image/gif', data: 'inline2' } },
+			]);
 		});
 
 		test('empty userMessage with no history -> finalContents is empty string', async () => {


### PR DESCRIPTION
<!-- auto-dev -->

## Summary

`ExtendedModelRequest.imageAttachments` was deprecated in favour of `inlineAttachments` (#1040) and kept as a backward-compat alias. Nothing in `src/` has set it since; the only remaining uses were three read-only merge sites in the two provider clients, each carrying its own `@typescript-eslint/no-deprecated` suppression to merge an array that was always `undefined`.

This removes the field and collapses those merges. The removal proceeds on the assumption the issue argues for and the maintainer approved: `src/index.ts` is not an external contract — this repo ships an Obsidian plugin, not an npm package, `main.js` is a build artifact rather than a published entry point, and there is no `types`/`exports` field pointing consumers at the barrel. On that reading the alias has no possible caller.

No behavior changes: the removed operand was always `undefined`, so every merge already evaluated to `inlineAttachments` alone. The compiler is the real gate here — with the field deleted, any surviving read would be a build error rather than a silent `undefined`, and the build is green.

Produced by the auto-dev pipeline from the plan approved on #1274.

Fixes #1274

## Changes

- `src/api/interfaces/model-api.ts` — delete the `imageAttachments?: InlineDataPart[]` field, its `@deprecated` comment, and the `@property imageAttachments` line from the interface JSDoc.
- `src/api/providers/gemini/client.ts` — collapse both merges (the Interactions step builder and the `generateContent` user-parts builder) to read `inlineAttachments` alone; drop two `no-deprecated` suppressions and their explanatory comment blocks.
- `src/api/providers/ollama/client.ts` — same for the third merge site, suppression, and comment.
- `test/api/providers/gemini/client.test.ts` — the `'both inlineAttachments and imageAttachments merged'` case became meaningless. Replaced (not deleted) with a multiple-`inlineAttachments` case that asserts both attachments reach the request in order, so the multi-attachment coverage survives and the assertion is now on content rather than just count.

Net effect: 3 of the 19 `@typescript-eslint/no-deprecated` suppressions in `src/` are gone. The other 16 (`setDynamicTooltip` / `setDestructive`, blocked on `minAppVersion`) are out of scope and untouched.

## Screenshots / Screencast

N/A — internal API surface only, no UI change.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer — #1274, plan approved 2026-07-30
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — full pre-flight run locally: `format-check`, `lint` (0 errors), `build`, `typecheck:test`, `test` (168 files / 3656 tests passing), plus `lint:cycles` (0 cycles)
- [ ] I have tested this change on Desktop — N/A for a live desktop run: this is dead-surface removal with no runnable surface to exercise. The removed operand was always `undefined`, so no observable behavior changes; the deletion is verified by the compiler (a surviving read would fail the build) and by the provider attachment tests. Behavioral verification not run in sandbox.
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — no platform-specific code touched; deletions only.
- [ ] Documentation has been updated (if applicable) — N/A. `imageAttachments` appears nowhere under `docs/`, and `AGENTS.md`'s attachment-pipeline section already documents `inlineAttachments` as the field, describing the rename as done.
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (auto-dev pipeline)
- [x] I have reviewed and understand all AI-generated code in this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y7EdYUiS2rvYo3eCzaCANn)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * Standardized multimodal requests to use `inlineAttachments` for inline image data.
  * Removed support for the deprecated `imageAttachments` field (legacy alias no longer included).
* **Bug Fixes**
  * Multiple inline attachments are now correctly propagated into Gemini requests (in order), including interaction payloads.
* **Documentation**
  * Updated extended-request documentation to explicitly describe supported fields such as `projectInstructions`, `availableTools`, and `inlineAttachments`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->