### PR TITLE
chore(daily): 2026-08-13 daily update

### DIFF
--- a/planning/changelog/2026-08-12.md
+++ b/planning/changelog/2026-08-12.md
@@ -1,0 +1,18 @@
+# Daily changelog — August 12, 2026
+
+**Date:** 2026-08-12
+**PRs merged:** 1
+
+---
+
+## Summary
+
+Quiet day — one cleanup PR landed, removing a dead UI code path that had no live entry point.
+
+## What shipped
+
+### [#1346 refactor(agent-view): remove the unreachable FilePickerModal chain and 5 dead UICallbacks fields](https://github.com/allenhutchison/obsidian-gemini/pull/1346)
+
+Deleted the unreachable `FilePickerModal` (170 lines) and its sole entry point, `AgentView.showFilePicker()`, after confirming via `git log -S` that the callback was never wired to a caller. The bulk-selection modal it powered had already been superseded by per-file affordances: shelf chips with a remove action, and `@`-mention / drag-and-drop for adding files. Also trimmed the 5 dead fields from the `UICallbacks` interface, a callerless one-line delegate in `AgentViewAttachments`, and the associated i18n keys across 21 locale files.
+
+Produced by the auto-dev pipeline from a plan approved on #1301.


### PR DESCRIPTION
## Summary

Automated daily housekeeping run (`daily-update` meta-skill) for 2026-08-13. Only the changelog sub-skill produced a working-tree change; the docs audit and issue triage both came back clean.

## Changes

- **daily-changelog**: added `planning/changelog/2026-08-12.md`, covering the one PR merged that day — [#1346](https://github.com/allenhutchison/obsidian-gemini/pull/1346) (removal of the unreachable `FilePickerModal` chain and 5 dead `UICallbacks` fields).
- **audit-product-docs**: no drift found against `src/`; no new docs warranted. (A stale `DEFAULT_SETTINGS.openaiModelName: 'gpt-5.6'` value was found in `src/main.ts` during the audit — the docs are correct, the code default is wrong, but it's out of scope for a docs-only sub-skill and self-heals via `reconcileOpenAI()`. Flagging here for a follow-up, not fixed in this PR.)
- **triage-issues**: no unlabeled open issues — nothing to label.

## Screenshots / Screencast

N/A — no UI or behavior change, docs/changelog only.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A, this is the recurring automated daily-update job, not an issue-driven change.
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — all run locally pre-push: format-check, lint (0 errors), build, typecheck:test, and the full test suite (3793 tests, 171 files) all green.
- [ ] I have tested this change on Desktop — N/A, no runtime behavior changed (new markdown file only).
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — docs-only change, no platform-specific code touched.
- [x] Documentation has been updated (if applicable) — this PR *is* the documentation update (daily changelog entry).
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (scheduled daily-update agent)
- [x] I have reviewed and understand all AI-generated code in this PR


---
_Generated by [Claude Code](https://claude.ai/code/session_01E3rQJDf5ApKp1ZqSD5uDBR)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed obsolete file-picker functionality and unused interface elements.
  * Cleaned up inactive attachment handling and related localization entries.
  * Added the August 12, 2026 daily changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->