### PR TITLE
fix(openai): make the GPT-5.6 models usable — unblock 400s, trim the catalog, fix context windows

### DIFF
--- a/docs/guide/openai-setup.md
+++ b/docs/guide/openai-setup.md
@@ -26,12 +26,20 @@ Example with [LM Studio](https://lmstudio.ai/):
 
 The same pattern works for MLX-served endpoints, Ollama's OpenAI-compatible endpoint (`http://localhost:11434/v1`), or any other server that implements the `/v1/chat/completions` and `/v1/models` endpoints.
 
-Requests to a non-`api.openai.com` base URL are not filtered against OpenAI's own non-chat model ids (embeddings, TTS, etc.) — a compatible server's `/models` catalog is taken at face value.
+A compatible server's `/models` catalog is taken at face value — the supported-model allowlist described below applies only to `api.openai.com`.
 
 ## Models
 
-- **`api.openai.com`** — the model list is enriched with curated metadata (context window, vision support) for current OpenAI models. `gpt-5.6` (chat), `gpt-5.6-terra` (summary), and `gpt-5.6-luna` (completions) are the defaults; older `gpt-5.x` and `gpt-4.x` models remain selectable.
+- **`api.openai.com`** — the endpoint advertises around ninety model ids, most of which this integration can't drive usefully (Responses-API-only, audio, embeddings, older families). The dropdowns are therefore limited to the three GPT-5.6 models that have been validated against the plugin: **`gpt-5.6-sol`** (chat default), **`gpt-5.6-terra`** (summary default), and **`gpt-5.6-luna`** (completions default). All three accept **922,000 input tokens**, which is what the token counter above the message box reflects.
+- **Where those numbers come from** — OpenAI's `/v1/models` returns no capability metadata (just an id and a creation date), so context windows are curated in the plugin rather than discovered. The 922,000 figure was measured directly against the live API, not taken from documentation.
 - **Compatible servers** — an unrecognized model id gets a conservative default: 128k context window, no vision, tool calling assumed. This covers most locally-served models correctly for tool calling, but vision won't be enabled automatically — there's no metadata to detect it from.
+
+### Reasoning and tool calling on GPT-5.6
+
+The GPT-5.6 models are reasoning models, which constrains what Chat Completions accepts:
+
+- **Sampling settings are ignored.** These models only accept the default temperature and top-p, so the plugin omits both rather than sending your configured values. Adjusting the temperature slider has no effect on a GPT-5.6 model.
+- **Tool calling runs with reasoning disabled.** `/v1/chat/completions` rejects function tools for these models unless reasoning effort is set to `none`, so any request carrying tools (all agent-mode turns) pins it there. Agent mode works normally; you just won't get reasoning output alongside tool use.
 
 ## What works
 
@@ -62,6 +70,7 @@ Nothing moves between providers unless you move it — a feature your default pr
 ## Tips
 
 - **Vision model detection** — Known OpenAI model ids report vision support from a curated metadata table; models from a compatible server default to no vision since the plugin has no way to know the server's capabilities. If your server serves a vision-capable model and attachments aren't working, this is why.
-- **Tool calling** — All current OpenAI models support function calling. Compatible-server models default to "tool calling assumed" — if a model genuinely doesn't support it, tool calls will fail rather than being pre-filtered.
+- **Tool calling** — All current OpenAI models support function calling; on GPT-5.6 models it runs with reasoning disabled (see above). Compatible-server models default to "tool calling assumed" — if a model genuinely doesn't support it, tool calls will fail rather than being pre-filtered.
+- **A model you want isn't listed** — On `api.openai.com` only the three validated GPT-5.6 models are offered. To use another OpenAI model, point the base URL at a proxy that serves it; catalogs from non-`api.openai.com` URLs aren't filtered.
 - **Placeholder API keys** — Required even when your server doesn't check them; the provider won't initialize with an empty key field.
 - **Refreshing the model list** — Click **Refresh OpenAI model list** in Settings → General after changing the base URL, loading a different model in a local server, or whenever a dropdown looks stale.

--- a/src/api/providers/openai/client.ts
+++ b/src/api/providers/openai/client.ts
@@ -130,7 +130,7 @@ export class OpenAIClient implements ModelApi {
 			});
 			return this.toModelResponse(completion);
 		} catch (error) {
-			this.plugin?.logger.error('[OpenAIClient] Error generating content:', this.describeError(error));
+			this.plugin?.logger.error('[OpenAIClient] Error generating content:', this.describeError(error), error);
 			throw error;
 		}
 	}
@@ -232,7 +232,7 @@ export class OpenAIClient implements ModelApi {
 				if (cancelled) {
 					return buildResult();
 				}
-				this.plugin?.logger.error('[OpenAIClient] Streaming error:', this.describeError(error));
+				this.plugin?.logger.error('[OpenAIClient] Streaming error:', this.describeError(error), error);
 				throw error;
 			}
 		})();
@@ -256,6 +256,10 @@ export class OpenAIClient implements ModelApi {
 	 * hides the one field that identifies the failure — the server's message.
 	 * Matched structurally rather than with `instanceof OpenAI.APIError` so the
 	 * check doesn't depend on the error carrying that exact class identity.
+	 *
+	 * Log this *alongside* the original error, never instead of it: for anything
+	 * that isn't an API error (a `TypeError` out of `buildChatRequest`, say) the
+	 * string is just `error.message` and the stack trace is the useful part.
 	 */
 	private describeError(error: unknown): string {
 		const apiError = error as { status?: number; code?: string | null; error?: { message?: string } } | null;

--- a/src/api/providers/openai/client.ts
+++ b/src/api/providers/openai/client.ts
@@ -67,6 +67,14 @@ interface StreamingToolCallAccumulator {
 }
 
 export class OpenAIClient implements ModelApi {
+	/**
+	 * GPT-5.6-family reasoning models reject any non-default `temperature`/
+	 * `top_p`, and `/v1/chat/completions` rejects function tools for them
+	 * unless `reasoning_effort` is 'none'. Matched by id (not base URL) so the
+	 * same handling applies when a proxy serves these models.
+	 */
+	private static readonly GPT56_MODEL_PATTERN = /^gpt-5\.6/;
+
 	private client: OpenAI;
 	private config: OpenAIClientConfig;
 	private prompts: GeminiPrompts;
@@ -107,8 +115,7 @@ export class OpenAIClient implements ModelApi {
 					model,
 					messages: [{ role: 'user', content: request.prompt }],
 					stream: false,
-					temperature: request.temperature ?? this.config.temperature,
-					top_p: request.topP ?? this.config.topP,
+					...this.samplingParams(model, request),
 				});
 				return this.toModelResponse(completion);
 			}
@@ -118,13 +125,12 @@ export class OpenAIClient implements ModelApi {
 				model,
 				messages,
 				stream: false,
-				temperature: request.temperature ?? this.config.temperature,
-				top_p: request.topP ?? this.config.topP,
-				...(tools && tools.length ? { tools } : {}),
+				...this.samplingParams(model, request),
+				...this.toolParams(model, tools),
 			});
 			return this.toModelResponse(completion);
 		} catch (error) {
-			this.plugin?.logger.error('[OpenAIClient] Error generating content:', error);
+			this.plugin?.logger.error('[OpenAIClient] Error generating content:', this.describeError(error));
 			throw error;
 		}
 	}
@@ -177,8 +183,7 @@ export class OpenAIClient implements ModelApi {
 							// Servers that ignore this option simply omit `usage` on chunks;
 							// toUsageMetadata() tolerates that by returning undefined.
 							stream_options: { include_usage: true },
-							temperature: request.temperature ?? this.config.temperature,
-							top_p: request.topP ?? this.config.topP,
+							...this.samplingParams(model, request),
 						},
 						{ signal: controller.signal }
 					);
@@ -190,9 +195,8 @@ export class OpenAIClient implements ModelApi {
 							messages,
 							stream: true,
 							stream_options: { include_usage: true },
-							temperature: request.temperature ?? this.config.temperature,
-							top_p: request.topP ?? this.config.topP,
-							...(tools && tools.length ? { tools } : {}),
+							...this.samplingParams(model, request),
+							...this.toolParams(model, tools),
 						},
 						{ signal: controller.signal }
 					);
@@ -228,7 +232,7 @@ export class OpenAIClient implements ModelApi {
 				if (cancelled) {
 					return buildResult();
 				}
-				this.plugin?.logger.error('[OpenAIClient] Streaming error:', error);
+				this.plugin?.logger.error('[OpenAIClient] Streaming error:', this.describeError(error));
 				throw error;
 			}
 		})();
@@ -243,6 +247,65 @@ export class OpenAIClient implements ModelApi {
 					this.plugin?.logger.debug('[OpenAIClient] Abort failed:', err);
 				}
 			},
+		};
+	}
+
+	/**
+	 * Flattens an SDK `APIError` into a readable string. The console serializes
+	 * an APIError's nested `error` body as the useless `"error":"Object"`, which
+	 * hides the one field that identifies the failure — the server's message.
+	 * Matched structurally rather than with `instanceof OpenAI.APIError` so the
+	 * check doesn't depend on the error carrying that exact class identity.
+	 */
+	private describeError(error: unknown): string {
+		const apiError = error as { status?: number; code?: string | null; error?: { message?: string } } | null;
+		if (apiError && typeof apiError === 'object' && typeof apiError.status === 'number') {
+			const detail = apiError.error?.message ?? (error instanceof Error ? error.message : undefined) ?? 'unknown error';
+			return `HTTP ${apiError.status}${apiError.code ? ` [${apiError.code}]` : ''}: ${detail}`;
+		}
+		return error instanceof Error ? error.message : String(error);
+	}
+
+	/** Whether `model` is a GPT-5.6-family reasoning model. */
+	private isGpt56Model(model: string): boolean {
+		return OpenAIClient.GPT56_MODEL_PATTERN.test(model);
+	}
+
+	/**
+	 * Sampling params for a request. GPT-5.6 models accept only the default
+	 * temperature/top_p and 400 on anything else, so they're omitted entirely
+	 * rather than sent with the configured values.
+	 */
+	private samplingParams(
+		model: string,
+		request: BaseModelRequest | ExtendedModelRequest
+	): { temperature?: number; top_p?: number } {
+		if (this.isGpt56Model(model)) {
+			return {};
+		}
+		return {
+			temperature: request.temperature ?? this.config.temperature,
+			top_p: request.topP ?? this.config.topP,
+		};
+	}
+
+	/**
+	 * Tool params for a request. `/v1/chat/completions` rejects function tools
+	 * for GPT-5.6 models unless reasoning is disabled, so those requests pin
+	 * `reasoning_effort: 'none'`. (Tool calling with reasoning would require the
+	 * Responses API, which this client deliberately doesn't target — see the
+	 * module header.)
+	 */
+	private toolParams(
+		model: string,
+		tools?: ChatTool[]
+	): { tools?: ChatTool[]; reasoning_effort?: OpenAI.ReasoningEffort } {
+		if (!tools || !tools.length) {
+			return {};
+		}
+		return {
+			tools,
+			...(this.isGpt56Model(model) && { reasoning_effort: 'none' as const }),
 		};
 	}
 

--- a/src/models.ts
+++ b/src/models.ts
@@ -153,6 +153,21 @@ export function remoteHostForModel(modelValue: string | null | undefined): strin
 }
 
 /**
+ * A model's own input token limit, or `null` when the list carries none.
+ *
+ * Providers whose windows differ per model (OpenAI: 922k on GPT-5.6 versus the
+ * 128k floor a compatible server gets) need this rather than the provider-wide
+ * `defaultInputTokenLimit`, which is only a fallback for models the list can't
+ * identify. Understating the window is not merely cosmetic — it makes the
+ * context manager compact history long before the real ceiling.
+ */
+export function contextWindowForModel(modelValue: string | null | undefined): number | null {
+	if (!modelValue) return null;
+	const windowIn = (list: GeminiModel[]) => list.find((m) => m.value === modelValue)?.contextWindow;
+	return windowIn(GEMINI_MODELS) ?? windowIn(DEFAULT_GEMINI_MODELS) ?? null;
+}
+
+/**
  * Whether a model is served exclusively by the Interactions API (see
  * `GeminiModel.interactionsOnly`). Checks the live model list first (which may
  * be a newer remote list), then the bundled defaults — a stale remote cache

--- a/src/services/context-manager.ts
+++ b/src/services/context-manager.ts
@@ -17,7 +17,7 @@ import { executeWithRetry } from '../utils/retry';
 import { createGoogleGenAI } from '../api/providers/gemini/google-genai-factory';
 import { truncateOldToolResults } from '../agent/agent-loop-helpers';
 import { getLegacyEntryTextTruthy } from '../utils/history-normalize';
-import { findModelProvider, resolveGenerateContentModel } from '../models';
+import { contextWindowForModel, findModelProvider, resolveGenerateContentModel } from '../models';
 import { isProviderActive, resolveProviderOrDefault } from '../api/provider-routing';
 import { getCapabilities } from '../api/providers/registry';
 
@@ -224,12 +224,18 @@ export class ContextManager {
 	 * three orders of magnitude across local models (4k to 1M), so a flat number
 	 * is wrong for nearly everyone: it showed a 262k-window model as 43% full at
 	 * 13.9k tokens and compacted history away at 2.4% of real capacity.
+	 *
+	 * Other providers take the window the model list carries, falling back to the
+	 * provider default only for a model the list can't identify. The same
+	 * understatement bites here: OpenAI's provider floor is 128k (the conservative
+	 * value for an unrecognized compatible-server model), while GPT-5.6 accepts
+	 * 922k, so trusting the floor would compact at ~14% of real capacity.
 	 */
 	private async getInputTokenLimit(modelName: string): Promise<number> {
 		const provider = this.providerForContextModel(modelName);
 		const capabilities = getCapabilities(provider);
 		if (provider !== 'ollama' || !modelName) {
-			return capabilities.defaultInputTokenLimit;
+			return contextWindowForModel(modelName) ?? capabilities.defaultInputTokenLimit;
 		}
 		return (await this.getOllamaInputTokenLimit(modelName)) ?? capabilities.defaultInputTokenLimit;
 	}

--- a/src/services/openai-models-service.ts
+++ b/src/services/openai-models-service.ts
@@ -10,48 +10,46 @@ interface OpenAIModelMetadata {
 }
 
 /**
+ * `/v1/models` reports no capability metadata at all — only id, created, and
+ * owned_by — so context windows have to be curated here. All three GPT-5.6
+ * models share one input limit, measured against the live API by submitting an
+ * over-limit request and reading the ceiling back out of the
+ * `context_length_exceeded` error ("Input tokens exceed the configured limit of
+ * 922000 tokens"). Re-measure that way rather than trusting published figures;
+ * the marketing "1M" does not match what the endpoint enforces.
+ */
+const GPT56_INPUT_TOKEN_LIMIT = 922_000;
+
+/**
  * Curated metadata for known OpenAI-hosted models, keyed by the model id
  * returned from `/v1/models`. Unknown ids — OpenAI-compatible local servers
  * (LM Studio, MLX, ...) whose catalog we have no curated data for — fall back
  * to `UNKNOWN_MODEL_DEFAULTS` in `toGeminiModel`.
  */
 const KNOWN_OPENAI_MODELS: Record<string, OpenAIModelMetadata> = {
-	// Current flagship family. 'gpt-5.6' is an alias of 'gpt-5.6-sol'.
-	'gpt-5.6': { contextWindow: 1_000_000, supportsVision: true, defaultForRoles: ['chat'] },
-	'gpt-5.6-sol': { contextWindow: 1_000_000, supportsVision: true },
-	'gpt-5.6-terra': { contextWindow: 400_000, supportsVision: true, defaultForRoles: ['summary'] },
-	'gpt-5.6-luna': { contextWindow: 128_000, supportsVision: true, defaultForRoles: ['completions'] },
-	// Still-available older families.
-	'gpt-5.1': { contextWindow: 400_000, supportsVision: true },
-	'gpt-5': { contextWindow: 400_000, supportsVision: true },
-	'gpt-4.1': { contextWindow: 400_000, supportsVision: true },
-	'gpt-4o': { contextWindow: 128_000, supportsVision: true },
+	// Current flagship family — the supported set on api.openai.com. Older
+	// families (gpt-5.1, gpt-4o, ...) are still reachable via a custom base URL
+	// but aren't offered here; see SUPPORTED_OPENAI_HOSTED_MODELS.
+	'gpt-5.6-sol': { contextWindow: GPT56_INPUT_TOKEN_LIMIT, supportsVision: true, defaultForRoles: ['chat'] },
+	'gpt-5.6-terra': { contextWindow: GPT56_INPUT_TOKEN_LIMIT, supportsVision: true, defaultForRoles: ['summary'] },
+	'gpt-5.6-luna': { contextWindow: GPT56_INPUT_TOKEN_LIMIT, supportsVision: true, defaultForRoles: ['completions'] },
 };
+
+/**
+ * The models offered when the base URL is api.openai.com. The endpoint
+ * advertises ~90 ids, most of which this Chat Completions client can't drive
+ * usefully (Responses-only, audio, embeddings, legacy families); rather than
+ * filter that catalog by heuristic, we allowlist the models actually validated
+ * against this client. A custom base URL is unaffected — a compatible server's
+ * catalog is whatever it advertises.
+ */
+const SUPPORTED_OPENAI_HOSTED_MODELS = new Set(Object.keys(KNOWN_OPENAI_MODELS));
 
 /** Applied to a model id absent from {@link KNOWN_OPENAI_MODELS}. */
 const UNKNOWN_MODEL_DEFAULTS: OpenAIModelMetadata = {
 	contextWindow: 128_000,
 	supportsVision: false,
 };
-
-/**
- * Model ids on api.openai.com that aren't chat-completion models (embeddings,
- * audio, image, moderation, legacy completion-only models, ...). Only applied
- * when the base URL is api.openai.com — a compatible local server's catalog
- * is whatever it advertises, and we don't second-guess it.
- */
-const NON_CHAT_ID_PATTERNS: RegExp[] = [
-	/embedding/i,
-	/whisper/i,
-	/\btts\b/i,
-	/dall-?e/i,
-	/moderation/i,
-	/davinci/i,
-	/babbage/i,
-	/realtime/i,
-	/\baudio\b/i,
-	/\bimage\b/i,
-];
 
 interface OpenAIModelListEntry {
 	id: string;
@@ -124,9 +122,9 @@ export class OpenAIModelsService {
 				throw new Error('Invalid /models response shape');
 			}
 
-			const filterNonChatIds = isOpenAIHostedEndpoint(baseUrl);
+			const restrictToSupported = isOpenAIHostedEndpoint(baseUrl);
 			this.cachedModels = data.data
-				.filter((m) => !filterNonChatIds || !NON_CHAT_ID_PATTERNS.some((re) => re.test(m.id)))
+				.filter((m) => !restrictToSupported || SUPPORTED_OPENAI_HOSTED_MODELS.has(m.id))
 				.map((m) => this.toGeminiModel(m.id));
 			this.lastBaseUrl = baseUrl;
 			this.lastApiKey = apiKey;

--- a/test/api/providers/openai/client.test.ts
+++ b/test/api/providers/openai/client.test.ts
@@ -1,7 +1,7 @@
 import type { Mock } from 'vitest';
 import { OpenAIClient } from '../../../../src/api/providers/openai/client';
 import type { OpenAIClientConfig } from '../../../../src/api/providers/openai/config';
-import { ExtendedModelRequest } from '../../../../src/api/interfaces/model-api';
+import { ExtendedModelRequest, ToolDefinition } from '../../../../src/api/interfaces/model-api';
 
 // vitest hoists vi.mock to the top of the file; vi.hoisted() lets us share
 // fixtures with the factory while keeping initialization order safe.
@@ -795,7 +795,7 @@ describe('OpenAIClient', () => {
 				choices: [{ message: { content: 'ok' } }],
 			});
 			const c = new OpenAIClient(
-				{ apiKey: 'sk-test', baseUrl: 'https://api.openai.com/v1', model: 'gpt-5.6' },
+				{ apiKey: 'sk-test', baseUrl: 'https://api.openai.com/v1', model: 'gpt-4o-mini' },
 				undefined,
 				buildPlugin()
 			);
@@ -804,6 +804,112 @@ describe('OpenAIClient', () => {
 			const args = openaiCalls.create.mock.calls[0][0];
 			expect(args.temperature).toBe(0.7);
 			expect(args.top_p).toBe(1);
+		});
+	});
+
+	// GPT-5.6 reasoning models reject a non-default temperature/top_p outright,
+	// and reject function tools in Chat Completions unless reasoning is off.
+	describe('GPT-5.6 parameter handling', () => {
+		const gpt56Config: OpenAIClientConfig = {
+			apiKey: 'sk-test',
+			baseUrl: 'https://api.openai.com/v1',
+			model: 'gpt-5.6-luna',
+			temperature: 0.4,
+			topP: 0.9,
+		};
+		const readFileTool: ToolDefinition = {
+			name: 'read_file',
+			description: 'reads a file',
+			parameters: { type: 'object', properties: { path: { type: 'string' } }, required: ['path'] },
+		};
+
+		let gpt56Client: OpenAIClient;
+
+		beforeEach(() => {
+			gpt56Client = new OpenAIClient(gpt56Config, undefined, buildPlugin());
+			openaiCalls.create.mockResolvedValue({ choices: [{ message: { content: 'ok' } }] });
+		});
+
+		it('omits temperature and top_p for a base request', async () => {
+			await gpt56Client.generateModelResponse({ kind: 'base', prompt: 'hi' });
+
+			const args = openaiCalls.create.mock.calls[0][0];
+			expect(args).not.toHaveProperty('temperature');
+			expect(args).not.toHaveProperty('top_p');
+		});
+
+		it('omits temperature and top_p even when the request supplies them', async () => {
+			await gpt56Client.generateModelResponse({ kind: 'base', prompt: 'hi', temperature: 0.2 });
+
+			const args = openaiCalls.create.mock.calls[0][0];
+			expect(args).not.toHaveProperty('temperature');
+			expect(args).not.toHaveProperty('top_p');
+		});
+
+		it("sets reasoning_effort 'none' when sending tools", async () => {
+			await gpt56Client.generateModelResponse({
+				prompt: '',
+				userMessage: 'read foo',
+				kind: 'extended',
+				conversationHistory: [],
+				availableTools: [readFileTool],
+			});
+
+			const args = openaiCalls.create.mock.calls[0][0];
+			expect(args.reasoning_effort).toBe('none');
+			expect(args.tools).toHaveLength(1);
+		});
+
+		it('does not set reasoning_effort when there are no tools', async () => {
+			await gpt56Client.generateModelResponse({
+				prompt: '',
+				userMessage: 'just chat',
+				kind: 'extended',
+				conversationHistory: [],
+			});
+
+			const args = openaiCalls.create.mock.calls[0][0];
+			expect(args).not.toHaveProperty('reasoning_effort');
+		});
+
+		it('applies the same handling on the streaming path', async () => {
+			async function* stream() {
+				yield { choices: [{ index: 0, delta: { content: 'ok' }, finish_reason: 'stop' }] };
+			}
+			openaiCalls.create.mockResolvedValue(stream());
+
+			const streaming = gpt56Client.generateStreamingResponse(
+				{
+					prompt: '',
+					userMessage: 'read foo',
+					kind: 'extended',
+					conversationHistory: [],
+					availableTools: [readFileTool],
+				},
+				() => {}
+			);
+			await streaming.complete;
+
+			const args = openaiCalls.create.mock.calls[0][0];
+			expect(args).not.toHaveProperty('temperature');
+			expect(args).not.toHaveProperty('top_p');
+			expect(args.reasoning_effort).toBe('none');
+		});
+
+		it('leaves non-GPT-5.6 models untouched', async () => {
+			const c = new OpenAIClient({ ...gpt56Config, model: 'gpt-4o-mini' }, undefined, buildPlugin());
+			await c.generateModelResponse({
+				prompt: '',
+				userMessage: 'read foo',
+				kind: 'extended',
+				conversationHistory: [],
+				availableTools: [readFileTool],
+			});
+
+			const args = openaiCalls.create.mock.calls[0][0];
+			expect(args.temperature).toBe(0.4);
+			expect(args.top_p).toBe(0.9);
+			expect(args).not.toHaveProperty('reasoning_effort');
 		});
 	});
 
@@ -832,7 +938,7 @@ describe('OpenAIClient', () => {
 			await expect(client.generateModelResponse({ kind: 'base', prompt: 'test' })).rejects.toThrow(
 				'connection refused'
 			);
-			expect(mockLogger.error).toHaveBeenCalledWith('[OpenAIClient] Error generating content:', expect.any(Error));
+			expect(mockLogger.error).toHaveBeenCalledWith('[OpenAIClient] Error generating content:', 'connection refused');
 		});
 
 		it('logs and re-throws streaming errors when not cancelled', async () => {
@@ -844,7 +950,28 @@ describe('OpenAIClient', () => {
 			);
 
 			await expect(streaming.complete).rejects.toThrow('connection refused');
-			expect(mockLogger.error).toHaveBeenCalledWith('[OpenAIClient] Streaming error:', expect.any(Error));
+			expect(mockLogger.error).toHaveBeenCalledWith('[OpenAIClient] Streaming error:', 'connection refused');
+		});
+
+		it('surfaces the server message from an API error body instead of a flattened object', async () => {
+			openaiCalls.create.mockRejectedValue(
+				Object.assign(new Error('400 status code (no body)'), {
+					status: 400,
+					code: 'unsupported_value',
+					error: { message: "Unsupported value: 'temperature' does not support 0.7 with this model." },
+				})
+			);
+
+			const streaming = client.generateStreamingResponse(
+				{ prompt: '', userMessage: 'hi', kind: 'extended', conversationHistory: [] },
+				() => {}
+			);
+			await expect(streaming.complete).rejects.toThrow();
+
+			expect(mockLogger.error).toHaveBeenCalledWith(
+				'[OpenAIClient] Streaming error:',
+				"HTTP 400 [unsupported_value]: Unsupported value: 'temperature' does not support 0.7 with this model."
+			);
 		});
 	});
 

--- a/test/api/providers/openai/client.test.ts
+++ b/test/api/providers/openai/client.test.ts
@@ -962,7 +962,7 @@ describe('OpenAIClient', () => {
 		});
 
 		// The formatted string is only `error.message` for a non-API error, so the
-		// raw error has to ride along or the stack trace never reaches the console.
+		// raw error has to ride along or its stack trace is never logged at all.
 		it('passes the original error through so its stack survives', async () => {
 			const raw = new TypeError('boom');
 			openaiCalls.create.mockRejectedValue(raw);

--- a/test/api/providers/openai/client.test.ts
+++ b/test/api/providers/openai/client.test.ts
@@ -938,7 +938,11 @@ describe('OpenAIClient', () => {
 			await expect(client.generateModelResponse({ kind: 'base', prompt: 'test' })).rejects.toThrow(
 				'connection refused'
 			);
-			expect(mockLogger.error).toHaveBeenCalledWith('[OpenAIClient] Error generating content:', 'connection refused');
+			expect(mockLogger.error).toHaveBeenCalledWith(
+				'[OpenAIClient] Error generating content:',
+				'connection refused',
+				expect.any(Error)
+			);
 		});
 
 		it('logs and re-throws streaming errors when not cancelled', async () => {
@@ -950,7 +954,22 @@ describe('OpenAIClient', () => {
 			);
 
 			await expect(streaming.complete).rejects.toThrow('connection refused');
-			expect(mockLogger.error).toHaveBeenCalledWith('[OpenAIClient] Streaming error:', 'connection refused');
+			expect(mockLogger.error).toHaveBeenCalledWith(
+				'[OpenAIClient] Streaming error:',
+				'connection refused',
+				expect.any(Error)
+			);
+		});
+
+		// The formatted string is only `error.message` for a non-API error, so the
+		// raw error has to ride along or the stack trace never reaches the console.
+		it('passes the original error through so its stack survives', async () => {
+			const raw = new TypeError('boom');
+			openaiCalls.create.mockRejectedValue(raw);
+
+			await expect(client.generateModelResponse({ kind: 'base', prompt: 'test' })).rejects.toThrow('boom');
+
+			expect(mockLogger.error).toHaveBeenCalledWith('[OpenAIClient] Error generating content:', 'boom', raw);
 		});
 
 		it('surfaces the server message from an API error body instead of a flattened object', async () => {
@@ -970,7 +989,8 @@ describe('OpenAIClient', () => {
 
 			expect(mockLogger.error).toHaveBeenCalledWith(
 				'[OpenAIClient] Streaming error:',
-				"HTTP 400 [unsupported_value]: Unsupported value: 'temperature' does not support 0.7 with this model."
+				"HTTP 400 [unsupported_value]: Unsupported value: 'temperature' does not support 0.7 with this model.",
+				expect.anything()
 			);
 		});
 	});

--- a/test/models.test.ts
+++ b/test/models.test.ts
@@ -9,6 +9,7 @@ import {
 	GeminiModel,
 	getUpdatedModelSettings,
 	isInteractionsOnlyModel,
+	contextWindowForModel,
 	migrateOllamaModelSetting,
 	providerForModel,
 	resolveGenerateContentModel,
@@ -619,6 +620,35 @@ describe('isInteractionsOnlyModel', () => {
 	it('honors an explicit false in the live list over the bundled flag', () => {
 		setGeminiModels([{ value: 'gemini-omni-flash-preview', label: 'Omni', interactionsOnly: false }]);
 		expect(isInteractionsOnlyModel('gemini-omni-flash-preview')).toBe(false);
+	});
+});
+
+describe('contextWindowForModel', () => {
+	let originalModels: GeminiModel[];
+
+	beforeEach(() => {
+		originalModels = [...GEMINI_MODELS];
+	});
+
+	afterEach(() => {
+		setGeminiModels(originalModels);
+	});
+
+	it('returns the window a discovered model carries', () => {
+		setGeminiModels([{ value: 'gpt-5.6-luna', label: 'gpt-5.6-luna', provider: 'openai', contextWindow: 922_000 }]);
+		expect(contextWindowForModel('gpt-5.6-luna')).toBe(922_000);
+	});
+
+	it('returns null for a model with no declared window, so callers use the provider default', () => {
+		setGeminiModels([{ value: 'some-local-model', label: 'Local', provider: 'openai' }]);
+		expect(contextWindowForModel('some-local-model')).toBeNull();
+	});
+
+	it('returns null for unknown models and empty values', () => {
+		expect(contextWindowForModel('not-a-real-model')).toBeNull();
+		expect(contextWindowForModel('')).toBeNull();
+		expect(contextWindowForModel(undefined)).toBeNull();
+		expect(contextWindowForModel(null)).toBeNull();
 	});
 });
 

--- a/test/services/model-manager.test.ts
+++ b/test/services/model-manager.test.ts
@@ -315,13 +315,13 @@ describe('ModelManager', () => {
 		it('initialize() merges discovered OpenAI models into the global model list', async () => {
 			mockedRequestUrl.mockResolvedValue({
 				status: 200,
-				json: { data: [{ id: 'gpt-5.6' }, { id: 'gpt-5.6-luna' }] },
+				json: { data: [{ id: 'gpt-5.6-sol' }, { id: 'gpt-5.6-luna' }] },
 			});
 
 			await openaiManager.initialize();
 
 			const active = GEMINI_MODELS.filter((m) => m.provider === 'openai').map((m) => m.value);
-			expect(active).toEqual(expect.arrayContaining(['gpt-5.6', 'gpt-5.6-luna']));
+			expect(active).toEqual(expect.arrayContaining(['gpt-5.6-sol', 'gpt-5.6-luna']));
 		});
 
 		it('initialize() still completes when the OpenAI endpoint is unreachable', async () => {

--- a/test/services/openai-models-service.test.ts
+++ b/test/services/openai-models-service.test.ts
@@ -22,18 +22,18 @@ describe('OpenAIModelsService', () => {
 	});
 
 	it('parses /models response into GeminiModel entries with curated metadata', async () => {
-		mockModelList(['gpt-5.6', 'gpt-5.6-terra', 'gpt-5.6-luna']);
+		mockModelList(['gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna']);
 
 		const svc = new OpenAIModelsService(buildPlugin());
 		const models = await svc.getModels();
 
 		expect(models).toHaveLength(3);
 		expect(models[0]).toMatchObject({
-			value: 'gpt-5.6',
+			value: 'gpt-5.6-sol',
 			provider: 'openai',
 			supportsTools: true,
 			supportsVision: true,
-			contextWindow: 1_000_000,
+			contextWindow: 922_000,
 			defaultForRoles: ['chat'],
 		});
 		expect(models[1]).toMatchObject({ value: 'gpt-5.6-terra', defaultForRoles: ['summary'] });
@@ -42,8 +42,8 @@ describe('OpenAIModelsService', () => {
 
 	it('applies conservative defaults to a model id with no curated metadata', async () => {
 		mockModelList(['some-custom-local-model']);
-
-		const svc = new OpenAIModelsService(buildPlugin());
+		// Unknown ids only survive the filter on a non-hosted (compatible) endpoint.
+		const svc = new OpenAIModelsService(buildPlugin({ settings: { openaiBaseUrl: 'http://localhost:1234/v1' } }));
 		const models = await svc.getModels();
 
 		expect(models).toEqual([
@@ -58,7 +58,7 @@ describe('OpenAIModelsService', () => {
 	});
 
 	it('sends the resolved API key as a Bearer token', async () => {
-		mockModelList(['gpt-5.6']);
+		mockModelList(['gpt-5.6-sol']);
 		const plugin = buildPlugin({ openaiApiKey: 'sk-secret' });
 
 		await new OpenAIModelsService(plugin).getModels();
@@ -68,14 +68,23 @@ describe('OpenAIModelsService', () => {
 		);
 	});
 
-	describe('non-chat model filtering', () => {
-		it('filters out non-chat ids on api.openai.com', async () => {
-			mockModelList(['gpt-5.6', 'text-embedding-3-large', 'whisper-1', 'tts-1', 'dall-e-3', 'text-moderation-latest']);
+	describe('model filtering', () => {
+		it('keeps only the supported GPT-5.6 models on api.openai.com', async () => {
+			mockModelList([
+				'gpt-5.6-sol',
+				'gpt-5.6-terra',
+				'gpt-5.6-luna',
+				'gpt-5.1',
+				'gpt-4o',
+				'text-embedding-3-large',
+				'whisper-1',
+				'dall-e-3',
+			]);
 
 			const svc = new OpenAIModelsService(buildPlugin());
 			const models = await svc.getModels();
 
-			expect(models.map((m) => m.value)).toEqual(['gpt-5.6']);
+			expect(models.map((m) => m.value)).toEqual(['gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna']);
 		});
 
 		it('does not filter model ids on a custom (non-api.openai.com) base URL', async () => {
@@ -97,7 +106,7 @@ describe('OpenAIModelsService', () => {
 	});
 
 	it('caches results and only re-fetches after invalidate()', async () => {
-		mockModelList(['gpt-5.6']);
+		mockModelList(['gpt-5.6-sol']);
 
 		const svc = new OpenAIModelsService(buildPlugin());
 		await svc.getModels();
@@ -136,7 +145,7 @@ describe('OpenAIModelsService', () => {
 	});
 
 	it('does not return stale models from a previous base URL after a failed refresh', async () => {
-		const plugin = buildPlugin();
+		const plugin = buildPlugin({ settings: { openaiBaseUrl: 'http://first-server:1234/v1' } });
 
 		mockModelList(['old-only-model', 'shared-model']);
 		const svc = new OpenAIModelsService(plugin);


### PR DESCRIPTION
## Summary

The OpenAI provider merged in #1286 could not complete a single request against the GPT-5.6 models on `api.openai.com` — every chat turn failed with a 400. This fixes that, trims the model dropdowns to the models the client can actually drive, and fixes a context-window bug found while chasing the first two.

Follow-up to #1286 / #1237. There is no separate issue for this; it was found by installing the merged build into a real vault and using it.

## Changes

- **`gpt-5.6*` requests no longer 400.** Two stacked causes: the client always sent `temperature`/`top_p`, which these reasoning models reject outright, and `/v1/chat/completions` rejects function tools for them unless `reasoning_effort` is `'none'` — so every agent-mode turn failed. Sampling params are now omitted for these models and tool-carrying requests pin `reasoning_effort: 'none'`. Gated on model id, not base URL, so a proxy serving them behaves the same; all other models are untouched.
- **API errors are now readable.** The console serialized the SDK's nested error body as `"error":"Object","code":"null"`, which hid the server message. This is why the temperature failure was invisible until reproduced by hand. Errors now log as `HTTP 400 [unsupported_value]: Unsupported value: 'temperature'…`.
- **Hosted model list narrowed to three.** `api.openai.com` advertises ~90 ids, most undrivable through Chat Completions; the old regex still let 91 through into every dropdown. Now an allowlist of `gpt-5.6-sol` (chat), `gpt-5.6-terra` (summary), `gpt-5.6-luna` (completions). Custom base URLs are unaffected — a compatible server's catalog is still taken at face value.
- **Context windows corrected to 922,000** for all three. `/v1/models` returns no capability metadata whatsoever, so these are curated by hand, and all three curated values were wrong (1M / 400k / 128k).
- **The context manager now reads a model's own window.** `getInputTokenLimit` consulted per-model data only for Ollama; every other provider got the flat provider default, so `contextWindow` was dead data for OpenAI. This is #1252's bug in the other direction — the 128k floor against a 922k model meant history was compacted at ~14% of real capacity.

## How the 922,000 figure was determined

Not from documentation — `/v1/models` returns only `id`, `created`, and `owned_by`. It was measured against the live API: an over-limit request is rejected before inference and names the ceiling in its error.

```
Input tokens exceed the configured limit of 922000 tokens.
Your messages resulted in 1120008 tokens.
```

Same result for `sol` and `luna`; `terra` accepted 800k, well past its claimed 400k. That procedure is documented in a code comment so the values can be re-measured when the family changes, rather than re-guessed.

## Reviewer notes

- The three commits are independently reviewable, and **the third is not OpenAI-specific** — it changes limit resolution for any provider whose models carry per-model windows. It is safe as written: Gemini's bundled entries declare no `contextWindow`, so they keep the 1M provider default, and Ollama's more authoritative runtime-allocation path is untouched. Happy to split it into its own PR if you would rather land it separately.
- The corrected window values in commit 2 are inert until commit 3 — worth knowing if you review them in isolation.
- `reasoning_effort: 'none'` means agent-mode turns on GPT-5.6 run without reasoning output. Tool calling with reasoning would require the Responses API, which this client deliberately does not target.

## Screenshots / Screencast

No UI changes. The one user-visible difference is the token budget readout, verified in a live vault: the same context previously reported `~10,657 / 128,000 (8.3%)` and now correctly reports `~10,657 / 922,000 (1.2%)`.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — **no prior issue**; this is a defect found while testing the merged #1286 in a real vault
- [x] All CI checks pass (`npm test` 3789 passing, `npm run build`, `npm run format-check`, `npm run typecheck:test`, `npm run lint`, `npm run lint:cycles`)
- [x] I have tested this change on Desktop — installed into a live vault; agent turn with tool calling verified end to end against the real API
- [x] I have verified this change does not break Mobile — provider/plumbing logic only; no platform APIs or Node built-ins introduced
- [x] Documentation has been updated — `docs/guide/openai-setup.md`
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for validated GPT-5.6 models with curated context limits and metadata.
  * Improved context-limit detection using discovered model information.
  * Compatible OpenAI endpoints can use their available model catalogs with fallback metadata.
* **Bug Fixes**
  * GPT-5.6 requests now handle sampling and tool-calling constraints correctly.
  * API and streaming errors provide clearer status, code, and message details.
* **Documentation**
  * Updated OpenAI setup guidance with model filtering, endpoint behavior, and GPT-5.6 limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->