### PR TITLE
chore(daily): 2026-08-04 daily update

### DIFF
--- a/docs/reference/provider-capabilities.md
+++ b/docs/reference/provider-capabilities.md
@@ -59,7 +59,7 @@ Consequences worth knowing:
 
 Each model dropdown lists the models of the provider serving that feature, so a chat-on-Ollama / summaries-on-Gemini setup offers the right models in each row.
 
-Ollama keeps one model resident at a time, so its summary and completions pickers default to **Same as chat model**. Choosing a distinct model there is supported but means Ollama reloads a model on every switch — worth it for a small, fast completions model, rarely worth it otherwise. OpenAI has no such constraint: each use case gets its own default model (currently `gpt-5.6` for chat, `gpt-5.6-terra` for summaries, `gpt-5.6-luna` for completions) and switching between them costs nothing extra.
+Ollama keeps one model resident at a time, so its summary and completions pickers default to **Same as chat model**. Choosing a distinct model there is supported but means Ollama reloads a model on every switch — worth it for a small, fast completions model, rarely worth it otherwise. OpenAI has no such constraint: each use case gets its own default model (currently `gpt-5.6-sol` for chat, `gpt-5.6-terra` for summaries, `gpt-5.6-luna` for completions) and switching between them costs nothing extra.
 
 ## Notes
 

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -201,7 +201,7 @@ Because each provider uses its own settings fields, re-routing a feature between
 
 - **Settings**: `openaiModelName`, `openaiSummaryModelName`, `openaiCompletionsModelName`
 - **Type**: String
-- **Default**: `'gpt-5.6'`, `'gpt-5.6-terra'`, `'gpt-5.6-luna'` respectively
+- **Default**: `'gpt-5.6-sol'`, `'gpt-5.6-terra'`, `'gpt-5.6-luna'` respectively
 - **Only shown when**: That feature is served by `openai`
 - **Description**: The OpenAI model used for each use case. Unlike Ollama, OpenAI has no single-resident-model constraint, so each use case keeps its own model rather than defaulting to "inherit the chat model." Populated from `GET <openaiBaseUrl>/models`.
 

--- a/planning/changelog/2026-08-03.md
+++ b/planning/changelog/2026-08-03.md
@@ -1,0 +1,10 @@
+# Daily changelog — August 3, 2026
+
+**Date:** 2026-08-03
+**PRs merged:** 0
+
+---
+
+## Summary
+
+No PRs merged today.


### PR DESCRIPTION
## Summary

Automated daily housekeeping run (`daily-update` meta-skill via the `maintainerd` plugin toolkit) bundling `daily-changelog`, `audit-product-docs`, and `triage-issues` for 2026-08-03 (Pacific time, the retrospective day this run covers).

Fixes N/A — routine automated daily housekeeping run.

## Changes

- **daily-changelog**: wrote [`planning/changelog/2026-08-03.md`](https://github.com/allenhutchison/obsidian-gemini/blob/daily-update-2026-08-04/planning/changelog/2026-08-03.md) — 0 PRs merged on 2026-08-03.
- **audit-product-docs**: audited `docs/guide/`, `docs/reference/`, `README.md`, and `AGENTS.md` against `src/`. Found and fixed one drift item: the documented OpenAI chat-model default (`docs/reference/settings.md`, `docs/reference/provider-capabilities.md`) said `gpt-5.6`, but that id isn't in `KNOWN_OPENAI_MODELS` (`src/services/openai-models-service.ts`) — the effective default users see is `gpt-5.6-sol`, confirmed by the `reconcileOpenAI` migration in `src/models.ts` that rewrites any settings value absent from the live model list to `getDefaultModelForRole('chat', 'openai')`. No other drift found; no new docs warranted.
- **triage-issues**: 0 unlabeled open issues — no-op.

This is a housekeeping-only PR — no `src/` behavior changes.

## Screenshots / Screencast

N/A — changelog and documentation changes only, no UI change.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A; routine automated daily housekeeping run
- [x] All CI checks pass locally: `npm run format-check` clean, `npm run lint` 0 errors (39 pre-existing warnings, untouched), `npm run build` clean, `npm run typecheck:test` clean, `npm test` 3792 passed / 170 files
- [ ] I have tested this change on Desktop — N/A, changelog/docs-only change; verified via local pre-flight checks
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A, no code change
- [x] Documentation has been updated (if applicable) — N/A beyond this PR's own content; the settings/provider-capabilities fix is itself the documentation update
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code