### PR TITLE
refactor(utils): reuse moveCursorToEnd in insertTextAtCursor

### DIFF
--- a/src/utils/dom-context.ts
+++ b/src/utils/dom-context.ts
@@ -50,14 +50,8 @@ export function insertTextAtCursor(element: HTMLElement, text: string): void {
 		// No selection, append to end
 		element.appendChild(doc.createTextNode(text));
 
-		// Move cursor to end - only if we have a selection object
-		if (selection) {
-			const range = doc.createRange();
-			range.selectNodeContents(element);
-			range.collapse(false);
-			selection.removeAllRanges();
-			selection.addRange(range);
-		}
+		// Move cursor to end - moveCursorToEnd no-ops when there is no selection object
+		moveCursorToEnd(element);
 		return;
 	}
 
@@ -81,11 +75,7 @@ export function insertTextAtCursor(element: HTMLElement, text: string): void {
 		element.appendChild(doc.createTextNode(text));
 
 		// Move cursor to end
-		const range = doc.createRange();
-		range.selectNodeContents(element);
-		range.collapse(false);
-		selection.removeAllRanges();
-		selection.addRange(range);
+		moveCursorToEnd(element);
 	}
 }
 


### PR DESCRIPTION
## Summary

`audit-architecture` nightly sweep flagged: **dry-violation** in `src/utils/dom-context.ts`.

`insertTextAtCursor` inlined `moveCursorToEnd`'s exact body twice — once in the no-selection branch (lines 53–60) and once in the selection-outside-the-element branch (lines 83–88) — while the exported `moveCursorToEnd` helper sits ~30 lines below in the same module. Both copies are the same five calls: `doc.createRange()` → `selectNodeContents(element)` → `collapse(false)` → `removeAllRanges()` → `addRange(range)`. The fix replaces both with a call to the existing helper.

Behaviour is preserved. The no-selection branch's `if (selection)` guard is redundant with `moveCursorToEnd`'s own identical `if (selection)` guard, and the helper re-derives `doc`/`win` from the same element via `getDOMContext`, so both call sites resolve the same document context and the same live `Selection` object. No new module, no new export, no signature change.

Not filed as an issue because the correct change is mechanical, single-file, and value-preserving — this is the shape the routing rule sends to a PR.

## Changes

- `src/utils/dom-context.ts` — replace the two inlined collapse-to-end blocks in `insertTextAtCursor` with `moveCursorToEnd(element)` (net −10 lines).

## Screenshots / Screencast

N/A — no visual change. This is a pure internal extraction in a DOM utility; the cursor ends up in the same place it did before.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: opened by the `audit-architecture` sweep, which routes mechanical single-file fixes straight to a PR rather than filing an issue first.
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — verified locally: `format-check` clean, `lint` 0 errors (40 pre-existing warnings, all in `test/`), `build` clean, `typecheck:test` clean, `npm test` 3797 passed / 171 files.
- [ ] I have tested this change on Desktop — N/A: no runtime behaviour change; covered by `test/ui/skill-mention-modal.test.ts`, which exercises `insertTextAtCursor` directly.
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — no platform-specific API is added or removed; `getDOMContext` already handles the popout/main-window split.
- [ ] Documentation has been updated (if applicable) — N/A: internal refactor with no user-facing surface.
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (`audit-architecture` skill)
- [x] I have reviewed and understand all AI-generated code in this PR

---

_Filed by the `audit-architecture` skill._

---
_Generated by [Claude Code](https://claude.ai/code/session_01HhCwBAQ4v9D6nMYvr6EzBu)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text insertion behavior when no text is selected or the cursor is outside the target field.
  * Ensured the cursor is placed correctly after inserting text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->