### PR TITLE
refactor(agent-view): share one diff-view open call between both entry points

### DIFF
--- a/src/ui/agent-view/agent-view-messages.ts
+++ b/src/ui/agent-view/agent-view-messages.ts
@@ -862,18 +862,7 @@ export class AgentViewMessages {
 				});
 
 				viewChangesBtn.addEventListener('click', () => {
-					void this.openDiffView(
-						diffContext,
-						handleResponse,
-						(view) => {
-							diffViewOpen = true;
-							activeDiffView = view;
-						},
-						() => {
-							diffViewOpen = false;
-							activeDiffView = null;
-						}
-					);
+					openDiffForReview(diffContext);
 				});
 			}
 
@@ -913,6 +902,24 @@ export class AgentViewMessages {
 				this.debouncedScrollToBottom();
 			};
 
+			// Both entry points into the diff view — the "View Changes" button above and
+			// the alwaysShowDiffView auto-open below — need the same arguments and the same
+			// open/close bookkeeping, so they share one call site.
+			const openDiffForReview = (ctx: DiffContext) => {
+				void this.openDiffView(
+					ctx,
+					handleResponse,
+					(view) => {
+						diffViewOpen = true;
+						activeDiffView = view;
+					},
+					() => {
+						diffViewOpen = false;
+						activeDiffView = null;
+					}
+				);
+			};
+
 			// Create named handlers so we can remove them later
 			const allowHandler = () => {
 				// If a diff view is open, get its current (possibly edited) content
@@ -947,18 +954,7 @@ export class AgentViewMessages {
 				this.autoOpenDiffTimeout = window.setTimeout(() => {
 					this.autoOpenDiffTimeout = null;
 					// Fire-and-forget: auto-opening the diff view is a UI side effect.
-					void this.openDiffView(
-						diffContext,
-						handleResponse,
-						(view) => {
-							diffViewOpen = true;
-							activeDiffView = view;
-						},
-						() => {
-							diffViewOpen = false;
-							activeDiffView = null;
-						}
-					);
+					openDiffForReview(diffContext);
 				}, 100);
 			}
 


### PR DESCRIPTION
## Summary

`audit-architecture` nightly sweep flagged: **dry-violation** in `src/ui/agent-view/agent-view-messages.ts`.

`displayConfirmationRequest` opens the diff view from two places — the "View Changes" button and the `alwaysShowDiffView` auto-open — and each site spelled out the same `this.openDiffView(...)` call with the same four arguments, including two identical inline closures that set and clear `diffViewOpen` / `activeDiffView`. The copies sat about 90 lines apart in the same method, which is far enough that a change to the open/close bookkeeping could easily land in one and not the other. This collapses them into a single local `openDiffForReview(ctx)` that both sites call.

Pure extraction: same arguments, same call order, no behaviour change. The helper takes the `DiffContext` as a parameter rather than closing over the optional `diffContext`, so each call site keeps its own `if (diffContext)` narrowing and the type stays non-optional inside the helper.

This is a fifth instance of the same shape tracked in #1293 (near-verbatim duplicate blocks inside a single file); it is not one of the four enumerated there, and #1293 remains the tracker for those.

## Changes

- `src/ui/agent-view/agent-view-messages.ts`: extract the duplicated `openDiffView` invocation into a local `openDiffForReview(ctx: DiffContext)` and call it from both the "View Changes" click handler and the `alwaysShowDiffView` timeout.

## Screenshots / Screencast

N/A — no rendered output changes. The diff view opens with the same arguments from the same two triggers.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: filed by the `audit-architecture` sweep, which routes mechanical single-file fixes straight to a PR rather than an issue. Related tracker: #1293.
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — run locally: `format-check` clean, `lint` 0 errors (40 pre-existing warnings, none in this file), `build` clean, `typecheck:test` clean, `npm test` 3797 passed / 171 files.
- [ ] I have tested this change on Desktop — N/A: not exercised in a live vault. The change is a mechanical extraction with no behaviour change, covered by the existing suite; a reviewer wanting live confirmation should trigger a `write_file` confirmation and check both the "View Changes" button and `alwaysShowDiffView`.
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — no platform-specific API touched; the extracted code is unchanged.
- [ ] Documentation has been updated (if applicable) — N/A: internal refactor, no user-facing behaviour or settings change.
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (`audit-architecture` skill)
- [x] I have reviewed and understand all AI-generated code in this PR

---

_Filed by the `audit-architecture` skill._

---
_Generated by [Claude Code](https://claude.ai/code/session_01SkU9vUqkWLXE6gUGDKSQGm)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency when opening confirmation change previews.
  * Manual and automatic “View Changes” actions now use the same behavior, including reliable open/close state tracking and response handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->