### PR TITLE
refactor(selection): share the empty-selection guard across the entry points

### DIFF
--- a/src/services/selection-action-service.ts
+++ b/src/services/selection-action-service.ts
@@ -16,6 +16,19 @@ export class SelectionActionService {
 	constructor(private plugin: ObsidianGemini) {}
 
 	/**
+	 * Return the editor's current selection, or null after notifying the user
+	 * that nothing is selected. Shared by the three selection-action entry points.
+	 */
+	private requireSelection(editor: Editor): string | null {
+		const selection = editor.getSelection();
+		if (!selection || selection.trim().length === 0) {
+			new Notice(t('notice.selection.noSelection'));
+			return null;
+		}
+		return selection;
+	}
+
+	/**
 	 * Handle "Explain Selection" action:
 	 * 1. Gets the selected text from editor
 	 * 2. Shows prompt selection modal (filtered by selection-action tag)
@@ -23,11 +36,8 @@ export class SelectionActionService {
 	 * 4. Shows response in modal with option to insert as callout
 	 */
 	async handleExplainSelection(editor: Editor, sourceFile: TFile | null): Promise<void> {
-		const selection = editor.getSelection();
-		if (!selection || selection.trim().length === 0) {
-			new Notice(t('notice.selection.noSelection'));
-			return;
-		}
+		const selection = this.requireSelection(editor);
+		if (selection === null) return;
 
 		// Capture selection end position now (before modal opens and potentially clears selection)
 		const selectionEnd = editor.getCursor('to');
@@ -57,11 +67,8 @@ export class SelectionActionService {
 	 * Handle a specific selection prompt
 	 */
 	async handleSelectionPrompt(editor: Editor, sourceFile: TFile | null, prompt: CustomPrompt): Promise<void> {
-		const selection = editor.getSelection();
-		if (!selection || selection.trim().length === 0) {
-			new Notice(t('notice.selection.noSelection'));
-			return;
-		}
+		const selection = this.requireSelection(editor);
+		if (selection === null) return;
 		const selectionEnd = editor.getCursor('to');
 		await this.generateAndShowResponseWithPosition(editor, selection, prompt.content, sourceFile, selectionEnd);
 	}
@@ -74,11 +81,8 @@ export class SelectionActionService {
 	 * 4. Shows response in modal with option to insert as callout
 	 */
 	async handleAskAboutSelection(editor: Editor, sourceFile: TFile | null): Promise<void> {
-		const selection = editor.getSelection();
-		if (!selection || selection.trim().length === 0) {
-			new Notice(t('notice.selection.noSelection'));
-			return;
-		}
+		const selection = this.requireSelection(editor);
+		if (selection === null) return;
 
 		// Show question input modal
 		const questionModal = new AskQuestionModal(this.plugin.app, selection, async (question: string) => {


### PR DESCRIPTION
## Summary

`audit-architecture` nightly sweep flagged: **dry-violation** in `src/services/selection-action-service.ts`.

`handleExplainSelection`, `handleSelectionPrompt` and `handleAskAboutSelection` each opened with the identical five-line block — read `editor.getSelection()`, and if it is missing or whitespace-only, show the `notice.selection.noSelection` notice and return. Three copies of the same guard means a change to how "nothing selected" is detected or reported has to be made in three places.

The fix extracts a private `requireSelection(editor): string | null` that returns the selection or `null` after showing the notice. It is safe because it is value-preserving: the same notice with the same i18n key, the same emptiness test (`!selection || selection.trim().length === 0`), and the same position in each method — in particular still ahead of the `editor.getCursor('to')` capture in the two callers that need the selection end.

## Changes

- `src/services/selection-action-service.ts` — add the private `requireSelection` helper; replace the three inlined guards with `const selection = this.requireSelection(editor); if (selection === null) return;`.

## Screenshots / Screencast

N/A — no UI change. The same `Notice` is shown by the same i18n key.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: filed directly by the `audit-architecture` sweep as a mechanical, value-preserving dedup.
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — also ran `npm run lint` (0 errors) and `npm run typecheck:test`; 3804 tests across 171 files pass.
- [ ] I have tested this change on Desktop — not run in a live vault; covered by `test/services/selection-action-service.test.ts`, which exercises the empty-selection path for these entry points.
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — no platform-sensitive API involved; the change is a private helper inside one service.
- [ ] Documentation has been updated (if applicable) — N/A: internal refactor with no user-visible behaviour, settings, or docs surface.
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (`audit-architecture` skill)
- [x] I have reviewed and understand all AI-generated code in this PR

---

_Filed by the `audit-architecture` skill._

---
_Generated by [Claude Code](https://claude.ai/code/session_01LNWuuQYmaDrqTH5uhxAzqr)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when no text is selected before running selection-based actions.
  * Consistently displays a notice when an action requires selected text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->