### PR TITLE
chore(daily): 2026-08-06 daily update

### DIFF
--- a/planning/changelog/2026-08-05.md
+++ b/planning/changelog/2026-08-05.md
@@ -1,0 +1,24 @@
+# Daily changelog — August 05, 2026
+
+**Date:** 2026-08-05
+**PRs merged:** 3
+
+---
+
+## Summary
+
+A light day: a security-motivated dependency bump, an `audit-architecture` type-derivation cleanup in the hooks subsystem, and the prior day's automated daily-update run landing.
+
+## What shipped
+
+### [#1316 chore(daily): 2026-08-05 daily update](https://github.com/allenhutchison/obsidian-gemini/pull/1316)
+
+Automated daily-update run covering 2026-08-04: wrote `planning/changelog/2026-08-04.md` (9 PRs merged that day, including the `knip` CI check going blocking and the last native `confirm()` dialog's retirement). `audit-product-docs` found no drift and re-flagged (not fixed, per the skill's scope) the pre-existing `src/main.ts` `DEFAULT_SETTINGS.openaiModelName` literal (`gpt-5.6`, not a real model id — self-corrects via the `reconcileOpenAI` migration, so not user-visible). No unlabeled issues to triage.
+
+### [#1314 refactor(hooks): derive HookCreateParams from Hook instead of re-listing it](https://github.com/allenhutchison/obsidian-gemini/pull/1314)
+
+`audit-architecture` sweep: `HookCreateParams` in `src/services/hook-types.ts` re-listed all 17 `Hook` fields by hand, so a field added to `Hook` alone stayed silently unsettable through `createHook`/`updateHook` with no compile error. Now derived as `Omit<Hook, 'filePath' | HookDefaultedField> & Partial<Pick<Hook, HookDefaultedField>>`, tying the two types together so future field additions must be explicitly categorized. Type-only change — `main.js` is byte-identical. The corresponding runtime-side fix (the same field list enumerated longhand across several functions) is filed as a separate issue, out of scope here.
+
+### [#1312 chore(deps): bump fast-uri from 3.1.4 to 3.1.5](https://github.com/allenhutchison/obsidian-gemini/pull/1312)
+
+Dependency bump addressing a security advisory ([GHSA-7p8r-x3mc-p8w7](https://github.com/fastify/fast-uri/security/advisories/GHSA-7p8r-x3mc-p8w7)) in `fast-uri`.


### PR DESCRIPTION
## Summary

Automated daily housekeeping run (`daily-update` meta-skill via the `maintainerd` plugin toolkit) bundling `daily-changelog`, `audit-product-docs`, and `triage-issues` for 2026-08-05 (Pacific time, the retrospective day this run covers).

Fixes N/A — routine automated daily housekeeping run.

## Changes

- **daily-changelog**: wrote [`planning/changelog/2026-08-05.md`](https://github.com/allenhutchison/obsidian-gemini/blob/daily-update-2026-08-06/planning/changelog/2026-08-05.md) — 3 PRs merged on 2026-08-05: a security-motivated `fast-uri` dependency bump (#1312, GHSA-7p8r-x3mc-p8w7), an `audit-architecture` sweep deriving `HookCreateParams` from `Hook` instead of hand-listing its 17 fields (#1314, type-only), and the prior day's automated daily-update PR (#1316).
- **audit-product-docs**: audited `docs/guide/`, `docs/reference/`, `README.md`, and `AGENTS.md` against `src/` in full (23 doc files, dozens of checked constants/defaults/tool lists/command IDs). No drift found; no new docs warranted. Re-verified the previously-flagged discrepancy: `src/main.ts`'s `DEFAULT_SETTINGS.openaiModelName` literal is still `'gpt-5.6'`, which isn't a real model id (`KNOWN_OPENAI_MODELS` only has `gpt-5.6-sol`/`-terra`/`-luna`); it still self-corrects via the `reconcileOpenAI` migration the first time a feature routes to OpenAI, so it remains non-user-visible, and the docs correctly state the real default (`gpt-5.6-sol`). Same item flagged by the 2026-08-01 through 2026-08-05 runs; still out of scope for a docs-only audit.
- **triage-issues**: 0 unlabeled open issues — no-op.

This is a housekeeping-only PR — no `src/` behavior changes.

## Screenshots / Screencast

N/A — changelog-only change, no UI change.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A; routine automated daily housekeeping run
- [x] All CI checks pass locally: `npm run format-check` clean, `npm run lint` 0 errors (40 pre-existing warnings, untouched), `npm run build` clean, `npm run typecheck:test` clean, `npm test` 3801 passed / 171 files
- [ ] I have tested this change on Desktop — N/A, changelog-only change; verified via local pre-flight checks
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A, no code change
- [x] Documentation has been updated (if applicable) — N/A beyond this PR's own content; no drift found, no new docs warranted
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01SsedSaTQtfiFtaUVRFb9ki)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added the August 5, 2026 daily changelog.
  - Recorded recent maintenance updates, including automated improvements, cleaner type handling, and security-related enhancements.
  - No changes were made to the application’s public interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->