### PR TITLE
refactor(agent-view): build the shared follow-up request fields once

### DIFF
--- a/src/ui/agent-view/agent-view-tool-followup.ts
+++ b/src/ui/agent-view/agent-view-tool-followup.ts
@@ -36,22 +36,42 @@ export interface RetryRequestParams extends PerTurnContext {
 }
 
 /**
+ * The request fields the follow-up and the empty-response retry share verbatim:
+ * everything except `userMessage` and (for the follow-up) `availableTools`.
+ * Built in one place so a change to the model/temperature/topP resolution or the
+ * project context passthrough can't land on one request shape and miss the other.
+ *
+ * `perTurnContext` is deliberately omitted from both: `buildToolHistoryTurns`
+ * already spliced it into the user turn of `updatedHistory`. Passing it here too
+ * would make `buildContents` append it a second time, duplicating the
+ * (potentially large) context payload on every tool iteration.
+ */
+function buildSharedRequestFields(params: RetryRequestParams): Omit<ExtendedModelRequest, 'userMessage'> {
+	const { plugin, currentSession, updatedHistory, customPrompt, projectInstructions, projectSkills, sessionStartedAt } =
+		params;
+	const modelConfig = currentSession?.modelConfig || {};
+
+	return {
+		kind: 'extended',
+		conversationHistory: updatedHistory,
+		model: modelConfig.model || getActiveChatModel(plugin.settings),
+		temperature: modelConfig.temperature ?? plugin.settings.temperature,
+		topP: modelConfig.topP ?? plugin.settings.topP,
+		prompt: '', // Unused in agent pipeline — context lives in conversationHistory
+		customPrompt,
+		projectInstructions,
+		projectSkills,
+		sessionStartedAt,
+		renderContent: false,
+	};
+}
+
+/**
  * Build the follow-up request sent to the model after tool execution.
  * Includes available tools so the model can chain additional calls.
  */
 export function buildFollowUpRequest(params: FollowUpRequestParams): ExtendedModelRequest {
-	const {
-		plugin,
-		currentSession,
-		updatedHistory,
-		customPrompt,
-		projectRootPath,
-		featureToolPolicy,
-		headless,
-		projectInstructions,
-		projectSkills,
-		sessionStartedAt,
-	} = params;
+	const { plugin, currentSession, projectRootPath, featureToolPolicy, headless } = params;
 
 	const availableToolsContext: ToolExecutionContext = {
 		plugin,
@@ -66,25 +86,9 @@ export function buildFollowUpRequest(params: FollowUpRequestParams): ExtendedMod
 		? plugin.toolRegistry.getAutoApprovedTools(availableToolsContext)
 		: plugin.toolRegistry.getEnabledTools(availableToolsContext);
 
-	const modelConfig = currentSession?.modelConfig || {};
-
-	// `perTurnContext` is deliberately omitted: `buildToolHistoryTurns` already
-	// spliced it into the user turn of `updatedHistory`. Passing it here too
-	// would make `buildContents` append it a second time, duplicating the
-	// (potentially large) context payload on every tool iteration.
 	return {
-		kind: 'extended',
+		...buildSharedRequestFields(params),
 		userMessage: '', // Empty since tool results are already in conversation history
-		conversationHistory: updatedHistory,
-		model: modelConfig.model || getActiveChatModel(plugin.settings),
-		temperature: modelConfig.temperature ?? plugin.settings.temperature,
-		topP: modelConfig.topP ?? plugin.settings.topP,
-		prompt: '', // Unused in agent pipeline — context lives in conversationHistory
-		customPrompt,
-		projectInstructions,
-		projectSkills,
-		sessionStartedAt,
-		renderContent: false,
 		availableTools, // Include tools so model can chain calls
 	};
 }
@@ -94,25 +98,9 @@ export function buildFollowUpRequest(params: FollowUpRequestParams): ExtendedMod
  * Does not include tools — just asks the model to summarize what it did.
  */
 export function buildRetryRequest(params: RetryRequestParams): ExtendedModelRequest {
-	const { plugin, currentSession, updatedHistory, customPrompt, projectInstructions, projectSkills, sessionStartedAt } =
-		params;
-	const modelConfig = currentSession?.modelConfig || {};
-
-	// `perTurnContext` is deliberately omitted — see `buildFollowUpRequest`:
-	// it is already embedded in `updatedHistory` via `buildToolHistoryTurns`.
 	return {
-		kind: 'extended',
+		...buildSharedRequestFields(params),
 		userMessage: 'Please summarize what you just did with the tools.',
-		conversationHistory: updatedHistory,
-		model: modelConfig.model || getActiveChatModel(plugin.settings),
-		temperature: modelConfig.temperature ?? plugin.settings.temperature,
-		topP: modelConfig.topP ?? plugin.settings.topP,
-		prompt: '', // Unused in agent pipeline — context lives in conversationHistory
-		customPrompt,
-		projectInstructions,
-		projectSkills,
-		sessionStartedAt,
-		renderContent: false,
 	};
 }
 


### PR DESCRIPTION
## Summary

audit-architecture nightly sweep flagged: **DRY violation** in `src/ui/agent-view/agent-view-tool-followup.ts`.

`buildFollowUpRequest` and `buildRetryRequest` each spelled out the same eleven-field `ExtendedModelRequest` body — the same `model` / `temperature` / `topP` resolution off `session.modelConfig`, the same project-context passthrough (`customPrompt`, `projectInstructions`, `projectSkills`, `sessionStartedAt`), the same `prompt: ''` and `renderContent: false`, and the same duplicated comment explaining why `perTurnContext` is deliberately omitted. The two requests differ only in `userMessage` and, for the follow-up, `availableTools`.

Extracting the common part means a future change to how the model or sampling parameters are resolved for a tool-loop request can't land on one shape and silently miss the other. `FollowUpRequestParams` is structurally a superset of `RetryRequestParams`, so the shared helper takes the narrower type and both call sites pass their own params through unchanged.

No behavior change — both requests carry the same fields with the same values as before.

Not linked to an approved issue: this is an automated audit PR, filed under the audit's standing PR budget rather than through the issue-approval flow.

## Changes

- `src/ui/agent-view/agent-view-tool-followup.ts` — add a module-private `buildSharedRequestFields(params: RetryRequestParams): Omit<ExtendedModelRequest, 'userMessage'>`; carry the `perTurnContext`-omission rationale onto it once instead of twice; have `buildFollowUpRequest` and `buildRetryRequest` spread it and add only their differing fields.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A, automated `audit-architecture` sweep PR
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — format-check clean, lint clean (0 errors), build + `typecheck:test` clean, 3797 tests in 171 files passing
- [ ] I have tested this change on Desktop — N/A, no runtime behavior change; the agent tool-loop tests in `test/ui/` and `test/agent/` cover both request builders
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — pure object-construction refactor, no platform APIs touched
- [ ] Documentation has been updated (if applicable) — N/A, internal refactor with no user-facing or settings change
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (`audit-architecture` skill)
- [x] I have reviewed and understand all AI-generated code in this PR

---

_Filed by the `audit-architecture` skill._

---
_Generated by [Claude Code](https://claude.ai/code/session_01HVaLmaDGhstwU7hWC79z3J)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved consistency between follow-up and retry requests by standardizing shared conversation, project, session, model, and rendering settings.
  * Preserved tool availability for follow-up interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->