### PR TITLE
refactor(openai): drop the dead DEFAULT_OPENAI_BASE_URL barrel re-export

### DIFF
--- a/src/api/providers/openai/index.ts
+++ b/src/api/providers/openai/index.ts
@@ -1,3 +1,2 @@
 export { OpenAIClient } from './client';
-export { DEFAULT_OPENAI_BASE_URL } from './config';
 export type { OpenAIClientConfig } from './config';


### PR DESCRIPTION
## Summary

`audit-architecture` nightly sweep flagged: **dead export** in `src/api/providers/openai/index.ts`.

`npm run knip` reports `DEFAULT_OPENAI_BASE_URL src/api/providers/openai/index.ts:2` as an unused export — the only knip finding in the tree. Every consumer of the constant imports it straight from `./config`:

- `src/api/factory.ts:15`
- `src/main.ts:50`
- `src/ui/settings-general.ts:31`
- `src/services/openai-models-service.ts:4`

Nothing ever resolved it through the barrel. The sibling `gemini/` and `ollama/` barrels export only the client and its config type, so removing the line also restores symmetry across the three provider packages.

The constant in `config.ts` and all four direct importers are untouched — this deletes one re-export line. `npm run knip` is clean afterwards.

## Changes

- `src/api/providers/openai/index.ts` — remove the `DEFAULT_OPENAI_BASE_URL` re-export.

## Screenshots / Screencast

N/A — internal refactor, no UI surface.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: filed directly by the `audit-architecture` sweep, which routes mechanical fixes to a PR rather than an issue.
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — verified locally: format-check clean, ESLint 0 errors, `tsc --noEmit` clean, `npm run typecheck:test` clean, `npm run knip` clean, 3792 tests passing across 170 files.
- [ ] I have tested this change on Desktop — not run in a live vault; deleting an unreferenced re-export has no runtime surface, and the build resolves every remaining import.
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — no platform-specific API involved.
- [ ] Documentation has been updated (if applicable) — N/A: internal refactor with no user-facing behaviour change.
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (`audit-architecture` skill)
- [x] I have reviewed and understand all AI-generated code in this PR

---

_Filed by the `audit-architecture` skill._

---
_Generated by [Claude Code](https://claude.ai/code/session_01XceYadUwHCFc2Pob4beK7n)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed the public export of an internal OpenAI base URL constant.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->