### PR TITLE
fix(gemini): abort the transport when a streaming response is cancelled

### DIFF
--- a/src/api/providers/gemini/client.ts
+++ b/src/api/providers/gemini/client.ts
@@ -346,6 +346,13 @@ export class GeminiClient implements ModelApi {
 		}
 
 		let cancelled = false;
+		// The `cancelled` flag alone only stops the loop on the *next* chunk, so a
+		// stalled or slow stream keeps the request alive after Stop. Thread an
+		// abort signal into the request from the start — the SDK rejects the
+		// in-flight fetch when it fires, which the cancelled-in-catch arm below
+		// turns into the accumulated partial response. Same shape the sibling
+		// `streamViaInteractions` and the Ollama/OpenAI clients already use.
+		const controller = new AbortController();
 		let accumulatedText = '';
 		let accumulatedRendered = '';
 		let accumulatedThoughts = '';
@@ -354,6 +361,7 @@ export class GeminiClient implements ModelApi {
 
 		const complete = (async (): Promise<ModelResponse> => {
 			const params = await this.buildGenerateContentParams(request);
+			params.config = { ...params.config, abortSignal: controller.signal };
 
 			// Assemble the response from the current accumulator state. Called from
 			// both the success return and the cancelled-in-catch return, which must
@@ -454,6 +462,14 @@ export class GeminiClient implements ModelApi {
 			complete,
 			cancel: () => {
 				cancelled = true;
+				try {
+					// Safe to call at any point: the controller exists before the request
+					// is built, so an abort that lands during setup pre-aborts the signal
+					// the SDK is about to read.
+					controller.abort();
+				} catch (err) {
+					this.plugin?.logger.debug('[GeminiClient] Abort failed:', err);
+				}
 			},
 		};
 	}

--- a/test/api/providers/gemini/client.test.ts
+++ b/test/api/providers/gemini/client.test.ts
@@ -9,15 +9,18 @@ import { ModelUseCase } from '../../../../src/api/model-use-case';
 // Capture every call to `client.models.generateContent` so tests can assert on
 // the params (system instruction, contents, etc.) the SDK sees. vi.hoisted lets
 // us share the spy with the factory while keeping vitest's mock-hoisting safe.
-const { generateContentMock, interactionsCreateMock, interactionsService } = vi.hoisted(() => {
-	return {
-		generateContentMock: vi.fn(),
-		interactionsCreateMock: vi.fn(),
-		interactionsService: {
-			create: vi.fn(),
-		},
-	};
-});
+const { generateContentMock, generateContentStreamMock, interactionsCreateMock, interactionsService } = vi.hoisted(
+	() => {
+		return {
+			generateContentMock: vi.fn(),
+			generateContentStreamMock: vi.fn(),
+			interactionsCreateMock: vi.fn(),
+			interactionsService: {
+				create: vi.fn(),
+			},
+		};
+	}
+);
 // Keep the create spy name the existing tests use.
 interactionsService.create = interactionsCreateMock;
 
@@ -27,7 +30,7 @@ vi.mock('@google/genai', () => ({
 			getModel: vi.fn(),
 			models: {
 				generateContent: generateContentMock,
-				generateContentStream: vi.fn(),
+				generateContentStream: generateContentStreamMock,
 			},
 			interactions: interactionsService,
 		};
@@ -1590,6 +1593,83 @@ describe('GeminiClient', () => {
 			expect(interactionsCreateMock.mock.calls[0][0].stream).toBe(true);
 			expect(chunks).toEqual([{ text: 'streamed' }]);
 			expect(response.markdown).toBe('streamed');
+		});
+	});
+
+	describe('generateStreamingResponse() cancellation (generateContent transport)', () => {
+		beforeEach(() => {
+			generateContentStreamMock.mockReset();
+			// Stub the plugin surface buildExtendedSystemInstruction depends on.
+			mockPlugin.agentsMemory = { read: vi.fn().mockResolvedValue('') };
+			mockPlugin.skillManager = { getSkillSummaries: vi.fn().mockResolvedValue([]) };
+			mockPlugin.settings = { userName: 'Tester', ragIndexing: { enabled: false } };
+		});
+
+		// A real abort() rejects the SDK's underlying fetch, which propagates out
+		// of the `for await` loop as a rejection. Mimic that here (rather than
+		// hanging on a promise the flag alone can't reach) so the test only passes
+		// when cancel() actually reaches the transport.
+		function pendingUntilAborted(signal?: AbortSignal): Promise<never> {
+			return new Promise((_, reject) => {
+				if (signal?.aborted) {
+					reject(new Error('Aborted'));
+					return;
+				}
+				signal?.addEventListener('abort', () => reject(new Error('Aborted')));
+			});
+		}
+
+		function textChunk(text: string) {
+			return { candidates: [{ content: { parts: [{ text }] } }] };
+		}
+
+		it('cancel() aborts the request signal and returns the accumulated partial response', async () => {
+			let capturedSignal: AbortSignal | undefined;
+			generateContentStreamMock.mockImplementation(async (params: any) => {
+				capturedSignal = params?.config?.abortSignal;
+				return (async function* () {
+					yield textChunk('partial');
+					await pendingUntilAborted(capturedSignal);
+				})();
+			});
+
+			const stream = client.generateStreamingResponse(
+				{ prompt: '', userMessage: 'hi', kind: 'extended', conversationHistory: [] },
+				() => {}
+			);
+			// Let the first chunk be consumed before cancelling.
+			await new Promise((r) => window.setTimeout(r, 0));
+			stream.cancel();
+			const result = await stream.complete;
+
+			expect(capturedSignal?.aborted).toBe(true);
+			expect(result.markdown).toBe('partial');
+			// A cancelled stream resolves with what it has; it must not reject.
+			expect(mockLogger.error).not.toHaveBeenCalled();
+		});
+
+		it('cancel() during request setup pre-aborts the signal the SDK reads', async () => {
+			let capturedSignal: AbortSignal | undefined;
+			generateContentStreamMock.mockImplementation(async (params: any) => {
+				capturedSignal = params?.config?.abortSignal;
+				return (async function* () {
+					// The await always rejects once cancel() fires, so this yield is
+					// never reached — it is here because a generator must have one.
+					await pendingUntilAborted(capturedSignal);
+					yield textChunk('never reached');
+				})();
+			});
+
+			const stream = client.generateStreamingResponse(
+				{ prompt: '', userMessage: 'hi', kind: 'extended', conversationHistory: [] },
+				() => {}
+			);
+			// Cancel synchronously, before buildGenerateContentParams has resolved.
+			stream.cancel();
+			const result = await stream.complete;
+
+			expect(capturedSignal?.aborted).toBe(true);
+			expect(result.markdown).toBe('');
 		});
 	});
 });


### PR DESCRIPTION
## Summary

audit-architecture nightly sweep flagged: **repo-invariant drift / cross-provider inconsistency** in `src/api/providers/gemini/client.ts`.

`GeminiClient.generateStreamingResponse` (the `generateContent` transport) was the only one of the four streaming paths in the codebase whose `cancel()` did not reach the transport. It set a `cancelled` flag and relied on the `for await` loop breaking on the *next* received chunk, so pressing Stop in the agent view left the HTTP request open and the server generating until a chunk arrived — indefinitely on a stalled stream.

Its three siblings all abort:

| Path | How `cancel()` stops the transport |
| --- | --- |
| `GeminiClient.streamViaInteractions` (same file, ~L200) | `activeStream?.controller?.abort()` |
| `OllamaClient.generateStreamingResponse` | `activeStream?.abort()` |
| `OpenAIClient.generateStreamingResponse` | `controller.abort()` on a signal threaded into the request |
| `GeminiClient.generateStreamingResponse` | **flag only — nothing** |

The comment already sitting on `streamViaInteractions` spells out the exact reasoning this path was missing: "aborting it actively interrupts an in-flight SSE read so `cancel()` doesn't have to wait for the next frame (or the server) to unblock the `for await`."

The fix threads an `AbortController` into `params.config.abortSignal` (supported by `@google/genai`) and aborts it in `cancel()`, matching the shape `OpenAIClient` already uses. The controller is created before the request is built, so a cancel landing during setup pre-aborts the signal the SDK is about to read. The abort rejects the in-flight fetch, which the existing cancelled-in-catch arm already converts into the accumulated partial response — so the resolved `ModelResponse` shape is unchanged and callers see no difference beyond the request actually stopping.

Fixes: n/a — filed directly by the audit sweep, no tracking issue.

## Changes

- `src/api/providers/gemini/client.ts` — create an `AbortController` in `generateStreamingResponse`, set `params.config.abortSignal` from it, and abort it in the returned `cancel()` (wrapped in the same best-effort `try`/`catch` + debug log the Ollama and OpenAI clients use).
- `test/api/providers/gemini/client.test.ts` — hoist `generateContentStreamMock` so the streaming transport is reachable from tests (it was an inline `vi.fn()` no test could reach), and add two cases: cancel mid-stream aborts the signal and resolves with the accumulated partial text without logging an error; cancel during request setup pre-aborts the signal the SDK reads.

Both new tests fail against `master` and pass with the fix.

## Screenshots / Screencast

N/A — no UI change. The change is internal to the API transport layer; the Stop button's appearance and behavior contract are unchanged, only the request now actually terminates.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: opened directly by the `audit-architecture` sweep, which files one unit of work per finding rather than pre-filing an issue for mechanical fixes.
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — plus `npm run lint` (0 errors, 40 pre-existing warnings) and `npm run typecheck:test`. Full suite: 171 files, 3797 tests passing.
- [ ] I have tested this change on Desktop — not verified in a live vault; covered by unit tests that assert the signal reaches the SDK and that a cancelled stream still resolves with its partial response. A maintainer pressing Stop mid-response on a Gemini model is the worthwhile manual check.
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — `AbortController` is a standard web API available on all Obsidian platforms; no Node.js or Electron surface is touched.
- [ ] Documentation has been updated (if applicable) — N/A: no user-facing behavior, setting, or surface changes. Stop already claimed to stop the response; this makes it true at the transport level.
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (`audit-architecture` skill)
- [x] I have reviewed and understand all AI-generated code in this PR

---

_Filed by the `audit-architecture` skill._

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mbctbn6yomScVEt53pnvPt)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cancellation of Gemini streaming responses.
  * Preserves partial output when a request is cancelled.
  * Prevents cancellation errors from surfacing during setup or streaming interruption.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->