### PR TITLE
refactor(tools): share one recent-identical-call filter in the loop detector

### DIFF
--- a/src/tools/loop-detector.ts
+++ b/src/tools/loop-detector.ts
@@ -49,16 +49,7 @@ export class ToolLoopDetector {
 	 * Check if executing this tool call would create a loop
 	 */
 	isLoopDetected(sessionId: string, toolCall: ToolCall): boolean {
-		const key = this.getToolCallKey(toolCall);
-		const history = this.executionHistory.get(sessionId) || [];
-		const now = Date.now();
-
-		// Count recent identical calls
-		const recentIdenticalCalls = history.filter(
-			(record) => record.key === key && now - record.timestamp < this.timeWindowMs
-		);
-
-		return recentIdenticalCalls.length >= this.loopThreshold;
+		return this.getRecentIdenticalCalls(sessionId, toolCall).length >= this.loopThreshold;
 	}
 
 	/**
@@ -67,12 +58,8 @@ export class ToolLoopDetector {
 	getLoopInfo(sessionId: string, toolCall: ToolCall): LoopDetectionInfo {
 		const key = this.getToolCallKey(toolCall);
 		const history = this.executionHistory.get(sessionId) || [];
-		const now = Date.now();
 
-		const recentIdenticalCalls = history.filter(
-			(record) => record.key === key && now - record.timestamp < this.timeWindowMs
-		);
-
+		const recentIdenticalCalls = this.getRecentIdenticalCalls(sessionId, toolCall);
 		const consecutiveCalls = this.countConsecutiveCalls(history, key);
 
 		return {
@@ -89,6 +76,21 @@ export class ToolLoopDetector {
 	 */
 	clearSession(sessionId: string) {
 		this.executionHistory.delete(sessionId);
+	}
+
+	/**
+	 * Records for this session matching the tool call, within the time window.
+	 *
+	 * The `isLoop` decision and the `identicalCallCount` reported alongside it are
+	 * the same count, so both entry points read it from here rather than each
+	 * repeating the key/history/window filter.
+	 */
+	private getRecentIdenticalCalls(sessionId: string, toolCall: ToolCall): ToolExecutionRecord[] {
+		const key = this.getToolCallKey(toolCall);
+		const history = this.executionHistory.get(sessionId) || [];
+		const now = Date.now();
+
+		return history.filter((record) => record.key === key && now - record.timestamp < this.timeWindowMs);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

`audit-architecture` nightly sweep flagged: **dry-violation** in `src/tools/loop-detector.ts`.

`isLoopDetected` and `getLoopInfo` each rebuilt the same three-part expression — tool-call key, session history, `now - record.timestamp < this.timeWindowMs` filter — and then compared the result length against `this.loopThreshold`. The copies sit five lines apart in the same class, and they have to stay in agreement: `getLoopInfo` reports `identicalCallCount` next to the `isLoop` verdict that `isLoopDetected` computes independently, so a change to the window or key rule that lands in one copy only makes the two disagree about the same call.

This extracts a private `getRecentIdenticalCalls(sessionId, toolCall)` and has both read from it. Pure extraction: the same filter, the same `>= loopThreshold` comparison, no behaviour change. `getLoopInfo` still needs the raw `history` array for `countConsecutiveCalls`, so that lookup stays.

No linked issue — this was surfaced by the nightly architecture sweep rather than a filed report. It is not one of the four clones tracked in #1293 (this one is below the jscpd thresholds that scan used).

## Changes

- `src/tools/loop-detector.ts` — add private `getRecentIdenticalCalls()`; `isLoopDetected` and `getLoopInfo` both delegate to it instead of each rebuilding the key/history/window filter.

## Screenshots / Screencast

N/A — internal refactor, no UI surface.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: opened by the automated architecture audit, which files one unit of work per PR; close it if the extraction isn't wanted.
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — plus `npm run lint` (0 errors) and `npm run typecheck:test`, run locally before pushing. 171 test files / 3797 tests pass.
- [ ] I have tested this change on Desktop — N/A: pure extraction with no behaviour change; covered by `test/tools/loop-detector.test.ts`.
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — no platform-specific API touched.
- [ ] Documentation has been updated (if applicable) — N/A: internal refactor, no user-facing or documented behaviour changes.
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (`audit-architecture` skill)
- [x] I have reviewed and understand all AI-generated code in this PR

---

_Filed by the `audit-architecture` skill._

---
_Generated by [Claude Code](https://claude.ai/code/session_01PjomAqvwXkEHcxAsnwfK8M)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved consistency in loop detection by centralizing recent duplicate-call filtering.
  * Preserved existing detection behavior, including matching criteria, time windows, and timestamps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->