### PR TITLE
feat(agent): replace native confirm() on session delete with an inline row confirm

### DIFF
--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -2744,7 +2744,16 @@ export const en = {
 	},
 	'agent.sessionList.deleteConfirm': {
 		message: 'Delete session "{title}"?',
-		context: 'Browser confirmation dialog before deleting a session. {title} is the session title.',
+		context:
+			'Inline confirmation prompt shown in the session row before deleting a session. {title} is the session title.',
+	},
+	'agent.sessionList.deleteConfirmAction': {
+		message: 'Delete',
+		context: 'Label on the button that confirms deleting a session, next to the inline confirmation prompt.',
+	},
+	'agent.sessionList.deleteCancel': {
+		message: 'Cancel',
+		context: 'Label on the button that dismisses the inline session-delete confirmation without deleting.',
 	},
 	'agent.sessionList.deleted': {
 		message: 'Session "{title}" deleted',

--- a/src/ui/agent-view/session-list-modal.ts
+++ b/src/ui/agent-view/session-list-modal.ts
@@ -22,6 +22,14 @@ export class SessionListModal extends Modal {
 	private projectMap: Map<string, string> = new Map();
 	/** Current filter selection: 'all', 'none', or a project file path. */
 	private selectedFilter: string = FILTER_ALL;
+	/**
+	 * Restores the action buttons of the row currently showing its delete
+	 * confirmation, or null when no row is confirming. Doubles as the "is a
+	 * confirm pending?" flag — at most one row confirms at a time.
+	 */
+	private pendingDelete: (() => void) | null = null;
+	/** Capture-phase Escape handler; cancels a pending confirm before the modal closes. */
+	private escapeHandler: ((evt: KeyboardEvent) => void) | null = null;
 
 	constructor(
 		app: App,
@@ -40,6 +48,17 @@ export class SessionListModal extends Modal {
 		contentEl.empty();
 		contentEl.addClass('gemini-session-modal');
 		this.modalEl.addClass('mod-gemini-session-modal');
+
+		// Escape cancels a pending row confirmation rather than closing the whole
+		// modal. Capture phase on modalEl runs before Obsidian's document-level
+		// close handler, so stopping propagation there keeps the modal open.
+		this.escapeHandler = (evt: KeyboardEvent) => {
+			if (evt.key !== 'Escape' || !this.pendingDelete) return;
+			evt.preventDefault();
+			evt.stopPropagation();
+			this.dismissDeleteConfirm();
+		};
+		this.modalEl.addEventListener('keydown', this.escapeHandler, true);
 
 		// Title
 		contentEl.createEl('h2', { text: t('agent.sessionList.title') });
@@ -172,6 +191,9 @@ export class SessionListModal extends Modal {
 	}
 
 	private renderSessionList(container: HTMLElement) {
+		// Any row mid-confirmation is about to be replaced; drop the stale restore
+		// callback so it can't rebuild actions on a detached element.
+		this.pendingDelete = null;
 		const filtered = this.getFilteredSessions();
 
 		if (filtered.length === 0) {
@@ -222,30 +244,7 @@ export class SessionListModal extends Modal {
 
 			// Actions
 			const actionsDiv = sessionItem.createDiv({ cls: 'gemini-session-actions' });
-
-			// Open button
-			const openBtn = actionsDiv.createEl('button', {
-				cls: 'gemini-session-action-btn',
-				title: t('agent.sessionList.openTooltip'),
-			});
-			setIcon(openBtn, 'arrow-right');
-
-			// Delete button
-			if (this.callbacks.onDelete) {
-				const deleteBtn = actionsDiv.createEl('button', {
-					cls: 'gemini-session-action-btn delete',
-					title: t('agent.sessionList.deleteTooltip'),
-				});
-				setIcon(deleteBtn, 'trash-2');
-
-				deleteBtn.addEventListener('click', (e) => {
-					e.stopPropagation();
-					// eslint-disable-next-line no-alert -- TODO: replace with Obsidian confirmation Modal
-					if (confirm(t('agent.sessionList.deleteConfirm', { title: session.title }))) {
-						void this.deleteSession(session);
-					}
-				});
-			}
+			this.renderSessionActions(actionsDiv, session);
 
 			// Click handler for the entire item
 			sessionItem.addEventListener('click', () => {
@@ -253,6 +252,91 @@ export class SessionListModal extends Modal {
 				this.close();
 			});
 		}
+	}
+
+	/**
+	 * Renders a row's default action buttons (open, and delete when a delete
+	 * callback was supplied). Rebuilt from scratch rather than shown/hidden, so
+	 * cancelling a confirmation restores buttons with live handlers.
+	 */
+	private renderSessionActions(actionsDiv: HTMLElement, session: ChatSession) {
+		actionsDiv.empty();
+		actionsDiv.removeClass('gemini-session-actions--confirming');
+
+		// Open button
+		const openBtn = actionsDiv.createEl('button', {
+			cls: 'gemini-session-action-btn',
+			title: t('agent.sessionList.openTooltip'),
+		});
+		setIcon(openBtn, 'arrow-right');
+
+		// Delete button
+		if (this.callbacks.onDelete) {
+			const deleteBtn = actionsDiv.createEl('button', {
+				cls: 'gemini-session-action-btn delete',
+				title: t('agent.sessionList.deleteTooltip'),
+			});
+			setIcon(deleteBtn, 'trash-2');
+
+			deleteBtn.addEventListener('click', (e) => {
+				// The row's own click handler opens the session and closes the modal,
+				// so a delete click must never reach it.
+				e.stopPropagation();
+				this.showDeleteConfirm(actionsDiv, session);
+			});
+		}
+	}
+
+	/**
+	 * Swaps a row's action buttons for an inline "delete?" confirmation. Keeps the
+	 * list's scroll position and filter state intact — unlike a full-pane swap —
+	 * and avoids stacking a second modal over the session list.
+	 */
+	private showDeleteConfirm(actionsDiv: HTMLElement, session: ChatSession) {
+		// At most one row confirms at a time.
+		this.dismissDeleteConfirm();
+
+		actionsDiv.empty();
+		actionsDiv.addClass('gemini-session-actions--confirming');
+
+		const prompt = t('agent.sessionList.deleteConfirm', { title: session.title });
+		actionsDiv.createSpan({
+			text: prompt,
+			cls: 'gemini-session-confirm-prompt',
+			// The row ellipsizes long titles; the tooltip keeps the full question reachable.
+			attr: { title: prompt },
+		});
+
+		const confirmBtn = actionsDiv.createEl('button', {
+			text: t('agent.sessionList.deleteConfirmAction'),
+			cls: 'gemini-session-confirm-delete',
+			// Names the session for screen readers, which don't get the row context.
+			attr: { 'aria-label': prompt },
+		});
+		const cancelBtn = actionsDiv.createEl('button', {
+			text: t('agent.sessionList.deleteCancel'),
+			cls: 'gemini-session-confirm-cancel',
+		});
+
+		this.pendingDelete = () => this.renderSessionActions(actionsDiv, session);
+
+		confirmBtn.addEventListener('click', (e) => {
+			e.stopPropagation();
+			// The row is about to be re-rendered by deleteSession; nothing to restore.
+			this.pendingDelete = null;
+			void this.deleteSession(session);
+		});
+		cancelBtn.addEventListener('click', (e) => {
+			e.stopPropagation();
+			this.dismissDeleteConfirm();
+		});
+	}
+
+	/** Restores the confirming row's buttons, if any row is confirming. */
+	private dismissDeleteConfirm() {
+		const restore = this.pendingDelete;
+		this.pendingDelete = null;
+		restore?.();
 	}
 
 	private async deleteSession(session: ChatSession) {
@@ -303,6 +387,11 @@ export class SessionListModal extends Modal {
 	}
 
 	onClose() {
+		if (this.escapeHandler) {
+			this.modalEl.removeEventListener('keydown', this.escapeHandler, true);
+			this.escapeHandler = null;
+		}
+		this.pendingDelete = null;
 		const { contentEl } = this;
 		contentEl.empty();
 	}

--- a/styles.css
+++ b/styles.css
@@ -1701,11 +1701,11 @@ body.theme-dark {
 /* Row-level delete confirmation. Replaces the row's action buttons in place, so
  * the list keeps its scroll position and filter state -- no second modal stacked
  * over the session list, and no full-pane swap. */
-/* The row's action area normally never shrinks; while confirming it may, so a long
- * session title ellipsizes the prompt instead of squeezing the title out of the row. */
 .gemini-session-actions--confirming {
 	align-items: center;
 	gap: var(--gs-space-2);
+	/* The action area normally never shrinks; while confirming it may, so a long
+	 * session title ellipsizes the prompt instead of being squeezed out of the row. */
 	flex-shrink: 1;
 	min-width: 0;
 }
@@ -1747,15 +1747,11 @@ body.theme-dark {
 	border-color: color-mix(in srgb, var(--gs-error) 80%, #000);
 }
 
-.gemini-session-confirm-cancel {
-	background-color: var(--interactive-normal);
-	border: 1px solid var(--gs-border);
-	color: var(--gs-text);
-}
-
-.gemini-session-confirm-cancel:hover {
-	background-color: var(--interactive-hover);
-}
+/* Cancel deliberately declares no colour of its own: it inherits Obsidian's native
+ * button chrome, which is what the scheduler/hook delete-confirm does too (there the
+ * cancel button is a bare <button> and only the destructive one is styled). Sizing
+ * comes from the shared rule above, so the non-destructive choice stays theme-native
+ * while Delete is the only one that reaches for colour. */
 
 /* Session filter bar */
 .gemini-session-filter-bar {

--- a/styles.css
+++ b/styles.css
@@ -1698,6 +1698,65 @@ body.theme-dark {
 	color: var(--text-error);
 }
 
+/* Row-level delete confirmation. Replaces the row's action buttons in place, so
+ * the list keeps its scroll position and filter state -- no second modal stacked
+ * over the session list, and no full-pane swap. */
+/* The row's action area normally never shrinks; while confirming it may, so a long
+ * session title ellipsizes the prompt instead of squeezing the title out of the row. */
+.gemini-session-actions--confirming {
+	align-items: center;
+	gap: var(--gs-space-2);
+	flex-shrink: 1;
+	min-width: 0;
+}
+
+.gemini-session-confirm-prompt {
+	font-size: var(--font-ui-smaller);
+	color: var(--gs-text-muted);
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	/* The prompt is the only part that gives way. */
+	min-width: 0;
+}
+
+.gemini-session-confirm-delete,
+.gemini-session-confirm-cancel {
+	font-size: var(--font-ui-smaller);
+	padding: var(--gs-space-1) var(--gs-space-2);
+	border-radius: var(--gs-radius-sm);
+	cursor: pointer;
+	white-space: nowrap;
+	/* Never squeeze the decision buttons -- they must stay readable and clickable. */
+	flex-shrink: 0;
+	transition: background-color var(--gs-dur-fast) var(--gs-ease);
+}
+
+/* --gs-error tracks Obsidian's --color-red across themes; --gs-on-error keeps the
+ * label readable on it regardless of the theme accent. Same pairing the scheduler
+ * modal's confirm-delete button uses. */
+.gemini-session-confirm-delete {
+	background-color: var(--gs-error);
+	border: 1px solid var(--gs-error);
+	color: var(--gs-on-error);
+	font-weight: 600;
+}
+
+.gemini-session-confirm-delete:hover {
+	background-color: color-mix(in srgb, var(--gs-error) 80%, #000);
+	border-color: color-mix(in srgb, var(--gs-error) 80%, #000);
+}
+
+.gemini-session-confirm-cancel {
+	background-color: var(--interactive-normal);
+	border: 1px solid var(--gs-border);
+	color: var(--gs-text);
+}
+
+.gemini-session-confirm-cancel:hover {
+	background-color: var(--interactive-hover);
+}
+
 /* Session filter bar */
 .gemini-session-filter-bar {
 	display: flex;

--- a/test/ui/agent-view/session-list-confirm.test.ts
+++ b/test/ui/agent-view/session-list-confirm.test.ts
@@ -1,0 +1,294 @@
+/**
+ * Tests for the session list's inline delete confirmation (#1275).
+ *
+ * The delete gate used to be the browser's native `confirm()`. These tests pin
+ * the replacement's decision surface: nothing is trashed until the user confirms
+ * in the row, cancelling is non-destructive, and a confirm click never leaks
+ * through to the row handler that opens the session.
+ */
+
+import { SessionListModal } from '../../../src/ui/agent-view/session-list-modal';
+import { TFile } from 'obsidian';
+import type { App } from 'obsidian';
+import type { ChatSession } from '../../../src/types/agent';
+import type { ObsidianGemini } from '../../../src/types/plugin';
+
+/**
+ * Give a real jsdom element the Obsidian DOM helpers the modal uses. Real DOM
+ * (not vi.fn() stubs) because these tests assert on rendered structure and on
+ * click/keydown propagation, which stubs can't model.
+ */
+function augment(element: HTMLElement): HTMLElement {
+	const el = element as any;
+	el.empty = function () {
+		while (this.firstChild) this.removeChild(this.firstChild);
+		return this;
+	};
+	el.addClass = function (...classes: string[]) {
+		for (const cls of classes) this.classList.add(cls);
+		return this;
+	};
+	el.removeClass = function (...classes: string[]) {
+		for (const cls of classes) this.classList.remove(cls);
+		return this;
+	};
+	el.createEl = function (tag: string, options?: any) {
+		const child = augment(document.createElement(tag));
+		if (options?.text) child.textContent = options.text;
+		if (options?.cls) {
+			for (const cls of String(options.cls).split(/\s+/).filter(Boolean)) child.classList.add(cls);
+		}
+		if (options?.title) child.setAttribute('title', options.title);
+		if (options?.attr) {
+			for (const [name, value] of Object.entries(options.attr)) child.setAttribute(name, String(value));
+		}
+		this.appendChild(child);
+		return child;
+	};
+	el.createDiv = function (options?: any) {
+		return this.createEl('div', options);
+	};
+	el.createSpan = function (options?: any) {
+		return this.createEl('span', options);
+	};
+	return element;
+}
+
+vi.mock('obsidian', async () => {
+	const original = await vi.importActual<any>('../../../__mocks__/obsidian.js');
+	class Modal {
+		app: any;
+		contentEl: HTMLElement;
+		modalEl: HTMLElement;
+		close = vi.fn();
+		open() {}
+		constructor(app: any) {
+			this.app = app;
+			this.contentEl = augment(document.createElement('div'));
+			this.modalEl = augment(document.createElement('div'));
+			this.modalEl.appendChild(this.contentEl);
+			document.body.appendChild(this.modalEl);
+		}
+	}
+	return { ...original, Modal, getLanguage: () => 'en' };
+});
+
+/** A session file, real `TFile` so the modal's `instanceof` checks hold. */
+function sessionFile(path: string, mtime: number): TFile {
+	const file = new TFile() as any;
+	file.path = path;
+	file.stat = { mtime, ctime: mtime, size: 0 };
+	return file as TFile;
+}
+
+const FOLDER = 'gemini-scribe/Agent-Sessions';
+
+function makeSession(id: string, title: string): ChatSession {
+	return {
+		id,
+		title,
+		historyPath: `${FOLDER}/${id}.md`,
+		context: { contextFiles: [] },
+	} as unknown as ChatSession;
+}
+
+interface Harness {
+	modal: SessionListModal;
+	trashFile: ReturnType<typeof vi.fn>;
+	onSelect: ReturnType<typeof vi.fn>;
+	onDelete: ReturnType<typeof vi.fn>;
+	contentEl: HTMLElement;
+}
+
+async function openModal(sessions: ChatSession[]): Promise<Harness> {
+	const files = sessions.map((s, i) => sessionFile(s.historyPath, 2000 - i));
+	const byPath = new Map(files.map((f) => [f.path, f]));
+
+	// Trashing really removes the file, so the list's post-delete re-render sees
+	// what it would see in the vault.
+	const trashFile = vi.fn((file: TFile) => {
+		byPath.delete(file.path);
+		const idx = files.indexOf(file);
+		if (idx !== -1) files.splice(idx, 1);
+		return Promise.resolve();
+	});
+	const app = {
+		vault: {
+			getMarkdownFiles: () => files,
+			getAbstractFileByPath: (path: string) => byPath.get(path) ?? null,
+		},
+		fileManager: { trashFile },
+	} as unknown as App;
+
+	const plugin = {
+		settings: { historyFolder: 'gemini-scribe' },
+		sessionManager: {
+			loadSession: vi.fn((path: string) => Promise.resolve(sessions.find((s) => s.historyPath === path) ?? null)),
+			createAgentSession: vi.fn(),
+		},
+		projectManager: { discoverProjects: () => [] },
+		logger: { error: vi.fn(), warn: vi.fn(), log: vi.fn(), debug: vi.fn() },
+	} as unknown as ObsidianGemini;
+
+	const onSelect = vi.fn();
+	const onDelete = vi.fn();
+	const modal = new SessionListModal(app, plugin, { onSelect, onDelete }, null);
+	await modal.onOpen();
+
+	return { modal, trashFile, onSelect, onDelete, contentEl: (modal as any).contentEl };
+}
+
+/** The rendered rows, in display order. */
+function rows(contentEl: HTMLElement): HTMLElement[] {
+	return Array.from(contentEl.querySelectorAll('.gemini-session-item'));
+}
+
+function deleteButton(row: HTMLElement): HTMLElement {
+	const btn = row.querySelector('.gemini-session-action-btn.delete');
+	if (!btn) throw new Error('row has no delete button');
+	return btn as HTMLElement;
+}
+
+function confirmButton(row: HTMLElement): HTMLElement | null {
+	return row.querySelector('.gemini-session-confirm-delete');
+}
+
+function cancelButton(row: HTMLElement): HTMLElement | null {
+	return row.querySelector('.gemini-session-confirm-cancel');
+}
+
+function click(el: HTMLElement) {
+	el.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+}
+
+describe('SessionListModal inline delete confirmation', () => {
+	beforeEach(() => {
+		document.body.innerHTML = '';
+		vi.clearAllMocks();
+	});
+
+	it('does not delete on the first delete click — it asks first', async () => {
+		const { contentEl, trashFile, onDelete } = await openModal([makeSession('a', 'Alpha')]);
+		const row = rows(contentEl)[0];
+
+		click(deleteButton(row));
+
+		expect(trashFile).not.toHaveBeenCalled();
+		expect(onDelete).not.toHaveBeenCalled();
+		// The row now asks, in place.
+		expect(confirmButton(row)).not.toBeNull();
+		expect(cancelButton(row)).not.toBeNull();
+		expect(row.querySelector('.gemini-session-confirm-prompt')?.textContent).toBe('Delete session "Alpha"?');
+		expect(row.querySelector('.gemini-session-action-btn.delete')).toBeNull();
+	});
+
+	it('never calls the native confirm() dialog', async () => {
+		const nativeConfirm = vi.fn(() => true);
+		vi.stubGlobal('confirm', nativeConfirm);
+		try {
+			const { contentEl } = await openModal([makeSession('a', 'Alpha')]);
+			click(deleteButton(rows(contentEl)[0]));
+			expect(nativeConfirm).not.toHaveBeenCalled();
+		} finally {
+			vi.unstubAllGlobals();
+		}
+	});
+
+	it('deletes only after the confirm button is clicked', async () => {
+		const session = makeSession('a', 'Alpha');
+		const { contentEl, trashFile, onDelete } = await openModal([session]);
+		const row = rows(contentEl)[0];
+
+		click(deleteButton(row));
+		click(confirmButton(row)!);
+		await vi.waitFor(() => expect(onDelete).toHaveBeenCalledWith(session));
+
+		expect(trashFile).toHaveBeenCalledTimes(1);
+		expect((trashFile.mock.calls[0][0] as TFile).path).toBe(session.historyPath);
+		// The deleted session is gone from the re-rendered list.
+		expect(rows(contentEl)).toHaveLength(0);
+	});
+
+	it('restores the row and keeps the session when cancelled', async () => {
+		const { contentEl, trashFile } = await openModal([makeSession('a', 'Alpha')]);
+		const row = rows(contentEl)[0];
+
+		click(deleteButton(row));
+		click(cancelButton(row)!);
+
+		expect(trashFile).not.toHaveBeenCalled();
+		expect(confirmButton(row)).toBeNull();
+		expect(row.querySelector('.gemini-session-action-btn.delete')).not.toBeNull();
+		expect(row.querySelector('.gemini-session-actions')?.classList.contains('gemini-session-actions--confirming')).toBe(
+			false
+		);
+	});
+
+	it('is still armed after a cancel — the restored delete button re-asks', async () => {
+		const { contentEl, trashFile } = await openModal([makeSession('a', 'Alpha')]);
+		const row = rows(contentEl)[0];
+
+		click(deleteButton(row));
+		click(cancelButton(row)!);
+		// The restored button must carry a live handler, not a dead clone.
+		click(deleteButton(row));
+
+		expect(confirmButton(row)).not.toBeNull();
+		expect(trashFile).not.toHaveBeenCalled();
+	});
+
+	it('confirming a second row dismisses the first row’s confirmation', async () => {
+		const { contentEl } = await openModal([makeSession('a', 'Alpha'), makeSession('b', 'Beta')]);
+		const [first, second] = rows(contentEl);
+
+		click(deleteButton(first));
+		click(deleteButton(second));
+
+		expect(confirmButton(second)).not.toBeNull();
+		expect(confirmButton(first)).toBeNull();
+		expect(first.querySelector('.gemini-session-action-btn.delete')).not.toBeNull();
+	});
+
+	it('does not open the session when the confirm or cancel button is clicked', async () => {
+		const session = makeSession('a', 'Alpha');
+		const { contentEl, onSelect, onDelete, modal } = await openModal([session]);
+		const row = rows(contentEl)[0];
+
+		// Cancelling must not select the row either.
+		click(deleteButton(row));
+		click(cancelButton(row)!);
+		expect(onSelect).not.toHaveBeenCalled();
+
+		click(deleteButton(row));
+		click(confirmButton(row)!);
+		await vi.waitFor(() => expect(onDelete).toHaveBeenCalledWith(session));
+
+		// The row handler opens the session and closes the modal; neither may fire
+		// from a click on the confirmation controls.
+		expect(onSelect).not.toHaveBeenCalled();
+		expect((modal as any).close).not.toHaveBeenCalled();
+	});
+
+	it('cancels the confirmation on Escape instead of closing the modal', async () => {
+		const { contentEl, modal, trashFile } = await openModal([makeSession('a', 'Alpha')]);
+		const row = rows(contentEl)[0];
+		click(deleteButton(row));
+
+		const escape = new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true });
+		row.dispatchEvent(escape);
+
+		expect(confirmButton(row)).toBeNull();
+		expect(row.querySelector('.gemini-session-action-btn.delete')).not.toBeNull();
+		expect(trashFile).not.toHaveBeenCalled();
+		// Escape was consumed by the confirm, so the modal's own close never runs.
+		expect(escape.defaultPrevented).toBe(true);
+	});
+
+	it('lets Escape through when no row is confirming', async () => {
+		const { contentEl } = await openModal([makeSession('a', 'Alpha')]);
+		const escape = new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true });
+		rows(contentEl)[0].dispatchEvent(escape);
+
+		expect(escape.defaultPrevented).toBe(false);
+	});
+});


### PR DESCRIPTION
<!-- auto-dev -->

## Summary

Deleting an agent session from the session list was gated by the browser's native `confirm()` — the only such call left in `src/`, carrying its own `no-alert` eslint suppression and a `TODO`. It renders outside Obsidian's modal system and its mobile-webview behavior isn't the plugin's to control, on the one dialog in the plugin where a mis-click is unrecoverable.

This replaces it with a **row-level inline confirm**: clicking the trash icon swaps that row's action buttons for the existing `Delete session "…"?` prompt plus **Delete** / **Cancel**; Cancel rebuilds the buttons. The list keeps its scroll position and filter state, and no second modal is stacked over the session list.

Two notes on the approach, since the issue's framing was slightly off:

- The issue described the existing pattern as modals that "turn the delete button into a confirm button in place." They don't — `ManagementModalBase.confirmDelete()` empties `contentEl` and renders a full-pane confirm screen. There was no row-level in-place confirm in the repo, so this is a new micro-pattern rather than reuse, and it's worth saying so plainly.
- `SessionListModal extends Modal` directly, not `ManagementModalBase`, so there was nothing to inherit either way. A full-pane swap here would discard the filtered list's scroll position to ask one question — the same re-render dance `deleteSession()` already performs after a successful delete.

This retires the last `no-alert` suppression from the codebase: `grep -rn '\bconfirm(\|\balert(' src/ --include='*.ts'` is now empty, and `npm run lint` passes with the suppression deleted rather than relocated.

Built by the auto-dev pipeline from the plan approved on the issue.

Fixes #1275

## Changes

- `src/ui/agent-view/session-list-modal.ts` — replace the `confirm()` branch with the inline confirm; delete the `eslint-disable-next-line no-alert` and its `TODO`. Row-action rendering moves into `renderSessionActions()` so cancelling rebuilds buttons with live handlers instead of un-hiding stale ones. `showDeleteConfirm()` renders the prompt and the two decision buttons; `dismissDeleteConfirm()` restores. State is one `pendingDelete` restore-callback on the instance, so at most one row confirms at a time — opening a confirm on a second row dismisses the first. Confirm and cancel clicks call `stopPropagation()`, since the row's own click handler opens the session and closes the modal; a leaked click there would be the worst possible misfire. `renderSessionList()` clears the pending callback so a filter change or post-delete re-render can't restore actions onto a detached element, and `onClose()` tears down both the callback and the key listener.
- `src/i18n/en.ts` — two new keys with `context` per the i18n rule (`agent.sessionList.deleteConfirmAction`, `agent.sessionList.deleteCancel`). `agent.sessionList.deleteConfirm` is reused as the prompt; its `context` was updated since it no longer describes a browser dialog. Per-language files regenerate via the `Update UI translations` workflow — no manual translation here, and `t()` falls back to English for the two new keys until it runs.
- `styles.css` — confirm-state styles from the `--gs-*` tokens only. The Delete button reuses the `--gs-error` / `--gs-on-error` pairing the scheduler modal's confirm-delete button uses (`--gs-on-error` landed in #1272, which has since merged, so no competing literal was needed). While confirming, the action area is allowed to shrink and the prompt ellipsizes, with `flex-shrink: 0` on both buttons so the decision controls are never squeezed by a long session title.
- `test/ui/agent-view/session-list-confirm.test.ts` (new) — 9 tests. This modal was on the untested list in #1262, so this is its first coverage.

**Escape handling:** Escape cancels a pending confirm instead of closing the modal, via a capture-phase `keydown` listener on `modalEl` — capture there runs before Obsidian's document-level close handler, so stopping propagation keeps the modal open. Scoping it to `modalEl` rather than `document` avoids swallowing Escape for any other surface. The listener only sees the event when focus is inside the modal, which is the case here because reaching the confirming state requires clicking the row's delete button. If focus were somehow outside, Escape closes the modal — which deletes nothing, so the degradation is safe.

**No docs update.** `docs/` and `README.md` describe session deletion as a user action, not the shape of its confirmation dialog — checked: the only nearby matches are `docs/reference/settings.md:523` (tool-permission confirmations, unrelated) and `README.md:305` (deleting session files manually). Nothing documents the browser dialog, so there is nothing to rewrite.

## Screenshots / Screencast

Not included — no Obsidian runtime in the build sandbox to capture one. See the verification note below; the visual pass is the one thing this PR asks a human to do.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer — #1275, plan approved on the issue
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — full pre-flight green locally: `format-check`, `lint` (0 errors), `build`, `typecheck:test`, `test` (169 files / 3665 tests), plus `lint:cycles` (no cycles)
- [ ] I have tested this change on Desktop — **not done.** No Obsidian runtime in the build sandbox, so the two-click flow, the Escape path, and the light/dark appearance were **not** exercised end-to-end. Behavioral verification not run in sandbox — needs a manual check. Covered by unit tests at the DOM level, which is not the same thing.
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards) — **not verified at runtime**, same reason. No platform guard is needed: the change removes a host-chrome dialog and replaces it with plugin-rendered DOM and Obsidian APIs only, which is strictly better on mobile than the `confirm()` it replaces. Worth a tap-target glance on a phone.
- [x] Documentation has been updated (if applicable) — N/A, see "No docs update" above
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (auto-dev pipeline)
- [x] I have reviewed and understand all AI-generated code in this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01P4XsYeBhkuVqWLA18UVDM1)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added inline delete confirmation controls to session list rows, with **Delete** and **Cancel** actions.
  * Escape now cancels an active row confirmation without closing the session list modal.
* **Bug Fixes**
  * Prevented accidental deletion by replacing blocking confirmation dialogs with an inline prompt.
  * Cancel now restores the row’s original actions and avoids cross-row impact.
* **Tests**
  * Added UI coverage for inline confirmation, cancellation, multi-row behavior, and keyboard handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->