### PR TITLE
feat: OpenAI-compatible provider with API key auth (#1237)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,13 @@
 
 Gemini Scribe is an Obsidian plugin that integrates Google's Gemini AI models, providing powerful AI-driven assistance for note-taking, writing, and knowledge management directly within Obsidian. It leverages your notes as context for AI interactions, making it a highly personalized and integrated experience.
 
-> **Note:** Pick one of two setup paths in plugin settings → **Provider**:
+> **Note:** Pick one of three setup paths in plugin settings → **Provider**:
 >
 > - **Google Gemini (cloud)** — requires a Gemini API key (free tier available at [Google AI Studio](https://aistudio.google.com/apikey)).
-> - **Ollama (local)** — runs locally with no API key; install [Ollama](https://ollama.com), pull a model, and select it in settings. See [docs/guide/ollama-setup.md](docs/guide/ollama-setup.md) and the [provider capability matrix](docs/reference/provider-capabilities.md) for what's supported.
+> - **Ollama (local)** — runs locally with no API key; install [Ollama](https://ollama.com), pull a model, and select it in settings. See [docs/guide/ollama-setup.md](docs/guide/ollama-setup.md) for details.
+> - **OpenAI (cloud)** — requires your own OpenAI API key, or point it at an OpenAI-compatible server (LM Studio, MLX, ...) with any placeholder key. See [docs/guide/openai-setup.md](docs/guide/openai-setup.md) for details.
+>
+> See the [provider capability matrix](docs/reference/provider-capabilities.md) for what's supported on each.
 
 ## What's New in v4.11.0
 
@@ -99,7 +102,7 @@ _A large feature release — a full visual refresh plus smarter, more responsive
 5. Manage sessions directly with command palette actions: "New agent session", "Browse agent sessions", "Link project to agent session", and "Agent session settings"
 6. Start using the AI agent to work with your vault!
 
-**Prefer running models locally?** Gemini Scribe also supports [Ollama](https://ollama.com) — install Ollama, pull a model with `ollama pull llama3.2`, and switch the **Provider** in settings to "Ollama (local)". A few Gemini-built-in features (Google Search, Google Maps, URL Context, Deep Research, image generation, RAG) have no local equivalent — but you can point those individually at Gemini under **Per-feature provider** while chat stays local. Nothing is sent to the cloud unless you route it there. See [docs/guide/ollama-setup.md](docs/guide/ollama-setup.md) for details.
+**Prefer running models locally, or already have an OpenAI key?** Gemini Scribe also supports [Ollama](https://ollama.com) — install Ollama, pull a model with `ollama pull llama3.2`, and switch the **Provider** in settings to "Ollama (local)" — and **OpenAI** — switch **Provider** to "OpenAI (cloud)", enter your API key, and optionally point the **OpenAI base URL** at an OpenAI-compatible server like LM Studio or MLX. A few Gemini-built-in features (Google Search, Google Maps, URL Context, Deep Research, image generation, RAG) have no equivalent on either provider — but you can point those individually at Gemini under **Per-feature provider** while chat stays on your chosen provider. Nothing is sent to the cloud unless you route it there. See [docs/guide/ollama-setup.md](docs/guide/ollama-setup.md) and [docs/guide/openai-setup.md](docs/guide/openai-setup.md) for details.
 
 ## Installation
 
@@ -125,9 +128,10 @@ _A large feature release — a full visual refresh plus smarter, more responsive
 2.  **Configure Plugin Settings:**
     - Open Obsidian Settings.
     - Go to "Gemini Scribe" under "Community plugins".
-    - **Provider:** Choose `Google Gemini (cloud)` (default) or `Ollama (local)`. This is the default for every feature; the Ollama option exposes a base-URL field and refreshes the model list from `GET /api/tags`.
+    - **Provider:** Choose `Google Gemini (cloud)` (default), `Ollama (local)`, or `OpenAI (cloud)`. This is the default for every feature; the Ollama option exposes a base-URL field and refreshes the model list from `GET /api/tags`, and the OpenAI option exposes an API key and base-URL field (also usable for OpenAI-compatible servers like LM Studio) and refreshes the model list from `GET /models`.
     - **Per-feature provider:** Route individual features (chat, summaries, completions, rewrite, web & search, vault search index, image generation) to a different provider. Each dropdown lists only the providers that support that feature. A feature your default provider can't serve stays off unless you explicitly assign it one — the plugin never falls back to the cloud on its own.
     - **API Key:** (Gemini only) Paste your Gemini API key here. Your key is stored securely using Obsidian's SecretStorage.
+    - **OpenAI API key / base URL:** (OpenAI only) Paste your OpenAI API key, or any placeholder value for a compatible server that doesn't check one. The base URL defaults to `https://api.openai.com/v1`.
     - **Chat model:** Select the preferred Gemini model for chat interactions (default: `gemini-flash-latest`).
     - **Summary model:** Select the preferred Gemini model for generating summaries (default: `gemini-flash-latest`).
     - **Completion model:** Select the preferred model for IDE-style completions (default: `gemini-flash-lite-latest`).
@@ -143,7 +147,7 @@ _A large feature release — a full visual refresh plus smarter, more responsive
     - **Advanced Settings:** (Click "Show advanced settings" to reveal)
       - **Temperature:** Control AI creativity and randomness (0-2.0, automatically adjusted based on available models).
       - **Top P:** Control response diversity and focus (0-1.0).
-      - **Model Discovery:** Gemini models are automatically fetched on startup (cached for 24h); click **Refresh model list** in General settings or run the "Gemini Scribe: Refresh model list" command to fetch a newly-published model immediately. Ollama users get a separate **Refresh Ollama model list** button to re-query the daemon after pulling new models. Each model dropdown lists the models of the provider serving that feature.
+      - **Model Discovery:** Gemini models are automatically fetched on startup (cached for 24h); click **Refresh model list** in General settings or run the "Gemini Scribe: Refresh model list" command to fetch a newly-published model immediately. Ollama users get a separate **Refresh Ollama model list** button to re-query the daemon after pulling new models, and OpenAI users get a **Refresh OpenAI model list** button to re-query `GET /models`. Each model dropdown lists the models of the provider serving that feature.
       - **API configuration:** Configure retry behavior, backoff delays, and the Use Interactions API transport (Gemini provider only; on by default, with `generateContent` retained as a fallback).
       - **Tool Execution:** Control whether to stop agent execution on tool errors.
       - **Tool loop detection:** Prevent infinite tool execution loops.
@@ -227,12 +231,14 @@ For detailed guides on all features, visit the [Documentation Site](https://alle
 - [Agent Skills Guide](docs/guide/agent-skills.md) - Create extensible AI skill packages
 - [Scheduled tasks Guide](docs/guide/scheduled-tasks.md) - Automate recurring AI prompts
 - [Lifecycle Hooks Guide](docs/guide/lifecycle-hooks.md) - Trigger AI runs from vault events
+- [Ollama Setup Guide](docs/guide/ollama-setup.md) - Run local models with Ollama
+- [OpenAI Setup Guide](docs/guide/openai-setup.md) - Use your OpenAI API key, or an OpenAI-compatible server
 
 **Configuration & Development:**
 
 - [Settings Reference](docs/reference/settings.md) - Complete settings documentation
 - [Advanced Settings Guide](docs/reference/advanced-settings.md)
-- [Provider Capabilities](docs/reference/provider-capabilities.md) - Gemini vs. Ollama feature matrix
+- [Provider Capabilities](docs/reference/provider-capabilities.md) - Gemini vs. Ollama vs. OpenAI feature matrix
 - [Tool Development Guide](docs/contributing/tool-development.md) - Create custom agent tools
 
 ### Chat Interface
@@ -348,7 +354,7 @@ The plugin UI follows **Obsidian's interface language** (Settings → About → 
 - **Parameter/Advanced Settings Issues:**
   - Check if your model supports the temperature range you're using
   - Reset temperature and Top P to defaults if getting unexpected responses
-  - Restart Obsidian to trigger a fresh model list fetch (for Gemini), or click **Refresh Ollama model list** (for Ollama)
+  - Restart Obsidian to trigger a fresh model list fetch (for Gemini), or click **Refresh Ollama model list** (for Ollama) / **Refresh OpenAI model list** (for OpenAI)
   - See the [Advanced Settings Guide](docs/reference/advanced-settings.md) for detailed configuration help
 - **Agent mode / Tool Issues:**
   - Verify your Gemini model supports function calling (all Gemini 2.0+ models do)

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -34,6 +34,7 @@ export default defineConfig({
 					items: [
 						{ text: 'Introduction', link: '/guide/getting-started' },
 						{ text: 'Ollama (Local Models)', link: '/guide/ollama-setup' },
+						{ text: 'OpenAI', link: '/guide/openai-setup' },
 						{ text: 'FAQ', link: '/guide/faq' },
 					],
 				},

--- a/docs/guide/agent-mode.md
+++ b/docs/guide/agent-mode.md
@@ -371,7 +371,7 @@ What do you remember about my vault?
 
 ### Web & Research Operations
 
-> All four tools in this section (`google_search`, `google_maps`, `fetch_url`, `deep_research`) require Gemini — they're registered only when the **Web and search** feature (Settings → Gemini Scribe → Per-feature provider) resolves to Gemini, whether that's your default provider or a per-feature override on an otherwise-Ollama setup. See the [Provider Capabilities reference](/reference/provider-capabilities) for the full matrix.
+> All four tools in this section (`google_search`, `google_maps`, `fetch_url`, `deep_research`) require Gemini — they're registered only when the **Web and search** feature (Settings → Gemini Scribe → Per-feature provider) resolves to Gemini, whether that's your default provider or a per-feature override on an otherwise-Ollama or otherwise-OpenAI setup. See the [Provider Capabilities reference](/reference/provider-capabilities) for the full matrix.
 
 #### google_search
 

--- a/docs/guide/faq.md
+++ b/docs/guide/faq.md
@@ -75,7 +75,9 @@ If the Gemma model you want is served through the Gemini API (ai.google.dev) it 
 
 ### Can I use non-Gemini providers like OpenAI, Anthropic, or Mistral?
 
-No. Gemini Scribe is intentionally a Gemini-only integration — it's built tightly around the `@google/genai` SDK, Gemini's tool-calling surface, URL Context, inline attachments, Google Search grounding, and the File Search API used for semantic vault search. Abstracting these to a generic provider interface would effectively be a rewrite, and there are other Obsidian plugins focused on multi-provider chat if that's what you need. ([#588](https://github.com/allenhutchison/obsidian-gemini/issues/588))
+**OpenAI is supported** as a provider — see the question below for setup, including using your own API key or an OpenAI-compatible local server. Ollama is also supported for local models — see [Can I use a local LLM via Ollama or llama.cpp?](#can-i-use-a-local-llm-via-ollama-or-llama-cpp) below.
+
+Anthropic and Mistral are not supported directly. A handful of Gemini-specific features — Google Search grounding, URL Context, and the File Search API used for semantic vault search — remain tightly coupled to the `@google/genai` SDK and are Gemini-only regardless of which provider serves chat; per-feature provider routing lets you mix, e.g. chat on OpenAI with those tools still on Gemini. ([#588](https://github.com/allenhutchison/obsidian-gemini/issues/588), [#1237](https://github.com/allenhutchison/obsidian-gemini/issues/1237))
 
 ### Can I point the plugin at Vertex AI for privacy or compliance reasons?
 
@@ -117,6 +119,12 @@ ollama pull deepseek-v4-pro:cloud
 ```
 
 Watch the tag format: models with a size tag take a `-cloud` suffix (`gpt-oss:120b-cloud`), while untagged models use `cloud` as the tag itself (`glm-5.2:cloud`). Note that a cloud model runs on ollama.com, so your notes leave your machine even though the provider is set to Ollama. See [Cloud models](./ollama-setup.md#cloud-models).
+
+### Can I use my own OpenAI API key, or point the plugin at LM Studio / another OpenAI-compatible server?
+
+**Yes to both.** Switch the provider to **OpenAI (cloud)** in Settings → Gemini Scribe → Provider, enter your API key from [platform.openai.com/api-keys](https://platform.openai.com/api-keys), and pick models for chat, summary, and completions. To use an OpenAI-compatible server instead — LM Studio, an MLX-served endpoint, Ollama's own OpenAI-compatible endpoint, etc. — point the **OpenAI base URL** field at it (e.g. `http://localhost:1234/v1` for LM Studio) and enter any placeholder value in the API key field if the server doesn't check one. See the [OpenAI Setup guide](./openai-setup.md) for a full walkthrough.
+
+This is API-key billing only — there is no "Sign in with ChatGPT" / ChatGPT-subscription auth. The same Gemini-only features listed above for Ollama (Deep Research, semantic vault search, Google Search/Maps grounding, URL Context, image generation) are also unavailable on OpenAI, and the same per-feature mixing applies: keep chat on OpenAI while routing individual cloud-only features to Gemini. See [Provider Capabilities](../reference/provider-capabilities.md). ([#1237](https://github.com/allenhutchison/obsidian-gemini/issues/1237))
 
 ## Language & Localization
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -28,9 +28,9 @@ Welcome to Gemini Scribe, an Obsidian plugin that integrates Google's Gemini AI 
 3. **Initialize Context** — Click "Initialize vault context" to help the agent understand your vault
 4. **Start Chatting** — Open Gemini chat with the ribbon icon or command palette and start giving the AI tasks!
 
-### Prefer running models locally?
+### Prefer running models locally, or already have an OpenAI key?
 
-Gemini Scribe also supports [Ollama](https://ollama.com) as a provider so you can use local models such as Llama 3.2, Qwen 2.5, or Gemma 3 without an API key. Some Gemini-built-in features (Google Search, Google Maps, URL Context, Deep Research, image generation, RAG) have no local equivalent, but each can be pointed at Gemini individually under **Per-feature provider** while chat stays local. See the [Ollama Setup Guide](/guide/ollama-setup) for details.
+Gemini Scribe also supports [Ollama](https://ollama.com) as a provider so you can use local models such as Llama 3.2, Qwen 2.5, or Gemma 3 without an API key — see the [Ollama Setup Guide](/guide/ollama-setup). If you'd rather use your own OpenAI API key, or point the plugin at an OpenAI-compatible server such as LM Studio or MLX, switch **Provider** to **OpenAI (cloud)** — see the [OpenAI Setup Guide](/guide/openai-setup). Some Gemini-built-in features (Google Search, Google Maps, URL Context, Deep Research, image generation, RAG) have no equivalent on either provider, but each can be pointed at Gemini individually under **Per-feature provider** while chat stays on your chosen provider.
 
 ## Feature Overview
 

--- a/docs/guide/openai-setup.md
+++ b/docs/guide/openai-setup.md
@@ -1,0 +1,67 @@
+# OpenAI
+
+Gemini Scribe can route chat, summary, completions, rewrite, and agent tool-calling through the **OpenAI Chat Completions API** instead of the Google Gemini API. Use this when you already pay for OpenAI models, or when you want to point the plugin at an **OpenAI-compatible server** — LM Studio, an MLX-served endpoint, Ollama's own OpenAI-compatible endpoint, or similar — running locally or on your network.
+
+This is API-key billing only: there is no "Sign in with ChatGPT" / ChatGPT-subscription (Codex-style) authentication. You need an OpenAI API key, or a placeholder key for a compatible server that doesn't check one.
+
+## Setup
+
+1. **Get an API key** — Visit [platform.openai.com/api-keys](https://platform.openai.com/api-keys), create a key, and copy it. If you're only targeting a local compatible server that doesn't validate keys, you can skip this and use any placeholder value instead — the provider still requires a key to be set.
+2. **Switch the provider in Gemini Scribe** — Open Settings → Gemini Scribe → Provider and choose **OpenAI (cloud)**. This sets the _default_ provider, which every feature uses unless you override it.
+3. **Enter your API key** — In the **OpenAI API key** field, click "Link..." and paste your key (or your placeholder value, for a compatible server). It's stored securely using Obsidian's SecretStorage, the same as the Gemini key.
+4. **Pick models** — Chat, summary, and completions each get their own model dropdown, populated from `GET <OpenAI base URL>/models`. Unlike Ollama, OpenAI has no single-resident-model constraint, so picking a different model per use case costs nothing extra. Click **Refresh OpenAI model list** in Settings → General if a model doesn't show up.
+
+If you're using the real OpenAI API, that's it — the base URL defaults to `https://api.openai.com/v1` and you're done.
+
+## Using an OpenAI-compatible server
+
+Point the **OpenAI base URL** field at your server instead of the default, and the plugin talks to it the same way it talks to OpenAI.
+
+Example with [LM Studio](https://lmstudio.ai/):
+
+1. Start LM Studio's local server (Developer tab → Start Server). By default it listens on `http://localhost:1234/v1`.
+2. In Gemini Scribe, set **OpenAI base URL** to `http://localhost:1234/v1`.
+3. LM Studio doesn't check API keys, but the plugin still requires the **OpenAI API key** field to be non-empty — enter any placeholder value (e.g. `lm-studio`).
+4. Click **Refresh OpenAI model list** to pull in whatever model you have loaded in LM Studio.
+
+The same pattern works for MLX-served endpoints, Ollama's OpenAI-compatible endpoint (`http://localhost:11434/v1`), or any other server that implements the `/v1/chat/completions` and `/v1/models` endpoints.
+
+Requests to a non-`api.openai.com` base URL are not filtered against OpenAI's own non-chat model ids (embeddings, TTS, etc.) — a compatible server's `/models` catalog is taken at face value.
+
+## Models
+
+- **`api.openai.com`** — the model list is enriched with curated metadata (context window, vision support) for current OpenAI models. `gpt-5.6` (chat), `gpt-5.6-terra` (summary), and `gpt-5.6-luna` (completions) are the defaults; older `gpt-5.x` and `gpt-4.x` models remain selectable.
+- **Compatible servers** — an unrecognized model id gets a conservative default: 128k context window, no vision, tool calling assumed. This covers most locally-served models correctly for tool calling, but vision won't be enabled automatically — there's no metadata to detect it from.
+
+## What works
+
+- Agent chat with streaming, tool calling, and conversation memory
+- Drag-and-drop / paste of **image** attachments to vision-capable models (auto-detected for known OpenAI models; off by default for unrecognized/compatible-server models)
+- File summarization, IDE-style completions, selection rewriting
+- Custom prompts, projects, agent skills, scheduled tasks, MCP servers
+- Retry with exponential backoff and streaming responses, identical to the Gemini and Ollama providers
+
+## What does not work
+
+Google Search, Google Maps, URL Context (web fetch), Deep Research, image generation, and the vault search index all depend on Gemini cloud services and are unavailable on OpenAI, same as on Ollama. See the [Provider Capabilities reference](/reference/provider-capabilities) for the full matrix.
+
+OpenAI's Chat Completions API also doesn't return model "thinking" the way Gemini does, so no reasoning is shown when talking to `api.openai.com`. A compatible server that emits a `reasoning_content` field on its responses will have that content shown as thoughts.
+
+## Mixed setup: OpenAI chat, Gemini extras
+
+You don't have to choose all-or-nothing. Under **Settings → Gemini Scribe → Per-feature provider**, each feature can be pointed at a different provider — so you can keep chat on OpenAI (or a local compatible server) while still using Gemini's web search or image generation, exactly as you could with an Ollama-primary setup.
+
+To do that:
+
+1. Set **Provider** to **OpenAI (cloud)** as above.
+2. Open the **Per-feature provider** section and set the features you want in Gemini's cloud — for example **Web and search** and **Image generation** — to **Google Gemini**.
+3. Enter your Gemini **API key** in the field that appears. It's needed by any feature routed to Gemini, even though chat stays on OpenAI.
+
+Nothing moves between providers unless you move it — a feature your default provider can't serve stays off; the plugin never silently substitutes another provider. See [Provider Capabilities](/reference/provider-capabilities) for the full privacy semantics.
+
+## Tips
+
+- **Vision model detection** — Known OpenAI model ids report vision support from a curated metadata table; models from a compatible server default to no vision since the plugin has no way to know the server's capabilities. If your server serves a vision-capable model and attachments aren't working, this is why.
+- **Tool calling** — All current OpenAI models support function calling. Compatible-server models default to "tool calling assumed" — if a model genuinely doesn't support it, tool calls will fail rather than being pre-filtered.
+- **Placeholder API keys** — Required even when your server doesn't check them; the provider won't initialize with an empty key field.
+- **Refreshing the model list** — Click **Refresh OpenAI model list** in Settings → General after changing the base URL, loading a different model in a local server, or whenever a dropdown looks stale.

--- a/docs/reference/advanced-settings.md
+++ b/docs/reference/advanced-settings.md
@@ -59,7 +59,7 @@ Route Gemini requests through Google's newer [Interactions API](https://ai.googl
 
 - **Setting name**: Use Interactions API
 - **Default**: on. Existing installs are migrated to the Interactions API automatically on upgrade — a one-time flip you can reverse by turning the toggle off, which is then respected on future launches.
-- **Scope**: Gemini transport only — the toggle is shown whenever Gemini serves at least one use case (chat, summary, completions, etc.), and hidden only in a fully local, all-Ollama setup.
+- **Scope**: Gemini transport only — the toggle is shown whenever Gemini serves at least one use case (chat, summary, completions, etc.), and hidden when no feature is routed to Gemini (an all-Ollama, all-OpenAI, or mixed Ollama/OpenAI setup).
 - **Privacy**: The plugin runs the Interactions API **statelessly** (`store: false`). Conversation history is replayed with each request, and the plugin does not persist Interactions state on Google's side between turns. (Requests are still sent to Google to generate each response, subject to Google's standard API data-handling terms.)
 - **Status**: Default transport. If you hit problems, turn it off to fall back to the proven `generateContent` path. Responses stream incrementally, including reasoning and tool calls.
 - **Interactions-only models**: Some models (e.g. Gemini Omni Flash Preview, an image-generation model) are only served by the Interactions API — `generateContent` rejects them outright. Requests to these models always use the Interactions API, even when this toggle is off; that includes image generation when an interactions-only model is selected as the image model. Features that still run on `generateContent` (Google Search grounding, web fetch, RAG semantic search) substitute the default chat model if an interactions-only model ever ends up configured as the chat model.
@@ -107,10 +107,11 @@ Configure how the plugin handles API failures:
 
 Model discovery is automatic — no configuration is required. On startup, the plugin fetches the latest available Gemini models from GitHub and caches the result for 24 hours. If the fetch fails, the bundled static model list is used as a fallback.
 
-Both providers expose a **Refresh model list** button in Settings → General:
+Every provider in use exposes its own **Refresh model list** button in Settings → General:
 
 - **Gemini** — bypasses the 24-hour cache and re-fetches the remote model list immediately. You can also trigger this from the command palette with **Gemini Scribe: Refresh model list** (`gemini-scribe:refresh-model-list`). Useful when a newly-published model doesn't appear yet.
 - **Ollama** — re-queries the Ollama daemon for any models you've pulled since the plugin loaded (`ollama pull <name>`). Use this instead of restarting Obsidian.
+- **OpenAI** — re-queries `GET <openaiBaseUrl>/models`. Useful after changing the base URL, or after loading a different model in an OpenAI-compatible local server such as LM Studio.
 
 ## Performance Optimization
 
@@ -176,8 +177,9 @@ In v4.0+, context is manually managed through session-based file selection:
 ### Model List
 
 1. **Use Refresh model list** in Settings → General (or run **Gemini Scribe: Refresh model list** from the command palette) to pick up newly published Gemini models without waiting for the 24-hour cache to expire
-2. **Use Refresh model list** (Ollama provider) after pulling new models with `ollama pull`
-3. **Check your API key** if the model list looks empty or stale
+2. **Use Refresh Ollama model list** after pulling new models with `ollama pull`
+3. **Use Refresh OpenAI model list** after changing the base URL or loading a different model in a compatible server
+4. **Check your API key** if the model list looks empty or stale
 
 ## Troubleshooting
 
@@ -216,7 +218,8 @@ In v4.0+, context is manually managed through session-based file selection:
 **Models not appearing or stale:**
 
 - For Gemini: click **Refresh model list** in Settings → General (or run the **Gemini Scribe: Refresh model list** command) to bypass the 24-hour cache; check API key validity and network connectivity if it still fails
-- For Ollama: click **Refresh model list** in Settings → General after pulling new models
+- For Ollama: click **Refresh Ollama model list** in Settings → General after pulling new models
+- For OpenAI: click **Refresh OpenAI model list** in Settings → General; check the base URL and API key if it still fails
 - If the list still looks wrong after refreshing, restart Obsidian
 
 ## Security Considerations

--- a/docs/reference/provider-capabilities.md
+++ b/docs/reference/provider-capabilities.md
@@ -1,25 +1,28 @@
 # Provider Capabilities
 
-Gemini Scribe can run on the **Google Gemini (cloud)** or **Ollama (local)** provider. You pick a **default provider** in Settings → Gemini Scribe → Provider, and — since per-feature provider selection landed — you can point individual features at a different provider from there. Some features depend on Gemini-specific cloud APIs and are unavailable on Ollama. This page is the single source of truth for what works where; `docs/guide/ollama-setup.md` links here instead of duplicating the table.
+Gemini Scribe can run on the **Google Gemini (cloud)**, **Ollama (local)**, or **OpenAI (cloud)** provider. You pick a **default provider** in Settings → Gemini Scribe → Provider, and — since per-feature provider selection landed — you can point individual features at a different provider from there. Some features depend on Gemini-specific cloud APIs and are unavailable on Ollama and OpenAI. This page is the single source of truth for what works where; `docs/guide/ollama-setup.md` and `docs/guide/openai-setup.md` link here instead of duplicating the table.
 
 ## Capability matrix
 
-| Feature                         | Gemini | Ollama                                                                              |
-| ------------------------------- | :----: | ----------------------------------------------------------------------------------- |
-| Chat                            |   ✓    | ✓                                                                                   |
-| Tool calling (agent mode)       |   ✓    | ✓ (model-dependent)                                                                 |
-| Vision (image attachments)      |   ✓    | ✓ (model-dependent, auto-detected)                                                  |
-| Scheduled tasks                 |   ✓    | ✓ (inherits the model's tool/vision limits)                                         |
-| Summaries                       |   ✓    | ✓                                                                                   |
-| Completions                     |   ✓    | ✓                                                                                   |
-| Rewrite                         |   ✓    | ✓                                                                                   |
-| RAG / Vault Semantic Search     |   ✓    | ✗ — tracked in [#705](https://github.com/allenhutchison/obsidian-gemini/issues/705) |
-| Image generation                |   ✓    | ✗ — tracked in [#706](https://github.com/allenhutchison/obsidian-gemini/issues/706) |
-| Google Search grounding         |   ✓    | ✗                                                                                   |
-| Google Maps grounding           |   ✓    | ✗                                                                                   |
-| URL Context (web fetch tool)    |   ✓    | ✗                                                                                   |
-| Deep Research                   |   ✓    | ✗                                                                                   |
-| PDF / audio / video attachments |   ✓    | ✗ (images only)                                                                     |
+| Feature                         | Gemini | Ollama                                                                              | OpenAI                                           |
+| ------------------------------- | :----: | ----------------------------------------------------------------------------------- | ------------------------------------------------ |
+| Chat                            |   ✓    | ✓                                                                                   | ✓                                                |
+| Tool calling (agent mode)       |   ✓    | ✓ (model-dependent)                                                                 | ✓                                                |
+| Vision (image attachments)      |   ✓    | ✓ (model-dependent, auto-detected)                                                  | ✓ (model-dependent, auto-detected)               |
+| Scheduled tasks                 |   ✓    | ✓ (inherits the model's tool/vision limits)                                         | ✓ (inherits the model's tool/vision limits)      |
+| Summaries                       |   ✓    | ✓                                                                                   | ✓                                                |
+| Completions                     |   ✓    | ✓                                                                                   | ✓                                                |
+| Rewrite                         |   ✓    | ✓                                                                                   | ✓                                                |
+| RAG / Vault Semantic Search     |   ✓    | ✗ — tracked in [#705](https://github.com/allenhutchison/obsidian-gemini/issues/705) | ✗                                                |
+| Image generation                |   ✓    | ✗ — tracked in [#706](https://github.com/allenhutchison/obsidian-gemini/issues/706) | ✗                                                |
+| Google Search grounding         |   ✓    | ✗                                                                                   | ✗                                                |
+| Google Maps grounding           |   ✓    | ✗                                                                                   | ✗                                                |
+| URL Context (web fetch tool)    |   ✓    | ✗                                                                                   | ✗                                                |
+| Deep Research                   |   ✓    | ✗                                                                                   | ✗                                                |
+| PDF / audio / video attachments |   ✓    | ✗ (images only)                                                                     | ✗ (images only)                                  |
+| Custom base URL                 |   ✓    | ✗ (uses its own `ollamaBaseUrl` setting)                                            | ✓ (also targets OpenAI-compatible local servers) |
+
+OpenAI's row covers both the real `api.openai.com` endpoint (billed with your own OpenAI API key) and any OpenAI-compatible server reachable at a custom base URL — LM Studio, an MLX-served endpoint, Ollama's own OpenAI-compatible endpoint, and similar. See the [OpenAI Setup Guide](/guide/openai-setup) for both paths. This is API-key billing only — there is no "Sign in with ChatGPT" / ChatGPT-subscription auth.
 
 ## Per-feature provider selection
 
@@ -35,9 +38,9 @@ Under **Settings → Gemini Scribe → Per-feature provider**, each of these can
 | Vault search index | Semantic search across your vault (RAG)                                  |
 | Image generation   | Generating images from a prompt                                          |
 
-Every row defaults to **Default (\<your provider\>)**. A dropdown only lists providers that actually support that feature, so the Image generation and Vault search index rows offer Gemini only — they're shown disabled when your default provider is the only candidate, which makes the capability gap visible rather than silently missing.
+Every row defaults to **Default (\<your provider\>)**. A dropdown only lists providers that actually support that feature, so the Image generation and Vault search index rows offer Gemini only — they're shown disabled when your default provider is the only candidate, which makes the capability gap visible rather than silently missing. Chat and agent, Summaries, Completions, and Rewrite each list Gemini, Ollama, and OpenAI.
 
-This is what makes a mixed setup work: run chat locally on Ollama for privacy and speed, but keep Gemini for web search and image generation. The cloud-only tools each make their own call to Google's API rather than riding on the chat request, so they work regardless of which provider serves chat — they only need a Gemini API key.
+This is what makes a mixed setup work: run chat locally on Ollama for privacy and speed, but keep Gemini for web search and image generation — or run chat on OpenAI (or an OpenAI-compatible server) while keeping Gemini for the cloud-only tools. The cloud-only tools each make their own call to Google's API rather than riding on the chat request, so they work regardless of which provider serves chat — they only need a Gemini API key.
 
 ### Privacy semantics
 
@@ -46,27 +49,29 @@ This is what makes a mixed setup work: run chat locally on Ollama for privacy an
 Consequences worth knowing:
 
 - Choosing Gemini for a feature means **that feature's requests — including any note content they send — go to Google.** The settings UI shows a "Some features use a different provider" notice listing exactly which ones whenever this is the case.
+- Choosing OpenAI for a feature means that feature's requests go to `api.openai.com` (or whatever base URL you've configured) instead.
 - **Vault search index** is the broadest of these: enabling it uploads note content to a cloud file-search store, not just the text of a single request.
-- The **API key** field appears whenever _any_ feature is routed to Gemini, not only when Gemini is your default.
-- With every feature on Ollama and every selected model pulled locally, the settings show the "Local-only feature notice" and nothing leaves your machine.
+- The **API key** field appears whenever _any_ feature is routed to Gemini, not only when Gemini is your default; the same is true of the **OpenAI API key** field for OpenAI.
+- With every feature on Ollama and every selected model pulled locally, the settings show the "Local-only feature notice" and nothing leaves your machine. Pointing the OpenAI provider's base URL at a local OpenAI-compatible server (LM Studio, MLX, ...) achieves the same thing for OpenAI-routed features — the request never leaves your machine even though the provider is "OpenAI".
 - Ollama can also serve **cloud-hosted models** (`gpt-oss:120b-cloud`, `deepseek-v4-pro:cloud`, …), which reach the daemon like local ones but run on ollama.com. Selecting one for any Ollama-served feature replaces the local-only reassurance with a "Cloud-hosted model notice" naming the model and host — provider alone no longer implies on-device execution. Detection uses the `remote_host` field Ollama reports for these entries, not the model name. See [Cloud models](/guide/ollama-setup#cloud-models).
 
 ### Models
 
 Each model dropdown lists the models of the provider serving that feature, so a chat-on-Ollama / summaries-on-Gemini setup offers the right models in each row.
 
-Ollama keeps one model resident at a time, so its summary and completions pickers default to **Same as chat model**. Choosing a distinct model there is supported but means Ollama reloads a model on every switch — worth it for a small, fast completions model, rarely worth it otherwise.
+Ollama keeps one model resident at a time, so its summary and completions pickers default to **Same as chat model**. Choosing a distinct model there is supported but means Ollama reloads a model on every switch — worth it for a small, fast completions model, rarely worth it otherwise. OpenAI has no such constraint: each use case gets its own default model (currently `gpt-5.6` for chat, `gpt-5.6-terra` for summaries, `gpt-5.6-luna` for completions) and switching between them costs nothing extra.
 
 ## Notes
 
-- **Tool calling** — Whether an Ollama model can call tools depends on the model itself; most modern instruct models (Llama 3.2, Qwen 2.5, Mistral 0.3, …) support it, smaller or older models may not.
-- **Vision** — Ollama vision support is auto-detected per model from its `/api/show` capabilities (with a template/name-hint fallback for older Ollama versions) — no manual configuration is needed when you pull a new multimodal model.
-- **Model discovery** — The Ollama picker is built from the daemon's `/api/tags`, which lists locally pulled models only. A cloud model must be pulled before it appears, even if you already use it from the Ollama app or CLI. The cloud tag takes one of two forms depending on whether the model carries a size tag — `ollama pull gpt-oss:120b-cloud` but `ollama pull glm-5.2:cloud`; see [Cloud models](/guide/ollama-setup#cloud-models) for the exact syntax per model.
+- **Tool calling** — Whether an Ollama model can call tools depends on the model itself; most modern instruct models (Llama 3.2, Qwen 2.5, Mistral 0.3, …) support it, smaller or older models may not. OpenAI's current models all support tool calling.
+- **Vision** — Ollama vision support is auto-detected per model from its `/api/show` capabilities (with a template/name-hint fallback for older Ollama versions) — no manual configuration is needed when you pull a new multimodal model. OpenAI vision support is auto-detected from a curated metadata map for known OpenAI model ids; an unrecognized model id (typically one served by an OpenAI-compatible server) defaults to no vision.
+- **Model discovery** — The Ollama picker is built from the daemon's `/api/tags`, which lists locally pulled models only. A cloud model must be pulled before it appears, even if you already use it from the Ollama app or CLI. The cloud tag takes one of two forms depending on whether the model carries a size tag — `ollama pull gpt-oss:120b-cloud` but `ollama pull glm-5.2:cloud`; see [Cloud models](/guide/ollama-setup#cloud-models) for the exact syntax per model. The OpenAI picker is built from `GET <openaiBaseUrl>/models`, enriched with curated metadata (context window, vision support) for current OpenAI models; unrecognized ids — including everything from a compatible server — get a conservative default (128k context, no vision, tool calling assumed). Click **Refresh OpenAI model list** after a compatible server's catalog changes.
 - **RAG, image generation, Google Search, Google Maps, URL Context, and Deep Research** all call Google's cloud APIs directly and require a Gemini API key. Their agent tools are only registered when the corresponding feature is routed to a provider that supports them; RAG's indexing service isn't initialized otherwise. What stays visible either way is the command palette and settings UI: the **Generate image** command, the RAG **Pause/Resume/Show status** commands, and the **Vault search index** settings toggle remain in place, but invoking one while its feature has no provider shows a notice pointing at the Per-feature provider settings rather than failing the call.
-- **Scheduled tasks** run through the same chat/tool-calling path as interactive agent sessions, so a task that needs vision or tool calling on Ollama is still bound by that model's capabilities.
-- **Context limits and token counting** follow the model in hand, not a global setting — a Gemini model is counted through Google's `countTokens` endpoint against a 1M-token window, while a local model uses a calibrated chars-per-token estimate. In a mixed setup both apply, each to its own model.
+- **Scheduled tasks** run through the same chat/tool-calling path as interactive agent sessions, so a task that needs vision or tool calling on Ollama or OpenAI is still bound by that model's capabilities.
+- **Context limits and token counting** follow the model in hand, not a global setting — a Gemini model is counted through Google's `countTokens` endpoint against a 1M-token window, while a local or OpenAI model uses a calibrated chars-per-token estimate. In a mixed setup each applies to its own model.
 - **Ollama context window** — Resolved per model from the daemon rather than assumed: the runtime allocation from `/api/ps` when the model is loaded, the model's advertised maximum from `/api/show` before that, and a conservative 32k fallback only when the daemon is unreachable. This matters because Ollama's own default window is VRAM-derived (4k under 24 GiB) and often a small fraction of what the model supports — see [Set the context window first](/guide/ollama-setup#set-the-context-window-first).
+- **OpenAI reasoning** — the Chat Completions API doesn't return model "thinking" the way Gemini and Ollama can, so no reasoning is shown for `api.openai.com`. A compatible server that emits a `reasoning_content` field on its responses will have that content shown as thoughts, same as the other providers.
 
 Changing the default provider or any per-feature provider takes effect immediately — no data is lost, and each provider's model choices persist across changes.
 
-See the [Ollama Setup Guide](/guide/ollama-setup) for installation steps and local-model tips.
+See the [Ollama Setup Guide](/guide/ollama-setup) and the [OpenAI Setup Guide](/guide/openai-setup) for installation/configuration steps and provider-specific tips.

--- a/docs/reference/provider-capabilities.md
+++ b/docs/reference/provider-capabilities.md
@@ -7,7 +7,7 @@ Gemini Scribe can run on the **Google Gemini (cloud)**, **Ollama (local)**, or *
 | Feature                         | Gemini | Ollama                                                                              | OpenAI                                           |
 | ------------------------------- | :----: | ----------------------------------------------------------------------------------- | ------------------------------------------------ |
 | Chat                            |   ✓    | ✓                                                                                   | ✓                                                |
-| Tool calling (agent mode)       |   ✓    | ✓ (model-dependent)                                                                 | ✓                                                |
+| Tool calling (agent mode)       |   ✓    | ✓ (model-dependent)                                                                 | ✓ (model-dependent on compatible servers)        |
 | Vision (image attachments)      |   ✓    | ✓ (model-dependent, auto-detected)                                                  | ✓ (model-dependent, auto-detected)               |
 | Scheduled tasks                 |   ✓    | ✓ (inherits the model's tool/vision limits)                                         | ✓ (inherits the model's tool/vision limits)      |
 | Summaries                       |   ✓    | ✓                                                                                   | ✓                                                |

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -33,21 +33,21 @@ UI sections without a dedicated topic in this reference: _Vault search index_ (c
 ### Provider
 
 - **Setting**: `provider`
-- **Type**: `'gemini' | 'ollama'`
+- **Type**: `'gemini' | 'ollama' | 'openai'`
 - **Default**: `'gemini'`
-- **Description**: The **default** model backend, used by every feature without an explicit override (see [Per-feature provider](#per-feature-provider)). `gemini` calls the Google Cloud API; `ollama` calls a local Ollama daemon.
-- **Notes**: Changing the provider re-initialises the plugin. Model selections persist across the change — the Gemini fields (`chatModelName`, `summaryModelName`, `completionsModelName`, `imageModelName`) and the Ollama fields (`ollamaModelName`, `ollamaSummaryModelName`, `ollamaCompletionsModelName`) are stored separately, so returning to a provider restores the model you had there; a value is only reset if it's actually stale for its own provider (e.g. a deprecated Gemini model id), never merely because you switched providers. Cloud-only features (Google Search, URL Context, Deep Research, image generation, RAG indexing) are off when `ollama` is the default — unless you route them to Gemini individually. See the [Ollama Setup Guide](/guide/ollama-setup) for details.
+- **Description**: The **default** model backend, used by every feature without an explicit override (see [Per-feature provider](#per-feature-provider)). `gemini` calls the Google Cloud API; `ollama` calls a local Ollama daemon; `openai` calls the OpenAI Chat Completions API (or a compatible server at a custom base URL).
+- **Notes**: Changing the provider re-initialises the plugin. Model selections persist across the change — the Gemini fields (`chatModelName`, `summaryModelName`, `completionsModelName`, `imageModelName`), the Ollama fields (`ollamaModelName`, `ollamaSummaryModelName`, `ollamaCompletionsModelName`), and the OpenAI fields (`openaiModelName`, `openaiSummaryModelName`, `openaiCompletionsModelName`) are each stored separately, so returning to a provider restores the model you had there; a value is only reset if it's actually stale for its own provider (e.g. a deprecated Gemini model id), never merely because you switched providers. Cloud-only features (Google Search, URL Context, Deep Research, image generation, RAG indexing) are off when `ollama` or `openai` is the default — unless you route them to Gemini individually. See the [Ollama Setup Guide](/guide/ollama-setup) and [OpenAI Setup Guide](/guide/openai-setup) for details.
 
 ### Per-feature provider
 
 - **Setting**: `providerOverrides`
-- **Type**: `Partial<Record<'chat' | 'summary' | 'completions' | 'rewrite' | 'webSearch' | 'rag' | 'imageGen', 'gemini' | 'ollama'>>`
+- **Type**: `Partial<Record<'chat' | 'summary' | 'completions' | 'rewrite' | 'webSearch' | 'rag' | 'imageGen', 'gemini' | 'ollama' | 'openai'>>`
 - **Default**: `{}` (every feature uses [`provider`](#provider))
-- **Description**: Routes individual features to a provider other than the default. Each settings row lists only the providers that support that feature, so e.g. Image generation offers Gemini only. This is what enables a mixed setup — chat on a local model, web search and image generation on Gemini.
+- **Description**: Routes individual features to a provider other than the default. Each settings row lists only the providers that support that feature, so e.g. Image generation offers Gemini only, while Chat/Summaries/Completions/Rewrite offer all three. This is what enables a mixed setup — chat on a local Ollama or OpenAI-compatible model, web search and image generation on Gemini.
 - **Notes**:
   - **A feature is never routed to the cloud on your behalf.** If the resolved provider can't serve a feature, that feature stays off; the plugin does not substitute a different one. Enabling a cloud feature is always an explicit choice.
-  - Choosing Gemini for a feature means that feature's requests — including note content — go to Google. The settings UI names the affected features whenever this is the case.
-  - The API key field is shown whenever _any_ feature is routed to Gemini, not just when Gemini is the default.
+  - Choosing Gemini for a feature means that feature's requests — including note content — go to Google. Choosing OpenAI means they go to your configured OpenAI base URL. The settings UI names the affected features whenever this is the case.
+  - The API key field is shown whenever _any_ feature is routed to Gemini, not just when Gemini is the default; the OpenAI API key field works the same way for OpenAI.
   - Changing any override re-initialises the plugin, since tool registration, RAG, and image generation all key off the resolved providers.
   - Unknown keys or provider ids in a hand-edited `data.json` are dropped on load.
 - **Full capability matrix**: [Provider Capabilities](/reference/provider-capabilities)
@@ -60,14 +60,31 @@ UI sections without a dedicated topic in this reference: _Vault search index_ (c
 - **Required when any feature uses `ollama`**: Yes
 - **Description**: HTTP endpoint of your Ollama daemon. Update if Ollama runs on a different host or port.
 
+### OpenAI base URL
+
+- **Setting**: `openaiBaseUrl`
+- **Type**: String
+- **Default**: `https://api.openai.com/v1`
+- **Required when any feature uses `openai`**: Yes (falls back to the default if cleared)
+- **Description**: Endpoint OpenAI Chat Completions requests are sent to. Point this at an OpenAI-compatible local server instead — LM Studio, MLX, Ollama's OpenAI-compatible endpoint, etc. — to keep requests on your machine. See the [OpenAI Setup Guide](/guide/openai-setup#using-an-openai-compatible-server).
+
 ### API Key
 
 - **Type**: String
-- **Required**: Yes, whenever any feature is routed to `gemini` — including a single [per-feature override](#per-feature-provider) under an `ollama` default. Not needed for an all-Ollama setup.
+- **Required**: Yes, whenever any feature is routed to `gemini` — including a single [per-feature override](#per-feature-provider) under an `ollama` or `openai` default. Not needed for an all-Ollama setup.
 - **Storage**: Stored securely using Obsidian's SecretStorage API (not saved in `data.json`)
 - **Description**: Your Google AI API key for accessing Gemini models
 - **How to obtain**: Visit [Google AI Studio](https://aistudio.google.com/apikey)
 - **Migration**: If upgrading from a previous version, your API key is automatically migrated from `data.json` to secure storage on first load
+
+### OpenAI API key
+
+- **Setting**: `openaiApiKeySecretName`
+- **Type**: String (SecretStorage key name; the key value itself is never in `data.json`)
+- **Default**: `""` (unset)
+- **Required**: Yes, whenever any feature is routed to `openai` — including a single per-feature override under a different default. For a local compatible server that doesn't validate keys, any placeholder value satisfies this requirement.
+- **Storage**: Stored securely using Obsidian's SecretStorage API, mirroring `apiKeySecretName` for Gemini
+- **How to obtain**: Visit [platform.openai.com/api-keys](https://platform.openai.com/api-keys)
 
 ### Your name
 
@@ -113,12 +130,13 @@ UI sections without a dedicated topic in this reference: _Vault search index_ (c
 
 ## Model Configuration
 
-Each model picker is filtered to the models of the provider serving **its own** feature, so a chat-on-Ollama / summaries-on-Gemini setup offers the right models in each row. Both providers' lists are loaded whenever both are in use.
+Each model picker is filtered to the models of the provider serving **its own** feature, so a chat-on-Ollama / summaries-on-Gemini setup offers the right models in each row. Every provider in use has its list loaded independently.
 
 - **Gemini** — models are loaded from the bundled list and auto-refreshed from GitHub on startup (cached for 24h). Click **Refresh model list** in Settings → General — or run the **Gemini Scribe: Refresh model list** command — to fetch the latest list immediately (bypasses the cache). `imageModelName` is Gemini-only.
 - **Ollama** — dropdowns are populated from `GET <ollamaBaseUrl>/api/tags`, listing whatever you have pulled. Click **Refresh Ollama model list** if a freshly pulled model doesn't appear. Ollama keeps only one model resident at a time, so its summary and completions pickers default to **Same as chat model** (`''`) — picking a distinct model there is supported but costs a model reload on every switch.
+- **OpenAI** — dropdowns are populated from `GET <openaiBaseUrl>/models`, enriched with curated metadata (context window, vision support) for current `api.openai.com` models; unrecognized ids (typically from a compatible server) get conservative defaults. Click **Refresh OpenAI model list** if a model doesn't appear. Unlike Ollama, OpenAI has no single-resident-model constraint, so chat, summary, and completions each default to their own model rather than inheriting the chat model.
 
-Because each provider uses its own settings fields, re-routing a feature between providers preserves both choices — returning to Gemini restores the exact model you had.
+Because each provider uses its own settings fields, re-routing a feature between providers preserves every provider's choice — returning to a provider restores the exact model you had.
 
 ### Chat model
 
@@ -178,6 +196,14 @@ Because each provider uses its own settings fields, re-routing a feature between
 - **Default**: `''` — **Same as chat model**
 - **Only shown when**: That feature is served by `ollama`
 - **Description**: Optional per-feature Ollama models. Ollama keeps one model resident at a time, so the default inherits `ollamaModelName` and avoids a reload on every call; set one only when the swap is worth it (a small, fast completions model is the usual case). A value naming a model the daemon no longer serves is reset to `''` rather than to another model, so the feature falls back to the chat model instead of silently switching.
+
+### OpenAI chat / summary / completions models
+
+- **Settings**: `openaiModelName`, `openaiSummaryModelName`, `openaiCompletionsModelName`
+- **Type**: String
+- **Default**: `'gpt-5.6'`, `'gpt-5.6-terra'`, `'gpt-5.6-luna'` respectively
+- **Only shown when**: That feature is served by `openai`
+- **Description**: The OpenAI model used for each use case. Unlike Ollama, OpenAI has no single-resident-model constraint, so each use case keeps its own model rather than defaulting to "inherit the chat model." Populated from `GET <openaiBaseUrl>/models`.
 
 ## Custom Prompts
 
@@ -331,7 +357,7 @@ Advanced settings for developers and power users. Access by clicking "Show advan
 - **Setting**: `useInteractionsApi`
 - **Type**: Boolean
 - **Default**: `true`
-- **Only applies when**: Gemini serves at least one use case (the toggle is hidden in an all-Ollama setup, shown whenever chat, summary, or any other feature is routed to Gemini)
+- **Only applies when**: Gemini serves at least one use case (the toggle is hidden when no feature is routed to Gemini — e.g. an all-Ollama or all-OpenAI setup — and shown whenever chat, summary, or any other feature is routed to Gemini)
 - **Description**: Routes Gemini requests through Google's GA [Interactions API](https://ai.google.dev/gemini-api/docs/interactions) (`interactions.create`) instead of the legacy `generateContent` API. This is now the default transport; existing installs are migrated to it automatically (a one-time flip you can reverse by turning the toggle off).
 - **Privacy**: Runs statelessly (`store: false`) — conversation history is replayed with each request, and the plugin does not persist Interactions state on Google's side between turns. (Requests are still sent to Google to generate each response, subject to Google's standard API data-handling terms.)
 - **Status**: Default-on. Responses stream incrementally (text, reasoning, and tool calls); turn it off to fall back to the legacy `generateContent` path if you hit issues.
@@ -343,7 +369,7 @@ Advanced settings for developers and power users. Access by clicking "Show advan
 - **Setting**: `customBaseUrl`
 - **Type**: String
 - **Default**: `""` (empty)
-- **Only applies when**: Gemini serves at least one use case (Ollama has its own `ollamaBaseUrl` setting and ignores this value; the field is hidden in an all-Ollama setup)
+- **Only applies when**: Gemini serves at least one use case (Ollama has its own `ollamaBaseUrl` setting and OpenAI has its own `openaiBaseUrl` setting; both ignore this value, and the field is hidden when no feature is routed to Gemini)
 - **Description**: Overrides the default Google API base URL for all SDK calls. Use this to route requests through a corporate proxy, local gateway, or regional mirror.
 - **Example**: `https://my-proxy.example.com`
 - **Scope**: Applies to every Google API call site in the plugin (chat, streaming, image generation, web fetch, Google Search/Maps grounding, RAG indexing, deep research, context management).
@@ -393,7 +419,7 @@ Advanced settings for developers and power users. Access by clicking "Show advan
 
 Model discovery is automatic — no user-configurable settings are required. On startup, the plugin fetches the latest available Gemini models from GitHub and falls back to the bundled list if the fetch fails. The remote list is cached in `data.json` under `remoteModelCache` for 24 hours; subsequent reloads within that window are no-ops.
 
-To pick up a newly-published model without waiting for the cache to expire, click **Refresh model list** in Settings → General, or run the **Gemini Scribe: Refresh model list** command (`gemini-scribe:refresh-model-list`). Both honor the same skip conditions as the auto-fetch — they no-op when no feature is routed to Gemini or the host reports offline, and surface the outcome via a `Notice`. When any feature uses Ollama, a separate **Refresh Ollama model list** row re-queries the daemon for newly pulled models; in a mixed setup both rows are shown.
+To pick up a newly-published model without waiting for the cache to expire, click **Refresh model list** in Settings → General, or run the **Gemini Scribe: Refresh model list** command (`gemini-scribe:refresh-model-list`). Both honor the same skip conditions as the auto-fetch — they no-op when no feature is routed to Gemini or the host reports offline, and surface the outcome via a `Notice`. When any feature uses Ollama, a separate **Refresh Ollama model list** row re-queries the daemon for newly pulled models; when any feature uses OpenAI, a **Refresh OpenAI model list** row re-queries `GET <openaiBaseUrl>/models`. In a mixed setup, only the rows for providers actually in use are shown.
 
 When Google retires a model (the API starts returning 404 "no longer available" — e.g. `gemini-3-pro-preview` in July 2026), it is removed from the catalog and any settings still pointing at it are migrated automatically on the next reload: to the retired model's designated successor when one exists (`gemini-3-pro-preview` → `gemini-3.1-pro-preview`), otherwise to the default model for that role.
 
@@ -552,7 +578,8 @@ Available permission bypasses:
 1. Check API key is valid
 2. For Gemini: click **Refresh** in the **Refresh model list** row (Settings → General), or run the **Gemini Scribe: Refresh model list** command. The auto-fetch runs at most once every 24 hours, so a freshly published model won't appear until the cache expires unless you force a refresh.
 3. For Ollama: go to Settings → General and click **Refresh** in the **Refresh Ollama model list** row after pulling new models
-4. Check console for errors (with Debug mode enabled)
+4. For OpenAI: go to Settings → General and click **Refresh** in the **Refresh OpenAI model list** row — useful after changing the base URL or loading a different model in a compatible server
+5. Check console for errors (with Debug mode enabled)
 
 ### Tool execution issues
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
 				"@codemirror/merge": "^6.12.2",
 				"@types/turndown": "^5.0.6",
 				"ollama": "^0.6.3",
+				"openai": "^7.3.0",
 				"turndown": "^7.2.4"
 			},
 			"devDependencies": {
@@ -36,7 +37,7 @@
 				"knip": "^6.29.0",
 				"lint-staged": "^17.2.0",
 				"madge": "^8.0.0",
-				"obsidian": "*",
+				"obsidian": "latest",
 				"prettier": "^3.9.6",
 				"tslib": "2.8.1",
 				"typescript": "^6.0.3",
@@ -10332,6 +10333,39 @@
 				"emoji-regex-xs": "^1.0.0",
 				"regex": "^6.0.1",
 				"regex-recursion": "^6.0.2"
+			}
+		},
+		"node_modules/openai": {
+			"version": "7.3.0",
+			"resolved": "https://registry.npmjs.org/openai/-/openai-7.3.0.tgz",
+			"integrity": "sha512-FLnIAkDEP3grs+BSDpqxEWVR37yG97/hs95lajF8SnHuA5nqtssh0uJVXbPhODNEoZqar+nEd+fIeGJgwoLUmg==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=22.0.0"
+			},
+			"peerDependencies": {
+				"@aws-sdk/credential-provider-node": ">=3.972.0 <4",
+				"@smithy/hash-node": ">=4.3.0 <5",
+				"@smithy/signature-v4": ">=5.4.0 <6",
+				"ws": "^8.18.0",
+				"zod": "^3.25 || ^4.0"
+			},
+			"peerDependenciesMeta": {
+				"@aws-sdk/credential-provider-node": {
+					"optional": true
+				},
+				"@smithy/hash-node": {
+					"optional": true
+				},
+				"@smithy/signature-v4": {
+					"optional": true
+				},
+				"ws": {
+					"optional": true
+				},
+				"zod": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/optionator": {

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
 		"@codemirror/merge": "^6.12.2",
 		"@types/turndown": "^5.0.6",
 		"ollama": "^0.6.3",
+		"openai": "^7.3.0",
 		"turndown": "^7.2.4"
 	},
 	"lint-staged": {

--- a/src/api/factory.ts
+++ b/src/api/factory.ts
@@ -11,10 +11,12 @@ import { GeminiClient } from './providers/gemini/client';
 import type { GeminiClientConfig } from './providers/gemini/config';
 import { OllamaClient } from './providers/ollama/client';
 import type { OllamaClientConfig } from './providers/ollama/config';
+import { OpenAIClient } from './providers/openai/client';
+import { DEFAULT_OPENAI_BASE_URL, type OpenAIClientConfig } from './providers/openai/config';
 import { ModelApi } from './interfaces/model-api';
 import { GeminiPrompts } from '../prompts';
 import { RetryDecorator } from './retry-decorator';
-import { getDefaultModelForRole, getOllamaModelForRole } from '../models';
+import { getDefaultModelForRole, getOllamaModelForRole, getOpenAIModelForRole } from '../models';
 import type { ObsidianGemini } from '../types/plugin';
 import { ModelUseCase } from './model-use-case';
 import { resolveProviderOrDefault } from './provider-routing';
@@ -57,7 +59,7 @@ export class ModelClientFactory {
 	static createFromPlugin(
 		plugin: ObsidianGemini,
 		useCase: ModelUseCase,
-		overrides?: Partial<GeminiClientConfig> & Partial<OllamaClientConfig>
+		overrides?: Partial<GeminiClientConfig> & Partial<OllamaClientConfig> & Partial<OpenAIClientConfig>
 	): ModelApi {
 		const settings = plugin.settings;
 		// Every ModelUseCase maps to a use case that all providers support, so the
@@ -84,6 +86,20 @@ export class ModelClientFactory {
 				...overrides,
 			};
 			const client = new OllamaClient(config, prompts, plugin);
+			return new RetryDecorator(client, retryConfig, plugin.logger);
+		}
+
+		if (provider === 'openai') {
+			const config: OpenAIClientConfig = {
+				apiKey: plugin.openaiApiKey,
+				baseUrl: settings.openaiBaseUrl || DEFAULT_OPENAI_BASE_URL,
+				model: modelName,
+				temperature: settings.temperature ?? 0.7,
+				topP: settings.topP ?? 1,
+				streamingEnabled: settings.streamingEnabled ?? true,
+				...overrides,
+			};
+			const client = new OpenAIClient(config, prompts, plugin);
 			return new RetryDecorator(client, retryConfig, plugin.logger);
 		}
 
@@ -124,6 +140,10 @@ export class ModelClientFactory {
 			// Ollama keeps one model resident, so the per-use-case fields default
 			// to inheriting the chat model rather than forcing a swap (#1077).
 			return getOllamaModelForRole(settings, role);
+		}
+
+		if (provider === 'openai') {
+			return getOpenAIModelForRole(settings, role);
 		}
 
 		const configured =

--- a/src/api/providers/openai/client.ts
+++ b/src/api/providers/openai/client.ts
@@ -262,9 +262,10 @@ export class OpenAIClient implements ModelApi {
 		// tool-role messages. `pendingCallIds` pairs functionCall parts with their
 		// functionResponse parts across adjacent Contents — see convertHistoryEntry.
 		const pendingCallIds = new Map<string, string[]>();
+		const declaredCallIds = new Set<string>();
 		let toolCallSeq = 0;
 		for (const entry of request.conversationHistory ?? []) {
-			const converted = this.convertHistoryEntry(entry, pendingCallIds, () => toolCallSeq++);
+			const converted = this.convertHistoryEntry(entry, pendingCallIds, declaredCallIds, () => toolCallSeq++);
 			if (converted) messages.push(...converted);
 		}
 
@@ -326,10 +327,16 @@ export class OpenAIClient implements ModelApi {
 	 * `id` pops the oldest pending id for its name so `tool_call_id` on the
 	 * resulting `tool` message lines up with the `id` on the assistant message's
 	 * `tool_calls` entry — mirroring Gemini's positional call/response pairing.
+	 *
+	 * `declaredCallIds` records every id emitted on an assistant `tool_calls`
+	 * entry. A `tool` message whose id was never declared (its functionCall was
+	 * trimmed away by history compaction) is dropped rather than emitted — the
+	 * Chat Completions API rejects the whole request otherwise.
 	 */
 	private convertHistoryEntry(
 		entry: unknown,
 		pendingCallIds: Map<string, string[]>,
+		declaredCallIds: Set<string>,
 		nextSeq: () => number
 	): ChatMessage[] | null {
 		if (!entry || typeof entry !== 'object') return null;
@@ -380,30 +387,43 @@ export class OpenAIClient implements ModelApi {
 
 			const out: ChatMessage[] = [];
 
-			// Tool responses become tool-role messages. Don't coalesce `null` to
-			// `{}` — an explicit null response carries different meaning ("no
-			// result") than an empty object, and JSON.stringify(null) === "null"
-			// is the correct serialization to preserve that.
-			for (const tr of toolResponseParts) {
-				const responseText = typeof tr.response === 'string' ? tr.response : JSON.stringify(tr.response);
-				out.push({ role: 'tool', tool_call_id: tr.id, content: responseText });
-			}
-
-			// Assistant turn (text + tool calls together)
+			// Assistant turn first (text + tool calls together): the API requires
+			// the assistant message declaring `tool_calls` to precede the tool-role
+			// messages that answer it.
 			if (role === 'assistant' && (textChunks.length || toolCallParts.length)) {
 				const message: OpenAI.ChatCompletionAssistantMessageParam = {
 					role: 'assistant',
 					content: textChunks.join('\n').trim() || null,
 				};
 				if (toolCallParts.length) {
-					message.tool_calls = toolCallParts.map((tc) => ({
-						id: tc.id,
-						type: 'function' as const,
-						function: { name: tc.name, arguments: JSON.stringify(tc.arguments) },
-					}));
+					message.tool_calls = toolCallParts.map((tc) => {
+						declaredCallIds.add(tc.id);
+						return {
+							id: tc.id,
+							type: 'function' as const,
+							function: { name: tc.name, arguments: JSON.stringify(tc.arguments) },
+						};
+					});
 				}
 				out.push(message);
-			} else if (role !== 'assistant' && (textChunks.length || imageParts.length)) {
+			}
+
+			// Tool responses become tool-role messages. Don't coalesce `null` to
+			// `{}` — an explicit null response carries different meaning ("no
+			// result") than an empty object, and JSON.stringify(null) === "null"
+			// is the correct serialization to preserve that. Responses whose call
+			// was never declared (trimmed by compaction) are dropped — the API
+			// rejects a `tool` message with an unknown `tool_call_id`.
+			for (const tr of toolResponseParts) {
+				if (!declaredCallIds.has(tr.id)) {
+					this.plugin?.logger?.log('OpenAI history: dropping orphaned tool response', tr.id);
+					continue;
+				}
+				const responseText = typeof tr.response === 'string' ? tr.response : JSON.stringify(tr.response);
+				out.push({ role: 'tool', tool_call_id: tr.id, content: responseText });
+			}
+
+			if (role !== 'assistant' && (textChunks.length || imageParts.length)) {
 				const text = textChunks.join('\n\n').trim();
 				if (role === 'user' && imageParts.length) {
 					const content: (TextContentPart | ImageContentPart)[] = [];

--- a/src/api/providers/openai/client.ts
+++ b/src/api/providers/openai/client.ts
@@ -1,0 +1,555 @@
+/**
+ * OpenAI API implementation of the ModelApi interface.
+ *
+ * Targets the Chat Completions endpoint (`/v1/chat/completions`) via the
+ * official `openai` npm SDK rather than the newer Responses API, so this
+ * client also works unmodified against OpenAI-compatible local servers
+ * (LM Studio, MLX, Ollama's OpenAI-compatible endpoint) that only implement
+ * Chat Completions. The SDK is constructed with `maxRetries: 0` because the
+ * plugin already wraps every client in its own `RetryDecorator`.
+ *
+ * Phase 1 scope:
+ *  - chat + tool calling for ExtendedModelRequest
+ *  - one-shot chat completion for BaseModelRequest (summary / completions / rewrite)
+ *  - streaming chat with cancellation via AbortController
+ *  - image attachments as `image_url` content parts (vision-capable models only)
+ *  - usageMetadata derived from `usage.prompt_tokens` / `usage.completion_tokens`
+ *  - `reasoning_content` -> thoughts, for OpenAI-compatible servers that return
+ *    it (not part of the official OpenAI API surface; read via a narrow local
+ *    type rather than widening the SDK's own types)
+ *
+ * Out of scope (no Chat Completions equivalent, or deferred to a later phase):
+ *  - cachedContentTokenCount (not exposed on CompletionUsage)
+ *  - search grounding / rendered HTML (Gemini-only)
+ *  - thoughtSignature / thought part fields (Gemini's thinking-mode replay markers)
+ *  - non-image inline attachments (audio/video/pdf) — this client only supports
+ *    image vision input, matching the OpenAI-compatible servers it targets
+ */
+
+import OpenAI from 'openai';
+import {
+	ModelApi,
+	BaseModelRequest,
+	ExtendedModelRequest,
+	ModelResponse,
+	ToolCall,
+	ToolDefinition,
+	StreamCallback,
+	StreamingModelResponse,
+	InlineDataPart,
+	isExtendedRequest,
+} from '../../interfaces/model-api';
+import { GeminiPrompts } from '../../../prompts';
+import type { ObsidianGemini } from '../../../types/plugin';
+import type { OpenAIClientConfig } from './config';
+import { getLegacyEntryText } from '../../../utils/history-normalize';
+
+type ChatMessage = OpenAI.ChatCompletionMessageParam;
+type ChatTool = OpenAI.ChatCompletionTool;
+type ImageContentPart = OpenAI.ChatCompletionContentPartImage;
+type TextContentPart = OpenAI.ChatCompletionContentPartText;
+
+/**
+ * Some OpenAI-compatible servers (e.g. reasoning-capable local models served
+ * through LM Studio/Ollama) return a non-standard `reasoning_content` field
+ * on the assistant message / streaming delta. The official SDK types don't
+ * declare it, so these local types widen just enough to read it without an
+ * `any` cast at every call site.
+ */
+type MessageWithReasoning = OpenAI.ChatCompletionMessage & { reasoning_content?: string | null };
+type DeltaWithReasoning = OpenAI.ChatCompletionChunk.Choice.Delta & { reasoning_content?: string | null };
+
+/** Accumulator for one in-progress tool call across streaming deltas, keyed by `index`. */
+interface StreamingToolCallAccumulator {
+	id?: string;
+	name?: string;
+	arguments: string;
+}
+
+export class OpenAIClient implements ModelApi {
+	private client: OpenAI;
+	private config: OpenAIClientConfig;
+	private prompts: GeminiPrompts;
+	private plugin?: ObsidianGemini;
+
+	constructor(config: OpenAIClientConfig, prompts?: GeminiPrompts, plugin?: ObsidianGemini) {
+		this.config = {
+			temperature: 0.7,
+			topP: 1,
+			streamingEnabled: true,
+			...config,
+		};
+		this.plugin = plugin;
+		this.prompts = prompts || new GeminiPrompts(plugin);
+		this.client = new OpenAI({
+			apiKey: this.config.apiKey,
+			baseURL: this.config.baseUrl,
+			dangerouslyAllowBrowser: true,
+			maxRetries: 0,
+		});
+	}
+
+	async generateModelResponse(request: BaseModelRequest | ExtendedModelRequest): Promise<ModelResponse> {
+		const isExtended = isExtendedRequest(request);
+		// The factory (`ModelClientFactory.resolveModelName`) is the single
+		// source of role-aware model resolution and always populates
+		// `config.model` per use case (chat / summary / completions / rewrite).
+		// We don't fall back to a chat default here — that would silently route
+		// e.g. a summary request to the chat model when `config.model` is empty.
+		const model = request.model || this.config.model;
+		if (!model) {
+			throw new Error('No OpenAI model selected. Choose a model in settings.');
+		}
+
+		try {
+			if (!isExtended) {
+				const completion = await this.client.chat.completions.create({
+					model,
+					messages: [{ role: 'user', content: request.prompt }],
+					stream: false,
+					temperature: request.temperature ?? this.config.temperature,
+					top_p: request.topP ?? this.config.topP,
+				});
+				return this.toModelResponse(completion);
+			}
+
+			const { messages, tools } = await this.buildChatRequest(request);
+			const completion = await this.client.chat.completions.create({
+				model,
+				messages,
+				stream: false,
+				temperature: request.temperature ?? this.config.temperature,
+				top_p: request.topP ?? this.config.topP,
+				...(tools && tools.length ? { tools } : {}),
+			});
+			return this.toModelResponse(completion);
+		} catch (error) {
+			this.plugin?.logger.error('[OpenAIClient] Error generating content:', error);
+			throw error;
+		}
+	}
+
+	generateStreamingResponse(
+		request: BaseModelRequest | ExtendedModelRequest,
+		onChunk: StreamCallback
+	): StreamingModelResponse {
+		const isExtended = isExtendedRequest(request);
+		// See note in generateModelResponse — the factory provides the
+		// role-correct model; no chat-default fallback here.
+		const model = request.model || this.config.model;
+
+		let cancelled = false;
+		// Unlike Ollama's post-hoc `stream.abort()` (which races cancel() firing
+		// before the stream reference is assigned), the signal is threaded into
+		// the request from the start, so aborting it is safe to call at any time
+		// — before, during, or after the awaits below.
+		const controller = new AbortController();
+		let accumulatedText = '';
+		let accumulatedThoughts = '';
+		const toolCallAccumulators = new Map<number, StreamingToolCallAccumulator>();
+		let usage: OpenAI.CompletionUsage | undefined;
+
+		const buildResult = (): ModelResponse => {
+			const toolCalls = this.finalizeToolCalls(toolCallAccumulators);
+			const usageMetadata = this.toUsageMetadata(usage);
+			return {
+				markdown: accumulatedText,
+				rendered: '',
+				...(accumulatedThoughts && { thoughts: accumulatedThoughts }),
+				...(toolCalls && toolCalls.length && { toolCalls }),
+				...(usageMetadata && { usageMetadata }),
+			};
+		};
+
+		const complete = (async (): Promise<ModelResponse> => {
+			if (!model) {
+				throw new Error('No OpenAI model selected. Choose a model in settings.');
+			}
+
+			try {
+				let stream: AsyncIterable<OpenAI.ChatCompletionChunk>;
+				if (!isExtended) {
+					stream = await this.client.chat.completions.create(
+						{
+							model,
+							messages: [{ role: 'user', content: request.prompt }],
+							stream: true,
+							// Servers that ignore this option simply omit `usage` on chunks;
+							// toUsageMetadata() tolerates that by returning undefined.
+							stream_options: { include_usage: true },
+							temperature: request.temperature ?? this.config.temperature,
+							top_p: request.topP ?? this.config.topP,
+						},
+						{ signal: controller.signal }
+					);
+				} else {
+					const { messages, tools } = await this.buildChatRequest(request);
+					stream = await this.client.chat.completions.create(
+						{
+							model,
+							messages,
+							stream: true,
+							stream_options: { include_usage: true },
+							temperature: request.temperature ?? this.config.temperature,
+							top_p: request.topP ?? this.config.topP,
+							...(tools && tools.length ? { tools } : {}),
+						},
+						{ signal: controller.signal }
+					);
+				}
+
+				// cancel() may have fired while the awaits above were outstanding —
+				// abort immediately so the server stops generating.
+				if (cancelled) {
+					controller.abort();
+				}
+
+				for await (const chunk of stream) {
+					if (cancelled) break;
+					this.accumulateStreamChunk(
+						chunk,
+						toolCallAccumulators,
+						(text) => {
+							accumulatedText += text;
+							onChunk({ text });
+						},
+						(thought) => {
+							accumulatedThoughts += thought;
+							onChunk({ text: '', thought });
+						}
+					);
+					if (chunk.usage) {
+						usage = chunk.usage;
+					}
+				}
+
+				return buildResult();
+			} catch (error) {
+				if (cancelled) {
+					return buildResult();
+				}
+				this.plugin?.logger.error('[OpenAIClient] Streaming error:', error);
+				throw error;
+			}
+		})();
+
+		return {
+			complete,
+			cancel: () => {
+				cancelled = true;
+				try {
+					controller.abort();
+				} catch (err) {
+					this.plugin?.logger.debug('[OpenAIClient] Abort failed:', err);
+				}
+			},
+		};
+	}
+
+	private async buildChatRequest(
+		request: ExtendedModelRequest
+	): Promise<{ messages: ChatMessage[]; tools?: ChatTool[] }> {
+		const systemInstruction = await this.buildSystemInstruction(request);
+		const messages: ChatMessage[] = [];
+
+		if (systemInstruction) {
+			messages.push({ role: 'system', content: systemInstruction });
+		}
+
+		// Convert conversation history. Entries may be in Gemini Content shape
+		// (role + parts[]) or our internal {role, message|text} shape. We flatten
+		// function-call / function-response parts into OpenAI's `tool_calls` /
+		// tool-role messages. `pendingCallIds` pairs functionCall parts with their
+		// functionResponse parts across adjacent Contents — see convertHistoryEntry.
+		const pendingCallIds = new Map<string, string[]>();
+		let toolCallSeq = 0;
+		for (const entry of request.conversationHistory ?? []) {
+			const converted = this.convertHistoryEntry(entry, pendingCallIds, () => toolCallSeq++);
+			if (converted) messages.push(...converted);
+		}
+
+		// Final user turn
+		const userTextParts: string[] = [];
+		if (request.userMessage && request.userMessage.trim()) {
+			userTextParts.push(request.userMessage);
+		}
+		if (request.perTurnContext && request.perTurnContext.trim()) {
+			userTextParts.push(request.perTurnContext);
+		}
+		const combinedText = userTextParts.join('\n\n');
+
+		const allAttachments: InlineDataPart[] = request.inlineAttachments ?? [];
+		const imageParts: ImageContentPart[] = [];
+		for (const att of allAttachments) {
+			if (att.mimeType.startsWith('image/')) {
+				imageParts.push(this.toImageContentPart(att));
+			} else {
+				throw new Error(
+					`OpenAI only supports image attachments; received ${att.mimeType}. ` +
+						`Switch to the Gemini provider for PDF, audio, or video input.`
+				);
+			}
+		}
+
+		if (combinedText || imageParts.length) {
+			if (imageParts.length) {
+				const content: (TextContentPart | ImageContentPart)[] = [];
+				if (combinedText) content.push({ type: 'text', text: combinedText });
+				content.push(...imageParts);
+				messages.push({ role: 'user', content });
+			} else {
+				messages.push({ role: 'user', content: combinedText });
+			}
+		}
+
+		const tools = request.availableTools ? this.toOpenAITools(request.availableTools) : undefined;
+
+		return { messages, ...(tools && tools.length ? { tools } : {}) };
+	}
+
+	private async buildSystemInstruction(request: ExtendedModelRequest): Promise<string> {
+		return this.prompts.buildExtendedSystemInstruction(request);
+	}
+
+	private toImageContentPart(att: InlineDataPart): ImageContentPart {
+		return { type: 'image_url', image_url: { url: `data:${att.mimeType};base64,${att.base64}` } };
+	}
+
+	/**
+	 * Convert one history entry (Gemini `Content` shape or the legacy internal
+	 * `{role, text|message}` shape) into zero or more OpenAI chat messages.
+	 *
+	 * `pendingCallIds` is a FIFO queue per tool name, threaded across the whole
+	 * history by the caller: each `functionCall` part pushes the id it was
+	 * assigned (its own `id` field if present, else a synthesized
+	 * `call_<name>_<seq>`), and each `functionResponse` part without its own
+	 * `id` pops the oldest pending id for its name so `tool_call_id` on the
+	 * resulting `tool` message lines up with the `id` on the assistant message's
+	 * `tool_calls` entry — mirroring Gemini's positional call/response pairing.
+	 */
+	private convertHistoryEntry(
+		entry: unknown,
+		pendingCallIds: Map<string, string[]>,
+		nextSeq: () => number
+	): ChatMessage[] | null {
+		if (!entry || typeof entry !== 'object') return null;
+		const record = entry as Record<string, unknown>;
+
+		// Gemini Content shape: { role: 'user'|'model', parts: Part[] }
+		if ('role' in record && Array.isArray(record.parts)) {
+			const role = record.role === 'model' ? 'assistant' : record.role === 'system' ? 'system' : 'user';
+			const textChunks: string[] = [];
+			const imageParts: ImageContentPart[] = [];
+			const toolCallParts: { id: string; name: string; arguments: Record<string, unknown> }[] = [];
+			const toolResponseParts: { id: string; response: unknown }[] = [];
+
+			for (const rawPart of record.parts) {
+				const part = rawPart as {
+					text?: unknown;
+					inlineData?: { mimeType?: string; data?: string };
+					functionCall?: { name: string; args?: Record<string, unknown>; id?: string };
+					functionResponse?: { name: string; response?: unknown; id?: string };
+				};
+				if (typeof part?.text === 'string') {
+					textChunks.push(part.text);
+				} else if (part?.inlineData?.mimeType?.startsWith('image/') && part.inlineData.data) {
+					imageParts.push(
+						this.toImageContentPart({ mimeType: part.inlineData.mimeType, base64: part.inlineData.data })
+					);
+				} else if (part?.inlineData?.mimeType) {
+					// Mirror buildChatRequest's current-turn handling so resumed sessions
+					// don't silently drop PDF/audio/video context the model never sees.
+					throw new Error(
+						`OpenAI only supports image attachments; conversation history contains ${part.inlineData.mimeType}. ` +
+							`Switch to the Gemini provider for PDF, audio, or video input.`
+					);
+				} else if (part?.functionCall) {
+					const name = part.functionCall.name;
+					const id = part.functionCall.id ?? `call_${name}_${nextSeq()}`;
+					const queue = pendingCallIds.get(name) ?? [];
+					queue.push(id);
+					pendingCallIds.set(name, queue);
+					toolCallParts.push({ id, name, arguments: part.functionCall.args || {} });
+				} else if (part?.functionResponse) {
+					const name = part.functionResponse.name;
+					const queue = pendingCallIds.get(name);
+					const id = part.functionResponse.id ?? queue?.shift() ?? `call_${name}_${nextSeq()}`;
+					toolResponseParts.push({ id, response: part.functionResponse.response });
+				}
+			}
+
+			const out: ChatMessage[] = [];
+
+			// Tool responses become tool-role messages. Don't coalesce `null` to
+			// `{}` — an explicit null response carries different meaning ("no
+			// result") than an empty object, and JSON.stringify(null) === "null"
+			// is the correct serialization to preserve that.
+			for (const tr of toolResponseParts) {
+				const responseText = typeof tr.response === 'string' ? tr.response : JSON.stringify(tr.response);
+				out.push({ role: 'tool', tool_call_id: tr.id, content: responseText });
+			}
+
+			// Assistant turn (text + tool calls together)
+			if (role === 'assistant' && (textChunks.length || toolCallParts.length)) {
+				const message: OpenAI.ChatCompletionAssistantMessageParam = {
+					role: 'assistant',
+					content: textChunks.join('\n').trim() || null,
+				};
+				if (toolCallParts.length) {
+					message.tool_calls = toolCallParts.map((tc) => ({
+						id: tc.id,
+						type: 'function' as const,
+						function: { name: tc.name, arguments: JSON.stringify(tc.arguments) },
+					}));
+				}
+				out.push(message);
+			} else if (role !== 'assistant' && (textChunks.length || imageParts.length)) {
+				const text = textChunks.join('\n\n').trim();
+				if (role === 'user' && imageParts.length) {
+					const content: (TextContentPart | ImageContentPart)[] = [];
+					if (text) content.push({ type: 'text', text });
+					content.push(...imageParts);
+					out.push({ role: 'user', content });
+				} else {
+					out.push({ role, content: text });
+				}
+			}
+
+			return out.length ? out : null;
+		}
+
+		// Internal shape: { role, text } or { role, message }
+		if ('role' in record) {
+			const text = getLegacyEntryText(record);
+			if (typeof text !== 'string' || !text.trim()) return null;
+			const role = record.role === 'model' || record.role === 'assistant' ? 'assistant' : 'user';
+			return [{ role, content: text }];
+		}
+
+		return null;
+	}
+
+	private toOpenAITools(tools: ToolDefinition[]): ChatTool[] {
+		return tools.map((tool) => ({
+			type: 'function' as const,
+			function: {
+				name: tool.name,
+				description: tool.description,
+				parameters: {
+					type: tool.parameters.type ?? 'object',
+					properties: tool.parameters.properties ?? {},
+					required: tool.parameters.required ?? [],
+				},
+			},
+		}));
+	}
+
+	private toModelResponse(completion: OpenAI.ChatCompletion): ModelResponse {
+		const message = completion.choices?.[0]?.message as MessageWithReasoning | undefined;
+		const toolCalls = this.toolCallsFromMessage(message);
+		const usageMetadata = this.toUsageMetadata(completion.usage);
+		return {
+			markdown: message?.content ?? '',
+			rendered: '',
+			...(message?.reasoning_content && { thoughts: message.reasoning_content }),
+			...(toolCalls && toolCalls.length && { toolCalls }),
+			...(usageMetadata && { usageMetadata }),
+		};
+	}
+
+	private toolCallsFromMessage(message: OpenAI.ChatCompletionMessage | undefined): ToolCall[] | undefined {
+		const rawToolCalls = message?.tool_calls;
+		if (!rawToolCalls?.length) return undefined;
+		const calls = rawToolCalls
+			.filter((tc): tc is OpenAI.ChatCompletionMessageFunctionToolCall => tc.type === 'function')
+			.map((tc) => ({
+				id: tc.id,
+				name: tc.function.name,
+				arguments: this.parseToolArguments(tc.function.name, tc.function.arguments),
+			}));
+		return calls.length ? calls : undefined;
+	}
+
+	/**
+	 * Parse a tool call's JSON-encoded arguments string. The model does not
+	 * always emit valid JSON (truncated streaming output, hallucinated
+	 * arguments); fall back to an empty object and log rather than let a
+	 * malformed tool call crash the whole response.
+	 */
+	private parseToolArguments(name: string, raw: string): Record<string, unknown> {
+		if (!raw) return {};
+		try {
+			return JSON.parse(raw) as Record<string, unknown>;
+		} catch (error) {
+			this.plugin?.logger.warn(`[OpenAIClient] Failed to parse tool call arguments for ${name}:`, error);
+			return {};
+		}
+	}
+
+	/**
+	 * Accumulate one streaming chunk's delta into the running text/thoughts
+	 * (via the provided emitters, which also forward to the caller's onChunk)
+	 * and the tool-call accumulator map, keyed by the delta's `index`. Tool
+	 * call id/name typically arrive on the first delta for that index;
+	 * arguments arrive as accumulating string fragments across many deltas.
+	 */
+	private accumulateStreamChunk(
+		chunk: OpenAI.ChatCompletionChunk,
+		toolCallAccumulators: Map<number, StreamingToolCallAccumulator>,
+		onText: (text: string) => void,
+		onThought: (thought: string) => void
+	): void {
+		const delta = chunk.choices?.[0]?.delta as DeltaWithReasoning | undefined;
+		if (!delta) return;
+
+		if (delta.content) {
+			onText(delta.content);
+		}
+		if (delta.reasoning_content) {
+			onThought(delta.reasoning_content);
+		}
+		if (delta.tool_calls?.length) {
+			for (const tc of delta.tool_calls) {
+				const existing = toolCallAccumulators.get(tc.index) ?? { arguments: '' };
+				if (tc.id) existing.id = tc.id;
+				if (tc.function?.name) existing.name = tc.function.name;
+				if (tc.function?.arguments) existing.arguments += tc.function.arguments;
+				toolCallAccumulators.set(tc.index, existing);
+			}
+		}
+	}
+
+	private finalizeToolCalls(accumulators: Map<number, StreamingToolCallAccumulator>): ToolCall[] | undefined {
+		if (!accumulators.size) return undefined;
+		const indices = Array.from(accumulators.keys()).sort((a, b) => a - b);
+		const calls: ToolCall[] = [];
+		for (const index of indices) {
+			const acc = accumulators.get(index);
+			if (!acc?.name) continue;
+			calls.push({
+				id: acc.id,
+				name: acc.name,
+				arguments: this.parseToolArguments(acc.name, acc.arguments),
+			});
+		}
+		return calls.length ? calls : undefined;
+	}
+
+	/**
+	 * Build a usageMetadata object from OpenAI's `CompletionUsage`. Unlike
+	 * Ollama's `prompt_eval_count`/`eval_count` (which can arrive independently),
+	 * OpenAI's `usage` is an atomic object present only when the server actually
+	 * reports token counts (always on non-streaming responses; only on the final
+	 * chunk when `stream_options.include_usage` is honored). Returning
+	 * `undefined` when absent preserves the distinction between "unknown" and
+	 * "zero tokens" in the token UI and eval reporter.
+	 */
+	private toUsageMetadata(usage: OpenAI.CompletionUsage | undefined): ModelResponse['usageMetadata'] | undefined {
+		if (!usage) return undefined;
+		return {
+			promptTokenCount: usage.prompt_tokens,
+			candidatesTokenCount: usage.completion_tokens,
+			totalTokenCount: usage.total_tokens,
+		};
+	}
+}

--- a/src/api/providers/openai/config.ts
+++ b/src/api/providers/openai/config.ts
@@ -1,0 +1,11 @@
+/** Default Chat Completions endpoint for api.openai.com. */
+export const DEFAULT_OPENAI_BASE_URL = 'https://api.openai.com/v1';
+
+export interface OpenAIClientConfig {
+	apiKey: string;
+	baseUrl: string;
+	model?: string;
+	temperature?: number;
+	topP?: number;
+	streamingEnabled?: boolean;
+}

--- a/src/api/providers/openai/index.ts
+++ b/src/api/providers/openai/index.ts
@@ -1,0 +1,3 @@
+export { OpenAIClient } from './client';
+export { DEFAULT_OPENAI_BASE_URL } from './config';
+export type { OpenAIClientConfig } from './config';

--- a/src/api/providers/registry.ts
+++ b/src/api/providers/registry.ts
@@ -21,7 +21,7 @@
  * `models.ts` re-exports it for backward compatibility and imports the router,
  * which would be a cycle if the type lived the other way round.
  */
-export type ModelProvider = 'gemini' | 'ollama';
+export type ModelProvider = 'gemini' | 'ollama' | 'openai';
 
 /**
  * A use case that can be routed to a provider independently.
@@ -145,10 +145,33 @@ export const PROVIDERS: Record<ModelProvider, ProviderDefinition> = {
 			defaultInputTokenLimit: 32_000,
 		},
 	},
+	openai: {
+		id: 'openai',
+		labelKey: 'settings.general.providerOptionOpenai',
+		capabilities: {
+			chat: true,
+			summary: true,
+			completions: true,
+			rewrite: true,
+			webSearch: false,
+			rag: false,
+			imageGen: false,
+			vision: 'auto-detect',
+			nativeTokenCount: false,
+			promptCache: false,
+			costMetrics: false,
+			interactionsApi: false,
+			customBaseUrl: true,
+			perUseCaseModels: true,
+			requiresApiKey: true,
+			/** Conservative floor for an unrecognized model; known models report their own via the models list. */
+			defaultInputTokenLimit: 128_000,
+		},
+	},
 };
 
 /** Every known provider id, in display order. */
-export const PROVIDER_IDS: readonly ModelProvider[] = ['gemini', 'ollama'] as const;
+export const PROVIDER_IDS: readonly ModelProvider[] = ['gemini', 'ollama', 'openai'] as const;
 
 /**
  * Capabilities for a provider, defaulting to Gemini for an unrecognized id

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -122,11 +122,11 @@ export const en = {
 	},
 	'settings.general.providerName': {
 		message: 'Provider',
-		context: 'Settings field name for choosing the AI model provider (Gemini or Ollama).',
+		context: 'Settings field name for choosing the AI model provider (Gemini, Ollama, or OpenAI).',
 	},
 	'settings.general.providerDesc': {
 		message:
-			'Choose the model provider. Gemini uses the Google Cloud API. Ollama runs models locally on your machine; install from https://ollama.com and pull a model with `ollama pull <name>`.',
+			'Choose the model provider. Gemini uses the Google Cloud API. Ollama runs models locally on your machine; install from https://ollama.com and pull a model with `ollama pull <name>`. OpenAI uses your OpenAI API key, or any OpenAI-compatible server (LM Studio, MLX, ...) via a custom base URL.',
 		context:
 			'Settings field description for the provider dropdown. Keep the URL and the backtick-quoted shell command untranslated.',
 	},

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -138,6 +138,11 @@ export const en = {
 		message: 'Ollama (local)',
 		context: 'Dropdown option label for the Ollama local provider. "Ollama" is a product name.',
 	},
+	'settings.general.providerOptionOpenai': {
+		message: 'OpenAI (cloud)',
+		context:
+			'Dropdown option label for the OpenAI cloud provider (also used for OpenAI-compatible local servers via a custom base URL). "OpenAI" is a product name.',
+	},
 	'settings.general.ollamaBaseUrlName': {
 		message: 'Ollama base URL',
 		context: 'Settings field name for the URL of the local Ollama server. Shown only when Ollama provider is selected.',
@@ -158,6 +163,49 @@ export const en = {
 	'settings.general.refreshModelListOllamaDesc': {
 		message: 'Re-query the Ollama daemon for available models.',
 		context: 'Settings field description for the refresh-models row when the Ollama provider is active.',
+	},
+	'settings.general.openaiApiKeyName': {
+		message: 'OpenAI API key',
+		context: 'Settings field name for the OpenAI API key input. Shown only when the OpenAI provider is active.',
+	},
+	'settings.general.openaiApiKeyDesc': {
+		message:
+			'Link your OpenAI API key. Click "Link..." and Obsidian will ask for a secret name (this is just a label — use any name like "openai-api") and a secret value (paste your API key here). Get a key at https://platform.openai.com/api-keys. Not needed for an OpenAI-compatible local server that doesn\'t require one.',
+		context:
+			'Settings field description for the OpenAI API key. "Link...", "Secret Name", and "Secret Value" refer to Obsidian secret-storage UI labels. Keep the URL untranslated.',
+	},
+	'settings.general.openaiBaseUrlName': {
+		message: 'OpenAI base URL',
+		context:
+			'Settings field name for the endpoint OpenAI Chat Completions requests are sent to. Shown only when the OpenAI provider is active.',
+	},
+	'settings.general.openaiBaseUrlDesc': {
+		message:
+			'Chat Completions endpoint. Default is the OpenAI API (api.openai.com). Point this at an OpenAI-compatible local server instead — such as LM Studio or MLX — to keep requests on your machine.',
+		context:
+			'Settings field description for the OpenAI base URL input, explaining it can target a local OpenAI-compatible server. Keep the URL and product names (LM Studio, MLX) untranslated.',
+	},
+	'settings.general.refreshOpenaiModelListName': {
+		message: 'Refresh OpenAI model list',
+		context:
+			'Settings field name for the button that re-fetches the available models from the configured OpenAI endpoint. "OpenAI" is a product name.',
+	},
+	'settings.general.refreshModelListOpenaiDesc': {
+		message: 'Re-query the configured endpoint for available models.',
+		context: 'Settings field description for the refresh-models row when the OpenAI provider is active.',
+	},
+	'settings.general.openaiModelsFoundSingular': {
+		message: 'Found {count} OpenAI model.',
+		context: 'Notice after refreshing the OpenAI model list when exactly one model was found. {count} is the number 1.',
+	},
+	'settings.general.openaiModelsFound': {
+		message: 'Found {count} OpenAI models.',
+		context: 'Notice after refreshing the OpenAI model list. {count} is the number of models found (0 or 2+).',
+	},
+	'settings.general.openaiChatModelDesc': {
+		message: 'Model used for agent chat sessions and selection rewriting.',
+		context:
+			'Settings field description for the OpenAI chat model dropdown. Unlike the generic chat model description, this omits web search tools since the OpenAI provider does not support them.',
 	},
 	'settings.general.refreshModelListGeminiDesc': {
 		message:
@@ -2958,6 +3006,11 @@ export const en = {
 		message:
 			'No Gemini API key configured. Open Settings → Gemini Scribe to add one. Get a free key at aistudio.google.com/apikey',
 		context: 'Error notice when the user has not configured a Gemini API key yet.',
+	},
+	'notice.main.noApiKeyOpenai': {
+		message:
+			'No OpenAI API key configured. Open Settings → Gemini Scribe to add one. Get a key at platform.openai.com/api-keys',
+		context: 'Error notice when the user has not configured an OpenAI API key yet (OpenAI is the primary provider).',
 	},
 	'notice.main.apiKeyRetrieveFailed': {
 		message:

--- a/src/index.ts
+++ b/src/index.ts
@@ -104,6 +104,10 @@ export { OllamaClient } from './api/providers/ollama';
 
 export type { OllamaClientConfig } from './api/providers/ollama';
 
+export { OpenAIClient } from './api/providers/openai';
+
+export type { OpenAIClientConfig } from './api/providers/openai';
+
 // Main Plugin Class (for type reference)
 export { default as ObsidianGeminiPlugin } from './main';
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -46,6 +46,7 @@ import { ScheduledTaskManager } from './services/scheduled-task-manager';
 import { HookManager } from './services/hook-manager';
 import { asRecord, getRawErrorMessage } from './utils/error-utils';
 import { t } from './i18n';
+import { apiKeySecretNameFor } from './ui/settings-helpers';
 import { DEFAULT_OPENAI_BASE_URL } from './api/providers/openai/config';
 
 // Settings interfaces live in a leaf module so the rest of the codebase can
@@ -283,8 +284,7 @@ export default class ObsidianGemini extends Plugin implements ObsidianGeminiApi 
 		// The secret-name field is provider-specific — an OpenAI-primary install
 		// checks its own key, not Gemini's, so a missing OpenAI key surfaces the
 		// same kind of actionable notice a missing Gemini key would.
-		const apiKeySecretName =
-			this.settings.provider === 'openai' ? this.settings.openaiApiKeySecretName : this.settings.apiKeySecretName;
+		const apiKeySecretName = apiKeySecretNameFor(this.settings, this.settings.provider);
 		return buildApiKeyErrorMessage({
 			provider: this.settings.provider,
 			lastInitError: this.lastInitError,

--- a/src/main.ts
+++ b/src/main.ts
@@ -46,6 +46,7 @@ import { ScheduledTaskManager } from './services/scheduled-task-manager';
 import { HookManager } from './services/hook-manager';
 import { asRecord, getRawErrorMessage } from './utils/error-utils';
 import { t } from './i18n';
+import { DEFAULT_OPENAI_BASE_URL } from './api/providers/openai/config';
 
 // Settings interfaces live in a leaf module so the rest of the codebase can
 // reference them without importing this hub file (see #1155).
@@ -71,6 +72,13 @@ const DEFAULT_SETTINGS: ObsidianGeminiSettings = {
 	// unless the user deliberately splits them.
 	ollamaSummaryModelName: '',
 	ollamaCompletionsModelName: '',
+	openaiBaseUrl: DEFAULT_OPENAI_BASE_URL,
+	openaiApiKeySecretName: '',
+	// OpenAI has no single-resident-model constraint (perUseCaseModels), so each
+	// use case gets its own default rather than inheriting the chat model.
+	openaiModelName: 'gpt-5.6',
+	openaiSummaryModelName: 'gpt-5.6-terra',
+	openaiCompletionsModelName: 'gpt-5.6-luna',
 	summaryFrontmatterKey: 'summary',
 	userName: 'User',
 	chatHistory: false,
@@ -141,6 +149,13 @@ export default class ObsidianGemini extends Plugin implements ObsidianGeminiApi 
 		return this.app.secretStorage.getSecret(secretName) ?? '';
 	}
 
+	/** The configured OpenAI API key, mirroring `apiKey` above. */
+	get openaiApiKey(): string {
+		const secretName = this.settings?.openaiApiKeySecretName;
+		if (!secretName) return '';
+		return this.app.secretStorage.getSecret(secretName) ?? '';
+	}
+
 	// Public service properties — assigned by LifecycleService
 	public gfile!: ScribeFile;
 	public agentView!: AgentView;
@@ -185,6 +200,7 @@ export default class ObsidianGemini extends Plugin implements ObsidianGeminiApi 
 	private ribbonIcon!: HTMLElement;
 	public isGeminiInitialized: boolean = false;
 	private previousApiKey: string = '';
+	private previousOpenaiApiKey: string = '';
 	private previousRagEnabled: boolean = false;
 	/**
 	 * Serialized provider routing (primary + every use case's resolved provider).
@@ -195,6 +211,7 @@ export default class ObsidianGemini extends Plugin implements ObsidianGeminiApi 
 	private previousRoutingKey: string = '';
 	private previousOllamaBaseUrl: string = '';
 	private previousCustomBaseUrl: string = '';
+	private previousOpenaiBaseUrl: string = '';
 	private previousHooksEnabled: boolean = false;
 	private lifecycle!: LifecycleService;
 	// Captures the last initialization failure so guarded commands can surface
@@ -226,10 +243,12 @@ export default class ObsidianGemini extends Plugin implements ObsidianGeminiApi 
 			this.isGeminiInitialized = true;
 			this.lastInitError = null;
 			this.previousApiKey = this.apiKey;
+			this.previousOpenaiApiKey = this.openaiApiKey;
 			this.previousRagEnabled = this.settings.ragIndexing.enabled;
 			this.previousRoutingKey = routingKey(this.settings);
 			this.previousOllamaBaseUrl = this.settings.ollamaBaseUrl;
 			this.previousCustomBaseUrl = this.settings.customBaseUrl;
+			this.previousOpenaiBaseUrl = this.settings.openaiBaseUrl;
 			this.previousHooksEnabled = this.settings.hooksEnabled;
 		} catch (error) {
 			this.logger.error('Failed to initialize Gemini Scribe:', error);
@@ -261,10 +280,15 @@ export default class ObsidianGemini extends Plugin implements ObsidianGeminiApi 
 	 * Distinguishes between "never configured" and "storage retrieval failure".
 	 */
 	private getApiKeyErrorMessage(): string {
+		// The secret-name field is provider-specific — an OpenAI-primary install
+		// checks its own key, not Gemini's, so a missing OpenAI key surfaces the
+		// same kind of actionable notice a missing Gemini key would.
+		const apiKeySecretName =
+			this.settings.provider === 'openai' ? this.settings.openaiApiKeySecretName : this.settings.apiKeySecretName;
 		return buildApiKeyErrorMessage({
 			provider: this.settings.provider,
 			lastInitError: this.lastInitError,
-			apiKeySecretName: this.settings.apiKeySecretName,
+			apiKeySecretName,
 			ollamaBaseUrl: this.settings.ollamaBaseUrl,
 		});
 	}
@@ -492,7 +516,7 @@ export default class ObsidianGemini extends Plugin implements ObsidianGeminiApi 
 		await this.saveData(this.settings);
 
 		// Check if we need to re-initialize
-		const apiKeyChanged = this.previousApiKey !== this.apiKey;
+		const apiKeyChanged = this.previousApiKey !== this.apiKey || this.previousOpenaiApiKey !== this.openaiApiKey;
 		// Any change to *which provider serves which use case* re-inits: tool
 		// registration, RAG, and image generation are all keyed off the resolved
 		// providers, not just the primary.
@@ -503,22 +527,34 @@ export default class ObsidianGemini extends Plugin implements ObsidianGeminiApi 
 			isProviderActive(this.settings, 'ollama') && this.previousOllamaBaseUrl !== this.settings.ollamaBaseUrl;
 		const customBaseUrlChanged =
 			isProviderActive(this.settings, 'gemini') && this.previousCustomBaseUrl !== this.settings.customBaseUrl;
+		const openaiBaseUrlChanged =
+			isProviderActive(this.settings, 'openai') && this.previousOpenaiBaseUrl !== this.settings.openaiBaseUrl;
 		// A primary that needs no key (Ollama) can initialize on the provider
 		// switch alone; overrides pointing at a cloud provider degrade gracefully
 		// without one rather than blocking init.
-		const hasCredentials = !getCapabilities(this.settings.provider).requiresApiKey || !!this.apiKey;
+		const activePrimaryApiKey = this.settings.provider === 'openai' ? this.openaiApiKey : this.apiKey;
+		const hasCredentials = !getCapabilities(this.settings.provider).requiresApiKey || !!activePrimaryApiKey;
 		const needsInit = !this.isGeminiInitialized && hasCredentials;
 
-		if (apiKeyChanged || providerChanged || ollamaUrlChanged || customBaseUrlChanged || needsInit) {
+		if (
+			apiKeyChanged ||
+			providerChanged ||
+			ollamaUrlChanged ||
+			customBaseUrlChanged ||
+			openaiBaseUrlChanged ||
+			needsInit
+		) {
 			try {
 				await this.lifecycle.setup();
 				this.isGeminiInitialized = true;
 				this.lastInitError = null;
 				this.previousApiKey = this.apiKey;
+				this.previousOpenaiApiKey = this.openaiApiKey;
 				this.previousRagEnabled = this.settings.ragIndexing.enabled;
 				this.previousRoutingKey = routingKey(this.settings);
 				this.previousOllamaBaseUrl = this.settings.ollamaBaseUrl;
 				this.previousCustomBaseUrl = this.settings.customBaseUrl;
+				this.previousOpenaiBaseUrl = this.settings.openaiBaseUrl;
 				this.previousHooksEnabled = this.settings.hooksEnabled;
 
 				// If this is the first successful initialization, we may need to

--- a/src/models.ts
+++ b/src/models.ts
@@ -92,10 +92,10 @@ export function getDefaultModelForRole(role: ModelRole, provider: ModelProvider 
 		return candidates[0].value;
 	}
 
-	// No models for this provider yet (e.g. Ollama before /api/tags returns).
-	// Returning an empty string lets callers handle the unconfigured state
-	// rather than throwing at module load.
-	if (provider === 'ollama') {
+	// No models for this provider yet (e.g. Ollama before /api/tags returns, or
+	// OpenAI before /v1/models returns). Returning an empty string lets callers
+	// handle the unconfigured state rather than throwing at module load.
+	if (provider === 'ollama' || provider === 'openai') {
 		return '';
 	}
 
@@ -203,20 +203,49 @@ export function getOllamaModelForRole(settings: OllamaModelSettingsSlice, role: 
 	return specific || settings.ollamaModelName || getDefaultModelForRole('chat', 'ollama');
 }
 
+/** The settings fields that hold OpenAI model choices, per use case. */
+export interface OpenAIModelSettingsSlice {
+	openaiModelName?: string;
+	openaiSummaryModelName?: string;
+	openaiCompletionsModelName?: string;
+}
+
+/**
+ * Resolve the OpenAI model for a use case.
+ *
+ * Unlike Ollama, OpenAI has no single-resident-model constraint
+ * (`capabilities.perUseCaseModels`), so each use case reads its own dedicated
+ * field rather than inheriting the chat model; an unset field falls back to
+ * the role's bundled/discovered default, not to `openaiModelName`.
+ */
+export function getOpenAIModelForRole(settings: OpenAIModelSettingsSlice, role: ModelRole): string {
+	const configured =
+		role === 'summary'
+			? settings.openaiSummaryModelName
+			: role === 'completions'
+				? settings.openaiCompletionsModelName
+				: settings.openaiModelName;
+	return configured || getDefaultModelForRole(role, 'openai');
+}
+
 /**
  * Resolve the chat model for whichever provider currently serves chat. Each
- * provider keeps its own persisted model (`chatModelName` vs `ollamaModelName`),
- * so re-routing chat back and forth never clobbers the other's choice. Use this
- * anywhere the "current chat model" is needed for a request or for history
- * metadata; the Gemini-cloud tools (search grounding, URL context, RAG)
- * intentionally keep reading `chatModelName` directly since they always call
- * Google's API.
+ * provider keeps its own persisted model (`chatModelName` vs `ollamaModelName`
+ * vs `openaiModelName`), so re-routing chat back and forth never clobbers
+ * another provider's choice. Use this anywhere the "current chat model" is
+ * needed for a request or for history metadata; the Gemini-cloud tools
+ * (search grounding, URL context, RAG) intentionally keep reading
+ * `chatModelName` directly since they always call Google's API.
  */
 export function getActiveChatModel(
-	settings: ProviderRoutingSlice & { chatModelName?: string } & OllamaModelSettingsSlice
+	settings: ProviderRoutingSlice & { chatModelName?: string } & OllamaModelSettingsSlice & OpenAIModelSettingsSlice
 ): string {
-	if (resolveProviderOrDefault(settings, 'chat') === 'ollama') {
+	const provider = resolveProviderOrDefault(settings, 'chat');
+	if (provider === 'ollama') {
 		return getOllamaModelForRole(settings, 'chat');
+	}
+	if (provider === 'openai') {
+		return getOpenAIModelForRole(settings, 'chat');
 	}
 	return settings.chatModelName || getDefaultModelForRole('chat', 'gemini');
 }
@@ -244,6 +273,14 @@ export interface ModelSettingsSlice {
 	 */
 	ollamaSummaryModelName?: string;
 	ollamaCompletionsModelName?: string;
+	/**
+	 * Optional: the OpenAI model is only reconciled once the discovered model
+	 * list is known, and callers (tests, partial fixtures) may omit the field
+	 * entirely.
+	 */
+	openaiModelName?: string;
+	openaiSummaryModelName?: string;
+	openaiCompletionsModelName?: string;
 }
 
 export interface ModelUpdateResult<T extends ModelSettingsSlice = ModelSettingsSlice> {
@@ -285,6 +322,7 @@ export function migrateOllamaModelSetting(
 export function getUpdatedModelSettings<T extends ModelSettingsSlice>(currentSettings: T): ModelUpdateResult<T> {
 	const geminiModelValues = new Set(GEMINI_MODELS.filter((m) => getModelProvider(m) === 'gemini').map((m) => m.value));
 	const ollamaModelValues = new Set(GEMINI_MODELS.filter((m) => getModelProvider(m) === 'ollama').map((m) => m.value));
+	const openaiModelValues = new Set(GEMINI_MODELS.filter((m) => getModelProvider(m) === 'openai').map((m) => m.value));
 	let settingsChanged = false;
 	const changedSettingsInfo: string[] = [];
 	const newSettings = { ...currentSettings };
@@ -357,6 +395,30 @@ export function getUpdatedModelSettings<T extends ModelSettingsSlice>(currentSet
 		};
 		clearStaleOllamaOverride('ollamaSummaryModelName', 'Ollama summary model');
 		clearStaleOllamaOverride('ollamaCompletionsModelName', 'Ollama completions model');
+	}
+
+	// OpenAI has no single-resident-model constraint (perUseCaseModels), so each
+	// use case is reconciled independently against the discovered model list —
+	// mirroring reconcileGemini above rather than Ollama's "inherit chat, blank
+	// on stale" pattern. Only runs once the list is known (models load lazily
+	// via /v1/models), same gating as the Ollama block above.
+	if (openaiModelValues.size > 0) {
+		const reconcileOpenAI = (
+			key: 'openaiModelName' | 'openaiSummaryModelName' | 'openaiCompletionsModelName',
+			role: ModelRole,
+			label: string
+		) => {
+			const previous = modelFields[key];
+			if (previous && openaiModelValues.has(previous)) return;
+			const next = getDefaultModelForRole(role, 'openai');
+			if (!next || next === previous) return;
+			modelFields[key] = next;
+			changedSettingsInfo.push(`${label}: '${previous ?? ''}' -> '${next}' (legacy model update)`);
+			settingsChanged = true;
+		};
+		reconcileOpenAI('openaiModelName', 'chat', 'OpenAI model');
+		reconcileOpenAI('openaiSummaryModelName', 'summary', 'OpenAI summary model');
+		reconcileOpenAI('openaiCompletionsModelName', 'completions', 'OpenAI completions model');
 	}
 
 	return {

--- a/src/services/generated-help-references.ts
+++ b/src/services/generated-help-references.ts
@@ -20,6 +20,7 @@ import refGettingStarted from '../../docs/guide/getting-started.md';
 import refLifecycleHooks from '../../docs/guide/lifecycle-hooks.md';
 import refMcpServers from '../../docs/guide/mcp-servers.md';
 import refOllamaSetup from '../../docs/guide/ollama-setup.md';
+import refOpenaiSetup from '../../docs/guide/openai-setup.md';
 import refProjects from '../../docs/guide/projects.md';
 import refScheduledTasks from '../../docs/guide/scheduled-tasks.md';
 import refSelectionPrompts from '../../docs/guide/selection-prompts.md';
@@ -45,6 +46,7 @@ export const helpResources = new Map<string, string>([
 	['references/lifecycle-hooks.md', refLifecycleHooks],
 	['references/mcp-servers.md', refMcpServers],
 	['references/ollama-setup.md', refOllamaSetup],
+	['references/openai-setup.md', refOpenaiSetup],
 	['references/projects.md', refProjects],
 	['references/scheduled-tasks.md', refScheduledTasks],
 	['references/selection-prompts.md', refSelectionPrompts],
@@ -72,6 +74,7 @@ export const helpReferencesTable = `| Reference | Topic |
 | \`references/lifecycle-hooks.md\` | Lifecycle Hooks |
 | \`references/mcp-servers.md\` | MCP servers |
 | \`references/ollama-setup.md\` | Ollama (Local Models) |
+| \`references/openai-setup.md\` | OpenAI |
 | \`references/projects.md\` | Projects |
 | \`references/scheduled-tasks.md\` | Scheduled tasks |
 | \`references/selection-prompts.md\` | Selection Prompts |

--- a/src/services/model-manager.ts
+++ b/src/services/model-manager.ts
@@ -11,6 +11,7 @@ import { activeProviders, resolveProviderOrDefault } from '../api/provider-routi
 import type { ObsidianGeminiSettings } from '../types/settings';
 import { ModelListProvider, RefreshResult } from './model-list-provider';
 import { OllamaModelsService } from './ollama-models-service';
+import { OpenAIModelsService } from './openai-models-service';
 import { ParameterValidationService, ParameterRanges } from './parameter-validation';
 
 export interface ModelUpdateOptions {
@@ -22,12 +23,14 @@ export class ModelManager {
 	private plugin: ObsidianGemini;
 	private listProvider: ModelListProvider;
 	private ollamaModelsService: OllamaModelsService;
+	private openaiModelsService: OpenAIModelsService;
 	private static staticModels: GeminiModel[] = [...DEFAULT_GEMINI_MODELS];
 
 	constructor(plugin: ObsidianGemini) {
 		this.plugin = plugin;
 		this.listProvider = new ModelListProvider(plugin);
 		this.ollamaModelsService = new OllamaModelsService(plugin);
+		this.openaiModelsService = new OpenAIModelsService(plugin);
 	}
 
 	/**
@@ -42,6 +45,9 @@ export class ModelManager {
 		const target = provider ?? resolveProviderOrDefault(this.plugin.settings, 'chat');
 		if (target === 'ollama') {
 			return this.ollamaModelsService.getModels(options.forceRefresh);
+		}
+		if (target === 'openai') {
+			return this.openaiModelsService.getModels(options.forceRefresh);
 		}
 		return this.listProvider.getTextModels();
 	}
@@ -76,6 +82,13 @@ export class ModelManager {
 				this.plugin.logger.warn('[ModelManager] Could not load Ollama models:', error);
 			}
 		}
+		if (providers.includes('openai')) {
+			try {
+				models.push(...(await this.openaiModelsService.getModels(forceRefresh)));
+			} catch (error) {
+				this.plugin.logger.warn('[ModelManager] Could not load OpenAI models:', error);
+			}
+		}
 		return models;
 	}
 
@@ -84,6 +97,13 @@ export class ModelManager {
 	 */
 	getOllamaModelsService(): OllamaModelsService {
 		return this.ollamaModelsService;
+	}
+
+	/**
+	 * Get the OpenAI models service for direct interaction (e.g. cache refresh).
+	 */
+	getOpenAIModelsService(): OpenAIModelsService {
+		return this.openaiModelsService;
 	}
 
 	/**
@@ -160,8 +180,12 @@ export class ModelManager {
 	 * widen the range beyond what chat actually accepts.
 	 */
 	private async getModelsForActiveProvider(): Promise<GeminiModel[]> {
-		if (resolveProviderOrDefault(this.plugin.settings, 'chat') === 'ollama') {
+		const provider = resolveProviderOrDefault(this.plugin.settings, 'chat');
+		if (provider === 'ollama') {
 			return this.ollamaModelsService.getModels();
+		}
+		if (provider === 'openai') {
+			return this.openaiModelsService.getModels();
 		}
 		return this.listProvider.getModels();
 	}

--- a/src/services/openai-models-service.ts
+++ b/src/services/openai-models-service.ts
@@ -66,7 +66,10 @@ function isOpenAIHostedEndpoint(baseUrl: string): boolean {
 	try {
 		return new URL(baseUrl).hostname === 'api.openai.com';
 	} catch {
-		return baseUrl.includes('api.openai.com');
+		// Unparseable base URL — treat as a compatible server rather than
+		// substring-matching (a host like `api.openai.com.evil.example` must
+		// never be classified as the official endpoint).
+		return false;
 	}
 }
 

--- a/src/services/openai-models-service.ts
+++ b/src/services/openai-models-service.ts
@@ -1,0 +1,165 @@
+import { requestUrl } from 'obsidian';
+import type { ObsidianGemini } from '../types/plugin';
+import { GeminiModel, ModelRole } from '../models';
+import { DEFAULT_OPENAI_BASE_URL } from '../api/providers/openai/config';
+
+interface OpenAIModelMetadata {
+	contextWindow: number;
+	supportsVision: boolean;
+	defaultForRoles?: ModelRole[];
+}
+
+/**
+ * Curated metadata for known OpenAI-hosted models, keyed by the model id
+ * returned from `/v1/models`. Unknown ids — OpenAI-compatible local servers
+ * (LM Studio, MLX, ...) whose catalog we have no curated data for — fall back
+ * to `UNKNOWN_MODEL_DEFAULTS` in `toGeminiModel`.
+ */
+const KNOWN_OPENAI_MODELS: Record<string, OpenAIModelMetadata> = {
+	// Current flagship family. 'gpt-5.6' is an alias of 'gpt-5.6-sol'.
+	'gpt-5.6': { contextWindow: 1_000_000, supportsVision: true, defaultForRoles: ['chat'] },
+	'gpt-5.6-sol': { contextWindow: 1_000_000, supportsVision: true },
+	'gpt-5.6-terra': { contextWindow: 400_000, supportsVision: true, defaultForRoles: ['summary'] },
+	'gpt-5.6-luna': { contextWindow: 128_000, supportsVision: true, defaultForRoles: ['completions'] },
+	// Still-available older families.
+	'gpt-5.1': { contextWindow: 400_000, supportsVision: true },
+	'gpt-5': { contextWindow: 400_000, supportsVision: true },
+	'gpt-4.1': { contextWindow: 400_000, supportsVision: true },
+	'gpt-4o': { contextWindow: 128_000, supportsVision: true },
+};
+
+/** Applied to a model id absent from {@link KNOWN_OPENAI_MODELS}. */
+const UNKNOWN_MODEL_DEFAULTS: OpenAIModelMetadata = {
+	contextWindow: 128_000,
+	supportsVision: false,
+};
+
+/**
+ * Model ids on api.openai.com that aren't chat-completion models (embeddings,
+ * audio, image, moderation, legacy completion-only models, ...). Only applied
+ * when the base URL is api.openai.com — a compatible local server's catalog
+ * is whatever it advertises, and we don't second-guess it.
+ */
+const NON_CHAT_ID_PATTERNS: RegExp[] = [
+	/embedding/i,
+	/whisper/i,
+	/\btts\b/i,
+	/dall-?e/i,
+	/moderation/i,
+	/davinci/i,
+	/babbage/i,
+	/realtime/i,
+	/\baudio\b/i,
+	/\bimage\b/i,
+];
+
+interface OpenAIModelListEntry {
+	id: string;
+}
+
+interface OpenAIModelListResponse {
+	data?: OpenAIModelListEntry[];
+}
+
+/** Whether `baseUrl` points at the real OpenAI API rather than a compatible server. */
+function isOpenAIHostedEndpoint(baseUrl: string): boolean {
+	try {
+		return new URL(baseUrl).hostname === 'api.openai.com';
+	} catch {
+		return baseUrl.includes('api.openai.com');
+	}
+}
+
+/**
+ * Fetches the list of models available from an OpenAI-compatible `/models`
+ * endpoint (api.openai.com or a custom base URL — LM Studio, MLX, ...) and
+ * returns them as `GeminiModel` entries that can be merged into the global
+ * model list.
+ *
+ * Uses Obsidian's `requestUrl` so the call works on both desktop and mobile
+ * without CORS preflight issues. Caching mirrors `OllamaModelsService`, keyed
+ * on base URL *and* API key — unlike Ollama's unauthenticated daemon, a
+ * changed key must not keep serving the previous key's model list.
+ */
+export class OpenAIModelsService {
+	private plugin: ObsidianGemini;
+	private cachedModels: GeminiModel[] | null = null;
+	private lastBaseUrl: string | null = null;
+	private lastApiKey: string | null = null;
+
+	constructor(plugin: ObsidianGemini) {
+		this.plugin = plugin;
+	}
+
+	/**
+	 * Returns the cached model list if available, otherwise fetches fresh.
+	 * Cache is invalidated when the base URL or API key changes.
+	 */
+	async getModels(forceRefresh = false): Promise<GeminiModel[]> {
+		const baseUrl = this.plugin.settings.openaiBaseUrl || DEFAULT_OPENAI_BASE_URL;
+		const apiKey = this.plugin.openaiApiKey;
+		const cacheMatches = this.lastBaseUrl === baseUrl && this.lastApiKey === apiKey;
+		if (!forceRefresh && this.cachedModels && cacheMatches) {
+			return this.cachedModels;
+		}
+
+		try {
+			const url = `${baseUrl.replace(/\/$/, '')}/models`;
+			const response = await requestUrl({
+				url,
+				method: 'GET',
+				headers: apiKey ? { Authorization: `Bearer ${apiKey}` } : undefined,
+				throw: false,
+			});
+
+			if (response.status !== 200) {
+				throw new Error(`OpenAI /models returned HTTP ${response.status}`);
+			}
+
+			const data = response.json as OpenAIModelListResponse;
+			if (!data || !Array.isArray(data.data)) {
+				throw new Error('Invalid /models response shape');
+			}
+
+			const filterNonChatIds = isOpenAIHostedEndpoint(baseUrl);
+			this.cachedModels = data.data
+				.filter((m) => !filterNonChatIds || !NON_CHAT_ID_PATTERNS.some((re) => re.test(m.id)))
+				.map((m) => this.toGeminiModel(m.id));
+			this.lastBaseUrl = baseUrl;
+			this.lastApiKey = apiKey;
+			this.plugin.logger.log(`[OpenAIModelsService] Loaded ${this.cachedModels.length} models from ${baseUrl}`);
+			return this.cachedModels;
+		} catch (error) {
+			this.plugin.logger.warn('[OpenAIModelsService] Failed to fetch model list:', error);
+			// Don't poison the cache with an empty array — that would stick until the
+			// user manually clicks "Refresh" even after the server comes back. Only
+			// reuse the cache when it matches the active base URL/key; falling back to
+			// another endpoint's models would let the dropdown surface entries that
+			// don't exist there and let the user save invalid selections.
+			return cacheMatches ? (this.cachedModels ?? []) : [];
+		}
+	}
+
+	/**
+	 * Drop the cache (e.g. when the base URL or API key changes, or the user
+	 * clicks "Refresh").
+	 */
+	invalidate(): void {
+		this.cachedModels = null;
+		this.lastBaseUrl = null;
+		this.lastApiKey = null;
+	}
+
+	private toGeminiModel(id: string): GeminiModel {
+		const meta = KNOWN_OPENAI_MODELS[id] ?? UNKNOWN_MODEL_DEFAULTS;
+		return {
+			value: id,
+			label: id,
+			provider: 'openai',
+			supportsTools: true,
+			supportsVision: meta.supportsVision,
+			contextWindow: meta.contextWindow,
+			...(meta.defaultForRoles && { defaultForRoles: [...meta.defaultForRoles] }),
+		};
+	}
+}

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -22,6 +22,9 @@ export interface ObsidianGemini extends Plugin {
 	/** Resolved API key for the active provider ('' when none is required/configured). */
 	readonly apiKey: string;
 
+	/** Resolved OpenAI API key ('' when not configured), mirroring `apiKey`. */
+	readonly openaiApiKey: string;
+
 	isGeminiInitialized: boolean;
 
 	/**

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -51,6 +51,22 @@ export interface ObsidianGeminiSettings {
 	 */
 	ollamaSummaryModelName: string;
 	ollamaCompletionsModelName: string;
+	/**
+	 * Base URL for the OpenAI Chat Completions API. Defaults to
+	 * `DEFAULT_OPENAI_BASE_URL` (api.openai.com); overridden to target an
+	 * OpenAI-compatible local server (LM Studio, MLX, ...).
+	 */
+	openaiBaseUrl: string;
+	/** SecretStorage key holding the OpenAI API key, mirroring `apiKeySecretName`. */
+	openaiApiKeySecretName: string;
+	/**
+	 * Per-use-case OpenAI models. Unlike Ollama, OpenAI has no single-resident-model
+	 * constraint (`capabilities.perUseCaseModels`), so each use case keeps its own
+	 * model rather than defaulting to "inherit the chat model".
+	 */
+	openaiModelName: string;
+	openaiSummaryModelName: string;
+	openaiCompletionsModelName: string;
 	summaryFrontmatterKey: string;
 	userName: string;
 	chatHistory: boolean;

--- a/src/ui/settings-general.ts
+++ b/src/ui/settings-general.ts
@@ -27,6 +27,7 @@ import {
 	providersSupporting,
 	type ProviderUseCase,
 } from '../api/providers/registry';
+import { DEFAULT_OPENAI_BASE_URL } from '../api/providers/openai/config';
 
 export async function renderGeneralSettings(
 	containerEl: HTMLElement,
@@ -143,6 +144,53 @@ async function renderGeneralSection(
 							models.length === 1
 								? t('settings.general.ollamaModelsFoundSingular', { count: models.length })
 								: t('settings.general.ollamaModelsFound', { count: models.length })
+						);
+						await rerender();
+					} catch (error) {
+						new Notice(t('settings.general.refreshFailedNotice', { error: getErrorMessage(error) }));
+					}
+				})
+			);
+	}
+
+	const usesOpenai = isProviderActive(plugin.settings, 'openai');
+	if (usesOpenai) {
+		new Setting(sectionEl)
+			.setName(t('settings.general.openaiApiKeyName'))
+			.setDesc(t('settings.general.openaiApiKeyDesc'))
+			.addComponent((el) =>
+				new SecretComponent(app, el).setValue(plugin.settings.openaiApiKeySecretName).onChange(async (secretName) => {
+					plugin.settings.openaiApiKeySecretName = secretName;
+					await plugin.saveSettings();
+				})
+			);
+
+		new Setting(sectionEl)
+			.setName(t('settings.general.openaiBaseUrlName'))
+			.setDesc(t('settings.general.openaiBaseUrlDesc'))
+			.addText((text) =>
+				text
+					.setPlaceholder(DEFAULT_OPENAI_BASE_URL)
+					.setValue(plugin.settings.openaiBaseUrl)
+					.onChange((value) => {
+						plugin.settings.openaiBaseUrl = value.trim() || DEFAULT_OPENAI_BASE_URL;
+						debouncedSave();
+					})
+			);
+
+		new Setting(sectionEl)
+			.setName(t('settings.general.refreshOpenaiModelListName'))
+			.setDesc(t('settings.general.refreshModelListOpenaiDesc'))
+			.addButton((button) =>
+				button.setButtonText(t('settings.general.refreshButton')).onClick(async () => {
+					try {
+						const manager = plugin.getModelManager();
+						manager.getOpenAIModelsService().invalidate();
+						const models = await manager.getAvailableModels({ forceRefresh: true }, 'openai');
+						new Notice(
+							models.length === 1
+								? t('settings.general.openaiModelsFoundSingular', { count: models.length })
+								: t('settings.general.openaiModelsFound', { count: models.length })
 						);
 						await rerender();
 					} catch (error) {
@@ -278,9 +326,11 @@ function renderPrivacyNotice(sectionEl: HTMLElement, plugin: ObsidianGemini): vo
 
 	// A keyless provider is enough to start the plugin, so a feature routed to a
 	// key-requiring provider without a key initializes fine and then fails at
-	// call time with an opaque auth error. Say so up front instead.
+	// call time with an opaque auth error. Say so up front instead. Since
+	// OpenAI (#1237) more than one active provider can require a key at once,
+	// so each one's own secret field is checked rather than assuming Gemini's.
 	const missingKey = activeProviders(plugin.settings).filter(
-		(id) => getCapabilities(id).requiresApiKey && !plugin.settings.apiKeySecretName
+		(id) => getCapabilities(id).requiresApiKey && !apiKeySecretNameFor(plugin.settings, id)
 	);
 	if (missingKey.length > 0) {
 		const providers = missingKey.map((id) => t(PROVIDERS[id].labelKey as TranslationKey)).join(', ');
@@ -318,6 +368,16 @@ function renderPrivacyNotice(sectionEl: HTMLElement, plugin: ObsidianGemini): vo
 	new Setting(sectionEl)
 		.setName(t('settings.general.localOnlyNoticeName'))
 		.setDesc(t('settings.general.localOnlyNoticeDesc'));
+}
+
+/**
+ * Which settings field holds a provider's API key secret name. Every
+ * key-requiring provider has its own field (`apiKeySecretName` for Gemini,
+ * `openaiApiKeySecretName` for OpenAI) rather than sharing one, so a mixed
+ * configuration with both active needs its own key each.
+ */
+function apiKeySecretNameFor(settings: ObsidianGemini['settings'], provider: ModelProvider): string {
+	return provider === 'openai' ? settings.openaiApiKeySecretName : settings.apiKeySecretName;
 }
 
 /**
@@ -373,6 +433,18 @@ async function renderModelPickers(sectionEl: HTMLElement, plugin: ObsidianGemini
 			'text',
 			'ollama'
 		);
+	} else if (chatProvider === 'openai') {
+		// OpenAI has no single-resident-model constraint (perUseCaseModels), so
+		// unlike Ollama it gets its own field rather than an "inherit" option.
+		await selectModelSetting(
+			sectionEl,
+			plugin,
+			'openaiModelName',
+			t('settings.general.chatModelName'),
+			t('settings.general.openaiChatModelDesc'),
+			'text',
+			'openai'
+		);
 	} else {
 		await selectModelSetting(
 			sectionEl,
@@ -398,6 +470,16 @@ async function renderModelPickers(sectionEl: HTMLElement, plugin: ObsidianGemini
 			'ollama',
 			t('settings.general.inheritOllamaChatModel')
 		);
+	} else if (summaryProvider === 'openai') {
+		await selectModelSetting(
+			sectionEl,
+			plugin,
+			'openaiSummaryModelName',
+			t('settings.general.summaryModelName'),
+			t('settings.general.summaryModelDesc'),
+			'text',
+			'openai'
+		);
 	} else {
 		await selectModelSetting(
 			sectionEl,
@@ -420,6 +502,16 @@ async function renderModelPickers(sectionEl: HTMLElement, plugin: ObsidianGemini
 			'text',
 			'ollama',
 			t('settings.general.inheritOllamaChatModel')
+		);
+	} else if (completionsProvider === 'openai') {
+		await selectModelSetting(
+			sectionEl,
+			plugin,
+			'openaiCompletionsModelName',
+			t('settings.general.completionModelName'),
+			t('settings.general.completionModelDesc'),
+			'text',
+			'openai'
 		);
 	} else {
 		await selectModelSetting(

--- a/src/ui/settings-general.ts
+++ b/src/ui/settings-general.ts
@@ -1,6 +1,7 @@
 import type { ObsidianGemini } from '../types/plugin';
 import { App, Notice, Setting, SecretComponent } from 'obsidian';
 import {
+	apiKeySecretNameFor,
 	createAlwaysOpenSection,
 	createCollapsibleSection,
 	createDebouncedSave,
@@ -368,16 +369,6 @@ function renderPrivacyNotice(sectionEl: HTMLElement, plugin: ObsidianGemini): vo
 	new Setting(sectionEl)
 		.setName(t('settings.general.localOnlyNoticeName'))
 		.setDesc(t('settings.general.localOnlyNoticeDesc'));
-}
-
-/**
- * Which settings field holds a provider's API key secret name. Every
- * key-requiring provider has its own field (`apiKeySecretName` for Gemini,
- * `openaiApiKeySecretName` for OpenAI) rather than sharing one, so a mixed
- * configuration with both active needs its own key each.
- */
-function apiKeySecretNameFor(settings: ObsidianGemini['settings'], provider: ModelProvider): string {
-	return provider === 'openai' ? settings.openaiApiKeySecretName : settings.apiKeySecretName;
 }
 
 /**

--- a/src/ui/settings-helpers.ts
+++ b/src/ui/settings-helpers.ts
@@ -32,6 +32,17 @@ export interface SettingsSectionContext {
  * @param logLabel - Debug-log prefix used when a save fails; pass a
  *   section-specific label to keep failure logs greppable.
  */
+/**
+ * Which settings field holds a provider's API key secret name. Every
+ * key-requiring provider has its own field (`apiKeySecretName` for Gemini,
+ * `openaiApiKeySecretName` for OpenAI) rather than sharing one, so a mixed
+ * configuration with both active needs its own key each. Single source of
+ * truth — the settings UI and the init-error path both resolve through this.
+ */
+export function apiKeySecretNameFor(settings: ObsidianGeminiSettings, provider: ModelProvider): string {
+	return provider === 'openai' ? settings.openaiApiKeySecretName : settings.apiKeySecretName;
+}
+
 export function createDebouncedSave(plugin: ObsidianGemini, logLabel: string = 'Failed to save settings:'): () => void {
 	return debounce(
 		async () => {

--- a/src/utils/error-utils.ts
+++ b/src/utils/error-utils.ts
@@ -19,6 +19,22 @@ export function asRecord(value: unknown): Record<string, unknown> {
 }
 
 /**
+ * Whether an error looks like it came from the `openai` SDK's `APIError`
+ * hierarchy (`BadRequestError`, `AuthenticationError`, `NotFoundError`, ...):
+ * a numeric `status` alongside a `type` or `code` string pulled from the
+ * response body's `error.type`/`error.code` fields.
+ *
+ * Duck-typed on that shape rather than an `instanceof` check against the SDK's
+ * error classes, so this stays a provider-agnostic leaf utility with no SDK
+ * import — and so a minifier renaming the SDK's class names can't break
+ * detection. Gemini's `ApiError` only ever carries `status`, so it can't
+ * false-positive here.
+ */
+function isOpenAIApiError(error: Record<string, unknown>): boolean {
+	return typeof error.status === 'number' && (typeof error.type === 'string' || typeof error.code === 'string');
+}
+
+/**
  * Extract the `details` array from various Google API error shapes.
  * Google errors may carry details at `error.details`, `error.error.details`,
  * `error.response.data.error.details`, or embedded as JSON in `error.message`.
@@ -189,6 +205,33 @@ export function getErrorMessage(error: unknown): string {
 		// HTTP status-code mapping below.
 		const message = error.message;
 		const messageLower = message.toLowerCase();
+
+		// OpenAI-shaped errors get provider-specific guidance for the two status
+		// codes generic wording serves poorly: 401 should point at the OpenAI key
+		// specifically, and 404 should mention the endpoint (since a custom base
+		// URL — LM Studio, MLX, ... — may simply not have the model). Checked
+		// before the generic message-substring checks below so this wins.
+		if (isOpenAIApiError(asRecord(error))) {
+			const statusCode = extractStatusCode(error);
+			if (statusCode === 401) {
+				return 'Invalid OpenAI API key. Please check the API key in Settings → Gemini Scribe.';
+			}
+			if (statusCode === 404) {
+				return 'Model not available on this endpoint. Please check your model settings or the configured base URL.';
+			}
+		}
+
+		// The openai SDK's fetch-layer failures (unreachable custom base URL —
+		// LM Studio/MLX not running, wrong port, DNS failure, ...) surface as
+		// `APIConnectionError`, whose own `.message` is the fixed, uninformative
+		// string "Connection error." — the actionable detail (ECONNREFUSED, etc.)
+		// lives on `.cause`, which callers don't reliably get to inspect. Matched
+		// on that exact message plus an absent status (real HTTP failures always
+		// carry one) rather than an SDK class import, for the same reason as
+		// `isOpenAIApiError` above.
+		if (message === 'Connection error.' && extractStatusCode(error) === null) {
+			return 'Could not connect to the model server. If you configured a custom base URL (LM Studio, MLX, etc.), make sure the server is running and the base URL in settings is correct.';
+		}
 
 		// API key errors
 		if (

--- a/src/utils/init-error-message.ts
+++ b/src/utils/init-error-message.ts
@@ -32,7 +32,7 @@ export function getApiKeyErrorMessage(params: ApiKeyErrorMessageParams): string 
 		return t('notice.main.ollamaUnreachable', { url: params.ollamaBaseUrl });
 	}
 	if (!params.apiKeySecretName) {
-		return t('notice.main.noApiKey');
+		return params.provider === 'openai' ? t('notice.main.noApiKeyOpenai') : t('notice.main.noApiKey');
 	}
 	return t('notice.main.apiKeyRetrieveFailed');
 }

--- a/test/api/factory.test.ts
+++ b/test/api/factory.test.ts
@@ -3,21 +3,26 @@ import { getDefaultModelForRole } from '../../src/models';
 
 // --- Mocks ---
 
-const { MockGeminiClient, MockOllamaClient, MockRetryDecorator, MockGeminiPrompts } = vi.hoisted(() => {
-	const MockGeminiClient = vi.fn().mockImplementation(function () {
-		return { generateModelResponse: vi.fn() };
-	});
-	const MockOllamaClient = vi.fn().mockImplementation(function () {
-		return { generateModelResponse: vi.fn() };
-	});
-	const MockRetryDecorator = vi.fn().mockImplementation(function (_client: any) {
-		return { _wrappedClient: _client };
-	});
-	const MockGeminiPrompts = vi.fn().mockImplementation(function () {
-		return {};
-	});
-	return { MockGeminiClient, MockOllamaClient, MockRetryDecorator, MockGeminiPrompts };
-});
+const { MockGeminiClient, MockOllamaClient, MockOpenAIClient, MockRetryDecorator, MockGeminiPrompts } = vi.hoisted(
+	() => {
+		const MockGeminiClient = vi.fn().mockImplementation(function () {
+			return { generateModelResponse: vi.fn() };
+		});
+		const MockOllamaClient = vi.fn().mockImplementation(function () {
+			return { generateModelResponse: vi.fn() };
+		});
+		const MockOpenAIClient = vi.fn().mockImplementation(function () {
+			return { generateModelResponse: vi.fn() };
+		});
+		const MockRetryDecorator = vi.fn().mockImplementation(function (_client: any) {
+			return { _wrappedClient: _client };
+		});
+		const MockGeminiPrompts = vi.fn().mockImplementation(function () {
+			return {};
+		});
+		return { MockGeminiClient, MockOllamaClient, MockOpenAIClient, MockRetryDecorator, MockGeminiPrompts };
+	}
+);
 
 vi.mock('../../src/api/providers/gemini/client', () => ({
 	GeminiClient: MockGeminiClient,
@@ -25,6 +30,10 @@ vi.mock('../../src/api/providers/gemini/client', () => ({
 
 vi.mock('../../src/api/providers/ollama/client', () => ({
 	OllamaClient: MockOllamaClient,
+}));
+
+vi.mock('../../src/api/providers/openai/client', () => ({
+	OpenAIClient: MockOpenAIClient,
 }));
 
 vi.mock('../../src/api/retry-decorator', () => ({
@@ -40,6 +49,7 @@ vi.mock('../../src/prompts', () => ({
 function createMockPlugin(overrides?: Record<string, any>) {
 	return {
 		apiKey: 'test-api-key',
+		openaiApiKey: 'sk-test-key',
 		settings: {
 			provider: 'gemini',
 			chatModelName: 'gemini-2.0-flash',
@@ -51,6 +61,10 @@ function createMockPlugin(overrides?: Record<string, any>) {
 			maxRetries: 3,
 			initialBackoffDelay: 1000,
 			ollamaBaseUrl: 'http://localhost:11434',
+			openaiBaseUrl: 'https://api.openai.com/v1',
+			openaiModelName: 'gpt-5.6',
+			openaiSummaryModelName: 'gpt-5.6-terra',
+			openaiCompletionsModelName: 'gpt-5.6-luna',
 			...overrides,
 		},
 		logger: {
@@ -156,6 +170,41 @@ describe('ModelClientFactory', () => {
 			const ollamaConfig = MockOllamaClient.mock.calls[0][0];
 			expect(ollamaConfig.baseUrl).toBe('http://localhost:11434');
 		});
+
+		it('should create an OpenAIClient when provider is openai', () => {
+			const plugin = createMockPlugin({ provider: 'openai' });
+			ModelClientFactory.createFromPlugin(plugin, ModelUseCase.CHAT);
+
+			expect(MockOpenAIClient).toHaveBeenCalledTimes(1);
+			expect(MockGeminiClient).not.toHaveBeenCalled();
+			expect(MockOllamaClient).not.toHaveBeenCalled();
+			expect(MockRetryDecorator).toHaveBeenCalledTimes(1);
+		});
+
+		it('should use the resolved OpenAI API key and base URL from settings', () => {
+			const plugin = createMockPlugin({ provider: 'openai', openaiBaseUrl: 'http://localhost:1234/v1' });
+			ModelClientFactory.createFromPlugin(plugin, ModelUseCase.CHAT);
+
+			const openaiConfig = MockOpenAIClient.mock.calls[0][0];
+			expect(openaiConfig.apiKey).toBe('sk-test-key');
+			expect(openaiConfig.baseUrl).toBe('http://localhost:1234/v1');
+		});
+
+		it('should default openaiBaseUrl to api.openai.com when empty', () => {
+			const plugin = createMockPlugin({ provider: 'openai', openaiBaseUrl: '' });
+			ModelClientFactory.createFromPlugin(plugin, ModelUseCase.CHAT);
+
+			const openaiConfig = MockOpenAIClient.mock.calls[0][0];
+			expect(openaiConfig.baseUrl).toBe('https://api.openai.com/v1');
+		});
+
+		it('should apply overrides to OpenAI config', () => {
+			const plugin = createMockPlugin({ provider: 'openai' });
+			ModelClientFactory.createFromPlugin(plugin, ModelUseCase.CHAT, { temperature: 0.3 });
+
+			const openaiConfig = MockOpenAIClient.mock.calls[0][0];
+			expect(openaiConfig.temperature).toBe(0.3);
+		});
 	});
 
 	describe('resolveModelName (via createFromPlugin)', () => {
@@ -255,6 +304,51 @@ describe('ModelClientFactory', () => {
 				// context with no Ollama models loaded this is the empty-string sentinel,
 				// which is exactly the unconfigured-Ollama state the resolver passes through.
 				expect(config.model).toBe(getDefaultModelForRole('chat', 'ollama'));
+			});
+		});
+
+		describe('OpenAI provider', () => {
+			// Unlike Ollama, OpenAI has no single-resident-model constraint
+			// (perUseCaseModels), so each use case resolves to its own configured field.
+			it('resolves CHAT to openaiModelName', () => {
+				const plugin = createMockPlugin({ provider: 'openai', openaiModelName: 'openai-chat' });
+				ModelClientFactory.createFromPlugin(plugin, ModelUseCase.CHAT);
+
+				expect(MockOpenAIClient).toHaveBeenCalledTimes(1);
+				expect(MockGeminiClient).not.toHaveBeenCalled();
+				expect(MockOpenAIClient.mock.calls[0][0].model).toBe('openai-chat');
+			});
+
+			it('resolves SUMMARY to openaiSummaryModelName independently of the chat model', () => {
+				const plugin = createMockPlugin({
+					provider: 'openai',
+					openaiModelName: 'openai-chat',
+					openaiSummaryModelName: 'openai-summary',
+				});
+				ModelClientFactory.createFromPlugin(plugin, ModelUseCase.SUMMARY);
+
+				expect(MockOpenAIClient.mock.calls[0][0].model).toBe('openai-summary');
+			});
+
+			it('resolves COMPLETIONS to openaiCompletionsModelName independently of the chat model', () => {
+				const plugin = createMockPlugin({
+					provider: 'openai',
+					openaiModelName: 'openai-chat',
+					openaiCompletionsModelName: 'openai-completions',
+				});
+				ModelClientFactory.createFromPlugin(plugin, ModelUseCase.COMPLETIONS);
+
+				expect(MockOpenAIClient.mock.calls[0][0].model).toBe('openai-completions');
+			});
+
+			it('resolves REWRITE and SEARCH to openaiModelName (no dedicated field)', () => {
+				const plugin = createMockPlugin({ provider: 'openai', openaiModelName: 'openai-chat' });
+
+				ModelClientFactory.createFromPlugin(plugin, ModelUseCase.REWRITE);
+				expect(MockOpenAIClient.mock.calls[0][0].model).toBe('openai-chat');
+
+				ModelClientFactory.createFromPlugin(plugin, ModelUseCase.SEARCH);
+				expect(MockOpenAIClient.mock.calls[1][0].model).toBe('openai-chat');
 			});
 		});
 	});
@@ -432,6 +526,24 @@ describe('ModelClientFactory', () => {
 
 			ModelClientFactory.createFromPlugin(plugin, ModelUseCase.COMPLETIONS);
 			expect(MockOllamaClient.mock.calls[0][0].model).toBe('ollama-tiny');
+		});
+
+		it('builds an OpenAI client for a use case overridden away from a local primary', () => {
+			const plugin = createMockPlugin({
+				provider: 'ollama',
+				providerOverrides: { summary: 'openai' },
+				openaiSummaryModelName: 'openai-summary',
+				ollamaModelName: 'ollama-local',
+			});
+
+			ModelClientFactory.createFromPlugin(plugin, ModelUseCase.SUMMARY);
+			expect(MockOpenAIClient).toHaveBeenCalledTimes(1);
+			expect(MockOpenAIClient.mock.calls[0][0].model).toBe('openai-summary');
+			expect(MockOllamaClient).not.toHaveBeenCalled();
+
+			ModelClientFactory.createFromPlugin(plugin, ModelUseCase.CHAT);
+			expect(MockOllamaClient).toHaveBeenCalledTimes(1);
+			expect(MockOllamaClient.mock.calls[0][0].model).toBe('ollama-local');
 		});
 	});
 });

--- a/test/api/provider-registry.test.ts
+++ b/test/api/provider-registry.test.ts
@@ -49,9 +49,31 @@ describe('capability matrix', () => {
 		expect(caps.perUseCaseModels).toBe(false);
 	});
 
+	it('matches the documented OpenAI capabilities', () => {
+		const caps = PROVIDERS.openai.capabilities;
+		expect(caps.chat).toBe(true);
+		expect(caps.summary).toBe(true);
+		expect(caps.completions).toBe(true);
+		expect(caps.rewrite).toBe(true);
+		// Cloud-only features this phase doesn't implement for OpenAI.
+		expect(caps.webSearch).toBe(false);
+		expect(caps.rag).toBe(false);
+		expect(caps.imageGen).toBe(false);
+		expect(caps.requiresApiKey).toBe(true);
+		expect(caps.nativeTokenCount).toBe(false);
+		expect(caps.promptCache).toBe(false);
+		expect(caps.costMetrics).toBe(false);
+		expect(caps.interactionsApi).toBe(false);
+		expect(caps.vision).toBe('auto-detect');
+		expect(caps.customBaseUrl).toBe(true);
+		// Each use case keeps its own model — no single-resident-model constraint.
+		expect(caps.perUseCaseModels).toBe(true);
+	});
+
 	it('gives every provider a smaller default context limit than Gemini where local', () => {
 		expect(PROVIDERS.gemini.capabilities.defaultInputTokenLimit).toBe(1_000_000);
 		expect(PROVIDERS.ollama.capabilities.defaultInputTokenLimit).toBe(32_000);
+		expect(PROVIDERS.openai.capabilities.defaultInputTokenLimit).toBe(128_000);
 	});
 
 	it('declares every routable use case for every provider', () => {
@@ -73,13 +95,13 @@ describe('capability matrix', () => {
 
 describe('lookup helpers', () => {
 	it('providersSupporting lists candidates in display order', () => {
-		expect(providersSupporting('chat')).toEqual(['gemini', 'ollama']);
+		expect(providersSupporting('chat')).toEqual(['gemini', 'ollama', 'openai']);
 		expect(providersSupporting('rag')).toEqual(['gemini']);
 		expect(providersSupporting('imageGen')).toEqual(['gemini']);
 	});
 
 	it('providerSupports rejects unknown providers rather than throwing', () => {
-		expect(providerSupports('openai' as never, 'chat')).toBe(false);
+		expect(providerSupports('anthropic' as never, 'chat')).toBe(false);
 		expect(providerSupports(null, 'chat')).toBe(false);
 		expect(providerSupports(undefined, 'chat')).toBe(false);
 	});
@@ -87,7 +109,7 @@ describe('lookup helpers', () => {
 	// A settings file written by a newer version and then downgraded shouldn't
 	// crash the plugin on load.
 	it('getCapabilities falls back to Gemini for an unknown provider', () => {
-		expect(getCapabilities('openai' as never)).toBe(PROVIDERS.gemini.capabilities);
+		expect(getCapabilities('anthropic' as never)).toBe(PROVIDERS.gemini.capabilities);
 		expect(getCapabilities(undefined)).toBe(PROVIDERS.gemini.capabilities);
 	});
 

--- a/test/api/provider-routing.test.ts
+++ b/test/api/provider-routing.test.ts
@@ -65,6 +65,23 @@ describe('resolveProvider', () => {
 	});
 });
 
+describe('OpenAI routing', () => {
+	it('resolves every routable use case OpenAI supports, and null for the rest', () => {
+		const enabled = PROVIDER_USE_CASES.filter((u) => resolveProvider({ provider: 'openai' }, u) !== null);
+		expect(enabled).toEqual(['chat', 'summary', 'completions', 'rewrite']);
+	});
+
+	it('participates in activeProviders and routingKey like any other provider', () => {
+		expect(activeProviders({ provider: 'openai' })).toEqual(['openai']);
+		expect(isProviderActive({ provider: 'ollama', providerOverrides: { chat: 'openai' } }, 'openai')).toBe(true);
+		expect(routingKey({ provider: 'openai' })).not.toBe(routingKey({ provider: 'gemini' }));
+	});
+
+	it('resolveProviderOrDefault keeps OpenAI for a mandatory-client use case', () => {
+		expect(resolveProviderOrDefault({ provider: 'openai' }, 'chat')).toBe('openai');
+	});
+});
+
 describe('backward compatibility', () => {
 	// An install from before #704 has a primary and no overrides. Every use case
 	// must resolve exactly as the old single-provider check did.
@@ -151,7 +168,9 @@ describe('sanitizeProviderOverrides', () => {
 	});
 
 	it('drops unknown use cases and unknown providers', () => {
-		expect(sanitizeProviderOverrides({ chat: 'openai', bogus: 'gemini', rag: 'gemini' })).toEqual({ rag: 'gemini' });
+		expect(sanitizeProviderOverrides({ chat: 'anthropic', bogus: 'gemini', rag: 'gemini' })).toEqual({
+			rag: 'gemini',
+		});
 	});
 
 	// A pairing resolveProvider would treat as null must not survive in storage:

--- a/test/api/providers/openai/client.test.ts
+++ b/test/api/providers/openai/client.test.ts
@@ -1,0 +1,810 @@
+import type { Mock } from 'vitest';
+import { OpenAIClient } from '../../../../src/api/providers/openai/client';
+import type { OpenAIClientConfig } from '../../../../src/api/providers/openai/config';
+import { ExtendedModelRequest } from '../../../../src/api/interfaces/model-api';
+
+// vitest hoists vi.mock to the top of the file; vi.hoisted() lets us share
+// fixtures with the factory while keeping initialization order safe.
+const { openaiCalls } = vi.hoisted(() => {
+	const openaiCalls: { create: Mock } = {
+		create: vi.fn(),
+	};
+	return { openaiCalls };
+});
+
+vi.mock('openai', () => ({
+	// Use function syntax so `new OpenAI()` works under vitest 4 (arrow impls
+	// aren't constructable).
+	default: vi.fn().mockImplementation(function (this: any, opts: any) {
+		this.constructorOpts = opts;
+		this.chat = {
+			completions: {
+				create: (...args: any[]) => openaiCalls.create(...args),
+			},
+		};
+	}),
+}));
+
+const mockLogger = {
+	log: vi.fn(),
+	debug: vi.fn(),
+	warn: vi.fn(),
+	error: vi.fn(),
+};
+
+const buildPlugin = () =>
+	({
+		logger: mockLogger,
+		settings: {
+			provider: 'openai',
+			userName: 'Tester',
+			ragIndexing: { enabled: false },
+		},
+		agentsMemory: { read: vi.fn().mockResolvedValue('') },
+		skillManager: { getSkillSummaries: vi.fn().mockResolvedValue([]) },
+		ragIndexing: null,
+	}) as any;
+
+const baseConfig: OpenAIClientConfig = {
+	apiKey: 'sk-test',
+	baseUrl: 'https://api.openai.com/v1',
+	model: 'gpt-4o-mini',
+	temperature: 0.4,
+	topP: 0.9,
+};
+
+describe('OpenAIClient', () => {
+	let client: OpenAIClient;
+
+	beforeEach(() => {
+		openaiCalls.create.mockReset();
+		mockLogger.error.mockReset();
+		mockLogger.warn.mockReset();
+		client = new OpenAIClient(baseConfig, undefined, buildPlugin());
+	});
+
+	describe('generateModelResponse (BaseModelRequest)', () => {
+		it('routes simple prompts through chat.completions.create and forwards options', async () => {
+			openaiCalls.create.mockResolvedValue({
+				choices: [{ message: { role: 'assistant', content: 'hello world' } }],
+				usage: { prompt_tokens: 10, completion_tokens: 4, total_tokens: 14 },
+			});
+
+			const response = await client.generateModelResponse({
+				kind: 'base',
+				prompt: 'say hi',
+				temperature: 0.2,
+			});
+
+			expect(openaiCalls.create).toHaveBeenCalledTimes(1);
+			const args = openaiCalls.create.mock.calls[0][0];
+			expect(args.model).toBe('gpt-4o-mini');
+			expect(args.messages).toEqual([{ role: 'user', content: 'say hi' }]);
+			expect(args.stream).toBe(false);
+			expect(args.temperature).toBe(0.2);
+			expect(args.top_p).toBe(0.9);
+
+			expect(response.markdown).toBe('hello world');
+			expect(response.usageMetadata).toEqual({
+				promptTokenCount: 10,
+				candidatesTokenCount: 4,
+				totalTokenCount: 14,
+			});
+		});
+	});
+
+	describe('generateModelResponse (ExtendedModelRequest)', () => {
+		it('routes chat through chat.completions.create with system + history + user message', async () => {
+			openaiCalls.create.mockResolvedValue({
+				choices: [{ message: { role: 'assistant', content: 'reply' } }],
+				usage: { prompt_tokens: 50, completion_tokens: 2, total_tokens: 52 },
+			});
+
+			const request: ExtendedModelRequest = {
+				prompt: '',
+				userMessage: 'what is up',
+				kind: 'extended',
+				conversationHistory: [
+					{ role: 'user', parts: [{ text: 'previous user turn' }] },
+					{ role: 'model', parts: [{ text: 'previous assistant turn' }] },
+				],
+			};
+
+			const response = await client.generateModelResponse(request);
+
+			expect(openaiCalls.create).toHaveBeenCalledTimes(1);
+			const args = openaiCalls.create.mock.calls[0][0];
+			expect(args.stream).toBe(false);
+			// system instruction always present (built from prompts module)
+			expect(args.messages[0].role).toBe('system');
+			expect(args.messages.some((m: any) => m.role === 'user' && m.content === 'previous user turn')).toBe(true);
+			expect(args.messages.some((m: any) => m.role === 'assistant' && m.content === 'previous assistant turn')).toBe(
+				true
+			);
+			expect(args.messages[args.messages.length - 1]).toEqual({ role: 'user', content: 'what is up' });
+			expect(response.markdown).toBe('reply');
+		});
+
+		it('maps tool calls in the assistant response', async () => {
+			openaiCalls.create.mockResolvedValue({
+				choices: [
+					{
+						message: {
+							role: 'assistant',
+							content: '',
+							tool_calls: [
+								{
+									id: 'call_read_file_0',
+									type: 'function',
+									function: { name: 'read_file', arguments: '{"path":"foo.md"}' },
+								},
+							],
+						},
+					},
+				],
+				usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+			});
+
+			const response = await client.generateModelResponse({
+				prompt: '',
+				userMessage: 'read foo',
+				kind: 'extended',
+				conversationHistory: [],
+				availableTools: [
+					{
+						name: 'read_file',
+						description: 'reads a file',
+						parameters: { type: 'object', properties: { path: { type: 'string' } }, required: ['path'] },
+					},
+				],
+			});
+
+			expect(response.toolCalls).toEqual([
+				{ id: 'call_read_file_0', name: 'read_file', arguments: { path: 'foo.md' } },
+			]);
+			expect(openaiCalls.create.mock.calls[0][0].tools).toEqual([
+				{
+					type: 'function',
+					function: {
+						name: 'read_file',
+						description: 'reads a file',
+						parameters: { type: 'object', properties: { path: { type: 'string' } }, required: ['path'] },
+					},
+				},
+			]);
+		});
+
+		it('falls back to an empty object and logs a warning for malformed tool call arguments', async () => {
+			openaiCalls.create.mockResolvedValue({
+				choices: [
+					{
+						message: {
+							role: 'assistant',
+							content: '',
+							tool_calls: [
+								{
+									id: 'call_1',
+									type: 'function',
+									function: { name: 'read_file', arguments: '{not valid json' },
+								},
+							],
+						},
+					},
+				],
+			});
+
+			const response = await client.generateModelResponse({
+				prompt: '',
+				userMessage: 'read foo',
+				kind: 'extended',
+				conversationHistory: [],
+			});
+
+			expect(response.toolCalls).toEqual([{ id: 'call_1', name: 'read_file', arguments: {} }]);
+			expect(mockLogger.warn).toHaveBeenCalled();
+		});
+
+		it('maps reasoning_content to thoughts', async () => {
+			openaiCalls.create.mockResolvedValue({
+				choices: [
+					{
+						message: { role: 'assistant', content: 'answer', reasoning_content: 'chain of thought' },
+					},
+				],
+			});
+
+			const response = await client.generateModelResponse({
+				prompt: '',
+				userMessage: 'think',
+				kind: 'extended',
+				conversationHistory: [],
+			});
+
+			expect(response.thoughts).toBe('chain of thought');
+			expect(response.markdown).toBe('answer');
+		});
+
+		it('attaches image inline data as an image_url content part on the user message', async () => {
+			openaiCalls.create.mockResolvedValue({
+				choices: [{ message: { role: 'assistant', content: 'ok' } }],
+			});
+
+			await client.generateModelResponse({
+				prompt: '',
+				userMessage: 'what is in this picture',
+				kind: 'extended',
+				conversationHistory: [],
+				inlineAttachments: [{ mimeType: 'image/png', base64: 'b64data' }],
+			});
+
+			const args = openaiCalls.create.mock.calls[0][0];
+			const userTurn = args.messages[args.messages.length - 1];
+			expect(userTurn.role).toBe('user');
+			expect(userTurn.content).toEqual([
+				{ type: 'text', text: 'what is in this picture' },
+				{ type: 'image_url', image_url: { url: 'data:image/png;base64,b64data' } },
+			]);
+		});
+
+		it('rejects non-image attachments with a clear error', async () => {
+			await expect(
+				client.generateModelResponse({
+					prompt: '',
+					userMessage: 'read this',
+					kind: 'extended',
+					conversationHistory: [],
+					inlineAttachments: [{ mimeType: 'application/pdf', base64: 'b64data' }],
+				})
+			).rejects.toThrow(/OpenAI only supports image attachments/);
+		});
+
+		it('transmits perTurnContext directly inside the user message', async () => {
+			openaiCalls.create.mockResolvedValue({
+				choices: [{ message: { role: 'assistant', content: 'ok' } }],
+			});
+
+			const renderedContext =
+				'CONTEXT FILES: foo.md\n\n==============================\nFile Label: Context File\nFile Name: foo.md\n==============================\n\nThe quick brown fox jumps over the lazy dog.';
+
+			await client.generateModelResponse({
+				prompt: '',
+				userMessage: 'what does the file say',
+				kind: 'extended',
+				conversationHistory: [],
+				perTurnContext: renderedContext,
+				projectInstructions: 'always cite file paths',
+				sessionStartedAt: '2026-05-09T10:00:00',
+			});
+
+			const args = openaiCalls.create.mock.calls[0][0];
+
+			const systemMessage = args.messages.find((m: any) => m.role === 'system');
+			expect(systemMessage).toBeDefined();
+			expect(systemMessage.content).not.toContain('## Turn Context');
+			expect(systemMessage.content).not.toContain('The quick brown fox jumps over the lazy dog.');
+			expect(systemMessage.content).toContain('always cite file paths');
+			expect(systemMessage.content).toContain('2026-05-09T10:00:00');
+
+			const userMessage = args.messages[args.messages.length - 1];
+			expect(userMessage.role).toBe('user');
+			expect(userMessage.content).toContain('what does the file say');
+			expect(userMessage.content).toContain(renderedContext);
+		});
+	});
+
+	describe('convertHistoryEntry() complex formats', () => {
+		beforeEach(() => {
+			openaiCalls.create.mockResolvedValue({
+				choices: [{ message: { role: 'assistant', content: 'ok' } }],
+			});
+		});
+
+		it('converts functionCall parts to an assistant message with tool_calls, synthesizing an id', async () => {
+			await client.generateModelResponse({
+				prompt: '',
+				userMessage: 'do it',
+				kind: 'extended',
+				conversationHistory: [
+					{ role: 'model', parts: [{ functionCall: { name: 'read_file', args: { path: 'test.md' } } }] },
+				],
+			});
+
+			const msgs = openaiCalls.create.mock.calls[0][0].messages;
+			const assistantMsg = msgs.find((m: any) => m.role === 'assistant' && m.tool_calls?.length);
+			expect(assistantMsg).toBeDefined();
+			expect(assistantMsg.content).toBeNull();
+			expect(assistantMsg.tool_calls).toEqual([
+				{
+					id: 'call_read_file_0',
+					type: 'function',
+					function: { name: 'read_file', arguments: '{"path":"test.md"}' },
+				},
+			]);
+		});
+
+		it('pairs a functionResponse with the preceding functionCall id (synthesized)', async () => {
+			await client.generateModelResponse({
+				prompt: '',
+				userMessage: 'ok',
+				kind: 'extended',
+				conversationHistory: [
+					{ role: 'model', parts: [{ functionCall: { name: 'read_file', args: { path: 'test.md' } } }] },
+					{
+						role: 'user',
+						parts: [{ functionResponse: { name: 'read_file', response: { content: 'data' } } }],
+					},
+				],
+			});
+
+			const msgs = openaiCalls.create.mock.calls[0][0].messages;
+			const assistantMsg = msgs.find((m: any) => m.role === 'assistant' && m.tool_calls?.length);
+			const toolMsg = msgs.find((m: any) => m.role === 'tool');
+			expect(toolMsg).toBeDefined();
+			expect(toolMsg.tool_call_id).toBe(assistantMsg.tool_calls[0].id);
+			expect(toolMsg.content).toBe('{"content":"data"}');
+		});
+
+		it('pairs a functionResponse with the functionCall id when explicitly provided by Gemini', async () => {
+			await client.generateModelResponse({
+				prompt: '',
+				userMessage: 'ok',
+				kind: 'extended',
+				conversationHistory: [
+					{
+						role: 'model',
+						parts: [{ functionCall: { name: 'read_file', args: { path: 'a.md' }, id: 'gemini-call-1' } }],
+					},
+					{
+						role: 'user',
+						parts: [{ functionResponse: { name: 'read_file', response: { ok: true }, id: 'gemini-call-1' } }],
+					},
+				],
+			});
+
+			const msgs = openaiCalls.create.mock.calls[0][0].messages;
+			const assistantMsg = msgs.find((m: any) => m.role === 'assistant' && m.tool_calls?.length);
+			const toolMsg = msgs.find((m: any) => m.role === 'tool');
+			expect(assistantMsg.tool_calls[0].id).toBe('gemini-call-1');
+			expect(toolMsg.tool_call_id).toBe('gemini-call-1');
+		});
+
+		it('pairs two calls to the same tool with their respective responses in order', async () => {
+			await client.generateModelResponse({
+				prompt: '',
+				userMessage: 'go',
+				kind: 'extended',
+				conversationHistory: [
+					{
+						role: 'model',
+						parts: [
+							{ functionCall: { name: 'read_file', args: { path: 'a.md' } } },
+							{ functionCall: { name: 'read_file', args: { path: 'b.md' } } },
+						],
+					},
+					{
+						role: 'user',
+						parts: [
+							{ functionResponse: { name: 'read_file', response: { path: 'a.md' } } },
+							{ functionResponse: { name: 'read_file', response: { path: 'b.md' } } },
+						],
+					},
+				],
+			});
+
+			const msgs = openaiCalls.create.mock.calls[0][0].messages;
+			const assistantMsg = msgs.find((m: any) => m.role === 'assistant' && m.tool_calls?.length);
+			const toolMsgs = msgs.filter((m: any) => m.role === 'tool');
+			expect(assistantMsg.tool_calls).toHaveLength(2);
+			expect(toolMsgs).toHaveLength(2);
+			expect(toolMsgs[0].tool_call_id).toBe(assistantMsg.tool_calls[0].id);
+			expect(toolMsgs[1].tool_call_id).toBe(assistantMsg.tool_calls[1].id);
+			expect(toolMsgs[0].content).toBe('{"path":"a.md"}');
+			expect(toolMsgs[1].content).toBe('{"path":"b.md"}');
+		});
+
+		it('serializes null functionResponse as "null"', async () => {
+			await client.generateModelResponse({
+				prompt: '',
+				userMessage: 'ok',
+				kind: 'extended',
+				conversationHistory: [
+					{ role: 'user', parts: [{ functionResponse: { name: 'tool1', response: null as any } }] },
+				],
+			});
+
+			const msgs = openaiCalls.create.mock.calls[0][0].messages;
+			const toolMsg = msgs.find((m: any) => m.role === 'tool');
+			expect(toolMsg.content).toBe('null');
+		});
+
+		it('passes string functionResponse as-is', async () => {
+			await client.generateModelResponse({
+				prompt: '',
+				userMessage: 'ok',
+				kind: 'extended',
+				conversationHistory: [
+					{ role: 'user', parts: [{ functionResponse: { name: 'tool1', response: 'raw result' as any } }] },
+				],
+			});
+
+			const msgs = openaiCalls.create.mock.calls[0][0].messages;
+			const toolMsg = msgs.find((m: any) => m.role === 'tool');
+			expect(toolMsg.content).toBe('raw result');
+		});
+
+		it('handles mixed text + functionCall in one model entry', async () => {
+			await client.generateModelResponse({
+				prompt: '',
+				userMessage: 'go',
+				kind: 'extended',
+				conversationHistory: [
+					{
+						role: 'model',
+						parts: [{ text: 'Let me read that.' }, { functionCall: { name: 'read_file', args: { path: 'x.md' } } }],
+					},
+				],
+			});
+
+			const msgs = openaiCalls.create.mock.calls[0][0].messages;
+			const assistantMsg = msgs.find((m: any) => m.role === 'assistant' && m.tool_calls?.length);
+			expect(assistantMsg).toBeDefined();
+			expect(assistantMsg.content).toBe('Let me read that.');
+			expect(assistantMsg.tool_calls[0].function).toEqual({
+				name: 'read_file',
+				arguments: '{"path":"x.md"}',
+			});
+		});
+
+		it('converts image inlineData in history to a user message with an image_url content part', async () => {
+			await client.generateModelResponse({
+				prompt: '',
+				userMessage: 'describe it',
+				kind: 'extended',
+				conversationHistory: [
+					{
+						role: 'user',
+						parts: [{ text: 'look at this' }, { inlineData: { mimeType: 'image/png', data: 'abc123' } }],
+					},
+				],
+			});
+
+			const msgs = openaiCalls.create.mock.calls[0][0].messages;
+			const imageMsg = msgs.find((m: any) => m.role === 'user' && Array.isArray(m.content));
+			expect(imageMsg).toBeDefined();
+			expect(imageMsg.content).toEqual([
+				{ type: 'text', text: 'look at this' },
+				{ type: 'image_url', image_url: { url: 'data:image/png;base64,abc123' } },
+			]);
+		});
+
+		it('throws for non-image inlineData in history', async () => {
+			await expect(
+				client.generateModelResponse({
+					prompt: '',
+					userMessage: 'read it',
+					kind: 'extended',
+					conversationHistory: [
+						{ role: 'user', parts: [{ inlineData: { mimeType: 'application/pdf', data: 'abc' } }] },
+					],
+				})
+			).rejects.toThrow(/OpenAI only supports image attachments/);
+		});
+
+		it('converts system role entry to system message', async () => {
+			await client.generateModelResponse({
+				prompt: '',
+				userMessage: 'hi',
+				kind: 'extended',
+				conversationHistory: [{ role: 'system', parts: [{ text: 'system instruction' }] }],
+			});
+
+			const msgs = openaiCalls.create.mock.calls[0][0].messages;
+			const systemMsgs = msgs.filter((m: any) => m.role === 'system');
+			const historySystem = systemMsgs.find((m: any) => m.content === 'system instruction');
+			expect(historySystem).toBeDefined();
+		});
+
+		it('skips null entries in history', async () => {
+			await client.generateModelResponse({
+				prompt: '',
+				userMessage: 'hi',
+				kind: 'extended',
+				conversationHistory: [null as any, { role: 'user', parts: [{ text: 'hello' }] }],
+			});
+
+			const msgs = openaiCalls.create.mock.calls[0][0].messages;
+			const userMsgs = msgs.filter((m: any) => m.role === 'user' && m.content === 'hello');
+			expect(userMsgs.length).toBe(1);
+		});
+
+		it('converts internal {role, text} format', async () => {
+			await client.generateModelResponse({
+				prompt: '',
+				userMessage: 'go',
+				kind: 'extended',
+				conversationHistory: [{ role: 'model', text: 'hello' } as any],
+			});
+
+			const msgs = openaiCalls.create.mock.calls[0][0].messages;
+			const assistantMsg = msgs.find((m: any) => m.role === 'assistant' && m.content === 'hello');
+			expect(assistantMsg).toBeDefined();
+		});
+
+		it('converts internal {role, message} format', async () => {
+			await client.generateModelResponse({
+				prompt: '',
+				userMessage: 'go',
+				kind: 'extended',
+				conversationHistory: [{ role: 'user', message: 'hey' } as any],
+			});
+
+			const msgs = openaiCalls.create.mock.calls[0][0].messages;
+			const userMsg = msgs.find((m: any) => m.role === 'user' && m.content === 'hey');
+			expect(userMsg).toBeDefined();
+		});
+
+		it('skips entries with empty text in internal format', async () => {
+			await client.generateModelResponse({
+				prompt: '',
+				userMessage: 'go',
+				kind: 'extended',
+				conversationHistory: [{ role: 'user', text: '  ' } as any],
+			});
+
+			const msgs = openaiCalls.create.mock.calls[0][0].messages;
+			const userMsgs = msgs.filter((m: any) => m.role === 'user');
+			expect(userMsgs.length).toBe(1);
+			expect(userMsgs[0].content).toBe('go');
+		});
+
+		it('maps "assistant" role in internal format to assistant', async () => {
+			await client.generateModelResponse({
+				prompt: '',
+				userMessage: 'go',
+				kind: 'extended',
+				conversationHistory: [{ role: 'assistant', text: 'response' } as any],
+			});
+
+			const msgs = openaiCalls.create.mock.calls[0][0].messages;
+			const assistantMsg = msgs.find((m: any) => m.role === 'assistant' && m.content === 'response');
+			expect(assistantMsg).toBeDefined();
+		});
+	});
+
+	describe('toUsageMetadata()', () => {
+		it('returns usage mapping when usage is provided', () => {
+			const result = (client as any).toUsageMetadata({
+				prompt_tokens: 10,
+				completion_tokens: 5,
+				total_tokens: 15,
+			});
+			expect(result).toEqual({ promptTokenCount: 10, candidatesTokenCount: 5, totalTokenCount: 15 });
+		});
+
+		it('returns undefined when usage is undefined', () => {
+			const result = (client as any).toUsageMetadata(undefined);
+			expect(result).toBeUndefined();
+		});
+	});
+
+	describe('generateStreamingResponse', () => {
+		function chunk(partial: any) {
+			return {
+				id: 'chunk',
+				object: 'chat.completion.chunk',
+				created: 0,
+				model: 'gpt-4o-mini',
+				choices: [{ index: 0, delta: partial.delta ?? {}, finish_reason: partial.finish_reason ?? null }],
+				...(partial.usage !== undefined ? { usage: partial.usage } : {}),
+			};
+		}
+
+		it('accumulates text deltas and reports usageMetadata from the final chunk', async () => {
+			async function* stream() {
+				yield chunk({ delta: { role: 'assistant', content: 'hel' } });
+				yield chunk({ delta: { content: 'lo' } });
+				yield chunk({
+					delta: {},
+					finish_reason: 'stop',
+					usage: { prompt_tokens: 5, completion_tokens: 3, total_tokens: 8 },
+				});
+			}
+			openaiCalls.create.mockResolvedValue(stream());
+
+			const chunks: string[] = [];
+			const streaming = client.generateStreamingResponse(
+				{ prompt: '', userMessage: 'hi', kind: 'extended', conversationHistory: [] },
+				(c) => chunks.push(c.text)
+			);
+			const result = await streaming.complete;
+
+			expect(chunks.join('')).toBe('hello');
+			expect(result.markdown).toBe('hello');
+			expect(result.usageMetadata).toEqual({
+				promptTokenCount: 5,
+				candidatesTokenCount: 3,
+				totalTokenCount: 8,
+			});
+
+			// stream_options.include_usage should be requested
+			const args = openaiCalls.create.mock.calls[0][0];
+			expect(args.stream_options).toEqual({ include_usage: true });
+		});
+
+		it('accumulates reasoning_content deltas into thoughts', async () => {
+			async function* stream() {
+				yield chunk({ delta: { role: 'assistant', reasoning_content: 'step 1' } });
+				yield chunk({ delta: { content: 'answer', reasoning_content: ' step 2' } });
+			}
+			openaiCalls.create.mockResolvedValue(stream());
+
+			const thoughts: string[] = [];
+			const streaming = client.generateStreamingResponse(
+				{ prompt: '', userMessage: 'think', kind: 'extended', conversationHistory: [] },
+				(c) => {
+					if (c.thought) thoughts.push(c.thought);
+				}
+			);
+			const result = await streaming.complete;
+
+			expect(result.thoughts).toBe('step 1 step 2');
+			expect(result.markdown).toBe('answer');
+			expect(thoughts).toEqual(['step 1', ' step 2']);
+		});
+
+		it('accumulates tool_call deltas by index across chunks', async () => {
+			async function* stream() {
+				yield chunk({
+					delta: {
+						tool_calls: [{ index: 0, id: 'call_1', type: 'function', function: { name: 'read_file', arguments: '' } }],
+					},
+				});
+				yield chunk({ delta: { tool_calls: [{ index: 0, function: { arguments: '{"path":' } }] } });
+				yield chunk({ delta: { tool_calls: [{ index: 0, function: { arguments: '"a.md"}' } }] } });
+				yield chunk({ delta: {}, finish_reason: 'tool_calls' });
+			}
+			openaiCalls.create.mockResolvedValue(stream());
+
+			const streaming = client.generateStreamingResponse(
+				{ prompt: '', userMessage: 'hi', kind: 'extended', conversationHistory: [] },
+				() => {}
+			);
+			const result = await streaming.complete;
+
+			expect(result.toolCalls).toEqual([{ id: 'call_1', name: 'read_file', arguments: { path: 'a.md' } }]);
+		});
+
+		// A real abort() rejects the SDK's underlying fetch, which propagates out
+		// of the `for await` loop as a rejection. Mimic that here (rather than
+		// hanging on an unresolved promise the mock's abort() can't reach) so
+		// cancellation actually unblocks the loop the way it does against a real
+		// server.
+		function pendingUntilAborted(signal?: AbortSignal): Promise<never> {
+			return new Promise((_, reject) => {
+				if (signal?.aborted) {
+					reject(new Error('Aborted'));
+					return;
+				}
+				signal?.addEventListener('abort', () => reject(new Error('Aborted')));
+			});
+		}
+
+		it('cancel() aborts the underlying request signal and unblocks the stream loop', async () => {
+			async function* slowStream(signal?: AbortSignal) {
+				yield chunk({ delta: { role: 'assistant', content: 'a' } });
+				await pendingUntilAborted(signal);
+			}
+			let capturedSignal: AbortSignal | undefined;
+			openaiCalls.create.mockImplementation((_body: any, options: any) => {
+				capturedSignal = options?.signal;
+				return Promise.resolve(slowStream(options?.signal));
+			});
+
+			const streaming = client.generateStreamingResponse(
+				{ prompt: '', userMessage: 'hi', kind: 'extended', conversationHistory: [] },
+				() => {}
+			);
+			// Allow the first chunk to be consumed
+			await new Promise((r) => window.setTimeout(r, 0));
+			streaming.cancel();
+			await streaming.complete;
+
+			expect(capturedSignal?.aborted).toBe(true);
+		});
+
+		it('omits usageMetadata when the stream cancels before a final usage chunk', async () => {
+			async function* slowStream(signal?: AbortSignal) {
+				yield chunk({ delta: { role: 'assistant', content: 'partial' } });
+				await pendingUntilAborted(signal);
+			}
+			openaiCalls.create.mockImplementation((_body: any, options: any) => Promise.resolve(slowStream(options?.signal)));
+
+			const streaming = client.generateStreamingResponse(
+				{ prompt: '', userMessage: 'hi', kind: 'extended', conversationHistory: [] },
+				() => {}
+			);
+			await new Promise((r) => window.setTimeout(r, 0));
+			streaming.cancel();
+			const result = await streaming.complete;
+
+			expect(result.markdown).toBe('partial');
+			expect(result.usageMetadata).toBeUndefined();
+		});
+
+		it('streams BaseModelRequest prompts too', async () => {
+			async function* stream() {
+				yield chunk({ delta: { role: 'assistant', content: 'hi there' } });
+				yield chunk({
+					delta: {},
+					finish_reason: 'stop',
+					usage: { prompt_tokens: 1, completion_tokens: 2, total_tokens: 3 },
+				});
+			}
+			openaiCalls.create.mockResolvedValue(stream());
+
+			const chunks: string[] = [];
+			const streaming = client.generateStreamingResponse({ kind: 'base', prompt: 'hello' }, (c) => chunks.push(c.text));
+			const result = await streaming.complete;
+
+			expect(chunks.join('')).toBe('hi there');
+			expect(result.markdown).toBe('hi there');
+			const args = openaiCalls.create.mock.calls[0][0];
+			expect(args.messages).toEqual([{ role: 'user', content: 'hello' }]);
+		});
+	});
+
+	describe('no model error', () => {
+		it('generateModelResponse throws when no model configured', async () => {
+			const c = new OpenAIClient({ apiKey: 'sk-test', baseUrl: 'https://api.openai.com/v1' }, undefined, buildPlugin());
+			await expect(c.generateModelResponse({ kind: 'base', prompt: 'test' })).rejects.toThrow(
+				'No OpenAI model selected'
+			);
+		});
+
+		it('streaming throws when no model configured', async () => {
+			const c = new OpenAIClient({ apiKey: 'sk-test', baseUrl: 'https://api.openai.com/v1' }, undefined, buildPlugin());
+			const streaming = c.generateStreamingResponse(
+				{ prompt: '', userMessage: 'hi', kind: 'extended', conversationHistory: [] },
+				() => {}
+			);
+			await expect(streaming.complete).rejects.toThrow('No OpenAI model selected');
+		});
+	});
+
+	describe('error propagation', () => {
+		it('logs and re-throws errors from generateModelResponse', async () => {
+			openaiCalls.create.mockRejectedValue(new Error('connection refused'));
+
+			await expect(client.generateModelResponse({ kind: 'base', prompt: 'test' })).rejects.toThrow(
+				'connection refused'
+			);
+			expect(mockLogger.error).toHaveBeenCalledWith('[OpenAIClient] Error generating content:', expect.any(Error));
+		});
+
+		it('logs and re-throws streaming errors when not cancelled', async () => {
+			openaiCalls.create.mockRejectedValue(new Error('connection refused'));
+
+			const streaming = client.generateStreamingResponse(
+				{ prompt: '', userMessage: 'hi', kind: 'extended', conversationHistory: [] },
+				() => {}
+			);
+
+			await expect(streaming.complete).rejects.toThrow('connection refused');
+			expect(mockLogger.error).toHaveBeenCalledWith('[OpenAIClient] Streaming error:', expect.any(Error));
+		});
+	});
+
+	describe('constructor', () => {
+		it('constructs the OpenAI SDK client with dangerouslyAllowBrowser and maxRetries: 0', async () => {
+			// The mocked constructor stashes its opts on the instance; reach in via
+			// the private `client` field to assert the wiring without a real network call.
+			const opts = (client as any).client.constructorOpts;
+			expect(opts).toEqual({
+				apiKey: 'sk-test',
+				baseURL: 'https://api.openai.com/v1',
+				dangerouslyAllowBrowser: true,
+				maxRetries: 0,
+			});
+		});
+	});
+});

--- a/test/api/providers/openai/client.test.ts
+++ b/test/api/providers/openai/client.test.ts
@@ -408,6 +408,7 @@ describe('OpenAIClient', () => {
 				userMessage: 'ok',
 				kind: 'extended',
 				conversationHistory: [
+					{ role: 'model', parts: [{ functionCall: { name: 'tool1', args: {} } }] },
 					{ role: 'user', parts: [{ functionResponse: { name: 'tool1', response: null as any } }] },
 				],
 			});
@@ -423,6 +424,7 @@ describe('OpenAIClient', () => {
 				userMessage: 'ok',
 				kind: 'extended',
 				conversationHistory: [
+					{ role: 'model', parts: [{ functionCall: { name: 'tool1', args: {} } }] },
 					{ role: 'user', parts: [{ functionResponse: { name: 'tool1', response: 'raw result' as any } }] },
 				],
 			});
@@ -430,6 +432,40 @@ describe('OpenAIClient', () => {
 			const msgs = openaiCalls.create.mock.calls[0][0].messages;
 			const toolMsg = msgs.find((m: any) => m.role === 'tool');
 			expect(toolMsg.content).toBe('raw result');
+		});
+
+		it('drops a tool response whose functionCall was trimmed from history', async () => {
+			await client.generateModelResponse({
+				prompt: '',
+				userMessage: 'ok',
+				kind: 'extended',
+				conversationHistory: [
+					// Compaction removed the model turn that declared this call.
+					{ role: 'user', parts: [{ functionResponse: { name: 'tool1', response: { ok: true } } }] },
+				],
+			});
+
+			const msgs = openaiCalls.create.mock.calls[0][0].messages;
+			expect(msgs.filter((m: any) => m.role === 'tool')).toHaveLength(0);
+		});
+
+		it('emits the assistant tool_calls message before its tool responses', async () => {
+			await client.generateModelResponse({
+				prompt: '',
+				userMessage: 'ok',
+				kind: 'extended',
+				conversationHistory: [
+					{ role: 'model', parts: [{ text: 'calling' }, { functionCall: { name: 'tool1', args: {} } }] },
+					{ role: 'user', parts: [{ functionResponse: { name: 'tool1', response: 'done' as any } }] },
+				],
+			});
+
+			const msgs = openaiCalls.create.mock.calls[0][0].messages;
+			const assistantIdx = msgs.findIndex((m: any) => m.role === 'assistant' && m.tool_calls?.length);
+			const toolIdx = msgs.findIndex((m: any) => m.role === 'tool');
+			expect(assistantIdx).toBeGreaterThanOrEqual(0);
+			expect(toolIdx).toBeGreaterThan(assistantIdx);
+			expect(msgs[toolIdx].tool_call_id).toBe(msgs[assistantIdx].tool_calls[0].id);
 		});
 
 		it('handles mixed text + functionCall in one model entry', async () => {
@@ -750,6 +786,24 @@ describe('OpenAIClient', () => {
 			expect(result.markdown).toBe('hi there');
 			const args = openaiCalls.create.mock.calls[0][0];
 			expect(args.messages).toEqual([{ role: 'user', content: 'hello' }]);
+		});
+	});
+
+	describe('sampling-parameter defaults', () => {
+		it('falls back to temperature 0.7 and top_p 1 when the config omits them', async () => {
+			openaiCalls.create.mockResolvedValue({
+				choices: [{ message: { content: 'ok' } }],
+			});
+			const c = new OpenAIClient(
+				{ apiKey: 'sk-test', baseUrl: 'https://api.openai.com/v1', model: 'gpt-5.6' },
+				undefined,
+				buildPlugin()
+			);
+			await c.generateModelResponse({ kind: 'base', prompt: 'test' });
+
+			const args = openaiCalls.create.mock.calls[0][0];
+			expect(args.temperature).toBe(0.7);
+			expect(args.top_p).toBe(1);
 		});
 	});
 

--- a/test/models.test.ts
+++ b/test/models.test.ts
@@ -5,6 +5,7 @@ import {
 	getActiveChatModel,
 	getDefaultModelForRole,
 	getOllamaModelForRole,
+	getOpenAIModelForRole,
 	GeminiModel,
 	getUpdatedModelSettings,
 	isInteractionsOnlyModel,
@@ -69,6 +70,15 @@ describe('getDefaultModelForRole', () => {
 		expect(() => getDefaultModelForRole('chat')).toThrow(
 			'CRITICAL: GEMINI_MODELS array is empty. Please configure available models.'
 		);
+	});
+
+	// Ollama and OpenAI models both load lazily (daemon /api/tags, /v1/models),
+	// so an empty candidate list is a real, non-error state for either — unlike
+	// the bundled Gemini list, which should never be empty.
+	it('should return an empty string for ollama/openai when no models are registered yet', () => {
+		setTestModels([]);
+		expect(getDefaultModelForRole('chat', 'ollama')).toBe('');
+		expect(getDefaultModelForRole('chat', 'openai')).toBe('');
 	});
 
 	// This test checks the actual imported GEMINI_MODELS state
@@ -376,6 +386,60 @@ describe('getUpdatedModelSettings', () => {
 		expect(result.updatedSettings.ollamaModelName).toBe('llama3.2');
 	});
 
+	it('tolerates a stale OpenAI model while the discovered list has not loaded yet', () => {
+		// Only Gemini models are registered — the OpenAI list loads later via
+		// /v1/models. The Gemini fields stay valid and the OpenAI fields are left
+		// untouched rather than throwing or being blanked.
+		const currentSettings = {
+			provider: 'openai',
+			chatModelName: 'gemini-chat-default',
+			summaryModelName: 'gemini-summary-default',
+			completionsModelName: 'gemini-completions-default',
+			imageModelName: 'gemini-image-default',
+			openaiModelName: 'gpt-5.6',
+		};
+		const result = getUpdatedModelSettings(currentSettings);
+		expect(result.settingsChanged).toBe(false);
+		expect(result.updatedSettings.openaiModelName).toBe('gpt-5.6');
+		expect(result.changedSettingsInfo).toEqual([]);
+	});
+
+	it('reconciles each OpenAI per-use-case field independently once the list has loaded (perUseCaseModels)', () => {
+		// Unlike Ollama, OpenAI reconciles chat/summary/completions independently
+		// against their own role defaults rather than inheriting the chat model.
+		setTestModels([
+			{ value: 'gemini-chat-default', label: 'Chat Default', defaultForRoles: ['chat'] },
+			{ value: 'gemini-summary-default', label: 'Summary Default', defaultForRoles: ['summary'] },
+			{ value: 'gemini-completions-default', label: 'Completions Default', defaultForRoles: ['completions'] },
+			{ value: 'gemini-image-default', label: 'Image Default', defaultForRoles: ['image'] },
+			{ value: 'gpt-5.6', label: 'gpt-5.6', provider: 'openai' as const, defaultForRoles: ['chat'] },
+			{ value: 'gpt-5.6-terra', label: 'gpt-5.6-terra', provider: 'openai' as const, defaultForRoles: ['summary'] },
+			{
+				value: 'gpt-5.6-luna',
+				label: 'gpt-5.6-luna',
+				provider: 'openai' as const,
+				defaultForRoles: ['completions'],
+			},
+		]);
+		const currentSettings = {
+			provider: 'openai',
+			chatModelName: 'gemini-chat-default',
+			summaryModelName: 'gemini-summary-default',
+			completionsModelName: 'gemini-completions-default',
+			imageModelName: 'gemini-image-default',
+			openaiModelName: 'retired-openai-model',
+			openaiSummaryModelName: '',
+			openaiCompletionsModelName: '',
+		};
+		const result = getUpdatedModelSettings(currentSettings);
+		expect(result.settingsChanged).toBe(true);
+		expect(result.updatedSettings.openaiModelName).toBe('gpt-5.6');
+		expect(result.updatedSettings.openaiSummaryModelName).toBe('gpt-5.6-terra');
+		expect(result.updatedSettings.openaiCompletionsModelName).toBe('gpt-5.6-luna');
+		// Gemini fields are preserved across an OpenAI-active reconcile.
+		expect(result.updatedSettings.chatModelName).toBe('gemini-chat-default');
+	});
+
 	it('should propagate error if GEMINI_MODELS is empty and a model update is attempted', () => {
 		setTestModels([]); // GEMINI_MODELS is empty
 		const currentSettings = {
@@ -595,6 +659,7 @@ describe('findModelProvider / providerForModel', () => {
 		setTestModels([
 			{ value: 'gemini-chat-default', label: 'Chat Default', defaultForRoles: ['chat'] },
 			{ value: 'llama3.2', label: 'Llama 3.2', provider: 'ollama' as const },
+			{ value: 'gpt-5.6', label: 'gpt-5.6', provider: 'openai' as const },
 		]);
 	});
 
@@ -605,6 +670,7 @@ describe('findModelProvider / providerForModel', () => {
 	it('identifies each provider from the union model list', () => {
 		expect(findModelProvider('gemini-chat-default')).toBe('gemini');
 		expect(findModelProvider('llama3.2')).toBe('ollama');
+		expect(findModelProvider('gpt-5.6')).toBe('openai');
 	});
 
 	// Ollama tags only enter the list once the daemon answers, so an unknown
@@ -669,6 +735,47 @@ describe('getOllamaModelForRole', () => {
 	});
 });
 
+describe('getOpenAIModelForRole', () => {
+	let originalModels: GeminiModel[];
+
+	beforeEach(() => {
+		originalModels = [...GEMINI_MODELS];
+		setTestModels([
+			{ value: 'gpt-5.6', label: 'gpt-5.6', provider: 'openai' as const, defaultForRoles: ['chat'] },
+			{ value: 'gpt-5.6-terra', label: 'gpt-5.6-terra', provider: 'openai' as const, defaultForRoles: ['summary'] },
+		]);
+	});
+
+	afterEach(() => {
+		setTestModels(originalModels);
+	});
+
+	// Unlike Ollama, OpenAI has no single-resident-model constraint: an unset
+	// per-use-case field falls back to that role's own default, not to
+	// `openaiModelName` (the chat model).
+	it('falls back to the role default rather than inheriting the chat model', () => {
+		const settings = { openaiModelName: 'gpt-5.6', openaiSummaryModelName: '', openaiCompletionsModelName: '' };
+		expect(getOpenAIModelForRole(settings, 'chat')).toBe('gpt-5.6');
+		expect(getOpenAIModelForRole(settings, 'summary')).toBe('gpt-5.6-terra');
+	});
+
+	it('uses a per-use-case model when one is configured', () => {
+		const settings = {
+			openaiModelName: 'gpt-5.6',
+			openaiSummaryModelName: 'gpt-5.6-terra',
+			openaiCompletionsModelName: 'gpt-5.6-luna',
+		};
+		expect(getOpenAIModelForRole(settings, 'chat')).toBe('gpt-5.6');
+		expect(getOpenAIModelForRole(settings, 'summary')).toBe('gpt-5.6-terra');
+		expect(getOpenAIModelForRole(settings, 'completions')).toBe('gpt-5.6-luna');
+	});
+
+	// Rewrite has no field of its own and deliberately reuses the chat model.
+	it('resolves roles without a dedicated field to the chat model', () => {
+		expect(getOpenAIModelForRole({ openaiModelName: 'gpt-5.6' }, 'rewrite')).toBe('gpt-5.6');
+	});
+});
+
 describe('getActiveChatModel under per-use-case routing', () => {
 	let originalModels: GeminiModel[];
 
@@ -678,6 +785,7 @@ describe('getActiveChatModel under per-use-case routing', () => {
 			{ value: 'gemini-chat-default', label: 'Chat Default', defaultForRoles: ['chat'] },
 			{ value: 'gemini-flash-lite', label: 'Flash Lite' },
 			{ value: 'llama3.2', label: 'Llama 3.2', provider: 'ollama' as const, defaultForRoles: ['chat'] },
+			{ value: 'gpt-5.6', label: 'gpt-5.6', provider: 'openai' as const, defaultForRoles: ['chat'] },
 		]);
 	});
 
@@ -706,5 +814,16 @@ describe('getActiveChatModel under per-use-case routing', () => {
 				ollamaModelName: 'llama3.2',
 			})
 		).toBe('gemini-flash-lite');
+	});
+
+	it('resolves the OpenAI model when OpenAI serves chat', () => {
+		expect(
+			getActiveChatModel({
+				provider: 'openai',
+				chatModelName: 'gemini-flash-lite',
+				ollamaModelName: 'llama3.2',
+				openaiModelName: 'gpt-5.6',
+			})
+		).toBe('gpt-5.6');
 	});
 });

--- a/test/services/model-manager.test.ts
+++ b/test/services/model-manager.test.ts
@@ -9,6 +9,7 @@ const mockPlugin = {
 		imageModelName: 'gemini-2.5-flash-image',
 	},
 	apiKey: 'test-api-key',
+	openaiApiKey: 'sk-test-key',
 	loadData: vi.fn().mockResolvedValue({}),
 	saveData: vi.fn(),
 	logger: {
@@ -278,6 +279,60 @@ describe('ModelManager', () => {
 
 		it('getParameterRanges() returns normalized numeric ranges', async () => {
 			const ranges = await ollamaManager.getParameterRanges();
+
+			expect(ranges.temperature.min).toBe(0);
+			expect(ranges.topP.min).toBe(0);
+			expect(ranges.temperature.step).toBeGreaterThan(0);
+			expect(ranges.topP.step).toBeGreaterThan(0);
+		});
+	});
+
+	describe('OpenAI provider', () => {
+		let openaiPlugin: any;
+		let openaiManager: ModelManager;
+
+		beforeEach(() => {
+			openaiPlugin = {
+				...mockPlugin,
+				settings: {
+					...mockPlugin.settings,
+					provider: 'openai',
+					openaiBaseUrl: 'https://api.openai.com/v1',
+				},
+			};
+			openaiManager = new ModelManager(openaiPlugin);
+		});
+
+		afterEach(() => {
+			setGeminiModels(originalModels);
+		});
+
+		it('initialize() populates models from the OpenAI endpoint', async () => {
+			// OpenAIModelsService returns an empty array when the endpoint is
+			// unreachable — best-effort. initialize() should still complete without error.
+			await openaiManager.initialize();
+			expect(true).toBe(true);
+		});
+
+		it('getAvailableModels() does not return Gemini bundled models', async () => {
+			const models = await openaiManager.getAvailableModels();
+
+			// OpenAIModelsService.getModels() may return empty if the endpoint is
+			// unreachable, but the important thing is it doesn't return Gemini bundled models.
+			expect(Array.isArray(models)).toBe(true);
+			const bundledValues = new Set(originalModels.map((m) => m.value));
+			expect(models.some((m) => bundledValues.has(m.value))).toBe(false);
+		});
+
+		it('getOpenAIModelsService() returns the internal service instance', () => {
+			const service = openaiManager.getOpenAIModelsService();
+			expect(service).toBeDefined();
+			expect(typeof service.getModels).toBe('function');
+			expect(typeof service.invalidate).toBe('function');
+		});
+
+		it('getParameterRanges() returns normalized numeric ranges', async () => {
+			const ranges = await openaiManager.getParameterRanges();
 
 			expect(ranges.temperature.min).toBe(0);
 			expect(ranges.topP.min).toBe(0);

--- a/test/services/model-manager.test.ts
+++ b/test/services/model-manager.test.ts
@@ -1,5 +1,9 @@
+import type { Mock } from 'vitest';
+import { requestUrl } from 'obsidian';
 import { ModelManager } from '../../src/services/model-manager';
 import { GeminiModel, setGeminiModels, GEMINI_MODELS } from '../../src/models';
+
+const mockedRequestUrl = requestUrl as unknown as Mock;
 
 const mockPlugin = {
 	settings: {
@@ -301,17 +305,30 @@ describe('ModelManager', () => {
 				},
 			};
 			openaiManager = new ModelManager(openaiPlugin);
+			mockedRequestUrl.mockReset();
 		});
 
 		afterEach(() => {
 			setGeminiModels(originalModels);
 		});
 
-		it('initialize() populates models from the OpenAI endpoint', async () => {
-			// OpenAIModelsService returns an empty array when the endpoint is
-			// unreachable — best-effort. initialize() should still complete without error.
+		it('initialize() merges discovered OpenAI models into the global model list', async () => {
+			mockedRequestUrl.mockResolvedValue({
+				status: 200,
+				json: { data: [{ id: 'gpt-5.6' }, { id: 'gpt-5.6-luna' }] },
+			});
+
 			await openaiManager.initialize();
-			expect(true).toBe(true);
+
+			const active = GEMINI_MODELS.filter((m) => m.provider === 'openai').map((m) => m.value);
+			expect(active).toEqual(expect.arrayContaining(['gpt-5.6', 'gpt-5.6-luna']));
+		});
+
+		it('initialize() still completes when the OpenAI endpoint is unreachable', async () => {
+			mockedRequestUrl.mockRejectedValue(new Error('ECONNREFUSED'));
+
+			await expect(openaiManager.initialize()).resolves.not.toThrow();
+			expect(GEMINI_MODELS.filter((m) => m.provider === 'openai')).toHaveLength(0);
 		});
 
 		it('getAvailableModels() does not return Gemini bundled models', async () => {

--- a/test/services/openai-models-service.test.ts
+++ b/test/services/openai-models-service.test.ts
@@ -1,0 +1,152 @@
+import type { Mock } from 'vitest';
+import { requestUrl } from 'obsidian';
+import { OpenAIModelsService } from '../../src/services/openai-models-service';
+
+const mockedRequestUrl = requestUrl as unknown as Mock;
+
+const buildPlugin = (overrides?: Record<string, any>) =>
+	({
+		logger: { log: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() },
+		settings: { openaiBaseUrl: 'https://api.openai.com/v1' },
+		openaiApiKey: 'sk-test-key',
+		...overrides,
+	}) as any;
+
+function mockModelList(ids: string[]) {
+	mockedRequestUrl.mockResolvedValue({ status: 200, json: { data: ids.map((id) => ({ id })) } });
+}
+
+describe('OpenAIModelsService', () => {
+	beforeEach(() => {
+		mockedRequestUrl.mockReset();
+	});
+
+	it('parses /models response into GeminiModel entries with curated metadata', async () => {
+		mockModelList(['gpt-5.6', 'gpt-5.6-terra', 'gpt-5.6-luna']);
+
+		const svc = new OpenAIModelsService(buildPlugin());
+		const models = await svc.getModels();
+
+		expect(models).toHaveLength(3);
+		expect(models[0]).toMatchObject({
+			value: 'gpt-5.6',
+			provider: 'openai',
+			supportsTools: true,
+			supportsVision: true,
+			contextWindow: 1_000_000,
+			defaultForRoles: ['chat'],
+		});
+		expect(models[1]).toMatchObject({ value: 'gpt-5.6-terra', defaultForRoles: ['summary'] });
+		expect(models[2]).toMatchObject({ value: 'gpt-5.6-luna', defaultForRoles: ['completions'] });
+	});
+
+	it('applies conservative defaults to a model id with no curated metadata', async () => {
+		mockModelList(['some-custom-local-model']);
+
+		const svc = new OpenAIModelsService(buildPlugin());
+		const models = await svc.getModels();
+
+		expect(models).toEqual([
+			expect.objectContaining({
+				value: 'some-custom-local-model',
+				provider: 'openai',
+				supportsTools: true,
+				supportsVision: false,
+				contextWindow: 128_000,
+			}),
+		]);
+	});
+
+	it('sends the resolved API key as a Bearer token', async () => {
+		mockModelList(['gpt-5.6']);
+		const plugin = buildPlugin({ openaiApiKey: 'sk-secret' });
+
+		await new OpenAIModelsService(plugin).getModels();
+
+		expect(mockedRequestUrl).toHaveBeenCalledWith(
+			expect.objectContaining({ headers: { Authorization: 'Bearer sk-secret' } })
+		);
+	});
+
+	describe('non-chat model filtering', () => {
+		it('filters out non-chat ids on api.openai.com', async () => {
+			mockModelList(['gpt-5.6', 'text-embedding-3-large', 'whisper-1', 'tts-1', 'dall-e-3', 'text-moderation-latest']);
+
+			const svc = new OpenAIModelsService(buildPlugin());
+			const models = await svc.getModels();
+
+			expect(models.map((m) => m.value)).toEqual(['gpt-5.6']);
+		});
+
+		it('does not filter model ids on a custom (non-api.openai.com) base URL', async () => {
+			mockModelList(['local-embedding-model', 'my-custom-chat-model']);
+			const plugin = buildPlugin({ settings: { openaiBaseUrl: 'http://localhost:1234/v1' } });
+
+			const svc = new OpenAIModelsService(plugin);
+			const models = await svc.getModels();
+
+			expect(models.map((m) => m.value).sort()).toEqual(['local-embedding-model', 'my-custom-chat-model']);
+		});
+	});
+
+	it('returns empty list when the endpoint responds with an error status', async () => {
+		mockedRequestUrl.mockResolvedValue({ status: 401, json: null });
+		const svc = new OpenAIModelsService(buildPlugin());
+		const models = await svc.getModels();
+		expect(models).toEqual([]);
+	});
+
+	it('caches results and only re-fetches after invalidate()', async () => {
+		mockModelList(['gpt-5.6']);
+
+		const svc = new OpenAIModelsService(buildPlugin());
+		await svc.getModels();
+		await svc.getModels();
+		expect(mockedRequestUrl).toHaveBeenCalledTimes(1);
+
+		svc.invalidate();
+		await svc.getModels();
+		expect(mockedRequestUrl).toHaveBeenCalledTimes(2);
+	});
+
+	it('invalidates the cache when the base URL changes', async () => {
+		const plugin = buildPlugin();
+		mockModelList([]);
+
+		const svc = new OpenAIModelsService(plugin);
+		await svc.getModels();
+		expect(mockedRequestUrl).toHaveBeenCalledTimes(1);
+
+		plugin.settings.openaiBaseUrl = 'http://localhost:1234/v1';
+		await svc.getModels();
+		expect(mockedRequestUrl).toHaveBeenCalledTimes(2);
+	});
+
+	it('invalidates the cache when the API key changes', async () => {
+		const plugin = buildPlugin({ openaiApiKey: 'sk-first' });
+		mockModelList([]);
+
+		const svc = new OpenAIModelsService(plugin);
+		await svc.getModels();
+		expect(mockedRequestUrl).toHaveBeenCalledTimes(1);
+
+		plugin.openaiApiKey = 'sk-second';
+		await svc.getModels();
+		expect(mockedRequestUrl).toHaveBeenCalledTimes(2);
+	});
+
+	it('does not return stale models from a previous base URL after a failed refresh', async () => {
+		const plugin = buildPlugin();
+
+		mockModelList(['old-only-model', 'shared-model']);
+		const svc = new OpenAIModelsService(plugin);
+		const initial = await svc.getModels();
+		expect(initial).toHaveLength(2);
+
+		plugin.settings.openaiBaseUrl = 'http://localhost:1234/v1';
+		mockedRequestUrl.mockRejectedValueOnce(new Error('ECONNREFUSED'));
+		const afterFailure = await svc.getModels();
+
+		expect(afterFailure).toEqual([]);
+	});
+});

--- a/test/ui/settings-general.test.ts
+++ b/test/ui/settings-general.test.ts
@@ -28,6 +28,9 @@ const { mockSelectModelSetting, capturedDropdowns, capturedRows, capturedButtons
 
 vi.mock('../../src/ui/settings-helpers', () => ({
 	selectModelSetting: mockSelectModelSetting,
+	// Real mapping, not a stub — the missing-key notice tests depend on it.
+	apiKeySecretNameFor: (settings: any, provider: any) =>
+		provider === 'openai' ? settings.openaiApiKeySecretName : settings.apiKeySecretName,
 	// The General section is rendered directly into the element we pass in.
 	createAlwaysOpenSection: (containerEl: any) => containerEl,
 	createCollapsibleSection: (_plugin: any, containerEl: any) => containerEl,

--- a/test/ui/settings-general.test.ts
+++ b/test/ui/settings-general.test.ts
@@ -8,15 +8,23 @@
  * to inheriting the chat model (#1077); image generation has no picker at all
  * when no provider serves it.
  */
-const { mockSelectModelSetting, capturedDropdowns, capturedRows } = vi.hoisted(() => ({
-	mockSelectModelSetting: vi.fn(),
-	// Records each rendered dropdown as { name, options, value, disabled } so
-	// tests can assert on the options a row actually offers.
-	capturedDropdowns: [] as Array<{ name: string; options: string[]; value: string; disabled: boolean }>,
-	// Records every rendered Setting row's name/description i18n key, so the
-	// privacy notices (which render as plain name+desc rows) can be asserted on.
-	capturedRows: [] as Array<{ name: string; desc: string }>,
-}));
+const { mockSelectModelSetting, capturedDropdowns, capturedRows, capturedButtons, capturedSecrets } = vi.hoisted(
+	() => ({
+		mockSelectModelSetting: vi.fn(),
+		// Records each rendered dropdown as { name, options, value, disabled } so
+		// tests can assert on the options a row actually offers.
+		capturedDropdowns: [] as Array<{ name: string; options: string[]; value: string; disabled: boolean }>,
+		// Records every rendered Setting row's name/description i18n key, so the
+		// privacy notices (which render as plain name+desc rows) can be asserted on.
+		capturedRows: [] as Array<{ name: string; desc: string }>,
+		// Records each rendered button as { name, text, onClick } so tests can
+		// invoke the handler directly (e.g. the refresh-model-list buttons).
+		capturedButtons: [] as Array<{ name: string; text: string; onClick: () => void | Promise<void> }>,
+		// Records each rendered SecretComponent as { value, onChange } so tests can
+		// assert which settings field an API key row is bound to.
+		capturedSecrets: [] as Array<{ value: string; onChange?: (v: string) => void }>,
+	})
+);
 
 vi.mock('../../src/ui/settings-helpers', () => ({
 	selectModelSetting: mockSelectModelSetting,
@@ -58,7 +66,18 @@ vi.mock('obsidian', () => {
 			return this;
 		}
 		addButton(cb: (c: any) => void) {
-			cb({ setButtonText: () => ({ onClick: () => this }) });
+			const record = { name: this.name, text: '', onClick: (() => {}) as () => void | Promise<void> };
+			const c: any = {};
+			c.setButtonText = (text: string) => {
+				record.text = text;
+				return c;
+			};
+			c.onClick = (handler: () => void | Promise<void>) => {
+				record.onClick = handler;
+				return c;
+			};
+			cb(c);
+			capturedButtons.push(record);
 			return this;
 		}
 		addDropdown(cb: (c: any) => void) {
@@ -103,11 +122,17 @@ vi.mock('obsidian', () => {
 		}
 	}
 	class SecretComponent {
-		constructor(_app: any, _el: any) {}
-		setValue() {
+		private record: { value: string; onChange?: (v: string) => void };
+		constructor(_app: any, _el: any) {
+			this.record = { value: '' };
+			capturedSecrets.push(this.record);
+		}
+		setValue(v: string) {
+			this.record.value = v;
 			return this;
 		}
-		onChange() {
+		onChange(fn: (v: string) => void) {
+			this.record.onChange = fn;
 			return this;
 		}
 	}
@@ -122,7 +147,7 @@ vi.mock('obsidian', () => {
 
 import { renderGeneralSettings } from '../../src/ui/settings-general';
 
-function createMockPlugin(provider: 'gemini' | 'ollama', providerOverrides: Record<string, string> = {}) {
+function createMockPlugin(provider: 'gemini' | 'ollama' | 'openai', providerOverrides: Record<string, string> = {}) {
 	return {
 		settings: {
 			provider,
@@ -136,6 +161,11 @@ function createMockPlugin(provider: 'gemini' | 'ollama', providerOverrides: Reco
 			ollamaCompletionsModelName: '',
 			ollamaBaseUrl: 'http://localhost:11434',
 			apiKeySecretName: 'test-secret',
+			openaiModelName: 'openai-chat-model',
+			openaiSummaryModelName: 'openai-summary-model',
+			openaiCompletionsModelName: 'openai-completions-model',
+			openaiBaseUrl: 'https://api.openai.com/v1',
+			openaiApiKeySecretName: 'openai-test-secret',
 			historyFolder: 'gemini-scribe',
 			expandedSettingsSections: [],
 		},
@@ -234,6 +264,39 @@ describe('renderGeneralSettings — model pickers per provider', () => {
 		]);
 	});
 
+	// OpenAI has no single-resident-model constraint (perUseCaseModels), so unlike
+	// Ollama each use case gets its own field and no "inherit the chat model"
+	// option (#1237).
+	it('routes every picker to its own OpenAI field, with no inherit option', async () => {
+		const plugin = createMockPlugin('openai');
+		await renderGeneralSettings({} as any, plugin, {} as any, createContext());
+
+		expect(renderedModelCalls()).toEqual([
+			{
+				settingName: 'openaiModelName',
+				label: 'settings.general.chatModelName',
+				desc: 'settings.general.openaiChatModelDesc',
+				provider: 'openai',
+			},
+			{
+				settingName: 'openaiSummaryModelName',
+				label: 'settings.general.summaryModelName',
+				desc: 'settings.general.summaryModelDesc',
+				provider: 'openai',
+			},
+			{
+				settingName: 'openaiCompletionsModelName',
+				label: 'settings.general.completionModelName',
+				desc: 'settings.general.completionModelDesc',
+				provider: 'openai',
+			},
+		]);
+		// No inherit-option arg (7th call arg) for any OpenAI row.
+		for (const call of mockSelectModelSetting.mock.calls) {
+			expect(call[7]).toBeUndefined();
+		}
+	});
+
 	// The point of #704: each row follows its own use case's provider.
 	it('binds each picker to its own use case provider in a mixed configuration', async () => {
 		const plugin = createMockPlugin('ollama', { summary: 'gemini', imageGen: 'gemini' });
@@ -287,7 +350,7 @@ describe('renderGeneralSettings — per-feature provider dropdowns', () => {
 		await renderGeneralSettings({} as any, plugin, {} as any, createContext());
 
 		const chat = dropdownFor('settings.general.useCaseChatName');
-		expect(chat?.options).toEqual(['', 'ollama']);
+		expect(chat?.options).toEqual(['', 'ollama', 'openai']);
 		expect(chat?.disabled).toBe(false);
 	});
 
@@ -436,5 +499,124 @@ describe('renderGeneralSettings — local-only vs cloud-hosted model notice', ()
 		expect(rowNamed('settings.general.mixedProviderNoticeName')).toBeDefined();
 		expect(rowNamed(REMOTE)).toBeUndefined();
 		expect(rowNamed(LOCAL_ONLY)).toBeUndefined();
+	});
+});
+
+/**
+ * Credentials/endpoint block for OpenAI (#1237), mirroring the Gemini API key
+ * row and the Ollama base-URL/refresh rows.
+ */
+describe('renderGeneralSettings — OpenAI credentials/endpoint block', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		capturedDropdowns.length = 0;
+		capturedRows.length = 0;
+		capturedButtons.length = 0;
+		capturedSecrets.length = 0;
+	});
+
+	const rowNamed = (name: string) => capturedRows.find((r) => r.name === name);
+	const API_KEY = 'settings.general.openaiApiKeyName';
+	const BASE_URL = 'settings.general.openaiBaseUrlName';
+	const REFRESH = 'settings.general.refreshOpenaiModelListName';
+
+	it('renders the API key, base URL, and refresh rows when OpenAI is active', async () => {
+		const plugin = createMockPlugin('openai');
+		await renderGeneralSettings({} as any, plugin, {} as any, createContext());
+
+		expect(rowNamed(API_KEY)).toBeDefined();
+		expect(rowNamed(BASE_URL)).toBeDefined();
+		expect(rowNamed(REFRESH)).toBeDefined();
+	});
+
+	it('hides the OpenAI block when no use case is routed to OpenAI', async () => {
+		const plugin = createMockPlugin('gemini');
+		await renderGeneralSettings({} as any, plugin, {} as any, createContext());
+
+		expect(rowNamed(API_KEY)).toBeUndefined();
+		expect(rowNamed(BASE_URL)).toBeUndefined();
+		expect(rowNamed(REFRESH)).toBeUndefined();
+	});
+
+	// Credentials are rendered for every provider serving *some* use case, not
+	// just the primary — a Gemini-primary install that overrides summary to
+	// OpenAI still needs the OpenAI key field (mirrors #704's rule for Ollama).
+	it('shows the OpenAI block when only an override routes a use case to it', async () => {
+		const plugin = createMockPlugin('gemini', { summary: 'openai' });
+		await renderGeneralSettings({} as any, plugin, {} as any, createContext());
+
+		expect(rowNamed(API_KEY)).toBeDefined();
+	});
+
+	it('binds the API key row to openaiApiKeySecretName, not the Gemini field', async () => {
+		const plugin = createMockPlugin('openai');
+		plugin.settings.openaiApiKeySecretName = 'my-openai-secret';
+		await renderGeneralSettings({} as any, plugin, {} as any, createContext());
+
+		const secret = capturedSecrets.find((s) => s.value === 'my-openai-secret');
+		expect(secret).toBeDefined();
+
+		secret!.onChange!('rotated-secret');
+		expect(plugin.settings.openaiApiKeySecretName).toBe('rotated-secret');
+		expect(plugin.settings.apiKeySecretName).toBe('test-secret'); // Gemini field untouched.
+		expect(plugin.saveSettings).toHaveBeenCalled();
+	});
+
+	it('refresh button invalidates the OpenAI models service and refetches with forceRefresh', async () => {
+		const invalidate = vi.fn();
+		const getAvailableModels = vi.fn().mockResolvedValue([{ value: 'gpt-5.6', label: 'gpt-5.6' }]);
+		const plugin = createMockPlugin('openai');
+		plugin.getModelManager = vi.fn().mockReturnValue({
+			getOpenAIModelsService: () => ({ invalidate }),
+			getAvailableModels,
+		});
+
+		// The refresh handler calls back into rerender(), which re-empties and
+		// re-renders this section — give the container a working `empty()`.
+		await renderGeneralSettings({ empty: () => {} } as any, plugin, {} as any, createContext());
+
+		const button = capturedButtons.find((b) => b.name === REFRESH);
+		expect(button).toBeDefined();
+
+		await button!.onClick();
+
+		expect(invalidate).toHaveBeenCalledOnce();
+		expect(getAvailableModels).toHaveBeenCalledWith({ forceRefresh: true }, 'openai');
+	});
+});
+
+/**
+ * Regression coverage for the missing-key notice now checking each active
+ * provider's own secret field (#1237) instead of assuming Gemini's
+ * `apiKeySecretName` — a Gemini key being present must not mask a missing
+ * OpenAI key, and vice versa.
+ */
+describe('renderGeneralSettings — missing-key notice is per-provider', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		capturedDropdowns.length = 0;
+		capturedRows.length = 0;
+	});
+
+	const rowNamed = (name: string) => capturedRows.find((r) => r.name === name);
+	const MISSING_KEY = 'settings.general.missingKeyNoticeName';
+
+	it('warns when the OpenAI key is missing even though the unrelated Gemini field is set', async () => {
+		const plugin = createMockPlugin('openai');
+		plugin.settings.openaiApiKeySecretName = '';
+		plugin.settings.apiKeySecretName = 'unrelated-gemini-secret';
+		await renderGeneralSettings({} as any, plugin, {} as any, createContext());
+
+		const notice = rowNamed(MISSING_KEY);
+		expect(notice).toBeDefined();
+		expect(notice?.desc).toContain('settings.general.providerOptionOpenai');
+	});
+
+	it('does not warn once the OpenAI key is configured', async () => {
+		const plugin = createMockPlugin('openai');
+		plugin.settings.openaiApiKeySecretName = 'configured-secret';
+		await renderGeneralSettings({} as any, plugin, {} as any, createContext());
+
+		expect(rowNamed(MISSING_KEY)).toBeUndefined();
 	});
 });

--- a/test/utils/error-utils.test.ts
+++ b/test/utils/error-utils.test.ts
@@ -195,6 +195,45 @@ describe('error-utils', () => {
 			});
 		});
 
+		describe('OpenAI SDK errors', () => {
+			// Mirrors the shape of `openai`'s APIError subclasses (status + type/code
+			// pulled from the response body) without importing the SDK — see
+			// isOpenAIApiError's own duck-typing rationale in error-utils.ts.
+			function fakeOpenAIError(status: number, message: string, extra: Record<string, unknown> = {}) {
+				const error = new Error(`${status} ${message}`) as Error & Record<string, unknown>;
+				Object.assign(error, { status, type: 'invalid_request_error', ...extra });
+				return error;
+			}
+
+			test('401 gets OpenAI-specific key guidance instead of the generic message', () => {
+				const error = fakeOpenAIError(401, 'Incorrect API key provided', { type: 'invalid_request_error' });
+				expect(getErrorMessage(error)).toBe(
+					'Invalid OpenAI API key. Please check the API key in Settings → Gemini Scribe.'
+				);
+			});
+
+			test('404 mentions the endpoint rather than the generic model-not-found wording', () => {
+				const error = fakeOpenAIError(404, 'The model `gpt-9` does not exist', { code: 'model_not_found' });
+				expect(getErrorMessage(error)).toBe(
+					'Model not available on this endpoint. Please check your model settings or the configured base URL.'
+				);
+			});
+
+			test('a plain 401 without the OpenAI shape keeps the generic message', () => {
+				const error = { status: 401, message: 'Unauthorized' };
+				expect(getErrorMessage(error)).toBe(
+					'Authentication failed: Invalid API key. Please check your model provider credentials in settings.'
+				);
+			});
+
+			test('APIConnectionError ("Connection error.", no status) gets local-server guidance', () => {
+				const error = new Error('Connection error.');
+				expect(getErrorMessage(error)).toBe(
+					'Could not connect to the model server. If you configured a custom base URL (LM Studio, MLX, etc.), make sure the server is running and the base URL in settings is correct.'
+				);
+			});
+		});
+
 		describe('Error message pattern matching', () => {
 			test('API key error', () => {
 				const error = new Error('Invalid API key provided');


### PR DESCRIPTION
## Motivation

Closes #1237 — Support ChatGPT-compatible integration.

Adds a third model provider, **`openai`**, alongside Gemini and Ollama. It talks to the OpenAI Chat Completions API with the user's own API key, and because the base URL is configurable it equally serves OpenAI-compatible runtimes (LM Studio, MLX-served endpoints, Ollama's OpenAI-compatible endpoint) — the core ask of the issue. Chat Completions (not the Responses API) was chosen deliberately for that compatibility.

## What's included

- **Provider package** (`src/api/providers/openai/`): `OpenAIClient implements ModelApi` via the official `openai` SDK (`dangerouslyAllowBrowser`, SDK retries off — the plugin's `RetryDecorator` owns retry). Streaming with cancellation, agent tool calling (Gemini `Content` history ↔ OpenAI messages with `tool_call_id` pairing), image attachments as data URLs on vision models (non-image attachments throw an actionable error), usage metadata mapping, and `reasoning_content` → thoughts for compatible servers that emit it.
- **Plumbing**: registry capability entry (chat / summary / completions / rewrite supported; web search, RAG, and image generation remain Gemini-only — per-use-case routing lets users mix providers), factory branch, per-use-case model resolution, provider-aware init errors, OpenAI-specific API error guidance (401 / 404 / connection refused).
- **Settings**: `openaiBaseUrl`, secret-storage API key, three per-use-case model fields (defaults `gpt-5.6` / `gpt-5.6-terra` / `gpt-5.6-luna`), re-init triggers on key/URL change.
- **Model discovery**: `openai-models-service` fetches `GET {baseUrl}/models`, enriches known OpenAI models from a curated metadata map (context windows, vision), filters non-chat model ids on api.openai.com, and falls back to safe defaults for unknown/compatible-server models. Refresh button in settings.
- **Settings UI**: API key + base URL block shown when the provider is active, per-use-case model pickers, privacy-notice integration. Also fixes a pre-existing bug: the missing-key notice checked Gemini's `apiKeySecretName` for every key-requiring provider, so a configured Gemini key would mask a missing OpenAI key.

Not included (explicitly out of scope): ChatGPT-subscription / "Sign in with ChatGPT" (Codex) auth — this provider is API-key billing only. That would be a possible follow-up.

## Documentation updated

- `docs/guide/openai-setup.md` (new) — setup guide incl. LM Studio walkthrough
- `docs/reference/provider-capabilities.md` — OpenAI column mirroring the registry
- `docs/reference/settings.md`, `docs/reference/advanced-settings.md` — new settings with actual defaults
- `docs/guide/faq.md` — corrected the now-wrong "can I use OpenAI? No" answer
- `docs/guide/getting-started.md`, `docs/guide/agent-mode.md`, `README.md`, VitePress sidebar

## Tests

- New: `test/api/providers/openai/client.test.ts` (36 tests), `test/services/openai-models-service.test.ts`
- Extended: factory, provider-registry, provider-routing, models, model-manager, settings-general, error-utils tests
- Gates all green: `npm run build`, `npm test` (170 files / 3775 tests), `npm run typecheck:test`, `npm run lint:cycles` (0), `npm run format-check`, `npm run docs:build` (no dead links)
- Manual testing in a live vault (chat, agent tool loop, streaming, compatible-server smoke test) still pending — recommend before merge

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OpenAI and OpenAI-compatible provider support.
  * Added API key, custom endpoint, model discovery, and separate model settings for chat, summaries, and completions.
  * Added per-feature routing alongside Gemini and Ollama.
  * Added streaming, tool calling, image attachments, reasoning, and cancellation where supported.
* **Documentation**
  * Added setup, capability, troubleshooting, FAQ, and settings guidance.
* **Bug Fixes**
  * Improved messages for missing credentials, authorization failures, and connection errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->