### PR TITLE
fix(scheduler): escape apostrophes when writing task frontmatter

### DIFF
--- a/src/services/scheduled-task-manager.ts
+++ b/src/services/scheduled-task-manager.ts
@@ -43,6 +43,22 @@ const STATE_FILE = 'scheduled-tasks-state.json';
 /** Milliseconds between scheduler ticks (60 s). Same cadence as ChatTimer. */
 const TICK_INTERVAL_MS = 60_000;
 
+/**
+ * Render a string as a single-quoted YAML scalar.
+ *
+ * A single-quoted scalar escapes an embedded `'` by doubling it. Interpolating
+ * the raw value instead terminates the scalar early, which makes the whole
+ * frontmatter block unparseable — and because `parseTaskFile` reads the block
+ * through `metadataCache`, an unparseable block makes the task silently vanish
+ * from the scheduler rather than fail loudly. A user-entered `outputPath` with
+ * an apostrophe ("Allen's Notes/{date}.md") is the realistic way to hit it;
+ * `schedule` is grammar-constrained by `computeNextRunAt` and goes through the
+ * same helper only so the writer has one rule instead of a per-field audit.
+ */
+function yamlSingleQuoted(value: string): string {
+	return `'${value.replace(/'/g, "''")}'`;
+}
+
 // ─── Manager ─────────────────────────────────────────────────────────────────
 
 /**
@@ -575,7 +591,7 @@ export class ScheduledTaskManager extends FileBackedFeatureManager<ScheduledTask
 		prompt: string;
 	}): string {
 		const lines: string[] = ['---'];
-		lines.push(`schedule: '${params.schedule}'`);
+		lines.push(`schedule: ${yamlSingleQuoted(params.schedule)}`);
 
 		const policyLines = formatToolPolicyYaml(params.toolPolicy);
 		if (policyLines) {
@@ -584,11 +600,11 @@ export class ScheduledTaskManager extends FileBackedFeatureManager<ScheduledTask
 
 		const defaultOutputPath = params.slug && normalizePath(`${this.runsFolder}/${params.slug}/{date}.md`);
 		if (params.outputPath && params.outputPath !== defaultOutputPath) {
-			lines.push(`outputPath: '${params.outputPath}'`);
+			lines.push(`outputPath: ${yamlSingleQuoted(params.outputPath)}`);
 		}
 
 		if (params.model) {
-			lines.push(`model: '${params.model}'`);
+			lines.push(`model: ${yamlSingleQuoted(params.model)}`);
 		}
 		if (params.maxIterations !== undefined) {
 			lines.push(`maxIterations: ${params.maxIterations}`);

--- a/test/services/scheduled-task-manager.test.ts
+++ b/test/services/scheduled-task-manager.test.ts
@@ -1674,6 +1674,43 @@ describe('ScheduledTaskManager', () => {
 			const written = (plugin.app.vault.create as Mock).mock.calls[0][1] as string;
 			expect(written).toContain("outputPath: 'Custom/Output/{date}.md'");
 		});
+
+		it('escapes an apostrophe in outputPath so the frontmatter block stays parseable', async () => {
+			const plugin = createMockPlugin();
+			plugin.app.vault.create = vi.fn().mockResolvedValue(undefined);
+			const manager = new ScheduledTaskManager(plugin);
+			await manager.initialize();
+
+			await manager.createTask({
+				slug: 'apostrophe-out',
+				schedule: 'daily',
+				outputPath: "Allen's Notes/{date}.md",
+				prompt: 'Apostrophe in the path.',
+			});
+
+			const written = (plugin.app.vault.create as Mock).mock.calls[0][1] as string;
+			// A single-quoted YAML scalar escapes `'` by doubling it; interpolating
+			// the raw value would terminate the scalar early and break the block.
+			expect(written).toContain("outputPath: 'Allen''s Notes/{date}.md'");
+			expect(written).not.toContain("outputPath: 'Allen's Notes/{date}.md'");
+		});
+
+		it('escapes an apostrophe in model', async () => {
+			const plugin = createMockPlugin();
+			plugin.app.vault.create = vi.fn().mockResolvedValue(undefined);
+			const manager = new ScheduledTaskManager(plugin);
+			await manager.initialize();
+
+			await manager.createTask({
+				slug: 'apostrophe-model',
+				schedule: 'daily',
+				model: "allen's-model",
+				prompt: 'Apostrophe in the model name.',
+			});
+
+			const written = (plugin.app.vault.create as Mock).mock.calls[0][1] as string;
+			expect(written).toContain("model: 'allen''s-model'");
+		});
 	});
 
 	// ── parseTaskFile — model and legacy migration ───────────────────────


### PR DESCRIPTION
## Summary

`audit-architecture` nightly sweep flagged: **repo-invariant drift / correctness** in `src/services/scheduled-task-manager.ts`.

`ScheduledTaskManager.serializeTask` built three single-quoted YAML scalars by raw interpolation — `schedule: '${...}'`, `outputPath: '${...}'`, `model: '${...}'`. A single-quoted YAML scalar escapes an embedded `'` by doubling it, so any value containing an apostrophe terminates the scalar early and leaves the whole frontmatter block unparseable.

That failure is silent rather than loud: `parseTaskFile` reads the block through `metadataCache` and returns `null` when `frontmatter.schedule` is missing, so a corrupted task just disappears from the scheduler list. `outputPath` is a free-text field in the scheduler modal (`scheduler-management-modal.ts:327`), and a vault folder with an apostrophe — `Allen's Notes/{date}.md` — is the realistic way to reach it.

The sibling writer `HookManager.serializeHook` already avoided this by running its free-text values through `JSON.stringify`; the scheduled-task writer was the one that didn't. This routes the three scalars through a `yamlSingleQuoted` helper that doubles embedded quotes, which fixes the bug while keeping the single-quoted on-disk format that `docs/guide/scheduled-tasks.md` shows.

Not fixed here, deliberately: `serializeHook` still emits `frontmatterFilter` keys unquoted (`  ${key}: ...`). That field has no UI or tool that sets it — only hand-written hook files — so it is a much narrower path and belongs in its own change rather than widening this one.

## Changes

- `src/services/scheduled-task-manager.ts` — add a module-private `yamlSingleQuoted()` helper and use it for the `schedule`, `outputPath`, and `model` scalars in `serializeTask`.
- `test/services/scheduled-task-manager.test.ts` — two regression tests: an `outputPath` containing an apostrophe is written as a doubled-quote escape (and not as the broken raw form), and the same for `model`.

## Screenshots / Screencast

N/A — no UI change; this only affects the bytes written to the task definition file.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: filed directly by the `audit-architecture` sweep, which opens a PR rather than an issue for mechanical, well-scoped fixes.
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — plus `npm run lint` (0 errors) and `npm run typecheck:test`, run locally before pushing.
- [ ] I have tested this change on Desktop — N/A: not manually exercised in a live vault; covered by the two new unit tests against the serializer.
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — pure string formatting, no platform APIs touched.
- [ ] Documentation has been updated (if applicable) — N/A: the on-disk format is unchanged for every value that was already being written correctly, so the `docs/guide/scheduled-tasks.md` examples stay accurate.
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (`audit-architecture` skill)
- [x] I have reviewed and understand all AI-generated code in this PR

---

_Filed by the `audit-architecture` skill._

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXX9UfcEVFBDLX1ZqfcY2d)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed scheduled task configurations containing apostrophes in schedule, output path, or model values.
  * These values are now escaped correctly, preserving valid configuration formatting and preventing task creation or loading errors.

* **Tests**
  * Added coverage for apostrophes in scheduled task settings to help prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->