### PR TITLE
chore(claude): point the maintainerd marketplace at Vycari/maintainerd

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,7 +3,7 @@
 		"maintainerd": {
 			"source": {
 				"source": "github",
-				"repo": "allenhutchison/maintainerd"
+				"repo": "Vycari/maintainerd"
 			}
 		}
 	},


### PR DESCRIPTION
The maintainerd plugin marketplace moved from `allenhutchison/maintainerd` to `Vycari/maintainerd`. This repo's `extraKnownMarketplaces` still named the old slug.

**Nothing was broken** — GitHub redirects the old location, so plugin installs kept resolving. That's exactly why it would otherwise have sat stale indefinitely: nothing ever fails to prompt the fix.

One line in `.claude/settings.json`. Config-only, no code path touched, JSON validity verified.

Companion to Vycari/maintainerd#22, which updated the marketplace's own metadata.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the marketplace repository source for Maintainerd.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->