### PR TITLE
refactor(prompts): share one frontmatter reader for bundled markdown

### DIFF
--- a/src/prompts/bundled-prompts.ts
+++ b/src/prompts/bundled-prompts.ts
@@ -5,6 +5,8 @@ import summarizeSelectionMd from '../../prompts/bundled-prompts/summarize-select
 import fixGrammarMd from '../../prompts/bundled-prompts/fix-grammar.md';
 import convertToBulletsMd from '../../prompts/bundled-prompts/convert-to-bullets.md';
 
+import { parseFrontmatterList, parseFrontmatterProperty, stripFrontmatter } from '../utils/bundled-frontmatter';
+
 interface BundledPrompt {
 	name: string;
 	description: string;
@@ -12,64 +14,14 @@ interface BundledPrompt {
 	tags: string[];
 }
 
-/**
- * Strip YAML frontmatter from a markdown string, returning only the body.
- */
-function stripFrontmatter(md: string): string {
-	const match = md.match(/^---\r?\n[\s\S]*?\r?\n---\r?\n?/);
-	if (match) {
-		return md.slice(match[0].length).trim();
-	}
-	return md.trim();
-}
-
-/**
- * Parse frontmatter property from YAML.
- * Simple parser — looks for key: ... line.
- */
-function parseProperty(md: string, key: string): string {
-	const match = md.match(/^---\r?\n([\s\S]*?)\r?\n---/);
-	if (!match) return '';
-	const frontmatter = match[1];
-	const propMatch = frontmatter.match(new RegExp(`^${key}:\\s*(.+)$`, 'm'));
-	if (!propMatch) return '';
-
-	const value = propMatch[1].trim();
-	// Remove quotes if present
-	if (value.startsWith('"') && value.endsWith('"')) {
-		return value.slice(1, -1);
-	}
-	if (value.startsWith("'") && value.endsWith("'")) {
-		return value.slice(1, -1);
-	}
-	return value;
-}
-
-/**
- * Parse tags from frontmatter.
- * Expects format: tags: ["tag1", "tag2"]
- */
-function parseTags(md: string): string[] {
-	const match = md.match(/^---\r?\n([\s\S]*?)\r?\n---/);
-	if (!match) return [];
-	const frontmatter = match[1];
-	const tagsMatch = frontmatter.match(/^tags:\s*\[(.*)\]/m);
-	if (!tagsMatch) return [];
-
-	return tagsMatch[1]
-		.split(',')
-		.map((t) => t.trim().replace(/['"]/g, ''))
-		.filter((t) => t.length > 0);
-}
-
 const prompts: Map<string, BundledPrompt> = new Map();
 
 function registerPrompt(id: string, content: string) {
 	prompts.set(id, {
-		name: parseProperty(content, 'name') || id,
-		description: parseProperty(content, 'description'),
+		name: parseFrontmatterProperty(content, 'name') || id,
+		description: parseFrontmatterProperty(content, 'description'),
 		content: stripFrontmatter(content),
-		tags: parseTags(content),
+		tags: parseFrontmatterList(content, 'tags'),
 	});
 }
 

--- a/src/services/bundled-skills.ts
+++ b/src/services/bundled-skills.ts
@@ -15,6 +15,8 @@ import recallSessionsSkillMd from '../../prompts/bundled-skills/recall-sessions/
 // Auto-generated help references from docs/ — see scripts/generate-help-references.mjs
 import { helpResources, helpReferencesTable } from './generated-help-references';
 
+import { parseFrontmatterProperty, stripFrontmatter } from '../utils/bundled-frontmatter';
+
 interface BundledSkill {
 	name: string;
 	description: string;
@@ -22,27 +24,9 @@ interface BundledSkill {
 	resources: Map<string, string>;
 }
 
-/**
- * Strip YAML frontmatter from a markdown string, returning only the body.
- */
-function stripFrontmatter(md: string): string {
-	const match = md.match(/^---\r?\n[\s\S]*?\r?\n---\r?\n?/);
-	if (match) {
-		return md.slice(match[0].length).trim();
-	}
-	return md.trim();
-}
-
-/**
- * Parse the description from YAML frontmatter.
- * Simple parser — looks for `description: ...` line.
- */
+/** Read a bundled skill's `description:` frontmatter line. */
 function parseDescription(md: string): string {
-	const match = md.match(/^---\r?\n([\s\S]*?)\r?\n---/);
-	if (!match) return '';
-	const frontmatter = match[1];
-	const descMatch = frontmatter.match(/^description:\s*(.+)$/m);
-	return descMatch ? descMatch[1].trim() : '';
+	return parseFrontmatterProperty(md, 'description');
 }
 
 const skills: Map<string, BundledSkill> = new Map();

--- a/src/utils/bundled-frontmatter.ts
+++ b/src/utils/bundled-frontmatter.ts
@@ -24,6 +24,15 @@ const FRONTMATTER_BLOCK = /^---\r?\n([\s\S]*?)\r?\n---/;
 /** Match the whole leading frontmatter block including its trailing newline. */
 const FRONTMATTER_WITH_TERMINATOR = /^---\r?\n[\s\S]*?\r?\n---\r?\n?/;
 
+/**
+ * Escape regex metacharacters so a key is matched literally. Callers pass
+ * literals today, but an unescaped `.` in e.g. `model.name` would also match
+ * `modelXname`, and an unescaped `|` would match a different property entirely.
+ */
+function escapeRegExp(value: string): string {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 /** Strip YAML frontmatter from a markdown string, returning only the body. */
 export function stripFrontmatter(md: string): string {
 	const match = md.match(FRONTMATTER_WITH_TERMINATOR);
@@ -43,7 +52,7 @@ export function stripFrontmatter(md: string): string {
 export function parseFrontmatterProperty(md: string, key: string): string {
 	const match = md.match(FRONTMATTER_BLOCK);
 	if (!match) return '';
-	const propMatch = match[1].match(new RegExp(`^${key}:\\s*(.+)$`, 'm'));
+	const propMatch = match[1].match(new RegExp(`^${escapeRegExp(key)}:\\s*(.+)$`, 'm'));
 	if (!propMatch) return '';
 
 	const value = propMatch[1].trim();
@@ -66,7 +75,7 @@ export function parseFrontmatterProperty(md: string, key: string): string {
 export function parseFrontmatterList(md: string, key: string): string[] {
 	const match = md.match(FRONTMATTER_BLOCK);
 	if (!match) return [];
-	const listMatch = match[1].match(new RegExp(`^${key}:\\s*\\[(.*)\\]`, 'm'));
+	const listMatch = match[1].match(new RegExp(`^${escapeRegExp(key)}:\\s*\\[(.*)\\]`, 'm'));
 	if (!listMatch) return [];
 
 	return listMatch[1]

--- a/src/utils/bundled-frontmatter.ts
+++ b/src/utils/bundled-frontmatter.ts
@@ -1,0 +1,76 @@
+/**
+ * Minimal YAML-frontmatter reader for markdown that is **bundled into the
+ * plugin at build time** — the `prompts/bundled-prompts/*.md` and
+ * `prompts/bundled-skills/<name>/SKILL.md` files that esbuild inlines as
+ * strings (see `src/declarations.d.ts`).
+ *
+ * This is deliberately separate from the two other frontmatter paths:
+ *
+ * - Vault files go through Obsidian's `app.metadataCache` /
+ *   `fileManager.processFrontMatter()`, per the Obsidian-API-first rule. These
+ *   strings never become `TFile`s, so there is no cache entry to read.
+ * - `extractMarkdownBody()` in `src/services/feature-definition.ts` strips
+ *   frontmatter from *vault* definition files (hooks, scheduled tasks) using a
+ *   different offset-based scanner; it is not interchangeable with this one.
+ *
+ * A leaf module (imports nothing) so both `src/prompts/bundled-prompts.ts` and
+ * `src/services/bundled-skills.ts` can depend on it without either importing
+ * the other.
+ */
+
+/** Match a leading `---` … `---` block; group 1 is the frontmatter body. */
+const FRONTMATTER_BLOCK = /^---\r?\n([\s\S]*?)\r?\n---/;
+
+/** Match the whole leading frontmatter block including its trailing newline. */
+const FRONTMATTER_WITH_TERMINATOR = /^---\r?\n[\s\S]*?\r?\n---\r?\n?/;
+
+/** Strip YAML frontmatter from a markdown string, returning only the body. */
+export function stripFrontmatter(md: string): string {
+	const match = md.match(FRONTMATTER_WITH_TERMINATOR);
+	if (match) {
+		return md.slice(match[0].length).trim();
+	}
+	return md.trim();
+}
+
+/**
+ * Read a scalar `key: value` line out of the frontmatter block.
+ *
+ * Returns `''` when there is no frontmatter or the key is absent. Surrounding
+ * single or double quotes are removed, so `name: 'Fix Grammar'` and
+ * `name: Fix Grammar` both yield `Fix Grammar`.
+ */
+export function parseFrontmatterProperty(md: string, key: string): string {
+	const match = md.match(FRONTMATTER_BLOCK);
+	if (!match) return '';
+	const propMatch = match[1].match(new RegExp(`^${key}:\\s*(.+)$`, 'm'));
+	if (!propMatch) return '';
+
+	const value = propMatch[1].trim();
+	if (value.startsWith('"') && value.endsWith('"')) {
+		return value.slice(1, -1);
+	}
+	if (value.startsWith("'") && value.endsWith("'")) {
+		return value.slice(1, -1);
+	}
+	return value;
+}
+
+/**
+ * Read an inline-array `key: ["a", "b"]` line out of the frontmatter block.
+ *
+ * Returns `[]` when there is no frontmatter, the key is absent, or the value
+ * is not in inline-array form. Block-sequence (`- item`) syntax is not
+ * supported — the bundled files all use the inline form.
+ */
+export function parseFrontmatterList(md: string, key: string): string[] {
+	const match = md.match(FRONTMATTER_BLOCK);
+	if (!match) return [];
+	const listMatch = match[1].match(new RegExp(`^${key}:\\s*\\[(.*)\\]`, 'm'));
+	if (!listMatch) return [];
+
+	return listMatch[1]
+		.split(',')
+		.map((item) => item.trim().replace(/['"]/g, ''))
+		.filter((item) => item.length > 0);
+}


### PR DESCRIPTION
## Summary

`audit-architecture` nightly sweep flagged: **dry-violation** between `src/prompts/bundled-prompts.ts` and `src/services/bundled-skills.ts`.

Both files read YAML frontmatter out of markdown that esbuild inlines at build time (`prompts/bundled-prompts/*.md`, `prompts/bundled-skills/<name>/SKILL.md`). Each grew its own reader: `stripFrontmatter` is byte-identical in the two files, and `parseDescription` in the skills copy is `parseProperty` from the prompts copy with the key hardcoded. Between them the same two frontmatter regexes were written out five times.

This is a third frontmatter path, distinct from the two that already exist, and the new module says so in its header so the next reader doesn't merge them by mistake: vault files go through Obsidian's `metadataCache` / `processFrontMatter()` per the Obsidian-API-first rule, and `extractMarkdownBody()` in `feature-definition.ts` handles vault-resident hook/task definitions with a different offset-based scanner. Bundled markdown never becomes a `TFile`, so neither of those applies.

**One behaviour change, called out deliberately:** the skills path now goes through `parseFrontmatterProperty`, which strips surrounding single/double quotes where the old `parseDescription` did not. No bundled `SKILL.md` quotes its `description:` (checked all ten), so the values produced today are unchanged — the effect is that the skills path now matches the long-standing prompts-path behaviour rather than diverging from it.

## Changes

- `src/utils/bundled-frontmatter.ts` (new) — leaf module exporting `stripFrontmatter`, `parseFrontmatterProperty`, and `parseFrontmatterList`, with the two frontmatter regexes defined once as named constants.
- `src/prompts/bundled-prompts.ts` — drop the local `stripFrontmatter` / `parseProperty` / `parseTags`; `parseTags` becomes `parseFrontmatterList(content, 'tags')`.
- `src/services/bundled-skills.ts` — drop the local `stripFrontmatter`; `parseDescription` becomes a one-line wrapper over the shared property reader, keeping the call sites unchanged.

## Screenshots / Screencast

N/A — no UI change.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: filed by the `audit-architecture` sweep, which routes mechanical fixes straight to a PR.
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — plus `npm run lint` (0 errors), `npm run typecheck:test`, `npm run knip`, and `npm run lint:cycles` (still zero cycles; the new module is a leaf). 171 test files / 3792 tests pass, including `test/prompts/bundled-prompts.test.ts` (which has a `stripFrontmatter (via registered prompts)` block) and `test/services/bundled-skills.test.ts`.
- [ ] I have tested this change on Desktop — N/A: pure extraction, covered by the existing registry tests on both call sites.
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — the new module is pure string manipulation with no platform API and no Node imports.
- [ ] Documentation has been updated (if applicable) — N/A: internal refactor; the bundled prompt/skill authoring format is unchanged.
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (`audit-architecture` skill)
- [x] I have reviewed and understand all AI-generated code in this PR

---

_Filed by the `audit-architecture` skill._

---
_Generated by [Claude Code](https://claude.ai/code/session_01ADrhfpCKQj3NzAehnL8t6W)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved handling of metadata in bundled prompts and skills.
  * Standardized extraction of descriptions, properties, tags, and lists from markdown frontmatter.
  * Improved support for quoted values, inline lists, and missing metadata while preserving readable content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->