### PR TITLE
refactor(utils): de-duplicate stored-error truncation into error-utils

### DIFF
--- a/src/ui/background-tasks-modal.ts
+++ b/src/ui/background-tasks-modal.ts
@@ -4,7 +4,7 @@ import type { BackgroundTask } from '../services/background-task-manager';
 import type { RagDetailedStatus } from '../services/rag-types';
 import type { ProgressListener } from '../services/rag-types';
 import type { RagIndexingService } from '../services/rag-indexing';
-import { getErrorMessage } from '../utils/error-utils';
+import { getErrorMessage, truncateStoredError } from '../utils/error-utils';
 import { renderRagOverview, renderRagFileList, renderRagFailures } from './components/rag-status-panel';
 import { openPluginSettingsTab } from '../utils/obsidian-settings';
 import { t } from '../i18n';
@@ -311,14 +311,7 @@ export class BackgroundTasksModal extends Modal {
 
 	/** Return the first meaningful line of an error, capped at 120 chars. */
 	private truncateError(raw: string): string {
-		const jsonMatch = raw.match(/"message"\s*:\s*"([^"]+)"/);
-		if (jsonMatch) {
-			const msg = jsonMatch[1].split(/[\n]/)[0].trim();
-			return msg.length > 120 ? msg.slice(0, 117) + '…' : msg;
-		}
-		const stripped = raw.replace(/^(ApiError:\s*)?\[\d+ [^\]]+\]\s*/, '').replace(/^ApiError:\s*/, '');
-		const firstLine = stripped.split(/[\n.]/)[0].trim();
-		return firstLine.length > 120 ? firstLine.slice(0, 117) + '…' : firstLine;
+		return truncateStoredError(raw);
 	}
 	// ---------------------------------------------------------------------------
 	// RAG tab

--- a/src/ui/scheduled-tasks-modal.ts
+++ b/src/ui/scheduled-tasks-modal.ts
@@ -1,6 +1,7 @@
 import { App, Modal, setIcon } from 'obsidian';
 import type { ObsidianGemini } from '../types/plugin';
 import type { ScheduledTask, TaskState } from '../services/scheduled-task-manager';
+import { truncateStoredError } from '../utils/error-utils';
 import { t } from '../i18n';
 
 /**
@@ -152,17 +153,7 @@ export class ScheduledTasksModal extends Modal {
 
 	/** Return the first meaningful line of an error, capped at 120 chars. */
 	private truncateError(raw: string): string {
-		// Try to extract the human-readable message from a Gemini JSON error blob
-		// e.g. ApiError: {"error":{"code":429,"message":"You exceeded..."}}
-		const jsonMatch = raw.match(/"message"\s*:\s*"([^"]+)"/);
-		if (jsonMatch) {
-			const msg = jsonMatch[1].split(/[\n]/)[0].trim();
-			return msg.length > 120 ? msg.slice(0, 117) + '…' : msg;
-		}
-		// Strip HTTP status prefix like "[429 Too Many Requests] "
-		const stripped = raw.replace(/^(ApiError:\s*)?\[\d+ [^\]]+\]\s*/, '').replace(/^ApiError:\s*/, '');
-		const firstLine = stripped.split(/[\n.]/)[0].trim();
-		return firstLine.length > 120 ? firstLine.slice(0, 117) + '…' : firstLine;
+		return truncateStoredError(raw);
 	}
 
 	private formatDate(date: Date): string {

--- a/src/ui/scheduler-management-modal.ts
+++ b/src/ui/scheduler-management-modal.ts
@@ -4,7 +4,7 @@ import { DEFAULT_HEADLESS_MAX_ITERATIONS } from '../agent/agent-loop';
 import type { FeatureToolPolicy } from '../types/tool-policy';
 import { ManagementModalBase } from './components/management-modal-base';
 import { ToolPolicyEditor } from './components/tool-policy-editor';
-import { getRawErrorMessage } from '../utils/error-utils';
+import { getRawErrorMessage, truncateStoredError } from '../utils/error-utils';
 import { t } from '../i18n';
 
 const SCHEDULE_PRESETS = [
@@ -472,14 +472,7 @@ export class SchedulerManagementModal extends ManagementModalBase<ScheduledTask,
 	 * extracts JSON "message" fields and strips ApiError prefixes.
 	 */
 	protected truncateError(raw: string): string {
-		const jsonMatch = raw.match(/"message"\s*:\s*"([^"]+)"/);
-		if (jsonMatch) {
-			const msg = jsonMatch[1].split(/[\n]/)[0].trim();
-			return msg.length > 120 ? msg.slice(0, 117) + '…' : msg;
-		}
-		const stripped = raw.replace(/^(ApiError:\s*)?\[\d+ [^\]]+\]\s*/, '').replace(/^ApiError:\s*/, '');
-		const firstLine = stripped.split(/[\n.]/)[0].trim();
-		return firstLine.length > 120 ? firstLine.slice(0, 117) + '…' : firstLine;
+		return truncateStoredError(raw);
 	}
 
 	private blankForm() {

--- a/src/utils/error-utils.ts
+++ b/src/utils/error-utils.ts
@@ -458,9 +458,22 @@ function getHttpErrorMessage(statusCode: number, error: unknown): string {
 export function truncateStoredError(raw: string): string {
 	// Prefer the human-readable message out of a Gemini JSON error blob,
 	// e.g. ApiError: {"error":{"code":429,"message":"You exceeded..."}}
-	const jsonMatch = raw.match(/"message"\s*:\s*"([^"]+)"/);
+	//
+	// The capture keeps backslash escape pairs intact, so an embedded \" does not
+	// end it early, and JSON.parse then turns \n and \" back into real characters
+	// — without decoding, a multi-line API error renders as one line with a
+	// literal "\n" in it. A blob that isn't valid JSON (e.g. a raw newline inside
+	// the string) fails to parse; fall back to the captured text rather than
+	// dropping the message.
+	const jsonMatch = raw.match(/"message"\s*:\s*"((?:[^"\\]|\\.)*)"/);
 	if (jsonMatch) {
-		const msg = jsonMatch[1].split(/[\n]/)[0].trim();
+		let decoded = jsonMatch[1];
+		try {
+			decoded = JSON.parse(`"${decoded}"`) as string;
+		} catch {
+			// Not a well-formed JSON string body — use the raw capture as-is.
+		}
+		const msg = decoded.split(/[\n]/)[0].trim();
 		return msg.length > 120 ? msg.slice(0, 117) + '…' : msg;
 	}
 	// Otherwise strip the HTTP status prefix like "[429 Too Many Requests] "

--- a/src/utils/error-utils.ts
+++ b/src/utils/error-utils.ts
@@ -444,6 +444,32 @@ function getHttpErrorMessage(statusCode: number, error: unknown): string {
 }
 
 /**
+ * Condense an already-stringified error into the first meaningful line,
+ * capped at 120 characters.
+ *
+ * Unlike {@link getShortErrorMessage}, this takes a raw string rather than an
+ * error value — the automation surfaces (scheduled tasks, hooks, background
+ * tasks) persist `lastError` as text, so by the time the UI renders it there is
+ * no error object left to inspect. It peels off the two shapes those stored
+ * strings arrive in: a Gemini JSON blob carrying the human-readable text in a
+ * `"message"` field, and an SDK prefix such as `ApiError: [429 Too Many
+ * Requests]`.
+ */
+export function truncateStoredError(raw: string): string {
+	// Prefer the human-readable message out of a Gemini JSON error blob,
+	// e.g. ApiError: {"error":{"code":429,"message":"You exceeded..."}}
+	const jsonMatch = raw.match(/"message"\s*:\s*"([^"]+)"/);
+	if (jsonMatch) {
+		const msg = jsonMatch[1].split(/[\n]/)[0].trim();
+		return msg.length > 120 ? msg.slice(0, 117) + '…' : msg;
+	}
+	// Otherwise strip the HTTP status prefix like "[429 Too Many Requests] "
+	const stripped = raw.replace(/^(ApiError:\s*)?\[\d+ [^\]]+\]\s*/, '').replace(/^ApiError:\s*/, '');
+	const firstLine = stripped.split(/[\n.]/)[0].trim();
+	return firstLine.length > 120 ? firstLine.slice(0, 117) + '…' : firstLine;
+}
+
+/**
  * Get a shortened error message suitable for inline display
  * (e.g., in status bars or small UI elements)
  */

--- a/test/utils/error-utils.test.ts
+++ b/test/utils/error-utils.test.ts
@@ -623,7 +623,20 @@ describe('error-utils', () => {
 			expect(truncateStoredError(raw)).toBe('You exceeded your current quota');
 		});
 
-		test('keeps only the first line of a multi-line JSON message', () => {
+		test('decodes an escaped newline and keeps only the first line', () => {
+			// A real Gemini blob escapes its newlines, so this is the common shape.
+			const raw = '{"message":"Quota exceeded\\nRetry in 30s"}';
+			expect(truncateStoredError(raw)).toBe('Quota exceeded');
+		});
+
+		test('decodes escaped quotes instead of ending the capture early', () => {
+			const raw = '{"message":"He said \\"boom\\" then failed"}';
+			expect(truncateStoredError(raw)).toBe('He said "boom" then failed');
+		});
+
+		test('falls back to the raw capture when the JSON string body is malformed', () => {
+			// A literal newline inside the string is invalid JSON, so the decode
+			// throws; the message must still survive rather than being dropped.
 			const raw = '{"message":"Quota exceeded\nRetry in 30s"}';
 			expect(truncateStoredError(raw)).toBe('Quota exceeded');
 		});

--- a/test/utils/error-utils.test.ts
+++ b/test/utils/error-utils.test.ts
@@ -6,6 +6,7 @@ import {
 	isNotFoundError,
 	isQuotaExhausted,
 	isRateLimitError,
+	truncateStoredError,
 } from '../../src/utils/error-utils';
 
 describe('error-utils', () => {
@@ -612,6 +613,47 @@ describe('error-utils', () => {
 			const error = { status: 500, message: 'Internal error. Try again later.' };
 			const short = getShortErrorMessage(error);
 			expect(short).toBe('Server error');
+		});
+	});
+
+	describe('truncateStoredError', () => {
+		test('extracts the message field from a Gemini JSON error blob', () => {
+			const raw =
+				'ApiError: {"error":{"code":429,"message":"You exceeded your current quota","status":"RESOURCE_EXHAUSTED"}}';
+			expect(truncateStoredError(raw)).toBe('You exceeded your current quota');
+		});
+
+		test('keeps only the first line of a multi-line JSON message', () => {
+			const raw = '{"message":"Quota exceeded\nRetry in 30s"}';
+			expect(truncateStoredError(raw)).toBe('Quota exceeded');
+		});
+
+		test('caps an over-long JSON message at 120 chars with an ellipsis', () => {
+			const long = 'q'.repeat(200);
+			const result = truncateStoredError(`{"message":"${long}"}`);
+			expect(result).toHaveLength(118);
+			expect(result.endsWith('…')).toBe(true);
+		});
+
+		test('strips the ApiError and HTTP status prefixes', () => {
+			expect(truncateStoredError('ApiError: [429 Too Many Requests] Slow down')).toBe('Slow down');
+			expect(truncateStoredError('[503 Service Unavailable] Model overloaded')).toBe('Model overloaded');
+			expect(truncateStoredError('ApiError: Something broke')).toBe('Something broke');
+		});
+
+		test('returns the first sentence of a plain error string', () => {
+			expect(truncateStoredError('Tool run failed. See the log for details.')).toBe('Tool run failed');
+		});
+
+		test('caps an over-long plain message at 120 chars with an ellipsis', () => {
+			const result = truncateStoredError('e'.repeat(200));
+			expect(result).toHaveLength(118);
+			expect(result.endsWith('…')).toBe(true);
+		});
+
+		test('returns short messages unchanged', () => {
+			expect(truncateStoredError('Disk full')).toBe('Disk full');
+			expect(truncateStoredError('')).toBe('');
 		});
 	});
 });


### PR DESCRIPTION
## Summary

`audit-architecture` nightly sweep flagged a **DRY violation**: the 10-line "return the first meaningful line of a stored error, capped at 120 chars" helper is copy-pasted verbatim into three UI modules.

The three copies are byte-identical. They exist because the automation surfaces (scheduled tasks, hooks, background tasks) persist `lastError` as a **string**, so by render time there is no error object left to inspect — `getShortErrorMessage(error: unknown)` in `error-utils.ts` does not fit. Each modal grew its own copy instead of a shared leaf helper.

This extracts it as `truncateStoredError(raw: string)` in `src/utils/error-utils.ts` — the leaf module the repo already uses for this concern (`coding.md`: "when a manager and a sibling need the same helper, put it in a leaf module both import").

Duplicate copies removed:

- `src/ui/scheduler-management-modal.ts:474` (override of the base method)
- `src/ui/background-tasks-modal.ts:313` (private, does not extend the base)
- `src/ui/scheduled-tasks-modal.ts:154` (private, does not extend the base)

`ManagementModalBase` keeps its own simpler 80-char `truncateError` default, so `HookManagementModal` — the one consumer that relied on the base rather than an override — is untouched. Deliberately no consolidation of the base's default with the richer version here: that *would* change hook error rendering, which is a separate judgment call.

## Behavior change (added after review)

The PR opened as pure code motion. Following CodeRabbit's review it now also **fixes a defect that was present, identically, in all three copies**: the message-extraction regex treated the JSON string body as plain text.

| input | before | after |
|---|---|---|
| `{"message":"He said \"boom\" then failed"}` | `He said \` | `He said "boom" then failed` |
| `{"message":"Quota exceeded\nRetry in 30s"}` | `Quota exceeded\nRetry in 30s` (literal `\n`) | `Quota exceeded` |

The escaped-newline case is the common one, not an edge case — a real Gemini `ApiError` blob is valid JSON, so its newlines are always escaped, which means the old `.split(/[\n]/)` never fired on the shape it was written for. The capture now keeps escape pairs intact and the body is decoded with a guarded `JSON.parse`; a malformed body (a raw newline inside the string, which is invalid JSON) throws and falls back to the captured text, preserving the old behavior for that case.

Only the rendering of a stored `lastError` line changes. The full message is still on the element's `title` for hover.

If you'd rather land the extraction alone and treat the decode fix as a separate PR, say so and I'll split it.

## Changes

- `src/utils/error-utils.ts` — add exported `truncateStoredError(raw: string)`, documented against its sibling `getShortErrorMessage(error: unknown)` so the raw-string vs. error-value distinction is explicit; decode JSON string escapes before line selection.
- `src/ui/scheduler-management-modal.ts` — override now delegates to the shared helper.
- `src/ui/background-tasks-modal.ts` — private method now delegates to the shared helper.
- `src/ui/scheduled-tasks-modal.ts` — private method now delegates to the shared helper.
- `test/utils/error-utils.test.ts` — 9 new cases covering JSON `"message"` extraction, escaped-newline and escaped-quote decoding, the malformed-JSON fallback, `ApiError:` / `[429 …]` prefix stripping, the 120-char cap on both paths, and short/empty passthrough. The helper previously had no direct coverage in any of its three homes.

## Screenshots / Screencast

N/A — no layout or styling change. The only visual delta is the two error-string cases in the table above, both of which render a malformed string correctly instead of incorrectly.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: opened by the `audit-architecture` nightly sweep, which files mechanical, well-scoped fixes directly per its routing rule. Close it if you'd rather discuss first.
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — plus `npm run lint` (0 errors, 39 pre-existing warnings) and `npm run typecheck:test`. 3693 tests pass.
- [ ] I have tested this change on Desktop — not manually exercised in a vault; the changed surface is pure string manipulation, covered by unit tests including the before/after cases above.
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — no platform-specific API involved.
- [ ] Documentation has been updated (if applicable) — N/A: internal refactor plus a display-string correction; no user-facing feature or settings change to document.
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (`audit-architecture` skill)
- [x] I have reviewed and understand all AI-generated code in this PR

---

_Filed by the `audit-architecture` skill._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task error messages across background, scheduled, and scheduler management views.
  * Error details now consistently remove technical prefixes, handle structured messages, show concise first-line summaries, and truncate overly long text for readability.
* **Tests**
  * Added coverage for structured, multiline, prefixed, empty, short, and lengthy error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->