### PR TITLE
refactor(agent): share the recent-session-file listing

### DIFF
--- a/src/agent/session-manager.ts
+++ b/src/agent/session-manager.ts
@@ -151,15 +151,23 @@ export class SessionManager {
 	}
 
 	/**
-	 * Get all recent agent sessions
+	 * The `limit` most recently modified session notes in the Agent-Sessions folder,
+	 * newest first. Empty when the folder doesn't exist yet.
 	 */
-	async getRecentAgentSessions(limit = 10): Promise<ChatSession[]> {
+	private listRecentSessionFiles(limit: number): TFile[] {
 		const agentSessionsFolder = this.getAgentSessionsFolder();
 		if (!agentSessionsFolder) return [];
-		const sessionFiles = agentSessionsFolder.children
+		return agentSessionsFolder.children
 			.filter((file): file is TFile => file instanceof TFile && file.extension === 'md')
 			.sort((a, b) => b.stat.mtime - a.stat.mtime)
 			.slice(0, limit);
+	}
+
+	/**
+	 * Get all recent agent sessions
+	 */
+	async getRecentAgentSessions(limit = 10): Promise<ChatSession[]> {
+		const sessionFiles = this.listRecentSessionFiles(limit);
 
 		const sessions: ChatSession[] = [];
 		for (const file of sessionFiles) {
@@ -179,12 +187,7 @@ export class SessionManager {
 	 * Reads raw frontmatter only — no wikilink resolution or TFile construction.
 	 */
 	async getSessionMetadata(limit = 10): Promise<SessionMetadata[]> {
-		const agentSessionsFolder = this.getAgentSessionsFolder();
-		if (!agentSessionsFolder) return [];
-		const sessionFiles = agentSessionsFolder.children
-			.filter((file): file is TFile => file instanceof TFile && file.extension === 'md')
-			.sort((a, b) => b.stat.mtime - a.stat.mtime)
-			.slice(0, limit);
+		const sessionFiles = this.listRecentSessionFiles(limit);
 
 		const results: SessionMetadata[] = [];
 		for (const file of sessionFiles) {


### PR DESCRIPTION
## Summary

`audit-architecture` nightly sweep flagged: **dry-violation** in `src/agent/session-manager.ts`.

`getRecentAgentSessions` (lines 156–162) and `getSessionMetadata` (181–187) open with the same four statements: resolve the Agent-Sessions folder, return `[]` when it's absent, filter the folder's children to markdown `TFile`s, sort by `stat.mtime` descending, and slice to `limit`. The two methods are the hydrated and the frontmatter-only reads of the *same* list, so any change to the ordering or the file filter has to be made twice or the two views of the session list silently disagree.

The fix extracts a private `listRecentSessionFiles(limit: number): TFile[]` and calls it from both. The `limit` parameter stays non-optional on the helper — both callers already default it to 10 at their own signatures, so the default is not duplicated either. No behaviour change; both methods still iterate the same files in the same order, and their differing per-file `try`/`catch` bodies (full hydration vs. raw frontmatter read) are untouched.

Not filed as an issue because the correct change is mechanical, single-file, and value-preserving.

## Changes

- `src/agent/session-manager.ts` — add a private `listRecentSessionFiles(limit)` helper and use it in `getRecentAgentSessions` and `getSessionMetadata`.

## Screenshots / Screencast

N/A — no UI surface; internal refactor in the session manager.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: opened by the `audit-architecture` sweep, which routes mechanical single-file fixes straight to a PR.
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — verified locally: `format-check` clean, `lint` 0 errors (40 pre-existing warnings, all in `test/`), `build` clean, `typecheck:test` clean, `npm test` 3797 passed / 171 files (including `test/agent/session-manager.test.ts` and `session-manager-integration.test.ts`, which cover both methods).
- [ ] I have tested this change on Desktop — N/A: no runtime behaviour change; both methods are covered by the existing session-manager unit and integration tests.
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — no platform-specific API touched; the helper uses the same Obsidian `TFolder.children` / `TFile` access as before.
- [ ] Documentation has been updated (if applicable) — N/A: internal refactor with no user-facing surface.
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (`audit-architecture` skill)
- [x] I have reviewed and understand all AI-generated code in this PR

---

_Filed by the `audit-architecture` skill._

---
_Generated by [Claude Code](https://claude.ai/code/session_01HhCwBAQ4v9D6nMYvr6EzBu)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved retrieval of recent agent sessions when the session folder is unavailable.
  * Standardized selection and ordering of recent session files for more consistent session history and metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->