### PR TITLE
chore(daily): 2026-08-16 daily update

### DIFF
--- a/planning/changelog/2026-08-15.md
+++ b/planning/changelog/2026-08-15.md
@@ -1,0 +1,24 @@
+# Daily changelog — August 15, 2026
+
+**Date:** 2026-08-15
+**PRs merged:** 3
+
+---
+
+## Summary
+
+A fix-heavy day: the standout change closes a real bug where cancelling a Gemini streaming response left the HTTP request running in the background. The other two PRs are the prior two days' automated daily-update runs landing back-to-back.
+
+## What shipped
+
+### [#1349 fix(gemini): abort the transport when a streaming response is cancelled](https://github.com/allenhutchison/obsidian-gemini/pull/1349)
+
+The `audit-architecture` nightly sweep found that `GeminiClient.generateStreamingResponse` was the only one of the four streaming transports in the codebase whose `cancel()` didn't actually abort the underlying request — it just set a flag and waited for the next chunk to arrive, so pressing Stop on a stalled Gemini stream could leave the request open indefinitely. The fix threads an `AbortController` into the request config and aborts it from `cancel()`, matching the pattern already used by the Ollama, OpenAI, and Gemini-interactions transports. Resolved `ModelResponse` shape is unchanged; only the request now actually stops.
+
+### [#1351 chore(daily): 2026-08-14 daily update](https://github.com/allenhutchison/obsidian-gemini/pull/1351)
+
+The automated daily-update run for 2026-08-14. Added `planning/changelog/2026-08-13.md` covering that day's two merged PRs. The docs audit and issue triage sub-skills both came back clean.
+
+### [#1353 chore(daily): 2026-08-15 daily update](https://github.com/allenhutchison/obsidian-gemini/pull/1353)
+
+The automated daily-update run for 2026-08-15. Added `planning/changelog/2026-08-14.md` (an empty day, no PRs merged). The docs audit reviewed a candidate fix for the OpenAI default chat model name but rejected it — `DEFAULT_SETTINGS.openaiModelName` in `src/main.ts` still doesn't match the curated model catalog, but the settings-reconciliation logic self-heals it at runtime, so the docs correctly keep documenting the healed value. Issue triage found all 27 open issues already labeled.


### PR DESCRIPTION
## Summary

Automated daily housekeeping run (`daily-update` meta-skill) for 2026-08-16.

## Changes

- **daily-changelog**: added `planning/changelog/2026-08-15.md`, covering the 3 PRs merged 2026-08-15:
  - [#1349](https://github.com/allenhutchison/obsidian-gemini/pull/1349) — fixed a real bug where `GeminiClient.generateStreamingResponse` didn't abort the underlying HTTP transport on cancel, unlike its three sibling streaming paths; fixed by threading an `AbortController` into the request and aborting it in `cancel()`.
  - [#1351](https://github.com/allenhutchison/obsidian-gemini/pull/1351) — the 2026-08-14 automated daily-update run.
  - [#1353](https://github.com/allenhutchison/obsidian-gemini/pull/1353) — the 2026-08-15 automated daily-update run.
- **audit-product-docs**: full pass over `docs/guide/`, `docs/reference/`, `README.md`, and `AGENTS.md` against `src/` (settings defaults, command IDs, tool names, schedule grammar, and more all cross-checked). No drift found, no new docs warranted. The previously-flagged, deliberately-untouched `openaiModelName` code/doc discrepancy (self-healed at runtime by `reconcileOpenAI()`) remains unchanged and out of scope for a docs-only sub-skill.
- **triage-issues**: no unlabeled open issues — nothing to label.

## Screenshots / Screencast

N/A — no UI or behavior change, changelog-only diff.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A, this is the recurring automated daily-update job, not an issue-driven change.
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — plus `npm run lint` (0 errors, 40 pre-existing warnings) and `npm run typecheck:test`. Full suite: 171 files, 3797 tests passing, all run locally pre-push.
- [ ] I have tested this change on Desktop — N/A, no runtime behavior changed (new markdown file only).
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — docs/changelog-only change, no platform-specific code touched.
- [x] Documentation has been updated (if applicable) — this PR *is* the documentation update (daily changelog entry); the docs audit found nothing else to update.
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (scheduled daily-update agent)
- [x] I have reviewed and understand all AI-generated code in this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01ER2w6Rgr7Pcse2wFzVgyDq)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added the August 15, 2026 daily changelog.
  * Recorded a streaming cancellation fix and updates related to documentation review and issue triage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->