### PR TITLE
chore(daily): 2026-08-14 daily update

### DIFF
--- a/planning/changelog/2026-08-13.md
+++ b/planning/changelog/2026-08-13.md
@@ -1,0 +1,22 @@
+# Daily changelog — August 13, 2026
+
+**Date:** 2026-08-13
+**PRs merged:** 2
+
+---
+
+## Summary
+
+Quiet day — a single correctness fix from the nightly architecture sweep, plus the prior day's automated housekeeping PR landing.
+
+## What shipped
+
+### [#1347 fix(scheduler): escape apostrophes when writing task frontmatter](https://github.com/allenhutchison/obsidian-gemini/pull/1347)
+
+Fixed a silent data-loss bug in `ScheduledTaskManager.serializeTask`: the `schedule`, `outputPath`, and `model` scalars were written as raw single-quoted YAML, so any value containing an apostrophe (e.g. an output path under `Allen's Notes/{date}.md`) terminated the scalar early and left the frontmatter block unparseable. Since `parseTaskFile` silently returns `null` on a missing `schedule` field, a corrupted task would simply vanish from the scheduler list with no error. The fix adds a `yamlSingleQuoted()` helper that doubles embedded quotes, matching the escaping `HookManager.serializeHook` already used for its own free-text fields.
+
+Flagged and filed by the `audit-architecture` nightly sweep.
+
+### [#1348 chore(daily): 2026-08-13 daily update](https://github.com/allenhutchison/obsidian-gemini/pull/1348)
+
+The previous day's automated daily-update run: added the `2026-08-12` changelog entry. The docs audit and issue triage sub-skills both came back clean that day. The PR body also flagged a stale `DEFAULT_SETTINGS.openaiModelName` default in `src/main.ts` for follow-up (self-heals via `reconcileOpenAI()`, so left unfixed as out of scope for a docs-only pass).


### PR DESCRIPTION
## Summary

Automated daily housekeeping run (`daily-update` meta-skill) for 2026-08-14. Only the changelog sub-skill produced a working-tree change; the docs audit and issue triage both came back clean.

## Changes

- **daily-changelog**: added `planning/changelog/2026-08-13.md`, covering the 2 PRs merged that day:
  - [#1347](https://github.com/allenhutchison/obsidian-gemini/pull/1347) — fixed a silent data-loss bug in `ScheduledTaskManager.serializeTask` where an apostrophe in a task's `outputPath`/`model`/`schedule` value broke the single-quoted YAML frontmatter, silently dropping the task from the scheduler list.
  - [#1348](https://github.com/allenhutchison/obsidian-gemini/pull/1348) — the prior day's automated daily-update run.
- **audit-product-docs**: no drift found across `README.md`, `AGENTS.md`, `docs/guide/`, `docs/reference/` (settings defaults, command IDs, tool names, schedule grammar, hook constants, MCP timeouts, i18n locale list, and more were all cross-checked against `src/`); no new docs warranted. Confirmed a pre-existing **code** bug — `DEFAULT_SETTINGS.openaiModelName` in `src/main.ts:80` is `'gpt-5.6'`, but the valid model id (and the one the docs already correctly reference) is `'gpt-5.6-sol'` — left untouched since fixing code is out of scope for a docs-only sub-skill and it self-heals via `reconcileOpenAI()`. Flagging here for a maintainer follow-up.
- **triage-issues**: no unlabeled open issues — nothing to label.

## Screenshots / Screencast

N/A — no UI or behavior change, changelog only.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A, this is the recurring automated daily-update job, not an issue-driven change.
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — all run locally pre-push: format-check, lint (0 errors), build, typecheck:test, and the full test suite (3795 tests, 171 files) all green.
- [ ] I have tested this change on Desktop — N/A, no runtime behavior changed (new markdown file only).
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — docs-only change, no platform-specific code touched.
- [x] Documentation has been updated (if applicable) — this PR *is* the documentation update (daily changelog entry).
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (scheduled daily-update agent)
- [x] I have reviewed and understand all AI-generated code in this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01Er5roN74X6x2nBsimTTWv4)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Scheduler tasks containing apostrophes in YAML frontmatter are now handled correctly, preventing valid tasks from disappearing.

- **Documentation**
  - Added the August 13, 2026 daily changelog.
  - Documented recent automated maintenance updates, including completed audits and a deferred model-default follow-up.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->