### PR TITLE
ci(knip): make the knip check blocking

### DIFF
--- a/.github/workflows/knip.yml
+++ b/.github/workflows/knip.yml
@@ -30,8 +30,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      # Non-blocking: surfaces a report without failing the PR while the allowlist
-      # settles. Drop `continue-on-error: true` in a follow-up to make it blocking.
+      # Blocking: a newly-dead export fails the PR that introduces it. Intentional
+      # public surface knip can't see belongs in `knip.json` (`entry`,
+      # `ignoreExportsUsedInFile`, `ignoreDependencies`) — that is the escape hatch.
       - name: Run knip
         run: npm run knip
-        continue-on-error: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@ npm run format-check # Check formatting without changes
 npm run lint         # Lint with ESLint (eslint-plugin-obsidianmd recommended preset)
 npm run lint:fix     # Auto-fix ESLint violations where possible
 npm run lint:cycles  # Fail on circular imports (madge --circular over src/; baseline is 0 and CI's lint workflow enforces it)
-npm run knip         # Detect unused files, exports, types, and dependencies (configured in knip.json)
+npm run knip         # Detect unused files, exports, types, and dependencies (configured in knip.json; CI's knip workflow enforces it, so a newly-dead export fails the PR — put intentional public surface in knip.json rather than re-arguing it per PR)
 npm run install:test-vault # Copy built artifacts into test vault. Target precedence: TEST_VAULT_PLUGIN_DIR (exact plugin folder, validated by id) > TEST_VAULT_DIR (vault root, scanned by id) > default ~/Obsidian/Test Vault
 npm run translate    # Regenerate AI translations in src/i18n/ (needs GOOGLE_API_KEY; not part of build/test — runs in its own `Update UI translations` workflow on en.ts changes, or manually)
 ```


### PR DESCRIPTION
<!-- auto-dev -->

## Summary

`.github/workflows/knip.yml` ran its `Run knip` step with `continue-on-error: true`, so the check produced the right answer on every push and pull request but could never fail one. That is why nine separate `audit-architecture` PRs in the last 90 days removed unreferenced exports that had already reached `master` — the gap was enforcement, not detection.

The workflow's own comment asked for this flip once the allowlist settled. It has: `npm run knip` on current `master` reports no findings now that #1291 removed `DEFAULT_OPENAI_BASE_URL`, the last one. Flipping the switch therefore costs nothing in backlog.

Produced by the auto-dev pipeline from the plan approved on the issue. The plan committed to holding the build until #1291 merged, since landing this first would have turned `master` red on a pre-existing finding; #1291 is now merged (`96be31c`), so that hold is released.

Fixes #1294

## Changes

- `.github/workflows/knip.yml` — delete `continue-on-error: true` from the `Run knip` step, and replace the two-line `# Non-blocking: …` comment (false the moment the flag goes) with one naming `knip.json` (`entry`, `ignoreExportsUsedInFile`, `ignoreDependencies`) as the escape hatch for intentional public surface knip cannot see.
- `AGENTS.md` — update the `npm run knip` line in the Commands block to say the check is enforced in CI and that intentional public surface belongs in `knip.json`, matching the framing the neighbouring `lint:cycles` line already uses.

The escape hatch is documented in a comment rather than in `knip.json` because that file is strict JSON (no JSONC), so there is nowhere in it to put a sentence without breaking the parse.

## Screenshots / Screencast

N/A — CI configuration and a docs line. No UI surface.

## Test plan

The change is a CI flag, so the meaningful verification is behavioural: does the check now actually fail, and does it pass on a clean tree? Both were exercised locally rather than assumed.

- `npm run knip` on this branch — **exit 0**, no findings. (Confirms the flip does not turn `master` red.)
- `npm run knip` with a scratch unreferenced export appended to `src/models.ts` — **exit 1**, reporting `SCRATCH_DEAD_EXPORT_FOR_VERIFICATION  modelsModule  src/models.ts:446:14`. The scratch edit was reverted; it is not in this branch. This is the load-bearing check: a "blocking" step that cannot return non-zero would leave the gap exactly as it was.
- The workflow YAML was parsed after editing to confirm it still loads and that the `Run knip` step is now `{"name":"Run knip","run":"npm run knip"}` with no `continue-on-error` key.

Full pre-flight, all green: `npm run format-check`, `npm run lint` (0 errors; 39 pre-existing `no-nodejs-modules` warnings, unchanged), `npm run build`, `npm run typecheck:test`, `npm test` (170 files / 3792 tests).

Note that the `Run knip` job on this very PR is also the test — it must pass here for the change to be correct.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [ ] I have tested this change on Desktop — N/A, no plugin runtime surface; the change is a GitHub Actions step and a docs line.
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A, same reason. No plugin code changed.
- [x] Documentation has been updated (if applicable) — `AGENTS.md`, the documented home for the lint/analysis commands.
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (auto-dev pipeline)
- [x] I have reviewed and understand all AI-generated code in this PR

## For the reviewer

This makes a previously advisory check able to block every PR in the repo, including human contributors'. The evidence says the allowlist has settled — one finding, now removed — but that is a snapshot, and the cost of being wrong is a red X on an unrelated PR while someone works out which `knip.json` key to reach for. That is why the `AGENTS.md` sentence ships with the flip rather than being optional. If you would rather it run advisory for another week, reverting is a one-line change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EXBU5Av3mneqAWBTpUe4Rh)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Unused-code checks now block pull requests when newly unused exports are detected.
  * Documented how to configure intentional public exports and updated the related command guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->