### PR TITLE
refactor(rag): collapse the identical create/modify sync-queue arms

### DIFF
--- a/src/services/rag-sync-queue.ts
+++ b/src/services/rag-sync-queue.ts
@@ -223,8 +223,8 @@ export class RagSyncQueue {
 				switch (change.type) {
 					// Upload is idempotent, so a create and a modify are the same work:
 					// re-upload the current content and stamp the cache entry with the
-					// new hash. Neither touches indexedCount — a modified file is
-					// already counted, and a created one is counted by the caller.
+					// new hash. Neither updates indexedCount per file — the whole batch
+					// refreshes it once via ragCache.refreshIndexedCount() below.
 					case 'create':
 					case 'modify': {
 						const file = this.plugin.app.vault.getAbstractFileByPath(change.path);

--- a/src/services/rag-sync-queue.ts
+++ b/src/services/rag-sync-queue.ts
@@ -221,34 +221,17 @@ export class RagSyncQueue {
 				currentChangeIndex = i;
 				const change = changes[i];
 				switch (change.type) {
-					case 'create': {
-						const file = this.plugin.app.vault.getAbstractFileByPath(change.path);
-						if (file instanceof TFile && vaultAdapter.shouldIndex(file.path)) {
-							const content = await vaultAdapter.readFileForUpload(file.path, file.path);
-							if (content) {
-								await fileUploader.uploadContent(content, storeName);
-								// Update cache for new file
-								if (this.ragCache.cache) {
-									this.ragCache.cache.files[file.path] = {
-										resourceName: storeName,
-										contentHash: content.hash,
-										lastIndexed: Date.now(),
-									};
-								}
-								// Incremental cache save for durability
-								changesSinceLastSave = await this.ragCache.incrementAndMaybeSaveCache(changesSinceLastSave);
-							}
-						}
-						break;
-					}
+					// Upload is idempotent, so a create and a modify are the same work:
+					// re-upload the current content and stamp the cache entry with the
+					// new hash. Neither touches indexedCount — a modified file is
+					// already counted, and a created one is counted by the caller.
+					case 'create':
 					case 'modify': {
-						// Update existing file - don't increment indexedCount since file is already indexed
 						const file = this.plugin.app.vault.getAbstractFileByPath(change.path);
 						if (file instanceof TFile && vaultAdapter.shouldIndex(file.path)) {
 							const content = await vaultAdapter.readFileForUpload(file.path, file.path);
 							if (content) {
 								await fileUploader.uploadContent(content, storeName);
-								// Update cache with new hash
 								if (this.ragCache.cache) {
 									this.ragCache.cache.files[file.path] = {
 										resourceName: storeName,


### PR DESCRIPTION
## Summary

`audit-architecture` nightly sweep flagged: **DRY violation** in `src/services/rag-sync-queue.ts`.

The `create` and `modify` arms of the change switch in `processQueue()` had byte-identical bodies — 21 lines each of the same `getAbstractFileByPath` lookup, `shouldIndex` guard, `readFileForUpload`, `uploadContent`, cache stamp, and incremental cache save. A `diff` of the two arm bodies comes back empty apart from the case labels and two comments.

Worse, one of those comments was misleading: the `modify` arm carried `// Update existing file - don't increment indexedCount since file is already indexed`, describing a distinction the code does not make — neither arm touches `indexedCount`.

This merges them into a single fall-through arm with one accurate comment. Pure de-duplication; the executed statements for both `create` and `modify` are the same as before, so behaviour is unchanged. The upload path can no longer be edited in one arm and forgotten in the other.

## Changes

- `src/services/rag-sync-queue.ts` — collapse `case 'create'` and `case 'modify'` into one fall-through arm; drop the two stale per-arm comments in favour of one that states why the two cases are the same work.

## Screenshots / Screencast

N/A — internal refactor, no UI surface.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: filed directly by the `audit-architecture` sweep, which routes mechanical fixes to a PR rather than an issue.
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — verified locally: format-check clean, ESLint 0 errors, `tsc --noEmit` clean, `npm run typecheck:test` clean, 3792 tests passing across 170 files.
- [ ] I have tested this change on Desktop — not run in a live vault. The change is a fall-through merge of two identical statement lists, covered by the existing `test/services/rag-sync-queue.test.ts` suite.
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — no platform-specific API involved.
- [ ] Documentation has been updated (if applicable) — N/A: internal refactor with no user-facing behaviour change.
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (`audit-architecture` skill)
- [x] I have reviewed and understand all AI-generated code in this PR

---

_Filed by the `audit-architecture` skill._

---
_Generated by [Claude Code](https://claude.ai/code/session_01XceYadUwHCFc2Pob4beK7n)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved synchronization of newly created and modified files.
  * Ensured current file content and cache metadata remain up to date during uploads.
  * Added more consistent incremental cache persistence for pending changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->