### PR TITLE
chore(daily): 2026-08-05 daily update

### DIFF
--- a/planning/changelog/2026-08-04.md
+++ b/planning/changelog/2026-08-04.md
@@ -1,0 +1,44 @@
+# Daily changelog — August 04, 2026
+
+**Date:** 2026-08-04
+**PRs merged:** 9
+
+---
+
+## Summary
+
+A catch-up day: three backlogged automated daily-update PRs (covering 2026-08-01 through 2026-08-03) merged alongside the day's own work. The most consequential change is `ci(knip)` flipping the unused-export check from advisory to blocking, closing a gap that let nine prior cleanup PRs land unused exports before removal. The last native `confirm()` dialog in the plugin was also retired in favor of an inline row confirm on session delete, and two `audit-architecture` sweeps removed more dead/duplicated surface from the settings and agent-view code.
+
+## What shipped
+
+### [#1299 chore(daily): 2026-08-02 daily update](https://github.com/allenhutchison/obsidian-gemini/pull/1299)
+
+Automated daily-update run covering 2026-08-01: wrote `planning/changelog/2026-08-01.md` (5 PRs merged that day — three `audit-architecture` mechanical cleanups, a dev-dependency bump, and the prior day's daily-update PR). No product-doc drift found; flagged (not fixed) a three-way disagreement between `src/main.ts`'s OpenAI default (`gpt-5.6`) and the docs/allowlist for maintainer follow-up. No unlabeled issues to triage.
+
+### [#1304 chore(daily): 2026-08-03 daily update](https://github.com/allenhutchison/obsidian-gemini/pull/1304)
+
+Automated daily-update run covering 2026-08-02 (a quiet day, 0 PRs merged). No doc drift found; the same OpenAI default discrepancy was flagged again for follow-up. No unlabeled issues to triage.
+
+### [#1311 chore(daily): 2026-08-04 daily update](https://github.com/allenhutchison/obsidian-gemini/pull/1311)
+
+Automated daily-update run covering 2026-08-03 (also a quiet day, 0 PRs merged). This run's `audit-product-docs` pass fixed the recurring OpenAI default drift: `docs/reference/settings.md` and `docs/reference/provider-capabilities.md` said `gpt-5.6`, but the effective default (confirmed via the `reconcileOpenAI` migration in `src/models.ts`) is `gpt-5.6-sol`. No unlabeled issues to triage.
+
+### [#1306 chore(deps): bump @hono/node-server from 1.19.13 to 2.0.12](https://github.com/allenhutchison/obsidian-gemini/pull/1306) and [#1305 chore(deps-dev): bump brace-expansion from 1.1.14 to 1.1.18](https://github.com/allenhutchison/obsidian-gemini/pull/1305)
+
+Dependency bumps: `@hono/node-server` picks up a WebSocket-handshake memory-leak DoS fix among other fixes; `brace-expansion` backports a security fix (CVE-2026-13149) to the 1.x line.
+
+### [#1307 refactor(settings): collapse the triple provider ladder in renderModelPickers](https://github.com/allenhutchison/obsidian-gemini/pull/1307)
+
+`audit-architecture` sweep: `renderModelPickers` in `src/ui/settings-general.ts` had three near-identical `if/else` provider ladders (chat, summary, completions) that had already drifted — only one arm used a provider-specific label. Replaced with a `TEXT_MODEL_PICKERS` table keyed by use case and provider plus a loop, so a missing provider spec is now a compile error instead of a silent fallthrough. No behavior change.
+
+### [#1300 refactor(agent-view): drop four SendContext fields nothing reads](https://github.com/allenhutchison/obsidian-gemini/pull/1300)
+
+`audit-architecture` sweep: removed four `SendContext` fields (`getChatContainer`, `isToolAllowedWithoutConfirmation`, `allowToolWithoutConfirmation`, `showConfirmationInChat`) from `agent-view-send.ts` that were populated by `AgentView` but never read — a class of dead surface knip doesn't catch since the containing interface and methods are still live elsewhere. No behavior change.
+
+### [#1297 ci(knip): make the knip check blocking](https://github.com/allenhutchison/obsidian-gemini/pull/1297)
+
+The `knip` CI step ran with `continue-on-error: true`, so it reported findings without ever failing a check — the reason nine separate `audit-architecture` PRs over 90 days had to remove unreferenced exports after they'd already reached `master`. With the allowlist settled (`npm run knip` clean on `master` after #1291), the flag is removed and the check now blocks. `AGENTS.md` updated to point contributors at `knip.json` for intentional public surface.
+
+### [#1280 feat(agent): replace native confirm() on session delete with an inline row confirm](https://github.com/allenhutchison/obsidian-gemini/pull/1280)
+
+Session deletion in the session list modal used the browser's native `confirm()` — the last one left in `src/`. Replaced with a row-level inline confirm: the trash icon swaps that row's actions for a `Delete session "…"?` prompt with Delete/Cancel, preserving scroll position and filter state. Escape cancels the pending confirm via a capture-phase listener rather than closing the modal. Retires the last `no-alert` eslint suppression in the codebase. Fixes #1275.


### PR DESCRIPTION
## Summary

Automated daily housekeeping run (`daily-update` meta-skill via the `maintainerd` plugin toolkit) bundling `daily-changelog`, `audit-product-docs`, and `triage-issues` for 2026-08-04 (Pacific time, the retrospective day this run covers).

Fixes N/A — routine automated daily housekeeping run.

## Changes

- **daily-changelog**: wrote [`planning/changelog/2026-08-04.md`](https://github.com/allenhutchison/obsidian-gemini/blob/daily-update-2026-08-05/planning/changelog/2026-08-04.md) — 9 PRs merged on 2026-08-04: a UX fix retiring the last native `confirm()` dialog (#1280), making the `knip` CI check blocking instead of advisory (#1297), two `audit-architecture` mechanical cleanups (#1300, #1307), two dependency bumps (#1305, #1306), and three backlogged automated daily-update PRs catching up 2026-08-01 through 2026-08-03 (#1299, #1304, #1311).
- **audit-product-docs**: audited `docs/guide/`, `docs/reference/`, `README.md`, and `AGENTS.md` against `src/`. No drift found; no new docs warranted. Re-verified that the OpenAI default-model doc fix from yesterday's run (#1311) is still accurate. Re-flagged (not fixed, per the skill's scope — code fixes are separate PRs) a pre-existing discrepancy: `src/main.ts`'s `DEFAULT_SETTINGS.openaiModelName` literal is `'gpt-5.6'`, which isn't a real model id (`KNOWN_OPENAI_MODELS` only has `gpt-5.6-sol`/`-terra`/`-luna`); it self-corrects via the `reconcileOpenAI` migration the first time a user routes a feature to OpenAI, so it isn't user-visible, but the source literal is misleading. This is the same item the 2026-08-01 and 2026-08-02 runs flagged.
- **triage-issues**: 0 unlabeled open issues — no-op.

This is a housekeeping-only PR — no `src/` behavior changes.

## Screenshots / Screencast

N/A — changelog-only change, no UI change.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A; routine automated daily housekeeping run
- [x] All CI checks pass locally: `npm run format-check` clean, `npm run lint` 0 errors (40 pre-existing warnings, untouched), `npm run build` clean, `npm run typecheck:test` clean, `npm test` 3801 passed / 171 files
- [ ] I have tested this change on Desktop — N/A, changelog-only change; verified via local pre-flight checks
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A, no code change
- [x] Documentation has been updated (if applicable) — N/A beyond this PR's own content; no drift found, no new docs warranted
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_01BsXATFdmVYPqtg8AMMYdav)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Session deletion now uses an inline confirmation row instead of a browser-native confirmation dialog, providing a clearer and more consistent experience.
  - Settings selection workflows have been refined for improved usability and maintainability.
  - Documentation has been updated to better reflect current product behavior.

- **Security**
  - Security updates were applied to address issues in supporting dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->