### PR TITLE
refactor(commands): share the RAG command entry gate

### DIFF
--- a/src/commands/register-commands.ts
+++ b/src/commands/register-commands.ts
@@ -9,6 +9,24 @@ import type { ObsidianGemini } from '../types/plugin';
 import { resolveProvider } from '../api/provider-routing';
 
 /**
+ * Shared entry gate for the RAG commands. Each of them opens with the same two
+ * checks — a provider must be routed to RAG, and the indexing service must
+ * exist — emitting the same two notices. Returns the service when both hold, or
+ * `null` when the caller should bail because the notice has already been shown.
+ */
+function resolveRagIndexing(plugin: ObsidianGemini): NonNullable<ObsidianGemini['ragIndexing']> | null {
+	if (resolveProvider(plugin.settings, 'rag') === null) {
+		new Notice(t('notice.main.ragUnavailableProvider'));
+		return null;
+	}
+	if (!plugin.ragIndexing) {
+		new Notice(t('notice.main.ragNotEnabled'));
+		return null;
+	}
+	return plugin.ragIndexing;
+}
+
+/**
  * Register all command-palette commands on the plugin instance.
  *
  * Extracted verbatim from `ObsidianGemini.registerUIAndCommands()` as a pure
@@ -335,23 +353,17 @@ export function registerCommands(plugin: ObsidianGemini): void {
 		id: 'rag-pause',
 		name: t('command.ragPause'),
 		callback: () => {
-			if (resolveProvider(plugin.settings, 'rag') === null) {
-				new Notice(t('notice.main.ragUnavailableProvider'));
-				return;
-			}
-			if (!plugin.ragIndexing) {
-				new Notice(t('notice.main.ragNotEnabled'));
-				return;
-			}
-			if (plugin.ragIndexing.isPaused()) {
+			const ragIndexing = resolveRagIndexing(plugin);
+			if (!ragIndexing) return;
+			if (ragIndexing.isPaused()) {
 				new Notice(t('notice.main.ragAlreadyPaused'));
 				return;
 			}
-			if (plugin.ragIndexing.isIndexing()) {
+			if (ragIndexing.isIndexing()) {
 				new Notice(t('notice.main.ragCannotPauseWhileIndexing'));
 				return;
 			}
-			plugin.ragIndexing.pause();
+			ragIndexing.pause();
 			new Notice(t('notice.main.ragPaused'));
 		},
 	});
@@ -360,19 +372,13 @@ export function registerCommands(plugin: ObsidianGemini): void {
 		id: 'rag-resume',
 		name: t('command.ragResume'),
 		callback: () => {
-			if (resolveProvider(plugin.settings, 'rag') === null) {
-				new Notice(t('notice.main.ragUnavailableProvider'));
-				return;
-			}
-			if (!plugin.ragIndexing) {
-				new Notice(t('notice.main.ragNotEnabled'));
-				return;
-			}
-			if (!plugin.ragIndexing.isPaused()) {
+			const ragIndexing = resolveRagIndexing(plugin);
+			if (!ragIndexing) return;
+			if (!ragIndexing.isPaused()) {
 				new Notice(t('notice.main.ragNotPaused'));
 				return;
 			}
-			plugin.ragIndexing.resume();
+			ragIndexing.resume();
 			new Notice(t('notice.main.ragResumed'));
 		},
 	});
@@ -381,18 +387,12 @@ export function registerCommands(plugin: ObsidianGemini): void {
 		id: 'rag-status',
 		name: t('command.ragStatus'),
 		callback: async () => {
-			if (resolveProvider(plugin.settings, 'rag') === null) {
-				new Notice(t('notice.main.ragUnavailableProvider'));
-				return;
-			}
-			if (!plugin.ragIndexing) {
-				new Notice(t('notice.main.ragNotEnabled'));
-				return;
-			}
+			const ragIndexing = resolveRagIndexing(plugin);
+			if (!ragIndexing) return;
 			// Trigger the same modal as clicking the status bar
 			try {
 				const { openRagStatusModal } = await import('../services/rag-status-bar');
-				await openRagStatusModal(plugin.app, plugin.ragIndexing, plugin.manifest.id);
+				await openRagStatusModal(plugin.app, ragIndexing, plugin.manifest.id);
 			} catch (error) {
 				plugin.logger.error('RAG Indexing: Failed to open status UI', error);
 				new Notice(t('notice.rag.uiError', { error: getErrorMessage(error) }));


### PR DESCRIPTION
## Summary

audit-architecture nightly sweep flagged: **DRY violation** in `src/commands/register-commands.ts`.

The three RAG commands (`rag-pause`, `rag-resume`, `rag-status`) each open with the same two guards — `resolveProvider(plugin.settings, 'rag') === null` → `notice.main.ragUnavailableProvider`, then `!plugin.ragIndexing` → `notice.main.ragNotEnabled`. Three copies means a change to the gate (a new precondition, a different notice, a different resolution order) has to be applied three times, and a fourth RAG command added tomorrow copies whichever one its author happened to look at.

`resolveRagIndexing(plugin)` runs both checks and returns the service, or `null` after showing the notice, so each callback becomes a two-line bail. The callbacks then use the returned non-null handle rather than re-reading `plugin.ragIndexing`, which also drops the repeated non-null narrowing.

No behavior change — the same checks run in the same order and produce the same notices. The `generate-image` command has a superficially similar two-check preamble, but its checks resolve a different use case and different service against different i18n keys, so it is deliberately left alone rather than forced through a shared abstraction.

Not linked to an approved issue: this is an automated audit PR, filed under the audit's standing PR budget rather than through the issue-approval flow.

## Changes

- `src/commands/register-commands.ts` — add a module-private `resolveRagIndexing(plugin): NonNullable<ObsidianGemini['ragIndexing']> | null`; replace the duplicated preamble in the `rag-pause`, `rag-resume`, and `rag-status` callbacks with a call to it, and use the returned handle for the subsequent `isPaused()` / `isIndexing()` / `pause()` / `resume()` / `openRagStatusModal` calls.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A, automated `audit-architecture` sweep PR
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — format-check clean, lint clean (0 errors), build + `typecheck:test` clean, 3797 tests in 171 files passing
- [ ] I have tested this change on Desktop — N/A, no runtime behavior change; the notices and guard order are unchanged
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — no platform APIs touched; the existing dynamic `import('../services/rag-status-bar')` in `rag-status` is unchanged
- [ ] Documentation has been updated (if applicable) — N/A, internal refactor with no user-facing or settings change
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (`audit-architecture` skill)
- [x] I have reviewed and understand all AI-generated code in this PR

---

_Filed by the `audit-architecture` skill._

---
_Generated by [Claude Code](https://claude.ai/code/session_01HVaLmaDGhstwU7hWC79z3J)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling for RAG indexing commands.
  * Pause, resume, and status operations now use consistent service availability and provider checks.
  * Existing command validation, actions, status displays, and error reporting remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->