### PR TITLE
refactor(mcp): share the connection-target debug log between connect and test

### DIFF
--- a/src/mcp/mcp-manager.ts
+++ b/src/mcp/mcp-manager.ts
@@ -32,6 +32,14 @@ function isHttpTransport(config: MCPServerConfig): boolean {
 	return config.transport === MCP_TRANSPORT_HTTP;
 }
 
+/**
+ * Describe a server config's connection target for the debug log — the URL for
+ * HTTP transports, the command and args for stdio ones.
+ */
+function describeConnectionTarget(config: MCPServerConfig, useHttp: boolean): string {
+	return useHttp ? `url: ${config.url}` : `command: ${config.command}, args: [${config.args.join(', ')}]`;
+}
+
 /** Union type for supported MCP transports */
 type MCPTransport = StdioClientTransportType | StreamableHTTPClientTransport;
 
@@ -255,13 +263,7 @@ export class MCPManager {
 
 		this.updateState(config.name, { status: MCPConnectionStatus.CONNECTING, toolNames: [] });
 
-		if (useHttp) {
-			this.logger.debug(`MCP: Connecting to "${config.name}" — url: ${config.url}`);
-		} else {
-			this.logger.debug(
-				`MCP: Connecting to "${config.name}" — command: ${config.command}, args: [${config.args.join(', ')}]`
-			);
-		}
+		this.logger.debug(`MCP: Connecting to "${config.name}" — ${describeConnectionTarget(config, useHttp)}`);
 
 		let transport: MCPTransport | null = null;
 		try {
@@ -444,13 +446,7 @@ export class MCPManager {
 			throw new Error(`${OFFLINE_ERROR_PREFIX} — cannot test HTTP MCP server`);
 		}
 
-		if (useHttp) {
-			this.logger.debug(`MCP: Test connection to "${config.name}" — url: ${config.url}`);
-		} else {
-			this.logger.debug(
-				`MCP: Test connection to "${config.name}" — command: ${config.command}, args: [${config.args.join(', ')}]`
-			);
-		}
+		this.logger.debug(`MCP: Test connection to "${config.name}" — ${describeConnectionTarget(config, useHttp)}`);
 
 		let transport: MCPTransport | null = null;
 		try {


### PR DESCRIPTION
## Summary

`audit-architecture` nightly sweep flagged: **dry-violation** in `src/mcp/mcp-manager.ts`.

`connectServer` and `queryToolsForConfig` each carried the same seven-line `if (useHttp) … else …` block whose only job is to pick between `url: <url>` and `command: <command>, args: [<args>]` for a single `logger.debug` line. The two copies differed only in the message prefix (`Connecting to` vs `Test connection to`), so adding a third transport meant editing the branch twice.

This extracts a module-level `describeConnectionTarget(config, useHttp)` returning just the target fragment, leaving each call site with its own prefix. It is safe because the emitted strings are byte-identical for both transports at both call sites — the same template pieces, reassembled in the same order.

## Changes

- `src/mcp/mcp-manager.ts` — add `describeConnectionTarget` next to the existing `isHttpTransport` helper; replace both inlined branch blocks with a single `logger.debug` call each.

## Screenshots / Screencast

N/A — debug logging only, no UI surface.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: filed directly by the `audit-architecture` sweep as a mechanical, value-preserving dedup.
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — also ran `npm run lint` (0 errors) and `npm run typecheck:test`; 3804 tests across 171 files pass.
- [ ] I have tested this change on Desktop — not run in a live vault; the change is confined to `logger.debug` string assembly, which only emits with debug mode on.
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — the helper is a pure string function with no Node/Electron API; the existing `Platform.isMobile` guard on stdio transports is untouched.
- [ ] Documentation has been updated (if applicable) — N/A: internal refactor with no user-visible behaviour, settings, or docs surface.
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (`audit-architecture` skill)
- [x] I have reviewed and understand all AI-generated code in this PR

---

_Filed by the `audit-architecture` skill._

---
_Generated by [Claude Code](https://claude.ai/code/session_01LNWuuQYmaDrqTH5uhxAzqr)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diagnostic logging for connection and connection-test operations.
  * HTTP and command-line connection targets are now described more consistently in debug output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->