### PR TITLE
refactor(scheduler): share listener/defer teardown between init and destroy

### DIFF
--- a/src/services/scheduled-task-manager.ts
+++ b/src/services/scheduled-task-manager.ts
@@ -146,22 +146,12 @@ export class ScheduledTaskManager extends FileBackedFeatureManager<ScheduledTask
 		if (this.initialized && !options?.refresh) return;
 		// Cancel any 500 ms defers still waiting from a previous initialization so
 		// stale callbacks cannot fire against the freshly-loaded state.
-		for (const id of this.pendingDefers) {
-			window.clearTimeout(id);
-		}
-		this.pendingDefers.clear();
+		this.cancelPendingDefers();
 		this.recentlyCreated.clear();
 
 		// Unregister previous listeners before re-registering so settings
 		// changes (e.g. historyFolder rename) don't leave stale handlers active.
-		if (this.metadataCacheHandler) {
-			this.plugin.app.metadataCache.off('changed', this.metadataCacheHandler);
-			this.metadataCacheHandler = null;
-		}
-		if (this.vaultCreateHandler) {
-			this.plugin.app.vault.off('create', this.vaultCreateHandler);
-			this.vaultCreateHandler = null;
-		}
+		this.detachVaultListeners();
 
 		await ensureFolderExists(this.plugin.app.vault, this.scheduledTasksFolder, 'scheduled tasks', this.plugin.logger);
 		await ensureFolderExists(this.plugin.app.vault, this.runsFolder, 'scheduled task runs', this.plugin.logger);
@@ -470,21 +460,11 @@ export class ScheduledTaskManager extends FileBackedFeatureManager<ScheduledTask
 			window.clearInterval(this.tickIntervalId);
 			this.tickIntervalId = null;
 		}
-		if (this.metadataCacheHandler) {
-			this.plugin.app.metadataCache.off('changed', this.metadataCacheHandler);
-			this.metadataCacheHandler = null;
-		}
-		if (this.vaultCreateHandler) {
-			this.plugin.app.vault.off('create', this.vaultCreateHandler);
-			this.vaultCreateHandler = null;
-		}
+		this.detachVaultListeners();
 		// Cancel any 500 ms defers still in flight — their callbacks check
 		// this.initialized before touching state, but clearing here is the
 		// belt-and-suspenders guarantee that no timer fires after teardown.
-		for (const id of this.pendingDefers) {
-			window.clearTimeout(id);
-		}
-		this.pendingDefers.clear();
+		this.cancelPendingDefers();
 		this.tasks.clear();
 		this.state = {};
 		this.recentlyCreated.clear();
@@ -493,6 +473,30 @@ export class ScheduledTaskManager extends FileBackedFeatureManager<ScheduledTask
 	}
 
 	// ── Private ──────────────────────────────────────────────────────────────
+
+	/**
+	 * Detach the metadata-cache and vault-create listeners and drop the stored
+	 * references. Both `initialize()` (re-init) and `destroy()` (teardown) need
+	 * this; the two must stay in step, so they share one implementation.
+	 */
+	private detachVaultListeners(): void {
+		if (this.metadataCacheHandler) {
+			this.plugin.app.metadataCache.off('changed', this.metadataCacheHandler);
+			this.metadataCacheHandler = null;
+		}
+		if (this.vaultCreateHandler) {
+			this.plugin.app.vault.off('create', this.vaultCreateHandler);
+			this.vaultCreateHandler = null;
+		}
+	}
+
+	/** Cancel every in-flight `vaultCreateHandler` defer and forget its timer id. */
+	private cancelPendingDefers(): void {
+		for (const id of this.pendingDefers) {
+			window.clearTimeout(id);
+		}
+		this.pendingDefers.clear();
+	}
 
 	protected parseDefinitionFile(file: TFile): Promise<ScheduledTask | null> {
 		return this.parseTaskFile(file);


### PR DESCRIPTION
## Summary

`audit-architecture` nightly sweep flagged: **dry-violation** in `src/services/scheduled-task-manager.ts`.

`initialize()` and `destroy()` each detach the `metadataCache.on('changed')` and `vault.on('create')` listeners and cancel the in-flight 500 ms `vaultCreateHandler` defers — the same eight lines, written out twice about 320 lines apart.

This is the kind of pair that has to stay in step to stay correct: a listener registered by `initialize()` and dropped from only one of the two teardown paths leaks on re-init (which `initialize({ refresh: true })` does on a `historyFolder` rename) or survives teardown. Two copies is exactly the shape where that drift happens without a reviewer noticing.

Extracted into `detachVaultListeners()` and `cancelPendingDefers()`. The two call sites keep their existing comments — those explain *why* each path needs the cleanup, which differs between them ("don't leave stale handlers active after a settings change" vs "belt-and-suspenders after teardown"); the helper doc comments cover *what* the cleanup is. Same operations in the same order at both sites, so no behaviour change.

Related but not fixed here: `HookManager` is the sibling subclass of `FileBackedFeatureManager` and does not have this pair, so there is no cross-file extraction to make — this stays a single-file change.

## Changes

- `src/services/scheduled-task-manager.ts` — add private `detachVaultListeners()` and `cancelPendingDefers()`; call them from `initialize()` and `destroy()` in place of the inline copies.

## Screenshots / Screencast

N/A — no UI change.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: filed by the `audit-architecture` sweep, which routes mechanical fixes straight to a PR.
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — plus `npm run lint` (0 errors), `npm run typecheck:test`, and `npm run knip`, all clean. 171 test files / 3792 tests pass, including the existing `test/services/scheduled-task-manager*` coverage.
- [ ] I have tested this change on Desktop — N/A: pure extraction with identical call ordering, covered by the existing scheduler tests.
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — no new API surface; the `window.clearTimeout` and `vault.off` calls are the same ones the file already made.
- [ ] Documentation has been updated (if applicable) — N/A: internal refactor with no user-facing behaviour change.
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (`audit-architecture` skill)
- [x] I have reviewed and understand all AI-generated code in this PR

---

_Filed by the `audit-architecture` skill._

---
_Generated by [Claude Code](https://claude.ai/code/session_01ADrhfpCKQj3NzAehnL8t6W)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scheduled task cleanup when shutting down or reinitializing.
  * Prevented lingering event listeners and pending file-creation operations.
  * Ensured scheduled task state is fully reset after teardown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->