### PR TITLE
refactor(settings): collapse the triple provider ladder in renderModelPickers

### DIFF
--- a/src/ui/settings-general.ts
+++ b/src/ui/settings-general.ts
@@ -400,119 +400,124 @@ function remotelyServedModels(
 	return remote;
 }
 
+/** The settings keys `selectModelSetting` accepts, without re-deriving its mapped type. */
+type ModelSettingKey = Parameters<typeof selectModelSetting>[2];
+
+/** How one use case's picker is wired for one provider. */
+interface ModelPickerSpec {
+	/** The settings field this provider persists its choice in. */
+	setting: ModelSettingKey;
+	labelKey: TranslationKey;
+	descKey: TranslationKey;
+	/**
+	 * Label for the "inherit the chat model" option. Only Ollama sets it: it
+	 * keeps a single model resident, so an extra per-use-case model costs a swap
+	 * on every call (#1077) and inheriting is the default. Providers with
+	 * `perUseCaseModels` get a dedicated field and no inherit option.
+	 */
+	inheritKey?: TranslationKey;
+}
+
+/**
+ * The text-model pickers, one per use case, as data.
+ *
+ * Each provider persists its own model per use case — re-routing chat from
+ * Gemini to Ollama and back never clobbers the other's choice — so the picker
+ * shown depends on the provider currently serving that use case. Keeping the
+ * three use cases in one table means adding a provider is a column, not a
+ * fourth copy of the same branch.
+ *
+ * Rewrite and search reuse the chat model, so they get no picker of their own;
+ * image generation is handled separately in `renderModelPickers` because it can
+ * resolve to no provider at all.
+ */
+const TEXT_MODEL_PICKERS: ReadonlyArray<{
+	useCase: ProviderUseCase;
+	byProvider: Record<ModelProvider, ModelPickerSpec>;
+}> = [
+	{
+		useCase: 'chat',
+		byProvider: {
+			gemini: {
+				setting: 'chatModelName',
+				labelKey: 'settings.general.chatModelName',
+				descKey: 'settings.general.chatModelDesc',
+			},
+			ollama: {
+				setting: 'ollamaModelName',
+				labelKey: 'settings.general.ollamaModelName',
+				descKey: 'settings.general.ollamaModelDesc',
+			},
+			openai: {
+				setting: 'openaiModelName',
+				labelKey: 'settings.general.chatModelName',
+				descKey: 'settings.general.openaiChatModelDesc',
+			},
+		},
+	},
+	{
+		useCase: 'summary',
+		byProvider: {
+			gemini: {
+				setting: 'summaryModelName',
+				labelKey: 'settings.general.summaryModelName',
+				descKey: 'settings.general.summaryModelDesc',
+			},
+			ollama: {
+				setting: 'ollamaSummaryModelName',
+				labelKey: 'settings.general.summaryModelName',
+				descKey: 'settings.general.ollamaSummaryModelDesc',
+				inheritKey: 'settings.general.inheritOllamaChatModel',
+			},
+			openai: {
+				setting: 'openaiSummaryModelName',
+				labelKey: 'settings.general.summaryModelName',
+				descKey: 'settings.general.summaryModelDesc',
+			},
+		},
+	},
+	{
+		useCase: 'completions',
+		byProvider: {
+			gemini: {
+				setting: 'completionsModelName',
+				labelKey: 'settings.general.completionModelName',
+				descKey: 'settings.general.completionModelDesc',
+			},
+			ollama: {
+				setting: 'ollamaCompletionsModelName',
+				labelKey: 'settings.general.completionModelName',
+				descKey: 'settings.general.ollamaCompletionsModelDesc',
+				inheritKey: 'settings.general.inheritOllamaChatModel',
+			},
+			openai: {
+				setting: 'openaiCompletionsModelName',
+				labelKey: 'settings.general.completionModelName',
+				descKey: 'settings.general.completionModelDesc',
+			},
+		},
+	},
+];
+
 /**
  * Model pickers, one per use case that has a configured model, each filtered to
  * the provider actually serving it.
- *
- * Rewrite and search reuse the chat model, so they get no picker of their own.
- * Under Ollama the summary/completions rows offer an "inherit the chat model"
- * option — the default — because Ollama keeps one model resident and an extra
- * model costs a swap on every call (#1077).
  */
 async function renderModelPickers(sectionEl: HTMLElement, plugin: ObsidianGemini): Promise<void> {
-	const chatProvider = resolveProviderOrDefault(plugin.settings, 'chat');
-	const summaryProvider = resolveProviderOrDefault(plugin.settings, 'summary');
-	const completionsProvider = resolveProviderOrDefault(plugin.settings, 'completions');
-
-	if (chatProvider === 'ollama') {
+	for (const { useCase, byProvider } of TEXT_MODEL_PICKERS) {
+		// Total lookup: `resolveProviderOrDefault` only ever returns a registered
+		// provider id, so every branch of the union has a spec above.
+		const provider = resolveProviderOrDefault(plugin.settings, useCase);
+		const spec = byProvider[provider];
 		await selectModelSetting(
 			sectionEl,
 			plugin,
-			'ollamaModelName',
-			t('settings.general.ollamaModelName'),
-			t('settings.general.ollamaModelDesc'),
+			spec.setting,
+			t(spec.labelKey),
+			t(spec.descKey),
 			'text',
-			'ollama'
-		);
-	} else if (chatProvider === 'openai') {
-		// OpenAI has no single-resident-model constraint (perUseCaseModels), so
-		// unlike Ollama it gets its own field rather than an "inherit" option.
-		await selectModelSetting(
-			sectionEl,
-			plugin,
-			'openaiModelName',
-			t('settings.general.chatModelName'),
-			t('settings.general.openaiChatModelDesc'),
-			'text',
-			'openai'
-		);
-	} else {
-		await selectModelSetting(
-			sectionEl,
-			plugin,
-			'chatModelName',
-			t('settings.general.chatModelName'),
-			t('settings.general.chatModelDesc'),
-			'text',
-			chatProvider
-		);
-	}
-
-	if (summaryProvider === 'ollama') {
-		// Only worth showing once chat is *not* also on Ollama, or as an explicit
-		// opt-in split; either way the inherit option keeps the default single-model.
-		await selectModelSetting(
-			sectionEl,
-			plugin,
-			'ollamaSummaryModelName',
-			t('settings.general.summaryModelName'),
-			t('settings.general.ollamaSummaryModelDesc'),
-			'text',
-			'ollama',
-			t('settings.general.inheritOllamaChatModel')
-		);
-	} else if (summaryProvider === 'openai') {
-		await selectModelSetting(
-			sectionEl,
-			plugin,
-			'openaiSummaryModelName',
-			t('settings.general.summaryModelName'),
-			t('settings.general.summaryModelDesc'),
-			'text',
-			'openai'
-		);
-	} else {
-		await selectModelSetting(
-			sectionEl,
-			plugin,
-			'summaryModelName',
-			t('settings.general.summaryModelName'),
-			t('settings.general.summaryModelDesc'),
-			'text',
-			summaryProvider
-		);
-	}
-
-	if (completionsProvider === 'ollama') {
-		await selectModelSetting(
-			sectionEl,
-			plugin,
-			'ollamaCompletionsModelName',
-			t('settings.general.completionModelName'),
-			t('settings.general.ollamaCompletionsModelDesc'),
-			'text',
-			'ollama',
-			t('settings.general.inheritOllamaChatModel')
-		);
-	} else if (completionsProvider === 'openai') {
-		await selectModelSetting(
-			sectionEl,
-			plugin,
-			'openaiCompletionsModelName',
-			t('settings.general.completionModelName'),
-			t('settings.general.completionModelDesc'),
-			'text',
-			'openai'
-		);
-	} else {
-		await selectModelSetting(
-			sectionEl,
-			plugin,
-			'completionsModelName',
-			t('settings.general.completionModelName'),
-			t('settings.general.completionModelDesc'),
-			'text',
-			completionsProvider
+			provider,
+			spec.inheritKey ? t(spec.inheritKey) : undefined
 		);
 	}
 


### PR DESCRIPTION
## Summary

`audit-architecture` nightly sweep flagged: **DRY violation** in `src/ui/settings-general.ts`.

`renderModelPickers` carried three near-identical `if (provider === 'ollama') / else if (provider === 'openai') / else` ladders — one each for chat, summary and completions — every arm calling `selectModelSetting` with the same eight arguments and differing only in the settings key, two i18n keys, and whether an inherit option is passed. Adding a provider meant a fourth arm in three places, and the copies had already drifted: only the chat/Ollama row uses a provider-specific *label* key, the other five reuse the generic one.

This replaces the ladders with a `TEXT_MODEL_PICKERS` table keyed by use case and provider, plus one loop. The table is `Record<ModelProvider, ModelPickerSpec>`, so adding a fourth provider becomes a compile error until every use case has a spec, instead of silently falling through to the Gemini branch.

Behaviour is unchanged: each picker resolves to the same settings key, label, description, provider filter, and inherit-option as before. `test/ui/settings-general.test.ts` already pins all three provider configurations argument-by-argument (including asserting the inherit-option arg is `undefined` for OpenAI), and passes untouched.

Not addressed here, and filed separately: the same provider × use-case matrix is also hand-expanded in `src/models.ts` and `src/types/settings.ts`, which is the structural half of the problem.

## Changes

- `src/ui/settings-general.ts`: add `ModelPickerSpec` / `TEXT_MODEL_PICKERS` (use case × provider) and rewrite `renderModelPickers` as a loop over it. The image-generation picker is left as-is — it can resolve to no provider at all, so it isn't part of the table.

## Screenshots / Screencast

None — no rendered output changes. The settings rows are produced by the same `selectModelSetting` calls with identical arguments; the existing test asserts that argument-by-argument.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: filed directly by the `audit-architecture` sweep, which routes mechanical fixes to a PR and judgment-heavy ones to an issue.
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — plus `npm run lint` (0 errors) and `npm run typecheck:test`. Full suite: 3792 tests, 170 files, all passing.
- [ ] I have tested this change on Desktop — not manually exercised in a vault. Verification is the existing `test/ui/settings-general.test.ts` coverage, which asserts the exact `selectModelSetting` arguments for the Gemini, Ollama, and OpenAI configurations.
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — no platform-specific API is touched.
- [ ] Documentation has been updated (if applicable) — N/A: internal refactor with no user-visible or settings-schema change.
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (`audit-architecture` skill)
- [x] I have reviewed and understand all AI-generated code in this PR

---

_Filed by the `audit-architecture` skill._


---
_Generated by [Claude Code](https://claude.ai/code/session_011Md5RzZ5xK6i6w59ttC59s)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved consistency in text-model selection across chat, summary, and completion settings.
  * Standardized provider labels and descriptions displayed in model pickers.
  * Image-generation model selection remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->