### PR TITLE
refactor(context-manager): make chars-per-token calibration provider-neutral

### DIFF
--- a/src/services/context-manager.ts
+++ b/src/services/context-manager.ts
@@ -31,13 +31,14 @@ const AGGRESSIVE_COMPACTION_THRESHOLD_PERCENT = 80;
 
 /**
  * Starting chars-per-token ratio for providers that don't expose a countTokens
- * endpoint (Ollama), used until real usage data calibrates a per-model ratio.
+ * endpoint (Ollama, OpenAI-compatible), used until real usage data calibrates a
+ * per-model ratio.
  * 4 is the standard char/token heuristic for English text.
  */
-const DEFAULT_OLLAMA_CHARS_PER_TOKEN = 4;
+const DEFAULT_CHARS_PER_TOKEN = 4;
 
 /** Weight given to each new observation when blending the calibrated ratio (EMA). */
-const OLLAMA_RATIO_CALIBRATION_WEIGHT = 0.5;
+const RATIO_CALIBRATION_WEIGHT = 0.5;
 
 /** Minimum number of recent turns to preserve during compaction */
 const MIN_RECENT_TURNS_TO_KEEP = 6;
@@ -96,10 +97,10 @@ export class ContextManager {
 	private lastUsageMetadata: UsageMetadata | null = null;
 	private acceptNextLowerUpdate = false;
 	private ai: GoogleGenAI | null;
-	/** Per-model chars-per-token ratio for Ollama, calibrated from real usage metadata. */
-	private ollamaCharsPerToken: Map<string, number> = new Map();
-	/** Char length of the most recent Ollama countTokens() estimate per model, awaiting calibration against the next real response. */
-	private pendingOllamaEstimateCharLength: Map<string, number> = new Map();
+	/** Per-model chars-per-token ratio for estimate-based providers, calibrated from real usage metadata. */
+	private estimatedCharsPerToken: Map<string, number> = new Map();
+	/** Char length of the most recent estimated countTokens() result per model, awaiting calibration against the next real response. */
+	private pendingEstimateCharLength: Map<string, number> = new Map();
 
 	constructor(
 		private plugin: ObsidianGemini,
@@ -144,13 +145,13 @@ export class ContextManager {
 	 *
 	 * When `modelName` names a model whose provider has no token-counting
 	 * endpoint, this also calibrates that model's chars-per-token ratio against
-	 * the real `promptTokenCount` just reported (see calibrateOllamaRatio).
+	 * the real `promptTokenCount` just reported (see calibrateEstimatedRatio).
 	 */
 	updateUsageMetadata(metadata: UsageMetadata, modelName?: string): void {
 		if (!metadata) return;
 
 		if (modelName && !getCapabilities(this.providerForContextModel(modelName)).nativeTokenCount) {
-			this.calibrateOllamaRatio(modelName, metadata.promptTokenCount);
+			this.calibrateEstimatedRatio(modelName, metadata.promptTokenCount);
 		}
 
 		const newPrompt = metadata.promptTokenCount ?? 0;
@@ -166,7 +167,7 @@ export class ContextManager {
 	}
 
 	/**
-	 * Calibrate this model's Ollama chars-per-token ratio from a real response.
+	 * Calibrate this model's estimated chars-per-token ratio from a real response.
 	 * Correlates the character length of the most recent countTokens() estimate
 	 * for this model (computed just before the request that produced this
 	 * response, via prepareHistory) against the response's actual
@@ -174,18 +175,17 @@ export class ContextManager {
 	 * exponential moving average. Requires no extra API call and converges
 	 * toward the model's real tokenization over a few turns.
 	 */
-	private calibrateOllamaRatio(modelName: string, promptTokenCount: number | undefined): void {
-		const charLength = this.pendingOllamaEstimateCharLength.get(modelName);
+	private calibrateEstimatedRatio(modelName: string, promptTokenCount: number | undefined): void {
+		const charLength = this.pendingEstimateCharLength.get(modelName);
 		if (!charLength || !promptTokenCount) return;
-		this.pendingOllamaEstimateCharLength.delete(modelName);
+		this.pendingEstimateCharLength.delete(modelName);
 
 		const observedRatio = charLength / promptTokenCount;
-		const previousRatio = this.ollamaCharsPerToken.get(modelName) ?? DEFAULT_OLLAMA_CHARS_PER_TOKEN;
-		const calibratedRatio =
-			previousRatio * (1 - OLLAMA_RATIO_CALIBRATION_WEIGHT) + observedRatio * OLLAMA_RATIO_CALIBRATION_WEIGHT;
-		this.ollamaCharsPerToken.set(modelName, calibratedRatio);
+		const previousRatio = this.estimatedCharsPerToken.get(modelName) ?? DEFAULT_CHARS_PER_TOKEN;
+		const calibratedRatio = previousRatio * (1 - RATIO_CALIBRATION_WEIGHT) + observedRatio * RATIO_CALIBRATION_WEIGHT;
+		this.estimatedCharsPerToken.set(modelName, calibratedRatio);
 		this.logger.debug(
-			`[ContextManager] Calibrated Ollama chars/token for ${modelName}: ${previousRatio.toFixed(2)} -> ${calibratedRatio.toFixed(2)}`
+			`[ContextManager] Calibrated estimated chars/token for ${modelName}: ${previousRatio.toFixed(2)} -> ${calibratedRatio.toFixed(2)}`
 		);
 	}
 
@@ -297,15 +297,16 @@ export class ContextManager {
 	}
 
 	/**
-	 * Chars-per-token estimate for Ollama, using this model's calibrated ratio
-	 * (falling back to the generic default until enough real data has arrived).
+	 * Chars-per-token estimate for providers without a countTokens endpoint, using
+	 * this model's calibrated ratio (falling back to the generic default until
+	 * enough real data has arrived).
 	 * Records the char length used so the next updateUsageMetadata() call for
 	 * this model can calibrate against it.
 	 */
 	private estimateTokensFromContents(modelName: string, contents: Content[]): number {
 		const json = JSON.stringify(contents ?? []);
-		const charsPerToken = this.ollamaCharsPerToken.get(modelName) ?? DEFAULT_OLLAMA_CHARS_PER_TOKEN;
-		this.pendingOllamaEstimateCharLength.set(modelName, json.length);
+		const charsPerToken = this.estimatedCharsPerToken.get(modelName) ?? DEFAULT_CHARS_PER_TOKEN;
+		this.pendingEstimateCharLength.set(modelName, json.length);
 		return Math.ceil(json.length / charsPerToken);
 	}
 
@@ -358,7 +359,7 @@ export class ContextManager {
 	 * Providers with a real counting endpoint (Gemini) are called directly. For
 	 * the rest we fall back to a chars-per-token estimate, seeded at 4 and
 	 * calibrated per-model from real promptTokenCount values as they arrive
-	 * (see calibrateOllamaRatio) — compaction precision improves as the session
+	 * (see calibrateEstimatedRatio) — compaction precision improves as the session
 	 * progresses instead of staying pinned to the generic heuristic.
 	 *
 	 * The choice follows the *model*, not a global setting, so a mixed
@@ -411,9 +412,9 @@ export class ContextManager {
 	 * the summary. It uses cached usageMetadata from the last API response to
 	 * decide whether compaction is needed; the compaction decision itself does
 	 * not call countTokens() (that only happens after compaction, to measure
-	 * the result size), but for Ollama every call still seeds the pending
-	 * chars-per-token calibration estimate for this model — see the note at
-	 * the top of the method body.
+	 * the result size), but for estimate-based providers every call still seeds
+	 * the pending chars-per-token calibration estimate for this model — see the
+	 * note at the top of the method body.
 	 */
 	async prepareHistory(
 		conversationHistory: Content[],
@@ -427,7 +428,7 @@ export class ContextManager {
 		// is the char length that will correlate with the next real
 		// promptTokenCount for this model — seed it unconditionally (not just on
 		// the compaction path below, which only runs when over threshold) so
-		// calibrateOllamaRatio() has something to calibrate against on ordinary
+		// calibrateEstimatedRatio() has something to calibrate against on ordinary
 		// turns too. The returned estimate itself isn't needed here.
 		if (!getCapabilities(this.providerForContextModel(modelName)).nativeTokenCount) {
 			this.estimateTokensFromContents(modelName, this.sanitizeContentsForTokenCount(conversationHistory));

--- a/test/services/context-manager.test.ts
+++ b/test/services/context-manager.test.ts
@@ -976,8 +976,8 @@ describe('ContextManager', () => {
 		describe('Ollama calibration seeding', () => {
 			// prepareHistory() is the entry point called before every outgoing
 			// request. Its normal (no-compaction-needed) paths don't call
-			// countTokens(), so they must still seed the pending Ollama estimate
-			// themselves or calibrateOllamaRatio() never has anything to
+			// countTokens(), so they must still seed the pending estimate
+			// themselves or calibrateEstimatedRatio() never has anything to
 			// calibrate against on ordinary turns (see #707 review feedback).
 			function buildOllamaContext() {
 				const ollamaPlugin = {

--- a/test/services/context-manager.test.ts
+++ b/test/services/context-manager.test.ts
@@ -1034,6 +1034,56 @@ describe('ContextManager', () => {
 				expect(recalibratedEstimate).toBeLessThan(baselineEstimate);
 			});
 		});
+
+		// The estimate-and-calibrate path is selected by capability (no
+		// `nativeTokenCount`), not by provider — OpenAI-compatible servers take it
+		// too. These guard against the guard narrowing back to Ollama-only, and
+		// against the Ollama-specific naming/logging returning (#1287).
+		describe('calibration for non-Ollama estimated providers', () => {
+			function buildOpenAIContext() {
+				const openaiPlugin = {
+					...mockPlugin,
+					apiKey: '',
+					settings: { ...mockPlugin.settings, provider: 'openai' },
+				};
+				return new ContextManager(openaiPlugin, mockLogger);
+			}
+
+			test('calibrates a model served by an estimate-only non-Ollama provider', async () => {
+				const openaiCtx = buildOpenAIContext();
+				const history = [
+					{ role: 'user', parts: [{ text: 'a'.repeat(400) }] },
+					{ role: 'model', parts: [{ text: 'Hi!' }] },
+				];
+
+				// Baseline under a never-seeded model name, so only prepareHistory()
+				// can seed calibration for the model under test.
+				const baselineEstimate = await openaiCtx.countTokens('gpt-test-baseline', history);
+
+				await openaiCtx.prepareHistory(history, 'gpt-test');
+
+				// Real response reports far fewer tokens than the default ratio predicted.
+				openaiCtx.updateUsageMetadata({ promptTokenCount: Math.round(baselineEstimate / 2) }, 'gpt-test');
+				const recalibratedEstimate = await openaiCtx.countTokens('gpt-test', history);
+				expect(recalibratedEstimate).toBeLessThan(baselineEstimate);
+			});
+
+			test('logs calibration without naming Ollama', async () => {
+				const openaiCtx = buildOpenAIContext();
+				const history = [{ role: 'user', parts: [{ text: 'a'.repeat(400) }] }];
+
+				await openaiCtx.prepareHistory(history, 'gpt-test');
+				openaiCtx.updateUsageMetadata({ promptTokenCount: 50 }, 'gpt-test');
+
+				const calibrationLogs = mockLogger.debug.mock.calls
+					.map((args: any[]) => String(args[0]))
+					.filter((message: string) => message.includes('Calibrated'));
+
+				expect(calibrationLogs).toHaveLength(1);
+				expect(calibrationLogs[0]).toContain('Calibrated estimated chars/token for gpt-test');
+				expect(calibrationLogs[0]).not.toContain('Ollama');
+			});
+		});
 	});
 
 	describe('reset', () => {


### PR DESCRIPTION
## Summary

The local chars-per-token calibration path in `ContextManager` was named for Ollama throughout, but it is a generic fallback for **any** provider whose capability-registry entry has no `nativeTokenCount` — which now includes the OpenAI-compatible provider added in #1286.

Confirmed in a live vault: an OpenAI chat turn logs

```
[ContextManager] Calibrated Ollama chars/token for gpt-5.6-luna: 4.00 -> 2.00
```

which is misleading when debugging a non-Ollama provider. The calibration itself works correctly for OpenAI — this is a naming/logging problem, not a behavior bug.

## Changes

- Renamed the provider-neutral calibration identifiers in `src/services/context-manager.ts`:

  | Old | New |
  |---|---|
  | `DEFAULT_OLLAMA_CHARS_PER_TOKEN` | `DEFAULT_CHARS_PER_TOKEN` |
  | `OLLAMA_RATIO_CALIBRATION_WEIGHT` | `RATIO_CALIBRATION_WEIGHT` |
  | `ollamaCharsPerToken` | `estimatedCharsPerToken` |
  | `pendingOllamaEstimateCharLength` | `pendingEstimateCharLength` |
  | `calibrateOllamaRatio` | `calibrateEstimatedRatio` |

- Debug log is now `[ContextManager] Calibrated estimated chars/token for <model>: …`
- Updated the doc comments on that path to stop claiming Ollama: the method doc now reads "this model's estimated chars-per-token ratio", `estimateTokensFromContents` says "for providers without a countTokens endpoint", and the `DEFAULT_CHARS_PER_TOKEN` comment lists `(Ollama, OpenAI-compatible)`.
- Updated the cross-references to the renamed method in `updateUsageMetadata`, `countTokens`, and `prepareHistory`, plus one comment in `test/services/context-manager.test.ts`.

**Behavior is unchanged** — no logic was touched. The only non-rename edit is Prettier collapsing the `calibratedRatio` assignment onto one line, now that the shorter constant names fit within the 120-column limit.

### Deliberately left alone

The genuinely Ollama-specific context-window resolution path keeps its Ollama naming, since it really is Ollama-only: `getOllamaInputTokenLimit`, the `provider !== 'ollama'` guard, and the `/api/ps` runtime-allocation lookup. Likewise the test's `describe('Ollama calibration seeding')` block and its `buildOllamaContext()` fixture, which exercise an actual Ollama-configured plugin.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — maintainer-authored internal cleanup; no separate issue was filed
- [x] All CI checks pass (`npm test` — 3779 tests / 170 files, `npm run build`, `npm run typecheck:test`, `prettier --check`)
- [ ] I have tested this change on Desktop — not exercised in a live vault; it is a pure rename with no logic change and the full suite is green
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — no platform-specific code touched
- [x] Documentation has been updated (if applicable) — no user-facing docs reference these private identifiers
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude (Claude Code)
- [x] I have reviewed and understand all AI-generated code in this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved token usage estimation across providers that do not offer native token counting.
  * Calibrated estimates using actual prompt usage on a per-model basis for more accurate context management.
  * Updated fallback token-counting behavior to use the generalized calibration process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->