### PR TITLE
refactor(agent-view): drop four SendContext fields nothing reads

### DIFF
--- a/src/ui/agent-view/agent-view-send.ts
+++ b/src/ui/agent-view/agent-view-send.ts
@@ -19,7 +19,6 @@ import { AgentViewTools } from './agent-view-tools';
 import { AgentViewSession } from './agent-view-session';
 import { AgentViewShelf } from './agent-view-shelf';
 import type { ObsidianGemini } from '../../types/plugin';
-import type { ConfirmationResult, DiffContext, Tool } from '../../tools/types';
 import { t } from '../../i18n';
 
 /**
@@ -34,21 +33,12 @@ export interface SendContext {
 	getUserInput: () => HTMLDivElement;
 	getSendButton: () => HTMLButtonElement;
 	getPlanModeButton: () => HTMLButtonElement;
-	getChatContainer: () => HTMLElement;
 	progress: AgentViewProgress;
 	messages: AgentViewMessages;
 	tools: AgentViewTools;
 	session: AgentViewSession;
 	displayMessage: (entry: GeminiConversationEntry) => Promise<void>;
 	updateTokenUsage: () => Promise<void>;
-	isToolAllowedWithoutConfirmation: (toolName: string) => boolean;
-	allowToolWithoutConfirmation: (toolName: string) => void;
-	showConfirmationInChat: (
-		tool: Tool,
-		parameters: Record<string, unknown>,
-		executionId: string,
-		diffContext?: DiffContext
-	) => Promise<ConfirmationResult>;
 }
 
 /**

--- a/src/ui/agent-view/agent-view.ts
+++ b/src/ui/agent-view/agent-view.ts
@@ -332,17 +332,12 @@ export class AgentView extends ItemView {
 			getUserInput: () => this.userInput,
 			getSendButton: () => this.sendButton,
 			getPlanModeButton: () => this.planModeButton,
-			getChatContainer: () => this.chatContainer,
 			progress: this.progress,
 			messages: this.messages,
 			tools: this.tools,
 			session: this.session,
 			displayMessage: (entry: GeminiConversationEntry) => this.displayMessage(entry),
 			updateTokenUsage: () => this.updateTokenUsage(),
-			isToolAllowedWithoutConfirmation: (toolName: string) => this.isToolAllowedWithoutConfirmation(toolName),
-			allowToolWithoutConfirmation: (toolName: string) => this.allowToolWithoutConfirmation(toolName),
-			showConfirmationInChat: (tool, parameters, executionId, diffContext) =>
-				this.showConfirmationInChat(tool, parameters, executionId, diffContext),
 		});
 
 		// Register session lifecycle event bus subscribers for token display

--- a/test/ui/agent-view.test.ts
+++ b/test/ui/agent-view.test.ts
@@ -200,16 +200,12 @@ describe('AgentView UI Tests', () => {
 				getShelf: () => (agentView as any).shelf,
 				getUserInput: () => (agentView as any).userInput,
 				getSendButton: () => (agentView as any).sendButton,
-				getChatContainer: () => (agentView as any).chatContainer,
 				progress: (agentView as any).progress || { show: vi.fn(), hide: vi.fn(), update: vi.fn() },
 				messages: (agentView as any).messages || { displayMessage: vi.fn(), settlePendingPlanApproval: vi.fn() },
 				tools: (agentView as any).tools || { handleToolCalls: vi.fn() },
 				session: (agentView as any).session || { autoLabelSessionIfNeeded: vi.fn() },
 				displayMessage: (agentView as any).displayMessage || vi.fn(),
 				updateTokenUsage: vi.fn(),
-				isToolAllowedWithoutConfirmation: vi.fn().mockReturnValue(false),
-				allowToolWithoutConfirmation: vi.fn(),
-				showConfirmationInChat: vi.fn(),
 			};
 			(agentView as any).send = new AgentViewSend(mockSendCtx as any);
 


### PR DESCRIPTION
## Summary

`audit-architecture` nightly sweep flagged: **dead surface** in `src/ui/agent-view/agent-view-send.ts`.

`SendContext` declares 17 fields. Four of them — `getChatContainer`, `isToolAllowedWithoutConfirmation`, `allowToolWithoutConfirmation`, and `showConfirmationInChat` — are populated by `AgentView` but never read by `AgentViewSend`. Tool confirmation reaches the view through `IConfirmationProvider` (`src/tools/types.ts`) as invoked by the execution engine, not through this context; the chat container is only ever touched via the messages helper. Verified with `grep -rn "ctx\.<field>" src/` across the whole tree — zero reads for all four.

Knip does not catch this class of dead surface: the containing interface is used and every target method is live elsewhere, so only the fields themselves are dead. Removing them narrows the contract between `AgentView` and `AgentViewSend` to what is actually consumed.

No behaviour change — nothing read these fields, so nothing observes their absence.

## Changes

- `src/ui/agent-view/agent-view-send.ts` — remove the four unread `SendContext` declarations, plus the now-unused `ConfirmationResult` / `DiffContext` / `Tool` type import they were the only consumers of.
- `src/ui/agent-view/agent-view.ts` — remove the four matching population sites in the `new AgentViewSend({...})` literal.
- `test/ui/agent-view.test.ts` — remove the four corresponding fields from the send-context mock, which existed only to mirror the interface.

## Screenshots / Screencast

N/A — no UI change. The removed fields were never read, so nothing rendered differently.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: filed directly by the `audit-architecture` sweep, which routes mechanical deletions to a PR rather than an issue.
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — run locally: format-check clean, `npm run lint` 0 errors (39 pre-existing warnings), build clean, `npm run typecheck:test` clean, `npm test` 3792 passed / 170 files.
- [ ] I have tested this change on Desktop — N/A: pure dead-field deletion with no reachable behaviour; covered by the full unit suite.
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — no platform-specific code touched.
- [ ] Documentation has been updated (if applicable) — N/A: internal type surface only, no user-facing behaviour or setting changed.
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (`audit-architecture` skill)
- [x] I have reviewed and understand all AI-generated code in this PR

---

_Filed by the `audit-architecture` skill._

---
_Generated by [Claude Code](https://claude.ai/code/session_01XpQarhu98HZre8dXa4epNf)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal message-sending configuration while preserving progress updates, messaging, tool handling, session management, and token usage.
* **Tests**
  * Updated automated test setup to reflect the streamlined configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->