### PR TITLE
chore(daily): 2026-08-22 daily update

### DIFF
--- a/planning/changelog/2026-08-21.md
+++ b/planning/changelog/2026-08-21.md
@@ -1,0 +1,32 @@
+# Daily changelog — August 21, 2026
+
+**Date:** 2026-08-21
+**PRs merged:** 5
+
+---
+
+## Summary
+
+Quiet day — the prior day's `daily-update` housekeeping PR merged first thing, followed by an automated i18n translation sync and three more `audit-architecture` dry-violation dedups (RAG indexing, selection-action guards, MCP connection logging). All five PRs landed within about two minutes of each other; no user-facing behavior changed.
+
+## What shipped
+
+### [#1380 chore(daily): 2026-08-20 daily update](https://github.com/allenhutchison/obsidian-gemini/pull/1380)
+
+The automated `daily-update` run for 2026-08-20: added `planning/changelog/2026-08-20.md` covering that day's 8 merged PRs, a docs audit that found no drift, and a triage pass that found all open issues already labeled.
+
+### [#1365 chore(i18n): Update UI translations](https://github.com/allenhutchison/obsidian-gemini/pull/1365)
+
+Automated regeneration of `src/i18n/` from the current English source strings in `src/i18n/en.ts`. Only keys whose English message or context changed were retranslated; hand-refined translations for unchanged keys were preserved.
+
+### [#1376 refactor(rag): reuse startResumeIndexing for the initial vault index](https://github.com/allenhutchison/obsidian-gemini/pull/1376)
+
+`audit-architecture` dry-violation fix: `RagIndexingService.initialize` hand-rolled the same open-modal-then-index-in-background sequence that `RagVaultScanner.startResumeIndexing` already implements. `startResumeIndexing` now takes an optional `failureLogMessage` parameter so the initial-index and resume-index call sites can share the one implementation while keeping their distinct log lines.
+
+### [#1377 refactor(selection): share the empty-selection guard across the entry points](https://github.com/allenhutchison/obsidian-gemini/pull/1377)
+
+`audit-architecture` dry-violation fix: `handleExplainSelection`, `handleSelectionPrompt`, and `handleAskAboutSelection` each repeated the same five-line "no selection" guard. Extracted into a private `requireSelection(editor)` helper in `src/services/selection-action-service.ts` that all three callers now share.
+
+### [#1378 refactor(mcp): share the connection-target debug log between connect and test](https://github.com/allenhutchison/obsidian-gemini/pull/1378)
+
+`audit-architecture` dry-violation fix: `connectServer` and `queryToolsForConfig` in `src/mcp/mcp-manager.ts` each carried an identical branch for building the connection-target string in debug logs. Extracted into a shared `describeConnectionTarget(config, useHttp)` helper.


### PR DESCRIPTION
## Summary

Automated daily housekeeping run (`daily-update` meta-skill) for 2026-08-22.

## Changes

- **daily-changelog**: added `planning/changelog/2026-08-21.md`, covering the 5 PRs merged 2026-08-21 (all landed within about two minutes of each other):
  - [#1380](https://github.com/allenhutchison/obsidian-gemini/pull/1380) — the prior day's `daily-update` housekeeping PR.
  - [#1365](https://github.com/allenhutchison/obsidian-gemini/pull/1365) — automated i18n translation regeneration from `src/i18n/en.ts`.
  - [#1376](https://github.com/allenhutchison/obsidian-gemini/pull/1376), [#1377](https://github.com/allenhutchison/obsidian-gemini/pull/1377), [#1378](https://github.com/allenhutchison/obsidian-gemini/pull/1378) — `audit-architecture` dry-violation dedup fixes in `rag-indexing.ts`/`rag-vault-scanner.ts`, `selection-action-service.ts`, and `mcp-manager.ts`.
- **audit-product-docs**: full pass over `docs/guide/`, `docs/reference/`, `README.md`, `AGENTS.md` against `src/` (settings defaults, command IDs, tool names, schedule grammar, lifecycle-hook schema, tool-policy presets, provider capability matrix, i18n language count, MCP transports). No drift found, no new docs warranted. Re-confirms an open, unfixed, out-of-scope code observation from prior runs for a maintainer follow-up: `src/main.ts`'s `DEFAULT_SETTINGS.openaiModelName` still defaults to `'gpt-5.6'` while the OpenAI catalog's actual chat-default id is `'gpt-5.6-sol'` (siblings `openaiSummaryModelName`/`openaiCompletionsModelName` correctly use `-terra`/`-luna`); docs already document the effective `'gpt-5.6-sol'` default since `reconcileOpenAI()` self-heals the mismatch on first model-list load, so no doc fix is needed.
- **triage-issues**: 0 unlabeled open issues — nothing to apply.

## Screenshots / Screencast

N/A — no UI or behavior change, changelog-only diff.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A, this is the recurring automated daily-update job, not an issue-driven change.
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — also ran `npm run lint` (0 errors, 40 pre-existing warnings, all in `test/`) and `npm run typecheck:test` locally; full suite 171 files / 3804 tests passing.
- [ ] I have tested this change on Desktop — N/A, no runtime behavior changed (new markdown file only).
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — docs/changelog-only change, no platform-specific code touched.
- [x] Documentation has been updated (if applicable) — this PR's sole content is the documentation/changelog artifact; the docs audit found nothing else to update.
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (scheduled daily-update automation)
- [x] I have reviewed and understand all AI-generated code in this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01QqbX92GKntWhbYRTKD4Vei)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added the August 21, 2026 daily changelog.
  * Recorded recent maintenance, localization synchronization, indexing improvements, selection safeguards, and connection-target logging.
  * No user-facing behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->