### PR TITLE
refactor(utils): drop the unused getShortErrorMessage helper

### DIFF
--- a/src/utils/error-utils.ts
+++ b/src/utils/error-utils.ts
@@ -490,7 +490,7 @@ function getHttpErrorMessage(statusCode: number, error: unknown): string {
  * Condense an already-stringified error into the first meaningful line,
  * capped at 120 characters.
  *
- * Unlike {@link getShortErrorMessage}, this takes a raw string rather than an
+ * Unlike {@link getErrorMessage}, this takes a raw string rather than an
  * error value — the automation surfaces (scheduled tasks, hooks, background
  * tasks) persist `lastError` as text, so by the time the UI renders it there is
  * no error object left to inspect. It peels off the two shapes those stored
@@ -523,22 +523,4 @@ export function truncateStoredError(raw: string): string {
 	const stripped = raw.replace(/^(ApiError:\s*)?\[\d+ [^\]]+\]\s*/, '').replace(/^ApiError:\s*/, '');
 	const firstLine = stripped.split(/[\n.]/)[0].trim();
 	return firstLine.length > 120 ? firstLine.slice(0, 117) + '…' : firstLine;
-}
-
-/**
- * Get a shortened error message suitable for inline display
- * (e.g., in status bars or small UI elements)
- */
-export function getShortErrorMessage(error: unknown): string {
-	const fullMessage = getErrorMessage(error);
-
-	// Extract just the first sentence or clause
-	const firstSentence = fullMessage.split(/[:.]/)[0];
-
-	// If it's still too long, truncate it
-	if (firstSentence.length > 80) {
-		return firstSentence.substring(0, 77) + '...';
-	}
-
-	return firstSentence;
 }

--- a/test/utils/error-utils.test.ts
+++ b/test/utils/error-utils.test.ts
@@ -2,7 +2,6 @@ import {
 	getErrorMessage,
 	getRawErrorMessage,
 	getRawErrorMessageOr,
-	getShortErrorMessage,
 	isNotFoundError,
 	isQuotaExhausted,
 	isRateLimitError,
@@ -612,46 +611,6 @@ describe('error-utils', () => {
 		test('handles non-Error values via String()', () => {
 			expect(isNotFoundError('plain 404 string')).toBe(true);
 			expect(isNotFoundError(null)).toBe(false);
-		});
-	});
-
-	describe('getShortErrorMessage', () => {
-		test('Extract first sentence from full message', () => {
-			const error = { status: 401 };
-			const short = getShortErrorMessage(error);
-			expect(short).toBe('Authentication failed');
-		});
-
-		test('Extract first clause (before colon)', () => {
-			const error = new Error('Network error: connection failed');
-			const short = getShortErrorMessage(error);
-			expect(short).toBe('Network error');
-		});
-
-		test('Truncate very long messages', () => {
-			// Create an error message that doesn't match any patterns
-			// so it returns "API error: <message>" where message is long
-			const longMessage =
-				'This is a very long error message that does not match any patterns and should be truncated when extracting the short version of the error message for display purposes';
-			const error = new Error(longMessage);
-			const short = getShortErrorMessage(error);
-			// The short message will be "API error" after splitting on ':'
-			// which is less than 80 chars, so this test doesn't actually test truncation
-			// Instead, test that we handle the first clause correctly
-			expect(short.length).toBeLessThanOrEqual(80);
-			expect(short).toBe('API error');
-		});
-
-		test('Short message returned as-is', () => {
-			const error = new Error('Short error');
-			const short = getShortErrorMessage(error);
-			expect(short).toBe('API error');
-		});
-
-		test('Handle complex multi-sentence message', () => {
-			const error = { status: 500, message: 'Internal error. Try again later.' };
-			const short = getShortErrorMessage(error);
-			expect(short).toBe('Server error');
 		});
 	});
 


### PR DESCRIPTION
## Summary

`audit-architecture` nightly sweep flagged **dead export** in `src/utils/error-utils.ts`.

`getShortErrorMessage()` — documented as "suitable for inline display (e.g., in status bars or small UI elements)" — has zero production call sites. The three surfaces that actually render a condensed error inline (`scheduled-tasks-modal.ts:156`, `background-tasks-modal.ts:314`, `scheduler-management-modal.ts:475`) all call `truncateStoredError()` instead, which was extracted in #1283 specifically to handle the stringified `lastError` those automation surfaces persist. `getShortErrorMessage` was left behind.

`npm run knip` doesn't catch it: `knip.json` lists `test/**/*.{test,spec}.ts` as entry points, so the function's own `describe` block counts as a reference and keeps it looking live. Removing the function and that block is mechanical and reversible — nothing in `src/` imports it, and it is not re-exported from `src/index.ts`.

No issue is linked; this was filed directly by the audit rather than through an approved issue.

## Changes

- `src/utils/error-utils.ts` — remove `getShortErrorMessage()`; retarget the `{@link getShortErrorMessage}` reference in `truncateStoredError()`'s docblock at `getErrorMessage` (the comparison it was actually drawing).
- `test/utils/error-utils.test.ts` — remove the `getShortErrorMessage` `describe` block and its import.

## Screenshots / Screencast

N/A — no UI surface changes; the removed function was never rendered anywhere.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: opened by the `audit-architecture` nightly sweep, which files mechanical fixes directly per its routing rules.
- [x] All CI checks pass — verified locally: `npm run format-check`, `npm run lint` (0 errors; 40 pre-existing warnings, all in unrelated test files), `npm run build`, `npm run typecheck:test`, `npm test` (171 files, 3792 tests passing), `npm run knip` (clean).
- [ ] I have tested this change on Desktop — N/A: pure dead-code deletion with no runtime reachability; covered by the test suite.
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — no platform-specific code involved.
- [ ] Documentation has been updated (if applicable) — N/A: internal helper, not referenced in `docs/` or `README.md` (verified by grep).
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (`audit-architecture` skill)
- [x] I have reviewed and understand all AI-generated code in this PR

---

_Filed by the `audit-architecture` skill._

---
_Generated by [Claude Code](https://claude.ai/code/session_01FZhJ5BkC57QuLpVWxvEbNw)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed an obsolete error-message shortening utility.
  * Updated related documentation to reflect the simplified error handling behavior.
* **Tests**
  * Removed tests covering the retired error-message shortening functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->