### PR TITLE
refactor(main): extract the init-baseline snapshot into markInitialized()

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -241,16 +241,7 @@ export default class ObsidianGemini extends Plugin implements ObsidianGeminiApi 
 		// Try to setup the plugin, but don't fail if API key is missing
 		try {
 			await this.lifecycle.setup();
-			this.isGeminiInitialized = true;
-			this.lastInitError = null;
-			this.previousApiKey = this.apiKey;
-			this.previousOpenaiApiKey = this.openaiApiKey;
-			this.previousRagEnabled = this.settings.ragIndexing.enabled;
-			this.previousRoutingKey = routingKey(this.settings);
-			this.previousOllamaBaseUrl = this.settings.ollamaBaseUrl;
-			this.previousCustomBaseUrl = this.settings.customBaseUrl;
-			this.previousOpenaiBaseUrl = this.settings.openaiBaseUrl;
-			this.previousHooksEnabled = this.settings.hooksEnabled;
+			this.markInitialized();
 		} catch (error) {
 			this.logger.error('Failed to initialize Gemini Scribe:', error);
 			this.lastInitError = getRawErrorMessage(error);
@@ -262,6 +253,29 @@ export default class ObsidianGemini extends Plugin implements ObsidianGeminiApi 
 		this.registerUIAndCommands();
 
 		this.app.workspace.onLayoutReady(() => this.lifecycle.onLayoutReady());
+	}
+
+	/**
+	 * Record a successful `lifecycle.setup()`: mark the plugin initialized and
+	 * snapshot every setting the re-init check in `saveSettings` compares against.
+	 *
+	 * Both the `onload` and `saveSettings` init paths must capture the *same*
+	 * baseline — a field snapshotted in one place but not the other leaves a
+	 * stale `previous*` value, so the next `saveSettings` sees a phantom change
+	 * (or misses a real one). Keeping the list in one method means adding a new
+	 * `previous*` field can't silently skip a call site.
+	 */
+	private markInitialized(): void {
+		this.isGeminiInitialized = true;
+		this.lastInitError = null;
+		this.previousApiKey = this.apiKey;
+		this.previousOpenaiApiKey = this.openaiApiKey;
+		this.previousRagEnabled = this.settings.ragIndexing.enabled;
+		this.previousRoutingKey = routingKey(this.settings);
+		this.previousOllamaBaseUrl = this.settings.ollamaBaseUrl;
+		this.previousCustomBaseUrl = this.settings.customBaseUrl;
+		this.previousOpenaiBaseUrl = this.settings.openaiBaseUrl;
+		this.previousHooksEnabled = this.settings.hooksEnabled;
 	}
 
 	/**
@@ -546,16 +560,7 @@ export default class ObsidianGemini extends Plugin implements ObsidianGeminiApi 
 		) {
 			try {
 				await this.lifecycle.setup();
-				this.isGeminiInitialized = true;
-				this.lastInitError = null;
-				this.previousApiKey = this.apiKey;
-				this.previousOpenaiApiKey = this.openaiApiKey;
-				this.previousRagEnabled = this.settings.ragIndexing.enabled;
-				this.previousRoutingKey = routingKey(this.settings);
-				this.previousOllamaBaseUrl = this.settings.ollamaBaseUrl;
-				this.previousCustomBaseUrl = this.settings.customBaseUrl;
-				this.previousOpenaiBaseUrl = this.settings.openaiBaseUrl;
-				this.previousHooksEnabled = this.settings.hooksEnabled;
+				this.markInitialized();
 
 				// If this is the first successful initialization, we may need to
 				// re-register UI components to make them functional


### PR DESCRIPTION
## Summary

`audit-architecture` nightly sweep flagged: **DRY violation** in `src/main.ts`.

Both initialization paths — `onload()` and the re-init branch of `saveSettings()` — repeated the same ten-line block that flips `isGeminiInitialized`/`lastInitError` and snapshots every setting the re-init check later compares against (`previousApiKey`, `previousRoutingKey`, `previousOpenaiBaseUrl`, …). The two copies must stay byte-identical to be correct: a `previous*` field snapshotted in one path but not the other leaves a stale value, so the next `saveSettings()` either sees a phantom change and re-inits needlessly, or misses a real one and doesn't. The list has already grown twice recently (`previousOpenaiApiKey` and `previousOpenaiBaseUrl` arrived with the OpenAI provider work in #1286/#1288), which is exactly when this kind of pair drifts.

This collapses both copies into a private `markInitialized()`. Pure code motion — identical assignments in identical order, no behaviour change.

## Changes

- `src/main.ts` — add `private markInitialized()` holding the initialization baseline snapshot; call it from `onload()` and from the re-init branch of `saveSettings()` in place of the two inline copies.

## Screenshots / Screencast

N/A — internal refactor, no UI surface.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: filed directly by the `audit-architecture` sweep, which routes mechanical fixes to a PR rather than an issue.
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — verified locally: format-check clean, ESLint 0 errors, `tsc --noEmit` clean, `npm run typecheck:test` clean, 3792 tests passing across 170 files.
- [ ] I have tested this change on Desktop — not run in a live vault; the change is a pure extraction with no behavioural delta, covered by the existing `test/main.test.ts` suite.
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — no platform-specific API involved.
- [ ] Documentation has been updated (if applicable) — N/A: internal refactor with no user-facing behaviour change.
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (`audit-architecture` skill)
- [x] I have reviewed and understand all AI-generated code in this PR

---

_Filed by the `audit-architecture` skill._

---
_Generated by [Claude Code](https://claude.ai/code/session_01XceYadUwHCFc2Pob4beK7n)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved initialization consistency during first-time setup and settings-triggered re-initialization.
  * Initialization now reliably clears previous errors and preserves the latest configuration state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->