### PR TITLE
chore(daily): 2026-08-02 daily update

### DIFF
--- a/planning/changelog/2026-08-01.md
+++ b/planning/changelog/2026-08-01.md
@@ -1,0 +1,32 @@
+# Daily changelog — August 1, 2026
+
+**Date:** 2026-08-01
+**PRs merged:** 5
+
+---
+
+## Summary
+
+Quiet day, mostly `audit-architecture` mechanical cleanups: three small DRY/dead-code fixes across `main.ts`, the RAG sync queue, and the OpenAI provider barrel (#1289, #1290, #1291), a dev-dependency bump (#1296), and the previous day's automated daily-update PR (#1295).
+
+## What shipped
+
+### [#1295 chore(daily): 2026-07-31 daily update](https://github.com/allenhutchison/obsidian-gemini/pull/1295)
+
+Automated daily housekeeping run for 2026-07-31: wrote that day's changelog, fixed one doc-drift item in `AGENTS.md` (the Architecture section still described only two model-client providers, stale since the OpenAI provider landed), and found no unlabeled issues to triage.
+
+### [#1289 refactor(main): extract the init-baseline snapshot into markInitialized()](https://github.com/allenhutchison/obsidian-gemini/pull/1289)
+
+`audit-architecture` flagged a DRY violation: `onload()` and the re-init branch of `saveSettings()` in `src/main.ts` repeated the same ten-line block snapshotting every setting the re-init check later compares against. Collapsed into a private `markInitialized()`. Pure code motion, no behavior change — the two copies had already drifted twice as `previous*` fields were added for the OpenAI provider work (#1286/#1288), which is exactly the failure mode this guards against.
+
+### [#1290 refactor(rag): collapse the identical create/modify sync-queue arms](https://github.com/allenhutchison/obsidian-gemini/pull/1290)
+
+The `create` and `modify` arms of the change switch in `RagSyncQueue.processQueue()` had byte-identical 21-line bodies apart from a stale comment in the `modify` arm describing a distinction the code doesn't actually make. Merged into one fall-through arm with a single accurate comment.
+
+### [#1291 refactor(openai): drop the dead DEFAULT_OPENAI_BASE_URL barrel re-export](https://github.com/allenhutchison/obsidian-gemini/pull/1291)
+
+`npm run knip` flagged `DEFAULT_OPENAI_BASE_URL` as unused in `src/api/providers/openai/index.ts` — every consumer already imports it directly from `./config`. Removing the barrel re-export also restores symmetry with the `gemini/` and `ollama/` provider barrels, which only ever exported the client and its config type.
+
+### [#1296 chore(deps-dev): bump the dev-dependencies group with 4 updates](https://github.com/allenhutchison/obsidian-gemini/pull/1296)
+
+Dependency bumps: `@google/genai` from 2.13.0 to 2.14.0, `@modelcontextprotocol/sdk`, `@types/node`, and `jsdom`.


### PR DESCRIPTION
## Summary

Automated daily housekeeping run (`daily-update` meta-skill via the `maintainerd` plugin toolkit) bundling `daily-changelog`, `audit-product-docs`, and `triage-issues` for 2026-08-01 (Pacific time, the retrospective day this run covers).

Fixes N/A — routine automated daily housekeeping run.

## Changes

- **daily-changelog**: wrote [`planning/changelog/2026-08-01.md`](https://github.com/allenhutchison/obsidian-gemini/blob/daily-update-2026-08-02/planning/changelog/2026-08-01.md) — 5 PRs merged on 2026-08-01: three `audit-architecture` mechanical cleanups (init-baseline extraction in `main.ts` #1289, collapsing identical create/modify arms in the RAG sync queue #1290, dropping a dead OpenAI barrel re-export #1291), a dev-dependency bump (#1296), and the prior day's automated daily-update PR (#1295). A quiet, internal-refactor-heavy day with no doc-facing surface.
- **audit-product-docs**: audited `docs/guide/`, `docs/reference/`, `README.md`, and `AGENTS.md` against `src/`, covering settings defaults, command IDs, tool names, schedule/cron parsing, hook/scheduled-task frontmatter, tool-policy presets, MCP timeouts, i18n language list, and the OpenAI provider architecture description. No drift found and no new docs warranted — today's 5 merged PRs have no doc-facing surface, and an independent pass over the rest of the doc set found nothing stale.
  - Flagging for maintainer follow-up (not fixed here — it's a code discrepancy, not doc drift, so patching the docs would mask it): `src/main.ts` hardcodes `openaiModelName: 'gpt-5.6'` as the default OpenAI chat model, but `src/services/openai-models-service.ts` only allowlists `gpt-5.6-sol`/`gpt-5.6-terra`/`gpt-5.6-luna` for `api.openai.com` — `'gpt-5.6'` never appears in the model dropdown or matches a curated entry. `docs/guide/openai-setup.md` documents the default as `gpt-5.6-sol`, while `docs/reference/settings.md` and `docs/reference/provider-capabilities.md` document it as `gpt-5.6` — both accurately reflect the (likely buggy) literal code default, hence the three-way disagreement. Recommend a follow-up issue against the OpenAI provider default.
- **triage-issues**: 0 unlabeled open issues — no-op.

This is a housekeeping-only PR — no `src/` behavior changes.

## Screenshots / Screencast

N/A — changelog-only change, no UI change.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A; routine automated daily housekeeping run
- [x] All CI checks pass locally: `npm run format-check` clean, `npm run lint` 0 errors (39 pre-existing warnings, untouched), `npm run build` clean, `npm run typecheck:test` clean, `npm test` 3792 passed / 170 files
- [ ] I have tested this change on Desktop — N/A, changelog-only change; verified via local pre-flight checks
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A, no code change
- [x] Documentation has been updated (if applicable) — N/A beyond this PR's own content; no drift found, no new docs warranted
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code


---
_Generated by [Claude Code](https://claude.ai/code/session_014qpxrkbMgN8SJuFchE1q4x)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added the August 1, 2026 daily changelog, documenting recent merged work.

* **Refactor**
  * Streamlined initialization handling and simplified background synchronization logic.
  * Removed an unused configuration export to reduce internal complexity.

* **Chores**
  * Updated a development dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->