### PR TITLE
refactor(api): resolve the provider once per client creation

### DIFF
--- a/src/api/factory.ts
+++ b/src/api/factory.ts
@@ -20,7 +20,7 @@ import { getDefaultModelForRole, getOllamaModelForRole, getOpenAIModelForRole } 
 import type { ObsidianGemini } from '../types/plugin';
 import { ModelUseCase } from './model-use-case';
 import { resolveProviderOrDefault } from './provider-routing';
-import type { ProviderUseCase } from './providers/registry';
+import type { ModelProvider, ProviderUseCase } from './providers/registry';
 
 /**
  * Which routable use case each model-client use case is billed to.
@@ -67,7 +67,7 @@ export class ModelClientFactory {
 		// features (RAG, image generation) never reach the client factory.
 		const provider = resolveProviderOrDefault(settings, ROUTING_USE_CASE[useCase]);
 
-		const modelName = this.resolveModelName(plugin, useCase);
+		const modelName = this.resolveModelName(plugin, useCase, provider);
 
 		const prompts = new GeminiPrompts(plugin);
 
@@ -131,9 +131,13 @@ export class ModelClientFactory {
 		}
 	}
 
-	private static resolveModelName(plugin: ObsidianGemini, useCase: ModelUseCase): string {
+	/**
+	 * The configured model for a use case. Takes the already-resolved provider
+	 * rather than re-deriving it, so the client and the model name can never be
+	 * chosen from two separate routing lookups.
+	 */
+	private static resolveModelName(plugin: ObsidianGemini, useCase: ModelUseCase, provider: ModelProvider): string {
 		const settings = plugin.settings;
-		const provider = resolveProviderOrDefault(settings, ROUTING_USE_CASE[useCase]);
 		const role = this.roleForUseCase(useCase);
 
 		if (provider === 'ollama') {


### PR DESCRIPTION
## Summary

`audit-architecture` nightly sweep flagged: **dry-violation** in `src/api/factory.ts`.

`ModelClientFactory.createFromPlugin` calls `resolveProviderOrDefault(settings, ROUTING_USE_CASE[useCase])` at line 68 to pick which client to build, then `resolveModelName` — called on the very next line — resolves the same provider a second time from the same `settings` and the same `useCase`. Two routing lookups decide two halves of one decision (which client, which model name) that must always agree.

This threads the already-resolved provider into `resolveModelName` as a parameter. Behaviour is unchanged: `resolveProviderOrDefault` is pure and both calls passed identical arguments, so they could only ever return the same value. What changes is that the agreement is now structural rather than coincidental — a future edit to either lookup can't silently route the client to one provider and the model name to another.

Not linked to an issue; this is an automated architecture-audit finding, filed directly as a PR because the fix is mechanical (one file, one private signature, no behaviour change).

## Changes

- `src/api/factory.ts` — `resolveModelName` takes the resolved `ModelProvider` as a third parameter instead of re-deriving it; `createFromPlugin` passes the provider it already resolved. Added a doc comment stating why the parameter exists, and imported the `ModelProvider` type (type-only, alongside the existing `ProviderUseCase` import from the same leaf module).

## Screenshots / Screencast

N/A — internal refactor with no UI surface.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: filed by the `audit-architecture` sweep, which routes mechanical findings straight to a PR and judgment-heavy ones to an issue.
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — verified locally: `format-check` clean, `lint` clean (0 errors, 40 pre-existing warnings unrelated to this diff), `build` clean, `typecheck:test` clean, `npm test` 3792 passed / 171 files.
- [ ] I have tested this change on Desktop — N/A: no runtime behaviour change to exercise; `test/api/factory.test.ts` covers `createFromPlugin` across all three providers and passes unchanged.
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — no platform-specific API is touched.
- [ ] Documentation has been updated (if applicable) — N/A: purely internal, no user-facing behaviour, settings, or documented API changed.
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (`audit-architecture` skill)
- [x] I have reviewed and understand all AI-generated code in this PR

---

_Filed by the `audit-architecture` skill._


---
_Generated by [Claude Code](https://claude.ai/code/session_01UaqRe93eHJRQSfZNFxiwfg)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model selection consistency by ensuring client creation and model resolution use the same provider routing result.
  * Prevented redundant provider lookups during plugin-based model setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->