### PR TITLE
fix(vault): use root-anchored containment for two folder checks

### DIFF
--- a/src/agent/session-manager.ts
+++ b/src/agent/session-manager.ts
@@ -9,7 +9,7 @@ import {
 	DestructiveAction,
 } from '../types/agent';
 import type { ObsidianGemini } from '../types/plugin';
-import { sanitizeFileName } from '../utils/file-utils';
+import { isPathInFolder, sanitizeFileName } from '../utils/file-utils';
 import { formatLocalDate } from '../utils/format-utils';
 import { FeatureToolPolicy, clonePolicy } from '../types/tool-policy';
 import { resolveFeatureToolPolicy } from '../services/feature-definition';
@@ -342,8 +342,10 @@ export class SessionManager {
 	private async loadSessionFromFile(file: TFile): Promise<ChatSession> {
 		const frontmatter = asRecord(this.plugin.app.metadataCache.getFileCache(file)?.frontmatter);
 
-		// Determine session type based on folder location
-		const isAgentSession = file.path.startsWith(this.getAgentSessionsFolderPath());
+		// Determine session type based on folder location. Root-anchored
+		// containment, so a sibling like `Agent-Sessions-archive/` isn't
+		// mistyped as an agent session.
+		const isAgentSession = isPathInFolder(file.path, this.getAgentSessionsFolderPath());
 
 		const session: ChatSession = {
 			id: asFrontmatterString(frontmatter.session_id) ?? this.generateSessionId(),

--- a/src/prompts/prompt-manager.ts
+++ b/src/prompts/prompt-manager.ts
@@ -4,6 +4,7 @@ import { CustomPrompt, PromptInfo } from './types';
 import { BundledPromptRegistry } from './bundled-prompts';
 import { t } from '../i18n';
 import { asRecord } from '../utils/error-utils';
+import { isPathInFolder } from '../utils/file-utils';
 
 export class PromptManager {
 	constructor(
@@ -78,8 +79,10 @@ export class PromptManager {
 
 		const prompts: PromptInfo[] = [];
 
-		// Use Vault.getMarkdownFiles() and filter by path
-		const markdownFiles = this.vault.getMarkdownFiles().filter((file) => file.path.startsWith(promptsDir));
+		// Use Vault.getMarkdownFiles() and filter by path. Root-anchored
+		// containment, so a sibling like `Prompts-archive/` or a stray
+		// `Prompts.md` next to the folder isn't listed as a custom prompt.
+		const markdownFiles = this.vault.getMarkdownFiles().filter((file) => isPathInFolder(file.path, promptsDir));
 
 		for (const file of markdownFiles) {
 			const prompt = await this.loadPromptFromFile(file.path);

--- a/test/agent/session-manager.test.ts
+++ b/test/agent/session-manager.test.ts
@@ -260,6 +260,37 @@ describe('SessionManager', () => {
 			// Verify context files were parsed correctly
 			expect(session.context.contextFiles).toHaveLength(1);
 		});
+
+		it('should not type a file in a sibling folder as an agent session', async () => {
+			const mockHistoryFile = {
+				// A bare prefix match on `gemini-scribe/Agent-Sessions` would swallow this.
+				path: 'gemini-scribe/Agent-Sessions-archive/old.md',
+				basename: 'old',
+				stat: { ctime: Date.now(), mtime: Date.now() },
+			} as any;
+
+			mockPlugin.app.vault.read.mockResolvedValue('test content');
+			mockPlugin.app.metadataCache.getFileCache.mockReturnValue({ frontmatter: {} });
+
+			const session = await (sessionManager as any).loadSessionFromFile(mockHistoryFile);
+
+			expect(session.type).toBe(SessionType.NOTE_CHAT);
+		});
+
+		it('should type a file inside the agent sessions folder as an agent session', async () => {
+			const mockHistoryFile = {
+				path: 'gemini-scribe/Agent-Sessions/nested/session.md',
+				basename: 'session',
+				stat: { ctime: Date.now(), mtime: Date.now() },
+			} as any;
+
+			mockPlugin.app.vault.read.mockResolvedValue('test content');
+			mockPlugin.app.metadataCache.getFileCache.mockReturnValue({ frontmatter: {} });
+
+			const session = await (sessionManager as any).loadSessionFromFile(mockHistoryFile);
+
+			expect(session.type).toBe(SessionType.AGENT_SESSION);
+		});
 	});
 
 	describe('loadSessionFromFile - accessed_files', () => {

--- a/test/prompts/prompt-manager.test.ts
+++ b/test/prompts/prompt-manager.test.ts
@@ -258,6 +258,46 @@ Content`;
 			});
 		});
 
+		it('should not list files from a sibling folder sharing the prompts prefix', async () => {
+			const mockFolder = Object.create(MockTFolder.prototype);
+			mockFolder.path = 'gemini-scribe/Prompts';
+
+			const inFolder = Object.assign(new TFile(), {
+				path: 'gemini-scribe/Prompts/prompt1.md',
+				basename: 'prompt1',
+			});
+
+			mockVault.getMarkdownFiles.mockReturnValue([
+				inFolder,
+				// Sibling folder and sibling file that a bare prefix match would swallow.
+				Object.assign(new TFile(), { path: 'gemini-scribe/Prompts-archive/old.md', basename: 'old' }),
+				Object.assign(new TFile(), { path: 'gemini-scribe/Prompts.md', basename: 'Prompts' }),
+			]);
+
+			mockVault.getAbstractFileByPath.mockImplementation((path: string) => {
+				if (path === 'gemini-scribe/Prompts') return mockFolder;
+				return Object.assign(new TFile(), { path });
+			});
+
+			mockPlugin.app.metadataCache.getFileCache.mockReturnValue({
+				frontmatter: { name: 'Test Prompt', description: 'Test', tags: ['test'] },
+				sections: [
+					{ type: 'yaml', position: { start: { line: 0 }, end: { line: 4 } } },
+					{ type: 'paragraph', position: { start: { line: 5 }, end: { line: 5 } } },
+				],
+			});
+			mockVault.read.mockResolvedValue(`---
+name: "Test Prompt"
+description: "Test"
+tags: [test]
+---
+Content`);
+
+			const result = await promptManager.listAvailablePrompts();
+
+			expect(result.map((p) => p.path)).toEqual(['gemini-scribe/Prompts/prompt1.md']);
+		});
+
 		it('should handle empty prompts directory', async () => {
 			mockVault.adapter.list.mockResolvedValue({
 				files: [],


### PR DESCRIPTION
## Summary

`audit-architecture` nightly sweep flagged: **repo-invariant drift** in `src/prompts/prompt-manager.ts` and `src/agent/session-manager.ts`.

`isPathInFolder()` in `src/utils/file-utils.ts` is documented as "the single source of truth for the 'is this path inside that directory?' check … so the semantics (and the over-match fix) live in one place." Two sites still did a bare `String.startsWith(folder)`, which matches not only the folder and its contents but any sibling whose name starts with the same characters:

- `PromptManager.listAvailablePrompts()` — `gemini-scribe/Prompts-archive/old.md`, and a stray `gemini-scribe/Prompts.md` sitting next to the folder, were both parsed and listed as custom prompts.
- `SessionManager.loadSessionFromFile()` — a history file under `gemini-scribe/Agent-Sessions-archive/` was typed `AGENT_SESSION` instead of `NOTE_CHAT`, which changes the session's default tool policy and context handling.

Neither case is reachable through the plugin's own folder creation; both are reachable in a vault where the user (or a sync/backup tool) has created a sibling folder alongside the plugin's. The fix is to route both through the existing helper.

The rest of the codebase already anchors correctly — `scheduled-task-manager.ts`, `file-backed-feature-manager.ts`, and `session-list-modal.ts` all build their prefix with a trailing `/`.

Fixes: n/a — found by the architecture sweep, no pre-existing issue.

## Changes

- `src/prompts/prompt-manager.ts` — `listAvailablePrompts()` filters with `isPathInFolder(file.path, promptsDir)`.
- `src/agent/session-manager.ts` — `loadSessionFromFile()` derives `isAgentSession` with `isPathInFolder(...)`.
- `test/prompts/prompt-manager.test.ts` — sibling folder and sibling file are not listed as prompts.
- `test/agent/session-manager.test.ts` — a file in a sibling folder stays `NOTE_CHAT`; a nested file inside the sessions folder is still `AGENT_SESSION`.

Both new tests were confirmed to fail against the old `startsWith` code and pass with the fix.

## Screenshots / Screencast

N/A — no UI change.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: filed directly by the `audit-architecture` sweep, which routes mechanical fixes to a PR and judgment calls to an issue.
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — also `npm run lint` (0 errors) and `npm run typecheck:test`.
- [ ] I have tested this change on Desktop — N/A: not manually exercised in a vault; covered by unit tests that reproduce both over-match cases.
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — pure path-string logic, no platform-specific API.
- [ ] Documentation has been updated (if applicable) — N/A: internal correctness fix; no user-facing behavior or setting changes.
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (`audit-architecture` skill)
- [x] I have reviewed and understand all AI-generated code in this PR

---

_Filed by the `audit-architecture` skill._

---
_Generated by [Claude Code](https://claude.ai/code/session_019wdEL79HZ8GBbiqgpuxVum)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session detection to prevent similarly named folders from being misclassified.
  * Restricted prompt discovery to files within the designated prompts folder, excluding similarly named sibling paths.

* **Tests**
  * Added regression coverage for session classification and prompt filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->