### PR TITLE
refactor(providers): inline the pass-through buildSystemInstruction wrapper

### DIFF
--- a/src/api/providers/ollama/client.ts
+++ b/src/api/providers/ollama/client.ts
@@ -227,7 +227,7 @@ export class OllamaClient implements ModelApi {
 		model: string,
 		stream: boolean
 	): Promise<ChatRequest & { stream: boolean }> {
-		const systemInstruction = await this.buildSystemInstruction(request);
+		const systemInstruction = await this.prompts.buildExtendedSystemInstruction(request);
 		const messages: Message[] = [];
 
 		if (systemInstruction) {
@@ -283,10 +283,6 @@ export class OllamaClient implements ModelApi {
 			options: this.buildOptions(request),
 			...(tools && tools.length ? { tools } : {}),
 		};
-	}
-
-	private async buildSystemInstruction(request: ExtendedModelRequest): Promise<string> {
-		return this.prompts.buildExtendedSystemInstruction(request);
 	}
 
 	private convertHistoryEntry(entry: unknown): Message[] | null {

--- a/src/api/providers/openai/client.ts
+++ b/src/api/providers/openai/client.ts
@@ -316,7 +316,7 @@ export class OpenAIClient implements ModelApi {
 	private async buildChatRequest(
 		request: ExtendedModelRequest
 	): Promise<{ messages: ChatMessage[]; tools?: ChatTool[] }> {
-		const systemInstruction = await this.buildSystemInstruction(request);
+		const systemInstruction = await this.prompts.buildExtendedSystemInstruction(request);
 		const messages: ChatMessage[] = [];
 
 		if (systemInstruction) {
@@ -373,10 +373,6 @@ export class OpenAIClient implements ModelApi {
 		const tools = request.availableTools ? this.toOpenAITools(request.availableTools) : undefined;
 
 		return { messages, ...(tools && tools.length ? { tools } : {}) };
-	}
-
-	private async buildSystemInstruction(request: ExtendedModelRequest): Promise<string> {
-		return this.prompts.buildExtendedSystemInstruction(request);
 	}
 
 	private toImageContentPart(att: InlineDataPart): ImageContentPart {


### PR DESCRIPTION
## Summary

`audit-architecture` nightly sweep flagged a **cross-file DRY violation** in `src/api/providers/openai/client.ts` and `src/api/providers/ollama/client.ts`.

Both clients carried a byte-identical private method:

```ts
private async buildSystemInstruction(request: ExtendedModelRequest): Promise<string> {
	return this.prompts.buildExtendedSystemInstruction(request);
}
```

Each had exactly one caller (its own `buildChatRequest()`), and the Gemini client has no equivalent wrapper — so this is duplicated indirection with no provider-specific behavior behind it. The wrapper adds a hop without adding a seam: a provider that genuinely needed to shape its system instruction would override the body, and none does.

Both call sites now invoke `this.prompts.buildExtendedSystemInstruction(request)` directly. No behavior change.

Fixes: N/A — filed directly by the architecture audit, no tracking issue.

## Changes

- `src/api/providers/openai/client.ts` — delete `buildSystemInstruction()`; call the prompts method directly in `buildChatRequest()`.
- `src/api/providers/ollama/client.ts` — same.

## Screenshots / Screencast

N/A — internal refactor, no UI change.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: opened by the `audit-architecture` sweep, which files findings directly per its configured `prCap`.
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — also `npm run lint` and `npm run typecheck:test`, all clean locally (3801 tests, 171 files).
- [ ] I have tested this change on Desktop — N/A: the removed wrappers were single-statement forwarders; the existing OpenAI/Ollama client tests cover the `buildChatRequest` paths that call through.
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — no platform-specific code touched.
- [ ] Documentation has been updated (if applicable) — N/A: private methods, no user-facing or documented surface.
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (`audit-architecture` skill)
- [x] I have reviewed and understand all AI-generated code in this PR

---

_Filed by the `audit-architecture` skill._

---
_Generated by [Claude Code](https://claude.ai/code/session_011MZrsi2qA5gNFPWYRoXWgf)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal chat request processing for Ollama and OpenAI providers.
  * No changes to user-facing functionality or public interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->