### PR TITLE
refactor(rag): drop two unread status getters, bind getDetailedStatus to its type

### DIFF
--- a/src/services/rag-indexing.ts
+++ b/src/services/rag-indexing.ts
@@ -17,7 +17,7 @@ import { createGoogleGenAI } from '../api/providers/gemini/google-genai-factory'
 import type {
 	IndexProgress,
 	IndexResult,
-	FailedFileEntry,
+	RagDetailedStatus,
 	RagIndexStatus,
 	RagProgressInfo,
 	ProgressListener,
@@ -239,22 +239,6 @@ export class RagIndexingService {
 		return this.ragCache.indexedCount;
 	}
 
-	getStatusInfo(): {
-		status: RagIndexStatus;
-		indexedCount: number;
-		storeName: string | null;
-		lastSync: number | null;
-		progress?: { current: number; total: number };
-	} {
-		return {
-			status: this.status,
-			indexedCount: this.ragCache.indexedCount,
-			storeName: this.plugin.settings.ragIndexing.fileSearchStoreName,
-			lastSync: this.ragCache.cache?.lastSync || null,
-			progress: this.status === 'indexing' ? this.vaultScanner?.getIndexingProgress() : undefined,
-		};
-	}
-
 	getProgressInfo(): RagProgressInfo {
 		return {
 			status: this.status,
@@ -269,20 +253,7 @@ export class RagIndexingService {
 		};
 	}
 
-	getPendingCount(): number {
-		return this.syncQueue?.getPendingCount() ?? 0;
-	}
-
-	getDetailedStatus(): {
-		status: RagIndexStatus;
-		indexedCount: number;
-		failedCount: number;
-		pendingCount: number;
-		storeName: string | null;
-		lastSync: number | null;
-		indexedFiles: Array<{ path: string; lastIndexed: number }>;
-		failedFiles: FailedFileEntry[];
-	} {
+	getDetailedStatus(): RagDetailedStatus {
 		// Build indexed files list from cache, sorted by lastIndexed (newest first)
 		const indexedFiles = this.ragCache.cache
 			? Object.entries(this.ragCache.cache.files)

--- a/test/services/rag-indexing.test.ts
+++ b/test/services/rag-indexing.test.ts
@@ -273,20 +273,6 @@ describe('RagIndexingService', () => {
 		});
 	});
 
-	describe('getPendingCount', () => {
-		it('should return 0 when no pending changes', () => {
-			expect(service.getPendingCount()).toBe(0);
-		});
-
-		it('should return count of pending changes', () => {
-			getSyncQueue(service).pendingChanges = new Map([
-				['file1.md', { type: 'create', path: 'file1.md', timestamp: Date.now() }],
-				['file2.md', { type: 'modify', path: 'file2.md', timestamp: Date.now() }],
-			]);
-			expect(service.getPendingCount()).toBe(2);
-		});
-	});
-
 	describe('change collapsing (queueChange)', () => {
 		beforeEach(() => {
 			// Setup service to be ready
@@ -542,31 +528,6 @@ describe('RagIndexingService', () => {
 			expect(status.pendingCount).toBe(1);
 			expect(status.indexedFiles).toHaveLength(1);
 			expect(status.failedFiles).toHaveLength(1);
-		});
-	});
-
-	describe('getStatusInfo', () => {
-		it('should return basic status info', () => {
-			(service as any).status = 'idle';
-			getRagCache(service).indexedCount = 5;
-			mockPlugin.settings.ragIndexing.fileSearchStoreName = 'my-store';
-			getRagCache(service).cache = { lastSync: 1234567890 };
-
-			const info = service.getStatusInfo();
-
-			expect(info.status).toBe('idle');
-			expect(info.indexedCount).toBe(5);
-			expect(info.storeName).toBe('my-store');
-			expect(info.lastSync).toBe(1234567890);
-		});
-
-		it('should include progress when indexing', () => {
-			(service as any).status = 'indexing';
-			getVaultScanner(service).indexingProgress = { current: 5, total: 10 };
-
-			const info = service.getStatusInfo();
-
-			expect(info.progress).toEqual({ current: 5, total: 10 });
 		});
 	});
 


### PR DESCRIPTION
## Summary

`audit-architecture` nightly sweep flagged **dead surface + duplicated type declaration** in `src/services/rag-indexing.ts`.

`RagIndexingService.getStatusInfo()` and `RagIndexingService.getPendingCount()` have no callers anywhere in `src/` — the only references were the tests written alongside them, so the tests existed solely to keep dead code alive. `getDetailedStatus()` already returns a strict superset of `getStatusInfo()`'s payload (including `pendingCount`), and it is the accessor `RagStatusProvider` (`src/services/rag-status-bar.ts:11`) actually declares. `knip` cannot see class methods, which is why these survived the earlier dead-export sweeps.

Separately, `getDetailedStatus()` re-declared the `RagDetailedStatus` shape inline as an anonymous return type. Structural typing kept it compiling, but the copy is hand-maintained: adding a field to `RagDetailedStatus` in `rag-types.ts` would not require the implementation to supply it. It is now annotated with the named type.

No behavior change — nothing in `src/` read either removed method.

Fixes: N/A — filed directly by the architecture audit, no tracking issue.

## Changes

- `src/services/rag-indexing.ts` — delete `getStatusInfo()` and `getPendingCount()`; annotate `getDetailedStatus()` as `RagDetailedStatus`; swap the now-unused `FailedFileEntry` type import for `RagDetailedStatus`.
- `test/services/rag-indexing.test.ts` — remove the two `describe` blocks that covered only the deleted methods. `pendingCount` remains covered through the existing `getDetailedStatus` assertions.

## Screenshots / Screencast

N/A — internal refactor, no UI change.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: opened by the `audit-architecture` sweep, which files findings directly per its configured `prCap`.
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — also `npm run lint` and `npm run typecheck:test`, all clean locally (3797 tests, 171 files).
- [ ] I have tested this change on Desktop — N/A: no reachable code path changed; the deleted methods had zero production callers.
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — no platform-specific code touched.
- [ ] Documentation has been updated (if applicable) — N/A: purely internal; the removed methods are not referenced in `docs/` or `README.md`.
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (`audit-architecture` skill)
- [x] I have reviewed and understand all AI-generated code in this PR

---

_Filed by the `audit-architecture` skill._

---
_Generated by [Claude Code](https://claude.ai/code/session_011MZrsi2qA5gNFPWYRoXWgf)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved consistency in reporting indexing status.
  * Removed an obsolete status information interface.

* **Tests**
  * Updated indexing service test coverage to reflect the streamlined status reporting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->