### PR TITLE
refactor(hooks): derive HookCreateParams from Hook instead of re-listing it

### DIFF
--- a/src/services/hook-types.ts
+++ b/src/services/hook-types.ts
@@ -130,30 +130,23 @@ export interface HookFireContext {
 }
 
 /**
+ * Fields that `Hook` requires but a caller may omit on create/update, because
+ * `HookManager` fills them in from a default (`toHook`) rather than failing.
+ */
+type HookDefaultedField = 'debounceMs' | 'cooldownMs' | 'enabledSkills' | 'enabled' | 'desktopOnly';
+
+/**
  * Parameters accepted by `HookManager.createHook` and the union of fields
  * `updateHook` understands. Mirrors the on-disk frontmatter schema; defaults
  * are applied at serialization time so callers can omit unset fields.
+ *
+ * Derived from `Hook` rather than re-listed so a new hook field can't land on
+ * `Hook` alone and silently become unsettable through create/update — the
+ * compiler now forces every addition to be either a create param or an
+ * explicit `HookDefaultedField`. `filePath` is excluded because the manager
+ * derives it from the slug.
  */
-export interface HookCreateParams {
-	slug: string;
-	trigger: HookTrigger;
-	action: HookAction;
-	prompt: string;
-	pathGlob?: string;
-	frontmatterFilter?: Record<string, unknown>;
-	debounceMs?: number;
-	maxRunsPerHour?: number;
-	cooldownMs?: number;
-	toolPolicy?: FeatureToolPolicy;
-	enabledSkills?: string[];
-	model?: string;
-	maxIterations?: number;
-	outputPath?: string;
-	enabled?: boolean;
-	desktopOnly?: boolean;
-	commandId?: string;
-	focusFile?: boolean;
-}
+export type HookCreateParams = Omit<Hook, 'filePath' | HookDefaultedField> & Partial<Pick<Hook, HookDefaultedField>>;
 
 export type HookUpdateParams = Partial<Omit<HookCreateParams, 'slug'>>;
 


### PR DESCRIPTION
## Summary

`audit-architecture` nightly sweep flagged: **improper typing / drift-prone parallel enumeration** in `src/services/hook-types.ts`.

`HookCreateParams` re-listed all 17 `Hook` fields by hand. Nothing tied the two together, so a field added to `Hook` alone stayed silently unsettable through `createHook` / `updateHook` — no compile error, just a frontmatter key the hook-management UI and the hook tools could never write. This derives `HookCreateParams` from `Hook` so the compiler forces every future field addition to be either a create param or an explicitly-defaulted one.

The derivation is exact: `Omit<Hook, 'filePath' | HookDefaultedField> & Partial<Pick<Hook, HookDefaultedField>>`, where `HookDefaultedField` names the five fields `Hook` requires but `HookManager.toHook` fills in from a default (`debounceMs`, `cooldownMs`, `enabledSkills`, `enabled`, `desktopOnly`). `filePath` is excluded because the manager derives it from the slug. The resulting field set and per-field optionality are identical to the hand-written interface — verified by the fact that `npm run build` produced a byte-identical `main.js` (no `main.js` change in this diff) and no call site needed adjusting.

This closes the type-level half of the problem only. The runtime half — the same field list enumerated longhand in `updateHook`'s merge ladder, `toHook`, `serializeHook`, `parseDefinitionFile`, and `hookToParams`, none of which the compiler cross-checks — is filed separately as an issue and is deliberately out of scope here.

Not linked to a pre-approved issue: this PR was opened by the `audit-architecture` sweep, which routes mechanical, type-only fixes straight to a PR and structural ones to an issue.

## Changes

- `src/services/hook-types.ts`: replace the hand-written `HookCreateParams` interface with a type derived from `Hook`; add the `HookDefaultedField` union documenting which required `Hook` fields are optional on create/update.

## Screenshots / Screencast

N/A — type-only change with no runtime or UI surface.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A, opened by the `audit-architecture` sweep under its mechanical-fix routing rule.
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — plus `npm run lint` (0 errors) and `npm run typecheck:test`; 171 test files / 3801 tests pass.
- [ ] I have tested this change on Desktop — N/A, no runtime change; the compiled bundle is unchanged.
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A, same reason.
- [ ] Documentation has been updated (if applicable) — N/A, internal type refactor with no user-facing behavior, settings, or docs surface.
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (`audit-architecture` skill)
- [x] I have reviewed and understand all AI-generated code in this PR

---

_Filed by the `audit-architecture` skill._

---
_Generated by [Claude Code](https://claude.ai/code/session_01F8uuEYCfq1YL4xWY3o9ojq)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal type consistency for hook creation data.
  * Ensured new hook fields are automatically reflected in creation workflows.
  * Preserved support for optional fields with default values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->