### PR TITLE
chore(daily): 2026-08-09 daily update

### DIFF
--- a/planning/changelog/2026-08-08.md
+++ b/planning/changelog/2026-08-08.md
@@ -1,0 +1,28 @@
+# Daily changelog — August 08, 2026
+
+**Date:** 2026-08-08
+**PRs merged:** 4
+
+---
+
+## Summary
+
+A quiet day dominated by the `audit-architecture` nightly sweep's DRY cleanups, plus the previous day's daily-update housekeeping PR landing. All four merges are internal refactors or automated housekeeping — no user-facing behavior changed.
+
+## What shipped
+
+### [#1327 chore(daily): 2026-08-08 daily update](https://github.com/allenhutchison/obsidian-gemini/pull/1327)
+
+The scheduled daily-update run for 2026-08-07: added the `2026-08-07.md` changelog entry, confirmed no doc drift from `audit-product-docs`, and reported zero unlabeled issues from `triage-issues`. Housekeeping-only, no `src/` changes.
+
+### [#1322 refactor(scheduler): derive scheduled-task create/update params from ScheduledTask](https://github.com/allenhutchison/obsidian-gemini/pull/1322)
+
+`audit-architecture` flagged that the scheduled-task field list was spelled out longhand in four places (the `createTask`/`updateTask` param types and both branches of `SchedulerManagementModal.handleSave`), risking a new task field landing on `ScheduledTask` but silently staying unsettable through create/update. Adds `ScheduledTaskCreateParams`/`ScheduledTaskUpdateParams` derived from `ScheduledTask`, and builds the modal's save payload once. No behavior change.
+
+### [#1323 refactor(agent-view): build the shared follow-up request fields once](https://github.com/allenhutchison/obsidian-gemini/pull/1323)
+
+`buildFollowUpRequest` and `buildRetryRequest` each spelled out the same eleven-field `ExtendedModelRequest` body, including a duplicated comment explaining why `perTurnContext` is deliberately omitted. Extracts a shared `buildSharedRequestFields` helper so the two call sites can't drift apart. No behavior change.
+
+### [#1324 refactor(commands): share the RAG command entry gate](https://github.com/allenhutchison/obsidian-gemini/pull/1324)
+
+The three RAG commands (`rag-pause`, `rag-resume`, `rag-status`) each repeated the same provider-availability and enabled-state guard. Adds a shared `resolveRagIndexing(plugin)` helper so the guard logic and its non-null narrowing live in one place. No behavior change.


### PR DESCRIPTION
## Summary

Scheduled daily-update run for 2026-08-08 (America/Los_Angeles). Runs the configured `dailyUpdate.subSkills` roster (`daily-changelog`, `audit-product-docs`, `triage-issues`) and bundles their output into one PR.

Fixes N/A — routine automated daily housekeeping run.

## Changes

- **daily-changelog**: added [`planning/changelog/2026-08-08.md`](https://github.com/allenhutchison/obsidian-gemini/blob/daily-update-2026-08-09/planning/changelog/2026-08-08.md) — 4 PRs merged on 2026-08-08 (local time): the prior day's daily-update housekeeping PR (#1327), and three `audit-architecture` DRY refactors (#1322 scheduled-task params, #1323 shared follow-up request fields, #1324 shared RAG command entry gate).
- **audit-product-docs**: audited `docs/guide/`, `docs/reference/`, `README.md`, and `AGENTS.md` in full against `src/` — settings/defaults, command IDs, frontmatter schemas, schedule grammar, model catalog, i18n language list, and tool/function names all checked. No drift found; no new docs warranted. Verified the day's three refactor PRs (#1322, #1323, #1324) touch no documented surface.
- **triage-issues**: 0 unlabeled open issues — no-op.

This is a housekeeping-only PR — no `src/` behavior changes.

**Non-doc finding surfaced during the audit (flagged, not fixed here — out of scope for a docs audit):** `src/main.ts`'s `DEFAULT_SETTINGS.openaiModelName` is hardcoded to `'gpt-5.6'`, which no longer exists in the OpenAI model catalog (`src/services/openai-models-service.ts` only has `gpt-5.6-sol`/`gpt-5.6-terra`/`gpt-5.6-luna` since PR #1288 renamed the chat entry). The docs (`settings.md`, `provider-capabilities.md`, `openai-setup.md`) all correctly document `gpt-5.6-sol` as the default, so this looks like a real code bug — a fresh OpenAI-provider install would persist an invalid model id. Worth a follow-up issue/PR.

## Screenshots / Screencast

N/A — changelog-only change, no UI change.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A; routine automated daily housekeeping run
- [x] All CI checks pass locally: `npm run format-check` clean, `npm run lint` 0 errors (40 pre-existing warnings, untouched), `npm run build` clean, `npm run typecheck:test` clean, `npm test` 3797 passed / 171 files
- [ ] I have tested this change on Desktop — N/A, changelog-only change; verified via local pre-flight checks
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A, no code change
- [x] Documentation has been updated (if applicable) — N/A beyond this PR's own content; no drift found, no new docs warranted
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ajr6WmmsPMn43m4NaoGjz1)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added the August 8, 2026 daily changelog entry.
  * Recorded recent maintenance and refactoring work for project tracking.

* **Refactor**
  * Improved internal consistency and shared handling across scheduled tasks, follow-up requests, and command availability checks.
  * No user-facing behavior changes in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->