### PR TITLE
chore(daily): 2026-08-18 daily update

### DIFF
--- a/planning/changelog/2026-08-18.md
+++ b/planning/changelog/2026-08-18.md
@@ -1,0 +1,32 @@
+# Daily changelog — August 18, 2026
+
+**Date:** 2026-08-18
+**PRs merged:** 5
+
+---
+
+## Summary
+
+Architecture-sweep day — three small refactors from the nightly `audit-architecture` scan landed alongside the previous two days' automated daily-update housekeeping PRs.
+
+## What shipped
+
+### [#1364 chore(daily): 2026-08-17 daily update](https://github.com/allenhutchison/obsidian-gemini/pull/1364)
+
+The 2026-08-17 automated daily-update run: a quiet day with zero PRs merged, so the changelog entry just records that, and the docs audit and issue triage sub-skills both came back clean.
+
+### [#1362 chore(daily): 2026-08-16 daily update](https://github.com/allenhutchison/obsidian-gemini/pull/1362)
+
+The 2026-08-16 automated daily-update run: the changelog entry for that day's 3 merged PRs, a clean docs audit, and a clean triage pass.
+
+### [#1361 refactor(context): use DEFAULT_CHARS_PER_TOKEN for the phase-1 truncation delta](https://github.com/allenhutchison/obsidian-gemini/pull/1361)
+
+`audit-architecture` flagged a magic-number/DRY issue in `context-manager.ts`: the phase-1 truncation byte-to-token conversion used a bare literal `4` instead of the already-named `DEFAULT_CHARS_PER_TOKEN` constant used everywhere else in the file. Same arithmetic, no behavior change, plus an expanded comment explaining why this site uses the generic constant rather than the per-model calibrated ratio.
+
+### [#1360 refactor(agent-view): derive the session prompt badge name once](https://github.com/allenhutchison/obsidian-gemini/pull/1360)
+
+`audit-architecture` flagged a DRY violation in the agent view's session header: the prompt-template display name was derived twice, six lines apart, and the two copies had already drifted — a lowercase `'custom'` fallback in the tooltip versus a title-case `'Custom'` on the badge. This derives the name once and routes the single remaining fallback through a new `agent.header.promptBadgeFallback` i18n key, so the tooltip and badge now agree.
+
+### [#1359 refactor(tools): share one recent-identical-call filter in the loop detector](https://github.com/allenhutchison/obsidian-gemini/pull/1359)
+
+`audit-architecture` flagged a DRY violation in `loop-detector.ts`: `isLoopDetected` and `getLoopInfo` each independently rebuilt the same tool-call-key/time-window filter before comparing against `loopThreshold`. This extracts a private `getRecentIdenticalCalls()` helper both methods delegate to. Pure extraction, no behavior change.


### PR DESCRIPTION
## Summary

Automated daily housekeeping run (`daily-update` meta-skill) for 2026-08-18.

## Changes

- **daily-changelog**: added `planning/changelog/2026-08-18.md`, covering the 5 PRs merged 2026-08-18:
  - [#1364](https://github.com/allenhutchison/obsidian-gemini/pull/1364) — the 2026-08-17 automated daily-update run (quiet day, zero PRs merged, clean docs audit and triage).
  - [#1362](https://github.com/allenhutchison/obsidian-gemini/pull/1362) — the 2026-08-16 automated daily-update run.
  - [#1361](https://github.com/allenhutchison/obsidian-gemini/pull/1361) — `audit-architecture` finding: reused `DEFAULT_CHARS_PER_TOKEN` instead of a bare literal `4` for the phase-1 truncation delta in `context-manager.ts`.
  - [#1360](https://github.com/allenhutchison/obsidian-gemini/pull/1360) — `audit-architecture` finding: deduplicated the agent-view session-header prompt-badge name derivation, fixing a `custom`/`Custom` i18n drift between the tooltip and badge.
  - [#1359](https://github.com/allenhutchison/obsidian-gemini/pull/1359) — `audit-architecture` finding: extracted a shared `getRecentIdenticalCalls()` helper in `loop-detector.ts` so `isLoopDetected` and `getLoopInfo` stop rebuilding the same filter independently.
- **audit-product-docs**: spot-checked the areas touched by #1359–#1361 (`docs/reference/loop-detection.md` against the loop-detector refactor, the new `agent.header.promptBadgeFallback` i18n key, and the context-manager truncation constant) plus a lighter pass over the rest of `docs/guide/`, `docs/reference/`, `README.md`, and `AGENTS.md`. No drift found, no new docs warranted — all three source PRs were internal refactors with no documented-behavior changes.
- **triage-issues**: all 30 open issues already carry at least one label — nothing to apply.

## Screenshots / Screencast

N/A — no UI or behavior change, changelog-only diff.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A, this is the recurring automated daily-update job, not an issue-driven change.
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — plus `npm run lint` (0 errors, 40 pre-existing warnings) and `npm run typecheck:test`. Full suite: 171 files, 3797 tests passing, all run locally pre-push.
- [ ] I have tested this change on Desktop — N/A, no runtime behavior changed (new markdown file only).
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — docs/changelog-only change, no platform-specific code touched.
- [x] Documentation has been updated (if applicable) — this PR *is* the documentation update (daily changelog entry); the docs audit found nothing else to update.
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (scheduled daily-update agent)
- [x] I have reviewed and understand all AI-generated code in this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01R7CUeaVeeCpjXJQ2SjvsuN)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added the August 18, 2026 daily changelog.
  - Recorded five merged changes, including automated daily updates and architecture improvements.

- **Refactor**
  - Improved consistency in token-based text handling.
  - Streamlined session prompt badge labeling and localization fallback behavior.
  - Unified recent repeated-call filtering to support more consistent loop detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->