### PR TITLE
refactor(rag): reuse startResumeIndexing for the initial vault index

### DIFF
--- a/src/services/rag-indexing.ts
+++ b/src/services/rag-indexing.ts
@@ -6,7 +6,6 @@ import { TFile, Notice } from 'obsidian';
 import type { FileUploader } from '@allenhutchison/gemini-utils';
 import type { ObsidianGemini } from '../types/plugin';
 import { ObsidianVaultAdapter } from './obsidian-file-adapter';
-import { getErrorMessage } from '../utils/error-utils';
 import { t } from '../i18n';
 import { RagCache } from './rag-cache';
 import { RagRateLimiter } from './rag-rate-limiter';
@@ -159,20 +158,9 @@ export class RagIndexingService {
 			if (this.ragCache.indexedCount === 0) {
 				new Notice(t('notice.rag.startingInitial'));
 
-				// Open progress modal for initial indexing
-				// Fire-and-forget: lazy-load and open the progress modal; indexing itself is handled below.
-				void import('../ui/rag-progress-modal').then(({ RagProgressModal }) => {
-					const progressModal = new RagProgressModal(this.plugin.app, this, (result) => {
-						new Notice(t('notice.rag.indexingComplete', { indexed: result.indexed, skipped: result.skipped }));
-					});
-					progressModal.open();
-				});
-
-				// Run indexing in background (don't await - modal handles display)
-				this.indexVault().catch((error) => {
-					this.plugin.logger.error('RAG Indexing: Initial indexing failed', error);
-					new Notice(t('notice.rag.indexingFailed', { error: getErrorMessage(error) }));
-				});
+				// Same open-modal-then-index-in-background sequence the scanner uses when
+				// resuming; this.indexVault() delegates to the scanner's either way.
+				this.vaultScanner.startResumeIndexing(this, 'RAG Indexing: Initial indexing failed');
 			}
 		} catch (error) {
 			this.plugin.logger.error('RAG Indexing: Failed to initialize', error);

--- a/src/services/rag-vault-scanner.ts
+++ b/src/services/rag-vault-scanner.ts
@@ -268,10 +268,18 @@ export class RagVaultScanner {
 	}
 
 	/**
-	 * Start resume indexing with progress modal.
+	 * Open the progress modal and start a vault index in the background.
+	 *
+	 * Used both when resuming an interrupted index and for the very first index
+	 * of a vault (see `RagIndexingService.initialize`) — the two differ only in
+	 * the message logged if the background index rejects.
 	 * @param progressProvider - The object to pass to the progress modal (typically the orchestrator)
+	 * @param failureLogMessage - Logger message used when the background index rejects
 	 */
-	startResumeIndexing(progressProvider: RagProgressProvider): void {
+	startResumeIndexing(
+		progressProvider: RagProgressProvider,
+		failureLogMessage = 'RAG Indexing: Resume indexing failed'
+	): void {
 		// Fire-and-forget: lazy-load and open the progress modal; indexing itself is handled below.
 		void import('../ui/rag-progress-modal').then(({ RagProgressModal }) => {
 			const progressModal = new RagProgressModal(this.plugin.app, progressProvider, (result) => {
@@ -282,7 +290,7 @@ export class RagVaultScanner {
 
 		// Run indexing in background (don't await - modal handles display)
 		this.indexVault().catch((error) => {
-			this.plugin.logger.error('RAG Indexing: Resume indexing failed', error);
+			this.plugin.logger.error(failureLogMessage, error);
 			new Notice(t('notice.rag.indexingFailed', { error: getErrorMessage(error) }));
 		});
 	}


### PR DESCRIPTION
## Summary

`audit-architecture` nightly sweep flagged: **dry-violation** in `src/services/rag-indexing.ts`.

`RagIndexingService.initialize` hand-rolled the same open-the-progress-modal-then-index-in-background sequence that `RagVaultScanner.startResumeIndexing` already owns — the same lazy `import('../ui/rag-progress-modal')`, the same `notice.rag.indexingComplete` callback, the same fire-and-forget `indexVault().catch()` emitting `notice.rag.indexingFailed`. The two copies differed only in the logger message (`Initial indexing failed` vs `Resume indexing failed`).

The duplication was already functionally redundant: `RagIndexingService.indexVault()` is a one-line delegation to `this.vaultScanner.indexVault()`, so both paths ran identical work. The orchestrator also already passes `this` as the `RagProgressProvider` to `vaultScanner.handleInterruptedIndexing(this)` a few lines above, so the call shape is the established one for this pair.

This is safe because it is value-preserving: same modal, same notices, same log strings. `startResumeIndexing` gains an optional `failureLogMessage` parameter defaulting to the existing resume string, so both call sites keep their distinct log line.

## Changes

- `src/services/rag-vault-scanner.ts` — `startResumeIndexing` takes an optional `failureLogMessage` (default unchanged); doc comment updated to say it serves the initial index as well as resume.
- `src/services/rag-indexing.ts` — the 14-line inline block in `initialize` becomes one call to `this.vaultScanner.startResumeIndexing(this, 'RAG Indexing: Initial indexing failed')`; the now-unused `getErrorMessage` import is dropped.

## Screenshots / Screencast

N/A — no UI change. The same `RagProgressModal` is opened by the same code path.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: filed directly by the `audit-architecture` sweep as a mechanical, value-preserving dedup.
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — also ran `npm run lint` (0 errors) and `npm run typecheck:test`; 3804 tests across 171 files pass.
- [ ] I have tested this change on Desktop — not run in a live vault; covered by `test/services/rag-indexing.test.ts` and `test/services/rag-vault-scanner.test.ts`.
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — no new platform-sensitive API; the lazy modal import that existed before is unchanged and now runs from one place instead of two.
- [ ] Documentation has been updated (if applicable) — N/A: internal refactor with no user-visible behaviour, settings, or docs surface.
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (`audit-architecture` skill)
- [x] I have reviewed and understand all AI-generated code in this PR

---

_Filed by the `audit-architecture` skill._

---
_Generated by [Claude Code](https://claude.ai/code/session_01LNWuuQYmaDrqTH5uhxAzqr)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resume indexing reliability by centralizing progress handling and background execution.
  * Added clearer failure logging for different indexing workflows.
  * Prevented duplicate progress dialogs during initial indexing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->