### PR TITLE
fix(vault-analyzer): exclude plugin state files from the vault fingerprint

### DIFF
--- a/src/services/vault-analyzer.ts
+++ b/src/services/vault-analyzer.ts
@@ -179,7 +179,13 @@ export class VaultAnalyzer {
 	 */
 	private collectVaultInformation(): string {
 		const vault = this.plugin.app.vault;
-		const allFiles = vault.getMarkdownFiles();
+		// Exclude the plugin state folder and the Obsidian config directory before
+		// anything is derived from the list. Beyond keeping the reported total
+		// honest, it keeps the large-vault cache usable: the fingerprint below is
+		// the newest mtime, and the plugin rewrites its own `Agent-Sessions/`
+		// files on every agent turn — counting those meant the cache was
+		// invalidated by our own writes and effectively never hit.
+		const allFiles = this.excludeSystemFiles(vault.getMarkdownFiles());
 		const fileCount = allFiles.length;
 
 		// Calculate vault fingerprint (file count + most recent modification)
@@ -285,14 +291,26 @@ export class VaultAnalyzer {
 	}
 
 	/**
+	 * Drop files that live in the plugin state folder or the Obsidian
+	 * configuration directory — neither is user content, so neither belongs in
+	 * anything we count, fingerprint, or show the model.
+	 *
+	 * Root-anchored containment so a sibling like `gemini-scribe-backup/` or a
+	 * renamed `_obsidian-notes/` is not wrongly excluded by a bare prefix match.
+	 */
+	private excludeSystemFiles(files: TFile[]): TFile[] {
+		const skipPaths = [this.plugin.settings.historyFolder, this.plugin.app.vault.configDir];
+		return files.filter((f) => !skipPaths.some((skip) => isPathInFolder(f.path, skip)));
+	}
+
+	/**
 	 * Get a representative sample of file names for topic analysis
 	 */
 	private getSampleFileNames(files: TFile[], limit: number = 20): string[] {
-		// Get files from different parts of the vault for diversity
-		const skipPaths = [this.plugin.settings.historyFolder, this.plugin.app.vault.configDir];
-		// Root-anchored containment so a sibling like `gemini-scribe-backup/` or a
-		// renamed `_obsidian-notes/` is not wrongly excluded by a bare prefix match.
-		const filteredFiles = files.filter((f) => !skipPaths.some((skip) => isPathInFolder(f.path, skip)));
+		// Get files from different parts of the vault for diversity. Callers
+		// inside collectVaultInformation already pass a filtered list; the filter
+		// stays here so the method is correct on its own.
+		const filteredFiles = this.excludeSystemFiles(files);
 
 		// Sort by modification time to get recent files
 		const sortedFiles = filteredFiles.sort((a, b) => b.stat.mtime - a.stat.mtime).slice(0, limit);

--- a/src/services/vault-analyzer.ts
+++ b/src/services/vault-analyzer.ts
@@ -16,6 +16,8 @@ interface VaultInfoCache {
 	vaultInfo: string;
 	fileCount: number;
 	lastModified: number;
+	/** The exclusion set the entry was built under — see `VaultAnalyzer.exclusionKey`. */
+	exclusionKey: string;
 	timestamp: number;
 }
 
@@ -191,12 +193,20 @@ export class VaultAnalyzer {
 		// Calculate vault fingerprint (file count + most recent modification)
 		const lastModified = allFiles.length > 0 ? Math.max(...allFiles.map((f) => f.stat.mtime)) : 0;
 
+		// Every part of the summary below is derived from the exclusion set, so a
+		// changed state folder must miss the cache even when the count and the
+		// newest mtime happen to land on the same values. `historyFolder` is
+		// editable at runtime and does not re-create this service — `saveSettings`
+		// only re-runs `lifecycle.setup()` for API-key/provider/base-URL changes.
+		const exclusionKey = this.exclusionKey();
+
 		// Check if we can use cached data (for large vaults)
 		if (this.vaultInfoCache && fileCount > 1000) {
 			const now = Date.now();
 			const cacheValid =
 				this.vaultInfoCache.fileCount === fileCount &&
 				this.vaultInfoCache.lastModified === lastModified &&
+				this.vaultInfoCache.exclusionKey === exclusionKey &&
 				now - this.vaultInfoCache.timestamp < this.CACHE_TTL_MS;
 
 			if (cacheValid) {
@@ -229,6 +239,7 @@ export class VaultAnalyzer {
 				vaultInfo,
 				fileCount,
 				lastModified,
+				exclusionKey,
 				timestamp: Date.now(),
 			};
 			this.plugin.logger.log('VaultAnalyzer: Cached vault information for large vault');
@@ -305,8 +316,18 @@ export class VaultAnalyzer {
 	 * renamed `_obsidian-notes/` is not wrongly excluded by a bare prefix match.
 	 */
 	private isSystemPath(path: string): boolean {
-		const skipPaths = [this.plugin.settings.historyFolder, this.plugin.app.vault.configDir];
-		return skipPaths.some((skip) => isPathInFolder(path, skip));
+		return (
+			isPathInFolder(path, this.plugin.settings.historyFolder) || isPathInFolder(path, this.plugin.app.vault.configDir)
+		);
+	}
+
+	/**
+	 * Identity of the current exclusion set, for cache validation. Reads the same
+	 * two paths as {@link isSystemPath} — keep them in step. `\n` can't appear in
+	 * a vault path, so it's an unambiguous separator.
+	 */
+	private exclusionKey(): string {
+		return `${this.plugin.settings.historyFolder}\n${this.plugin.app.vault.configDir}`;
 	}
 
 	/** Files that survive {@link isSystemPath}. */

--- a/src/services/vault-analyzer.ts
+++ b/src/services/vault-analyzer.ts
@@ -287,20 +287,31 @@ export class VaultAnalyzer {
 	 * Count markdown files in a folder (including subfolders)
 	 */
 	private countMarkdownFilesInFolder(folder: TFolder): number {
-		return collectFilesFromFolder(folder, { filter: (f) => f.extension === 'md' }).length;
+		// Prune rather than post-filter: a state folder nested under a user folder
+		// (e.g. `Meta/gemini-scribe/`) would otherwise inflate that parent's count
+		// even though the reported total excludes it.
+		return collectFilesFromFolder(folder, {
+			filter: (f) => f.extension === 'md',
+			prune: (item) => this.isSystemPath(item.path),
+		}).length;
 	}
 
 	/**
-	 * Drop files that live in the plugin state folder or the Obsidian
+	 * Whether a path is inside the plugin state folder or the Obsidian
 	 * configuration directory — neither is user content, so neither belongs in
 	 * anything we count, fingerprint, or show the model.
 	 *
 	 * Root-anchored containment so a sibling like `gemini-scribe-backup/` or a
 	 * renamed `_obsidian-notes/` is not wrongly excluded by a bare prefix match.
 	 */
-	private excludeSystemFiles(files: TFile[]): TFile[] {
+	private isSystemPath(path: string): boolean {
 		const skipPaths = [this.plugin.settings.historyFolder, this.plugin.app.vault.configDir];
-		return files.filter((f) => !skipPaths.some((skip) => isPathInFolder(f.path, skip)));
+		return skipPaths.some((skip) => isPathInFolder(path, skip));
+	}
+
+	/** Files that survive {@link isSystemPath}. */
+	private excludeSystemFiles(files: TFile[]): TFile[] {
+		return files.filter((f) => !this.isSystemPath(f.path));
 	}
 
 	/**

--- a/test/services/vault-analyzer.test.ts
+++ b/test/services/vault-analyzer.test.ts
@@ -229,6 +229,24 @@ describe('VaultAnalyzer', () => {
 			expect(count).toBe(2);
 		});
 
+		it('should not count files inside a nested plugin state folder', () => {
+			// historyFolder nested under a user folder: the parent's count must
+			// match the total, which excludes plugin state.
+			mockPlugin.settings.historyFolder = 'Meta/gemini-scribe';
+
+			const parent = createMockFolder('Meta', 'Meta');
+			const state = createMockFolder('Meta/gemini-scribe', 'gemini-scribe');
+			const note = createMockFile('Meta/note.md');
+			note.extension = 'md';
+			const session = createMockFile('Meta/gemini-scribe/session.md');
+			session.extension = 'md';
+			state.children = [session];
+			parent.children = [note, state];
+
+			const count = (analyzer as any).countMarkdownFilesInFolder(parent);
+			expect(count).toBe(1);
+		});
+
 		it('should return 0 for empty folder', () => {
 			const folder = createMockFolder('empty', 'empty');
 			folder.children = [];

--- a/test/services/vault-analyzer.test.ts
+++ b/test/services/vault-analyzer.test.ts
@@ -475,6 +475,26 @@ describe('VaultAnalyzer', () => {
 			expect(mockPlugin.logger.log).toHaveBeenCalledWith(expect.stringContaining('Using cached'));
 		});
 
+		it('should not reuse the cache after the state folder changes', () => {
+			// Same file count and same newest mtime under either setting, so only
+			// the exclusion set distinguishes the two results.
+			const inA = createMockFile('A/x.md', 500);
+			const inB = createMockFile('B/y.md', 500);
+			const userFiles = Array.from({ length: 1001 }, (_, i) => createMockFile(`file${i}.md`, 100));
+			mockPlugin.app.vault.getMarkdownFiles.mockReturnValue([inA, inB, ...userFiles]);
+
+			mockPlugin.settings.historyFolder = 'A';
+			const withAExcluded = (analyzer as any).collectVaultInformation();
+			expect(withAExcluded).toContain('B/y');
+			expect(withAExcluded).not.toContain('A/x');
+
+			mockPlugin.settings.historyFolder = 'B';
+			const withBExcluded = (analyzer as any).collectVaultInformation();
+
+			expect(withBExcluded).toContain('A/x');
+			expect(withBExcluded).not.toContain('B/y');
+		});
+
 		it('should not cache for small vaults (<= 1000 files)', () => {
 			const files = [createMockFile('a.md', 100)];
 			mockPlugin.app.vault.getMarkdownFiles.mockReturnValue(files);

--- a/test/services/vault-analyzer.test.ts
+++ b/test/services/vault-analyzer.test.ts
@@ -427,6 +427,36 @@ describe('VaultAnalyzer', () => {
 			expect(mockPlugin.logger.log).toHaveBeenCalledWith(expect.stringContaining('Using cached'));
 		});
 
+		it('should exclude plugin state and config files from the reported count', () => {
+			const files = [
+				createMockFile('notes/a.md', 100),
+				createMockFile('gemini-scribe/Agent-Sessions/session.md', 200),
+				createMockFile('.obsidian/plugins/notes.md', 300),
+			];
+			mockPlugin.app.vault.getMarkdownFiles.mockReturnValue(files);
+
+			const result = (analyzer as any).collectVaultInformation();
+
+			expect(result).toContain('1 markdown files');
+		});
+
+		it('should not invalidate the large-vault cache when only state files change', () => {
+			const userFiles = Array.from({ length: 1001 }, (_, i) => createMockFile(`file${i}.md`, 100));
+			const sessionFile = createMockFile('gemini-scribe/Agent-Sessions/session.md', 500);
+			mockPlugin.app.vault.getMarkdownFiles.mockReturnValue([...userFiles, sessionFile]);
+
+			const result1 = (analyzer as any).collectVaultInformation();
+
+			// The plugin rewrites its own session file on every agent turn.
+			const touchedSession = createMockFile('gemini-scribe/Agent-Sessions/session.md', 9999);
+			mockPlugin.app.vault.getMarkdownFiles.mockReturnValue([...userFiles, touchedSession]);
+
+			const result2 = (analyzer as any).collectVaultInformation();
+
+			expect(result2).toBe(result1);
+			expect(mockPlugin.logger.log).toHaveBeenCalledWith(expect.stringContaining('Using cached'));
+		});
+
 		it('should not cache for small vaults (<= 1000 files)', () => {
 			const files = [createMockFile('a.md', 100)];
 			mockPlugin.app.vault.getMarkdownFiles.mockReturnValue(files);


### PR DESCRIPTION
## Summary

`audit-architecture` nightly sweep flagged: **repo-invariant drift** in `src/services/vault-analyzer.ts`.

`collectVaultInformation()` enumerated every markdown file in the vault, including the plugin state folder (`settings.historyFolder`) and the Obsidian configuration directory — the invariant in `.claude/guidelines/invariants.md` says both are always excluded from vault file operations. Two things follow from that:

- The `**Total Files:** N markdown files` line that goes into the vault-analysis prompt counted the plugin's own `Agent-Sessions/`, `Prompts/`, and `Scheduled-Tasks/` notes, so the number the model reasons about was inflated by plugin state rather than user content.
- The large-vault cache (`fileCount > 1000`) is fingerprinted on the newest `mtime` across that same list. The plugin rewrites its session file on every agent turn, so the fingerprint moved on each turn and the cache was invalidated by the plugin's own writes — it effectively never hit during a chat session, which is exactly when it is supposed to help.

The fix filters once at the top of `collectVaultInformation()`. `getSampleFileNames()` already carried the same skip list inline; both now share one `excludeSystemFiles()` helper, and the filter stays in `getSampleFileNames()` so it remains correct when called on its own.

Fixes: n/a — found by the architecture sweep, no pre-existing issue.

## Changes

- `src/services/vault-analyzer.ts` — add the private `excludeSystemFiles()` helper (root-anchored containment via the existing `isPathInFolder()` leaf helper); apply it to `vault.getMarkdownFiles()` in `collectVaultInformation()` before the count and fingerprint are derived; `getSampleFileNames()` now calls it instead of rebuilding the skip list.
- `test/services/vault-analyzer.test.ts` — two regression tests: the reported count excludes state/config files, and touching a `gemini-scribe/Agent-Sessions/` file no longer invalidates the large-vault cache.

## Screenshots / Screencast

N/A — no UI change.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: filed directly by the `audit-architecture` sweep, which routes mechanical fixes to a PR and judgment calls to an issue.
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — also `npm run lint` (0 errors) and `npm run typecheck:test`.
- [ ] I have tested this change on Desktop — N/A: not manually exercised in a vault; covered by unit tests against the analyzer's own helpers.
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — no platform-specific API involved.
- [ ] Documentation has been updated (if applicable) — N/A: internal correctness fix, no user-facing behavior or setting changes.
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (`audit-architecture` skill)
- [x] I have reviewed and understand all AI-generated code in this PR

---

_Filed by the `audit-architecture` skill._

---
_Generated by [Claude Code](https://claude.ai/code/session_019wdEL79HZ8GBbiqgpuxVum)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Vault analysis now excludes plugin state folders and Obsidian configuration files from file counts and sampled file listings.
  * Cache results remain stable when only plugin session files change.
  * Cached results are refreshed when configured exclusion paths change, ensuring updated file inclusion.

* **Tests**
  * Added coverage for nested system-file exclusion, cache stability, and cache invalidation when exclusion settings change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->