### PR TITLE
chore(daily): 2026-08-10 daily update

### DIFF
--- a/planning/changelog/2026-08-09.md
+++ b/planning/changelog/2026-08-09.md
@@ -1,0 +1,24 @@
+# Daily changelog — August 09, 2026
+
+**Date:** 2026-08-09
+**PRs merged:** 7
+
+---
+
+## Summary
+
+A light, mostly-automated day: five dependency bumps, one dead-code removal flagged by the `audit-architecture` sweep, and the previous day's daily-update housekeeping PR.
+
+## What shipped
+
+### [#1331 refactor(utils): drop the unused getShortErrorMessage helper](https://github.com/allenhutchison/obsidian-gemini/pull/1331)
+
+Removed `getShortErrorMessage()` from `src/utils/error-utils.ts` after the `audit-architecture` nightly sweep flagged it as a dead export — `npm run knip` missed it because its own test `describe` block counted as a reference. The three surfaces that render condensed inline errors already use `truncateStoredError()` (extracted in #1283) instead. The corresponding test block was removed along with it.
+
+### [#1335 chore(daily): 2026-08-09 daily update](https://github.com/allenhutchison/obsidian-gemini/pull/1335)
+
+The prior day's scheduled daily-update run: added the 2026-08-08 changelog entry, an audit-product-docs pass that found no drift, and a triage-issues no-op. The PR also flagged (but did not fix) a real code bug found during the audit — `DEFAULT_SETTINGS.openaiModelName` in `src/main.ts` is hardcoded to `'gpt-5.6'`, a model id that no longer exists in `openai-models-service.ts`'s catalog (renamed to `gpt-5.6-sol` in #1288) — as a candidate for a follow-up issue.
+
+### Dependency bumps: [#1328](https://github.com/allenhutchison/obsidian-gemini/pull/1328), [#1329](https://github.com/allenhutchison/obsidian-gemini/pull/1329), [#1330](https://github.com/allenhutchison/obsidian-gemini/pull/1330), [#1333](https://github.com/allenhutchison/obsidian-gemini/pull/1333), [#1334](https://github.com/allenhutchison/obsidian-gemini/pull/1334)
+
+Routine Dependabot updates: `openai` 7.3.0 → 7.4.0, `actions/attest-build-provenance` 4.1.1 → 4.2.2, the dev-dependencies group (`@google/genai`, `@typescript-eslint/parser`, `knip`, `lint-staged`, `typescript-eslint`), `hono` 4.12.32 → 4.13.1, and `js-yaml` 4.2.0 → 4.3.1 (includes a security backport removing quadratic complexity from `!!omap` duplicate-key detection).


### PR DESCRIPTION
## Summary

Scheduled daily-update run for 2026-08-09 (America/Los_Angeles). Runs the configured `dailyUpdate.subSkills` roster (`daily-changelog`, `audit-product-docs`, `triage-issues`) and bundles their output into one PR.

Fixes N/A — routine automated daily housekeeping run.

## Changes

- **daily-changelog**: added [`planning/changelog/2026-08-09.md`](https://github.com/allenhutchison/obsidian-gemini/blob/daily-update-2026-08-10/planning/changelog/2026-08-09.md) — 7 PRs merged on 2026-08-09 (local time): one `audit-architecture`-flagged dead-code removal (#1331), the prior day's daily-update housekeeping PR (#1335), and five routine Dependabot bumps (#1328, #1329, #1330, #1333, #1334).
- **audit-product-docs**: full validation pass over `docs/guide/`, `docs/reference/`, `README.md`, and `AGENTS.md` against `src/` — settings/defaults, command IDs, schedule grammar, MCP timeouts, hook/task safety constants, tool names, model catalogs, and i18n language count all checked against source. No drift found; no new docs warranted (the only PR since the last audit, #1331, was a dead-code removal with no doc-facing surface).
- **triage-issues**: 0 unlabeled open issues (24 open issues, all labeled) — no-op.

This is a housekeeping-only PR — no `src/` behavior changes.

**Recurring finding, still unfixed (flagged again, not fixed here — out of scope for a docs audit):** `src/main.ts:80`'s `DEFAULT_SETTINGS.openaiModelName` is still hardcoded to `'gpt-5.6'`, which does not exist in `src/services/openai-models-service.ts`'s model catalog (only `gpt-5.6-sol`/`gpt-5.6-terra`/`gpt-5.6-luna` exist since #1288 renamed the chat entry). The docs (`settings.md`) correctly document `gpt-5.6-sol` as the default, so this is a real code bug — a fresh OpenAI-provider install would persist an invalid model id. First flagged in yesterday's daily-update PR (#1335); still present today. Worth a follow-up issue/PR.

**Config note:** `config.paths.prTemplate` (`.github/PULL_REQUEST_TEMPLATE.md`) does not exist in the repo, so this PR uses the fallback Summary/Changes/Checklist structure instead.

## Screenshots / Screencast

N/A — changelog-only change, no UI change.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A; routine automated daily housekeeping run
- [x] All CI checks pass locally: `npm run format-check` clean, `npm run lint` 0 errors (40 pre-existing warnings, untouched), `npm run build` clean, `npm run typecheck:test` clean, `npm test` 3792 passed / 171 files
- [ ] I have tested this change on Desktop — N/A, changelog-only change; verified via local pre-flight checks
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A, no code change
- [x] Documentation has been updated (if applicable) — N/A beyond this PR's own content; no drift found, no new docs warranted
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01JE8AfMNcH2QempwtiYm849)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added the August 9, 2026 daily changelog.
  * Recorded recent maintenance updates, an identified model configuration issue, and several dependency updates.
  * Documented removal of an unused error-handling component and automated housekeeping activities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->