### PR TITLE
refactor(utils): share one escapeHtml instead of three copies

### DIFF
--- a/src/api/providers/gemini/grounding-render.ts
+++ b/src/api/providers/gemini/grounding-render.ts
@@ -31,20 +31,12 @@
  * guarantee; it must not be weakened without updating every caller.
  */
 
+import { escapeHtml } from '../../../utils/html-entities';
+
 /** A normalized grounding source: an external URL and an optional display title. */
 export interface RenderableGroundingSource {
 	url: string;
 	title?: string;
-}
-
-/** Escape a string for safe interpolation into HTML text/attribute context. */
-export function escapeHtml(value: string): string {
-	return value
-		.replace(/&/g, '&amp;')
-		.replace(/</g, '&lt;')
-		.replace(/>/g, '&gt;')
-		.replace(/"/g, '&quot;')
-		.replace(/'/g, '&#39;');
 }
 
 /** Return `value` only if it's an http(s) URL, else '#' — blocks javascript:/data: hrefs. */

--- a/src/mcp/mcp-oauth-callback.ts
+++ b/src/mcp/mcp-oauth-callback.ts
@@ -1,15 +1,6 @@
 import { createServer, IncomingMessage, ServerResponse } from 'http';
 import { OAUTH_CALLBACK_PORT } from './mcp-oauth-provider';
-
-/** Escape untrusted values for safe HTML embedding. */
-function escapeHtml(value: string): string {
-	return value
-		.replace(/&/g, '&amp;')
-		.replace(/</g, '&lt;')
-		.replace(/>/g, '&gt;')
-		.replace(/"/g, '&quot;')
-		.replace(/'/g, '&#39;');
-}
+import { escapeHtml } from '../utils/html-entities';
 
 /** Default timeout for the callback server (2 minutes) */
 const CALLBACK_TIMEOUT_MS = 120_000;

--- a/src/utils/html-entities.ts
+++ b/src/utils/html-entities.ts
@@ -1,10 +1,30 @@
 /**
- * Utility for decoding HTML entities in Gemini API responses.
+ * HTML entity encoding and decoding.
  *
- * Gemini models (especially Flash Lite) sometimes return HTML entities
- * despite system prompt instructions not to. Entities can be double or
- * triple-encoded (e.g., &amp;amp;quot; → &amp;quot; → &quot; → ").
+ * Decoding: Gemini models (especially Flash Lite) sometimes return HTML
+ * entities despite system prompt instructions not to. Entities can be double
+ * or triple-encoded (e.g., &amp;amp;quot; → &amp;quot; → &quot; → ").
+ *
+ * Encoding: {@link escapeHtml} is the shared escaper for the places that build
+ * HTML strings by hand — grounding-citation rendering and the MCP OAuth
+ * callback page. It lives here, in a leaf module both can import, rather than
+ * being re-implemented at each call site.
  */
+
+/**
+ * Escape a string for safe interpolation into HTML text/attribute context.
+ *
+ * Escapes the five significant characters (`& < > " '`). `&` is replaced first
+ * so the entities introduced by the later replacements are not re-escaped.
+ */
+export function escapeHtml(value: string): string {
+	return value
+		.replace(/&/g, '&amp;')
+		.replace(/</g, '&lt;')
+		.replace(/>/g, '&gt;')
+		.replace(/"/g, '&quot;')
+		.replace(/'/g, '&#39;');
+}
 
 /** Named HTML entities we decode. */
 const NAMED_ENTITIES: Record<string, string> = {

--- a/test/api/providers/gemini/grounding-render.test.ts
+++ b/test/api/providers/gemini/grounding-render.test.ts
@@ -1,10 +1,10 @@
 import { describe, test, expect } from 'vitest';
 import {
 	renderGroundingSources,
-	escapeHtml,
 	safeExternalUrl,
 	type RenderableGroundingSource,
 } from '../../../../src/api/providers/gemini/grounding-render';
+import { escapeHtml } from '../../../../src/utils/html-entities';
 
 describe('grounding-render: shared search-grounding renderer', () => {
 	test('no sources -> empty string', () => {

--- a/test/mcp/mcp-oauth-callback.test.ts
+++ b/test/mcp/mcp-oauth-callback.test.ts
@@ -161,6 +161,27 @@ describe('startOAuthCallbackServer', () => {
 		expect(mockRes.writeHead).toHaveBeenCalledWith(400, { 'Content-Type': 'text/html' });
 	});
 
+	it('should escape HTML in error_description before writing it into the error page', async () => {
+		const { startOAuthCallbackServer } = await import('../../src/mcp/mcp-oauth-callback');
+		const handle = await startOAuthCallbackServer();
+
+		const handler = (mockServer as any)._handler;
+		const mockReq = {
+			url: '/callback?error=access_denied&error_description=%3Cscript%3Ealert%281%29%3C%2Fscript%3E',
+		};
+		const mockRes = {
+			writeHead: vi.fn(),
+			end: vi.fn(),
+		};
+
+		handler(mockReq, mockRes);
+
+		await expect(handle.waitForCode).rejects.toThrow('OAuth authorization failed');
+		const body = mockRes.end.mock.calls[0][0] as string;
+		expect(body).toContain('&lt;script&gt;alert(1)&lt;/script&gt;');
+		expect(body).not.toContain('<script>alert(1)</script>');
+	});
+
 	it('should return 404 for non-callback paths', async () => {
 		const { startOAuthCallbackServer } = await import('../../src/mcp/mcp-oauth-callback');
 		await startOAuthCallbackServer();

--- a/test/mcp/mcp-oauth-callback.test.ts
+++ b/test/mcp/mcp-oauth-callback.test.ts
@@ -33,19 +33,10 @@ vi.mock('../../src/mcp/mcp-oauth-provider', () => ({
 // Import after mocks
 import { createServer } from 'http';
 
-// --- escapeHtml is a private function; we test it indirectly through
-//     the server's error response HTML. For direct testing we re-implement
-//     the same logic and verify parity. ---
-
-// Standalone copy of escapeHtml for direct testing (private in source)
-function escapeHtml(value: string): string {
-	return value
-		.replace(/&/g, '&amp;')
-		.replace(/</g, '&lt;')
-		.replace(/>/g, '&gt;')
-		.replace(/"/g, '&quot;')
-		.replace(/'/g, '&#39;');
-}
+// The callback page escapes untrusted query values with the shared
+// `escapeHtml` from src/utils/html-entities; exercise that same function here
+// rather than a local copy, so the two cannot drift apart.
+import { escapeHtml } from '../../src/utils/html-entities';
 
 describe('escapeHtml (pure function)', () => {
 	it('should escape ampersands', () => {


### PR DESCRIPTION
## Summary

`audit-architecture` nightly sweep flagged: **dry-violation** across `src/api/providers/gemini/grounding-render.ts`, `src/mcp/mcp-oauth-callback.ts`, and `test/mcp/mcp-oauth-callback.test.ts`.

The same five-character HTML escaper (`& < > " '`) existed verbatim in three places. The third copy is the telling one — the test file's own comment reads *"escapeHtml is a private function ... For direct testing we re-implement the same logic and verify parity"* — i.e. the duplication was already known and worked around rather than removed.

The fix moves the function into `src/utils/html-entities.ts`, a leaf module both call sites can import without either reaching into the other's package (importing the Gemini provider's copy from `src/mcp/` would have cut against the provider-encapsulation rule). It also sits next to the existing `decodeHtmlEntities`, which is the same concern in the other direction. The moved body is byte-identical to both source copies, so there is no behaviour change.

Not fixed here: `AgentViewProgress.escapeHtml` is a genuinely different implementation (DOM `textContent` round-trip, and it does not escape `'`), so it is deliberately left alone rather than folded in — swapping it would be a behaviour change, not a de-duplication.

## Changes

- `src/utils/html-entities.ts` — add the exported `escapeHtml`; widen the module doc to cover encoding as well as decoding.
- `src/api/providers/gemini/grounding-render.ts` — drop the local definition, import the shared one. The module's HTML-safety contract comment is unchanged and still accurate.
- `src/mcp/mcp-oauth-callback.ts` — drop the private copy, import the shared one.
- `test/api/providers/gemini/grounding-render.test.ts` — import `escapeHtml` from its new home; existing assertions unchanged.
- `test/mcp/mcp-oauth-callback.test.ts` — delete the standalone re-implementation and its parity comment; the seven existing cases now run against the real function.

## Screenshots / Screencast

N/A — no UI change.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: filed by the `audit-architecture` sweep, which routes mechanical fixes straight to a PR.
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — plus `npm run lint` (0 errors), `npm run typecheck:test`, and `npm run knip`, all clean. 171 test files / 3792 tests pass.
- [ ] I have tested this change on Desktop — N/A: pure code motion with a byte-identical body, covered by unit tests on both call sites.
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — the shared helper is pure string manipulation with no platform API; `mcp-oauth-callback.ts` keeps its existing desktop-only guards.
- [ ] Documentation has been updated (if applicable) — N/A: internal refactor with no user-facing behaviour change.
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (`audit-architecture` skill)
- [x] I have reviewed and understand all AI-generated code in this PR

---

_Filed by the `audit-architecture` skill._

---
_Generated by [Claude Code](https://claude.ai/code/session_01ADrhfpCKQj3NzAehnL8t6W)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTML escaping for rendered content and authentication callback pages.
  * Prevented unsafe characters from being interpreted as HTML.

* **Refactor**
  * Consolidated HTML escaping into a shared utility for consistent behavior.

* **Tests**
  * Expanded coverage for escaping HTML in authentication error messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->