### PR TITLE
refactor(context): use DEFAULT_CHARS_PER_TOKEN for the phase-1 truncation delta

### DIFF
--- a/src/services/context-manager.ts
+++ b/src/services/context-manager.ts
@@ -486,8 +486,11 @@ export class ContextManager {
 		// Phase 1: try truncating old tool-result payloads. Cheap (no LLM
 		// call), deterministic, and often enough on its own when a single big
 		// `read_file` is responsible for most of the bloat. We reuse the
-		// existing 4-chars-per-token heuristic to estimate the post-truncation
-		// size without spending a `countTokens` roundtrip.
+		// generic DEFAULT_CHARS_PER_TOKEN heuristic to estimate the
+		// post-truncation size without spending a `countTokens` roundtrip
+		// (deliberately the generic constant, not the per-model calibrated
+		// ratio — the calibration is keyed to whole-history char length, and
+		// applying it to a delta would mix two different measurements).
 		//
 		// Phase 2: if truncation alone didn't get us back under threshold, fall
 		// through to summarization. Summarization runs against the truncated
@@ -499,7 +502,7 @@ export class ContextManager {
 			const truncationDelta = JSON.stringify(conversationHistory).length - JSON.stringify(truncatedHistory).length;
 			if (truncationDelta > 0) {
 				this.logger.log(`[ContextManager] Phase 1 (truncation): shed ~${truncationDelta} bytes from old tool results`);
-				postPhase1Tokens = Math.max(0, estimatedTokens - Math.ceil(truncationDelta / 4));
+				postPhase1Tokens = Math.max(0, estimatedTokens - Math.ceil(truncationDelta / DEFAULT_CHARS_PER_TOKEN));
 			}
 		}
 


### PR DESCRIPTION
## Summary

`audit-architecture` nightly sweep flagged: **magic number / DRY** in `src/services/context-manager.ts`.

`prepareHistory` converts the phase-1 truncation byte delta into a token delta with a bare `Math.ceil(truncationDelta / 4)`, while the comment two lines above calls it "the existing 4-chars-per-token heuristic". That number is already named in the same file — `DEFAULT_CHARS_PER_TOKEN` — and every other estimate site reads it from there. A literal copy of a value the file has a constant for is the shape that survives a later change to the constant and silently keeps the old number.

This references the constant instead, and extends the comment to record why this site deliberately uses the generic constant rather than the per-model calibrated ratio in `estimatedCharsPerToken`: the calibration is derived from whole-history char length against a real `promptTokenCount`, so applying it to a byte *delta* would mix two different measurements. That judgment call is left alone — this PR only removes the duplicate literal.

Same arithmetic, no behaviour change.

No linked issue — surfaced by the nightly architecture sweep.

## Changes

- `src/services/context-manager.ts` — phase-1 truncation delta divides by `DEFAULT_CHARS_PER_TOKEN` instead of a literal `4`; comment updated to name the constant and explain why the calibrated ratio isn't used here.

## Screenshots / Screencast

N/A — internal, no UI surface.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: opened by the automated architecture audit, which files one unit of work per PR; close it if the change isn't wanted.
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — plus `npm run lint` (0 errors) and `npm run typecheck:test`, run locally before pushing. 171 test files / 3797 tests pass.
- [ ] I have tested this change on Desktop — N/A: the expression evaluates identically (`4` and `DEFAULT_CHARS_PER_TOKEN` are the same value); `test/services/context-manager.test.ts` covers the compaction paths.
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — no platform-specific API touched.
- [ ] Documentation has been updated (if applicable) — N/A: internal constant reference, no user-facing or documented behaviour change.
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (`audit-architecture` skill)
- [x] I have reviewed and understand all AI-generated code in this PR

---

_Filed by the `audit-architecture` skill._

---
_Generated by [Claude Code](https://claude.ai/code/session_01PjomAqvwXkEHcxAsnwfK8M)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved token estimation during context compaction for more consistent truncation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->