### PR TITLE
refactor(rag): build the empty index cache in one place

### DIFF
--- a/src/services/rag-cache.ts
+++ b/src/services/rag-cache.ts
@@ -41,6 +41,20 @@ export class RagCache {
 	}
 
 	/**
+	 * Build a fresh, empty cache at the current version. `storeName` is carried over
+	 * on a version reset so an existing File Search store isn't orphaned; it defaults
+	 * to empty for the no-file and load-failure paths, which have nothing to carry.
+	 */
+	private static emptyCache(storeName = ''): RagIndexCache {
+		return {
+			version: CACHE_VERSION,
+			storeName,
+			lastSync: 0,
+			files: {},
+		};
+	}
+
+	/**
 	 * Load the index cache from disk
 	 */
 	async loadCache(): Promise<void> {
@@ -74,12 +88,7 @@ export class RagCache {
 							typeof version === 'number' ? version : 'unknown'
 						}, expected ${CACHE_VERSION}), resetting cache`
 					);
-					this._cache = {
-						version: CACHE_VERSION,
-						storeName: typeof parsed.storeName === 'string' ? parsed.storeName : '',
-						lastSync: 0,
-						files: {},
-					};
+					this._cache = RagCache.emptyCache(typeof parsed.storeName === 'string' ? parsed.storeName : '');
 				} else {
 					// Version matched the expected shape — treat as a validated RagIndexCache.
 					this._cache = parsed as unknown as RagIndexCache;
@@ -93,22 +102,12 @@ export class RagCache {
 				this.plugin.logger.log(`RAG Indexing: Loaded cache with ${this._indexedCount} files`);
 			} else {
 				// Initialize empty cache - no file exists
-				this._cache = {
-					version: CACHE_VERSION,
-					storeName: '',
-					lastSync: 0,
-					files: {},
-				};
+				this._cache = RagCache.emptyCache();
 				this._indexedCount = 0;
 			}
 		} catch (error) {
 			this.plugin.logger.error('RAG Indexing: Failed to load cache', error);
-			this._cache = {
-				version: CACHE_VERSION,
-				storeName: '',
-				lastSync: 0,
-				files: {},
-			};
+			this._cache = RagCache.emptyCache();
 			this._indexedCount = 0;
 		}
 	}


### PR DESCRIPTION
## Summary

`audit-architecture` nightly sweep flagged: **dry-violation** in `src/services/rag-cache.ts`.

`loadCache` constructed the same empty-`RagIndexCache` literal three times: the version-mismatch reset (lines 77–82), the no-cache-file branch (96–101), and the load-failure `catch` (106–111). Two of the three are byte-identical; the third differs only in carrying the parsed `storeName` forward rather than defaulting it to `''`. Adding a field to `RagIndexCache` today means remembering all three sites, and missing one produces a cache object that silently omits it on whichever recovery path was skipped.

The fix extracts a private `static emptyCache(storeName = '')` and calls it from all three sites. Values are preserved exactly — the version-reset path still carries `storeName` through, the other two still default to `''`, and `lastSync`/`files` are unchanged. `_indexedCount = 0` stays at the call sites because the version-reset path deliberately recounts from the loaded cache instead.

Not filed as an issue because the correct change is mechanical, single-file, and value-preserving.

## Changes

- `src/services/rag-cache.ts` — add a private `RagCache.emptyCache(storeName = '')` factory and use it at all three construction sites in `loadCache`.

## Screenshots / Screencast

N/A — no UI surface; this is an internal cache-construction refactor.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: opened by the `audit-architecture` sweep, which routes mechanical single-file fixes straight to a PR.
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — verified locally: `format-check` clean, `lint` 0 errors (40 pre-existing warnings, all in `test/`), `build` clean, `typecheck:test` clean, `npm test` 3797 passed / 171 files (including `test/services/rag-cache.test.ts`, which covers the version-mismatch, missing-file, and read-failure paths).
- [ ] I have tested this change on Desktop — N/A: no runtime behaviour change; the three affected paths are covered by the existing `rag-cache` unit tests.
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — no platform-specific API touched.
- [ ] Documentation has been updated (if applicable) — N/A: internal refactor with no user-facing surface.
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (`audit-architecture` skill)
- [x] I have reviewed and understand all AI-generated code in this PR

---

_Filed by the `audit-architecture` skill._

---
_Generated by [Claude Code](https://claude.ai/code/session_01HhCwBAQ4v9D6nMYvr6EzBu)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cache recovery when cached data is missing, outdated, or cannot be loaded.
  * Preserves the associated search store during cache resets to prevent unnecessary reconfiguration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->