### PR TITLE
refactor(hooks): share the markdown trigger-file guard between summarize and rewrite

### DIFF
--- a/src/services/hook-runner.ts
+++ b/src/services/hook-runner.ts
@@ -79,19 +79,8 @@ export class HookRunner {
 	// ── summarize action ─────────────────────────────────────────────────────
 
 	private async runSummarize(isCancelled: () => boolean): Promise<string | undefined> {
-		if (isCancelled()) return undefined;
-		const file = this.resolveTriggerFile();
+		const file = this.resolveMarkdownTriggerFile('summarize', isCancelled);
 		if (!file) return undefined;
-		// Existing summary feature only supports markdown — non-md fires are a
-		// silent no-op rather than a failure, so a hook with a broad pathGlob
-		// that catches images doesn't pollute the failure counter.
-		if (file.extension !== 'md') {
-			this.plugin.logger.log(
-				`[HookRunner] Hook "${this.ctx.hook.slug}" — summarize: skipping non-markdown file ${file.path}`
-			);
-			return undefined;
-		}
-		if (isCancelled()) return undefined;
 		const summarizer = this.plugin.summarizer ?? new GeminiSummary(this.plugin);
 		await summarizer.summarizeFile(file);
 		// summarize writes back to frontmatter on the original file rather
@@ -103,16 +92,8 @@ export class HookRunner {
 	// ── rewrite action ───────────────────────────────────────────────────────
 
 	private async runRewrite(isCancelled: () => boolean): Promise<string | undefined> {
-		if (isCancelled()) return undefined;
-		const file = this.resolveTriggerFile();
+		const file = this.resolveMarkdownTriggerFile('rewrite', isCancelled);
 		if (!file) return undefined;
-		if (file.extension !== 'md') {
-			this.plugin.logger.log(
-				`[HookRunner] Hook "${this.ctx.hook.slug}" — rewrite: skipping non-markdown file ${file.path}`
-			);
-			return undefined;
-		}
-		if (isCancelled()) return undefined;
 		const instructions = renderPrompt(this.ctx.hook.prompt, this.promptVars());
 		const rewriter = new SelectionRewriter(this.plugin);
 		await rewriter.rewriteFile(file, instructions);
@@ -166,6 +147,32 @@ export class HookRunner {
 			throw new Error(`[HookRunner] Command "${commandId}" not found or refused to run`);
 		}
 		return undefined;
+	}
+
+	/**
+	 * Shared preamble for the markdown-only actions (summarize, rewrite): honour
+	 * cancellation on both sides of the lookup, resolve the trigger file, and skip
+	 * non-markdown fires.
+	 *
+	 * The summary and rewrite features only support markdown — a non-md fire is a
+	 * silent no-op rather than a failure, so a hook with a broad pathGlob that
+	 * catches images doesn't pollute the failure counter.
+	 *
+	 * Returns `undefined` when the caller should skip (cancelled, file gone, or
+	 * not markdown); the skip reason is logged here.
+	 */
+	private resolveMarkdownTriggerFile(action: string, isCancelled: () => boolean): TFile | undefined {
+		if (isCancelled()) return undefined;
+		const file = this.resolveTriggerFile();
+		if (!file) return undefined;
+		if (file.extension !== 'md') {
+			this.plugin.logger.log(
+				`[HookRunner] Hook "${this.ctx.hook.slug}" — ${action}: skipping non-markdown file ${file.path}`
+			);
+			return undefined;
+		}
+		if (isCancelled()) return undefined;
+		return file;
 	}
 
 	private resolveTriggerFile(): TFile | undefined {


### PR DESCRIPTION
## Summary

`audit-architecture` nightly sweep flagged: **dry-violation** in `src/services/hook-runner.ts`.

`HookRunner.runSummarize` and `HookRunner.runRewrite` each opened with the same eight-line preamble — cancel check, `resolveTriggerFile()`, null guard, non-markdown skip with a `logger.log` line, second cancel check — where the only difference between the two copies was the action name inside the log message. It sits below the size where a reviewer notices it in a diff and above the size where the copies stay in step; a third markdown-only action would make it three copies.

The fix extracts the block as a private `resolveMarkdownTriggerFile(action, isCancelled)` that returns the `TFile` or `undefined` when the caller should skip. This is a pure extraction with no behaviour change: the log message is assembled from the same parts (`action` is passed as `'summarize'` / `'rewrite'`, producing byte-identical output), and both cancellation points are preserved in the same order relative to the file lookup.

Not linked to an issue — filed directly by the nightly audit, which routes mechanical fixes to a PR and judgment calls to an issue.

## Changes

- `src/services/hook-runner.ts`: add private `resolveMarkdownTriggerFile(action, isCancelled)`; call it from `runSummarize` and `runRewrite` in place of the duplicated preamble.

## Screenshots / Screencast

N/A — internal refactor, no UI surface.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: opened by the `audit-architecture` sweep, which files mechanical, well-scoped fixes directly and routes anything needing design discussion to an issue instead.
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — run locally: `format-check` clean, `lint` 0 errors (40 pre-existing warnings in `test/`), `build` clean, `typecheck:test` clean, `npm test` 3804 passed / 171 files.
- [ ] I have tested this change on Desktop — N/A: no runtime behaviour change; covered by `test/services/hook-runner.test.ts`.
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — no platform-specific API touched.
- [ ] Documentation has been updated (if applicable) — N/A: internal refactor with no user-facing change, per the docs rule in `.claude/guidelines/invariants.md`.
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (`audit-architecture` skill)
- [x] I have reviewed and understand all AI-generated code in this PR

---

_Filed by the `audit-architecture` skill._

---
_Generated by [Claude Code](https://claude.ai/code/session_01TxuS5UrMkNJKg2NEgvY3Xo)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of summarize and rewrite actions when trigger files are missing, cancelled, or use unsupported formats.
  * Ensured markdown validation and trigger-file checks are applied consistently before actions run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->