### PR TITLE
refactor(scheduler): derive scheduled-task create/update params from ScheduledTask

### DIFF
--- a/src/services/scheduled-task-manager.ts
+++ b/src/services/scheduled-task-manager.ts
@@ -14,11 +14,25 @@ import { FailurePauseTracker, MAX_CONSECUTIVE_FAILURES } from './failure-pause-t
 import { computeNextRunAt } from './scheduled-tasks/schedule';
 import { detectMissedRuns as detectMissedRunsInWindow } from './scheduled-tasks/missed-runs';
 import { submitTask as submitTaskDispatch, type ExecutionDeps } from './scheduled-tasks/execution';
-import type { PendingCatchUp, ScheduledTask, ScheduledTasksState, TaskState } from './scheduled-tasks/types';
+import type {
+	PendingCatchUp,
+	ScheduledTask,
+	ScheduledTaskCreateParams,
+	ScheduledTasksState,
+	ScheduledTaskUpdateParams,
+	TaskState,
+} from './scheduled-tasks/types';
 
 // Re-export the task types and the pure schedule helper from their new module
 // homes so existing import paths (`from '.../scheduled-task-manager'`) keep working.
-export type { PendingCatchUp, ScheduledTask, ScheduledTasksState, TaskState } from './scheduled-tasks/types';
+export type {
+	PendingCatchUp,
+	ScheduledTask,
+	ScheduledTaskCreateParams,
+	ScheduledTasksState,
+	ScheduledTaskUpdateParams,
+	TaskState,
+} from './scheduled-tasks/types';
 export { computeNextRunAt } from './scheduled-tasks/schedule';
 
 // ─── Folder / file layout ─────────────────────────────────────────────────────
@@ -309,17 +323,7 @@ export class ScheduledTaskManager extends FileBackedFeatureManager<ScheduledTask
 	 * Create a new scheduled task by writing a markdown file to the tasks folder.
 	 * The metadata cache 'create' listener will pick it up within ~500 ms.
 	 */
-	async createTask(params: {
-		slug: string;
-		schedule: string;
-		toolPolicy?: FeatureToolPolicy;
-		outputPath?: string;
-		model?: string;
-		maxIterations?: number;
-		enabled?: boolean;
-		runIfMissed?: boolean;
-		prompt: string;
-	}): Promise<void> {
+	async createTask(params: ScheduledTaskCreateParams): Promise<void> {
 		const slug = params.slug.trim();
 		if (!slug) throw new Error('Task slug cannot be empty');
 		if (this.tasks.has(slug)) throw new Error(`A task named "${slug}" already exists`);
@@ -372,19 +376,7 @@ export class ScheduledTaskManager extends FileBackedFeatureManager<ScheduledTask
 	 * Rewrite a task's definition file (frontmatter + prompt body).
 	 * Slug is the stable identifier — renaming is not supported via this method.
 	 */
-	async updateTask(
-		slug: string,
-		params: {
-			schedule?: string;
-			toolPolicy?: FeatureToolPolicy;
-			outputPath?: string;
-			model?: string;
-			maxIterations?: number;
-			enabled?: boolean;
-			runIfMissed?: boolean;
-			prompt?: string;
-		}
-	): Promise<void> {
+	async updateTask(slug: string, params: ScheduledTaskUpdateParams): Promise<void> {
 		const task = this.tasks.get(slug);
 		if (!task) throw new Error(`Scheduled task "${slug}" not found`);
 

--- a/src/services/scheduled-tasks/types.ts
+++ b/src/services/scheduled-tasks/types.ts
@@ -57,6 +57,30 @@ export interface ScheduledTask {
 	filePath: string;
 }
 
+/**
+ * Fields `ScheduledTaskManager.createTask` defaults when the caller omits them
+ * (`outputPath` from the runs-folder template, `enabled` to true, `runIfMissed`
+ * to false), so they are optional on the create params but required on the
+ * parsed `ScheduledTask`.
+ */
+type ScheduledTaskDefaultedField = 'outputPath' | 'enabled' | 'runIfMissed';
+
+/**
+ * Parameters accepted by `ScheduledTaskManager.createTask`.
+ *
+ * Derived from `ScheduledTask` rather than re-listed so a new task field can't
+ * land on `ScheduledTask` alone and silently become unsettable through
+ * create/update — the compiler now forces every addition to be either a create
+ * param or an explicit `ScheduledTaskDefaultedField`. `filePath` is excluded
+ * because the manager derives it from the slug. Mirrors the `HookCreateParams`
+ * shape in `../hook-types`.
+ */
+export type ScheduledTaskCreateParams = Omit<ScheduledTask, 'filePath' | ScheduledTaskDefaultedField> &
+	Partial<Pick<ScheduledTask, ScheduledTaskDefaultedField>>;
+
+/** The fields `updateTask` understands. Slug is immutable after creation. */
+export type ScheduledTaskUpdateParams = Partial<Omit<ScheduledTaskCreateParams, 'slug'>>;
+
 /** Per-task volatile runtime state stored in the sidecar JSON. */
 export interface TaskState {
 	/** ISO-8601 date string for the next scheduled run. */

--- a/src/ui/scheduler-management-modal.ts
+++ b/src/ui/scheduler-management-modal.ts
@@ -1,5 +1,10 @@
 import { Notice, Setting } from 'obsidian';
-import type { ScheduledTask, TaskState, ScheduledTasksState } from '../services/scheduled-task-manager';
+import type {
+	ScheduledTask,
+	ScheduledTaskCreateParams,
+	TaskState,
+	ScheduledTasksState,
+} from '../services/scheduled-task-manager';
 import { DEFAULT_HEADLESS_MAX_ITERATIONS } from '../agent/agent-loop';
 import type { FeatureToolPolicy } from '../types/tool-policy';
 import { ManagementModalBase } from './components/management-modal-base';
@@ -395,31 +400,26 @@ export class SchedulerManagementModal extends ManagementModalBase<ScheduledTask,
 			return;
 		}
 
+		// Create and update send the identical field set; only `slug` differs
+		// (it is immutable after creation). Built once so a new form field can't
+		// be added to one branch and forgotten in the other.
+		const params: Omit<ScheduledTaskCreateParams, 'slug'> = {
+			schedule,
+			toolPolicy: this.form.toolPolicy,
+			outputPath: this.form.outputPath || undefined,
+			model: this.form.model || undefined,
+			maxIterations,
+			enabled: this.form.enabled,
+			runIfMissed: this.form.runIfMissed,
+			prompt: this.form.prompt,
+		};
+
 		try {
 			if (isEdit && this.editingSlug) {
-				await manager.updateTask(this.editingSlug, {
-					schedule,
-					toolPolicy: this.form.toolPolicy,
-					outputPath: this.form.outputPath || undefined,
-					model: this.form.model || undefined,
-					maxIterations,
-					enabled: this.form.enabled,
-					runIfMissed: this.form.runIfMissed,
-					prompt: this.form.prompt,
-				});
+				await manager.updateTask(this.editingSlug, params);
 				new Notice(t('scheduler.taskUpdated', { slug: this.editingSlug }));
 			} else {
-				await manager.createTask({
-					slug: this.form.slug,
-					schedule,
-					toolPolicy: this.form.toolPolicy,
-					outputPath: this.form.outputPath || undefined,
-					model: this.form.model || undefined,
-					maxIterations,
-					enabled: this.form.enabled,
-					runIfMissed: this.form.runIfMissed,
-					prompt: this.form.prompt,
-				});
+				await manager.createTask({ slug: this.form.slug, ...params });
 				new Notice(t('scheduler.taskCreated', { slug: this.form.slug }));
 			}
 			this.view = 'list';


### PR DESCRIPTION
## Summary

audit-architecture nightly sweep flagged: **DRY violation** in `src/services/scheduled-task-manager.ts`, `src/services/scheduled-tasks/types.ts`, and `src/ui/scheduler-management-modal.ts`.

The scheduled-task field list is written out longhand in four places: the inline param type on `createTask`, the inline param type on `updateTask`, and both branches of `SchedulerManagementModal.handleSave`. Nothing ties them together, so a new task field can land on `ScheduledTask` and silently be unsettable through create/update, or be wired into the modal's create branch and forgotten in the update branch.

This mirrors the shape hooks already use after #1314 (derive `HookCreateParams` from `Hook`) and #1273 (build the hook save payload once): derive the param types from the entity interface and build the payload once. No behavior change — the derived types expand to exactly the field sets the inline types listed, and the payload object holds the same values.

Not linked to an approved issue: this is an automated audit PR, filed under the audit's standing PR budget rather than through the issue-approval flow.

## Changes

- `src/services/scheduled-tasks/types.ts` — add `ScheduledTaskCreateParams` (derived from `ScheduledTask` via `Omit<…, 'filePath' | ScheduledTaskDefaultedField> & Partial<Pick<…>>`) and `ScheduledTaskUpdateParams`.
- `src/services/scheduled-task-manager.ts` — replace the two inline param types on `createTask`/`updateTask` with the derived types; re-export both alongside the existing task-type re-exports.
- `src/ui/scheduler-management-modal.ts` — build the save payload once as `Omit<ScheduledTaskCreateParams, 'slug'>` and spread `slug` in on the create branch.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A, automated `audit-architecture` sweep PR
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — format-check clean, lint clean (0 errors), build + `typecheck:test` clean, 3797 tests in 171 files passing
- [ ] I have tested this change on Desktop — N/A, no runtime behavior change; covered by the existing scheduled-task test suite
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — type-only and object-construction change, no platform APIs touched
- [ ] Documentation has been updated (if applicable) — N/A, internal refactor with no user-facing or settings change
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (`audit-architecture` skill)
- [x] I have reviewed and understand all AI-generated code in this PR

---

_Filed by the `audit-architecture` skill._

---
_Generated by [Claude Code](https://claude.ai/code/session_01HVaLmaDGhstwU7hWC79z3J)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved scheduled task creation and update handling with consistent parameter validation.
  * Preserved existing task settings when editing or saving scheduled tasks.
  * Added clearer support for optional task defaults, such as output paths and missed-run behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->