### PR TITLE
chore(daily): 2026-08-16 daily update

### DIFF
--- a/planning/changelog/2026-08-16.md
+++ b/planning/changelog/2026-08-16.md
@@ -1,0 +1,24 @@
+# Daily changelog — August 16, 2026
+
+**Date:** 2026-08-16
+**PRs merged:** 3
+
+---
+
+## Summary
+
+Quiet day — one small architecture-sweep refactor, the previous day's automated housekeeping PR, and a dependency bump.
+
+## What shipped
+
+### [#1355 refactor(agent-view): share one diff-view open call between both entry points](https://github.com/allenhutchison/obsidian-gemini/pull/1355)
+
+The `audit-architecture` nightly sweep flagged a DRY violation in `agent-view-messages.ts`: `displayConfirmationRequest` opened the diff view from two call sites — the "View Changes" button and the `alwaysShowDiffView` auto-open — each spelling out the same `openDiffView(...)` call with identical open/close bookkeeping closures. This extracts a local `openDiffForReview(ctx)` helper both sites call. Pure extraction, no behavior change.
+
+### [#1357 chore(daily): 2026-08-16 daily update](https://github.com/allenhutchison/obsidian-gemini/pull/1357)
+
+The prior day's automated daily-update run: added the 2026-08-15 changelog entry, a docs audit that found no drift, and a triage pass with no unlabeled issues to act on.
+
+### [#1354 chore(deps-dev): bump the dev-dependencies group with 7 updates](https://github.com/allenhutchison/obsidian-gemini/pull/1354)
+
+Dependency bumps: #1354 — 7 dev-dependency updates via Dependabot.


### PR DESCRIPTION
## Summary

Automated daily housekeeping run (`daily-update` meta-skill) for 2026-08-16.

## Changes

- **daily-changelog**: added `planning/changelog/2026-08-16.md`, covering the 3 PRs merged 2026-08-16:
  - [#1355](https://github.com/allenhutchison/obsidian-gemini/pull/1355) — extracted a duplicated `openDiffView` call in `agent-view-messages.ts` into a shared `openDiffForReview(ctx)` helper (pure refactor, `audit-architecture` sweep finding).
  - [#1357](https://github.com/allenhutchison/obsidian-gemini/pull/1357) — the 2026-08-15 automated daily-update run.
  - [#1354](https://github.com/allenhutchison/obsidian-gemini/pull/1354) — Dependabot dev-dependency group bump (7 updates).
- **audit-product-docs**: full pass over `docs/guide/`, `docs/reference/`, `README.md`, and `AGENTS.md` against `src/` (settings defaults, command IDs, tool names, schedule grammar, timing constants, i18n language list, and more all cross-checked). No drift found, no new docs warranted. Re-confirmed the previously-flagged `openaiModelName` placeholder-vs-catalog discrepancy in `main.ts` is self-healed at runtime by `reconcileOpenAI()` — no doc or code change needed.
- **triage-issues**: no unlabeled open issues — nothing to label.

## Screenshots / Screencast

N/A — no UI or behavior change, changelog-only diff.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A, this is the recurring automated daily-update job, not an issue-driven change.
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — plus `npm run lint` (0 errors, 40 pre-existing warnings) and `npm run typecheck:test`. Full suite: 171 files, 3797 tests passing, all run locally pre-push.
- [ ] I have tested this change on Desktop — N/A, no runtime behavior changed (new markdown file only).
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — docs/changelog-only change, no platform-specific code touched.
- [x] Documentation has been updated (if applicable) — this PR *is* the documentation update (daily changelog entry); the docs audit found nothing else to update.
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (scheduled daily-update agent)
- [x] I have reviewed and understand all AI-generated code in this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_0181d1HxcmXwLSizCtz2hivK)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added the August 16, 2026 daily changelog.
  - Documented recent architecture improvements, automated documentation and triage updates, and development dependency maintenance.
  - No changes were made to publicly available features or interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->