### PR TITLE
refactor(tools): drop the loop detector's write-only state

### DIFF
--- a/src/tools/loop-detector.ts
+++ b/src/tools/loop-detector.ts
@@ -34,7 +34,7 @@ export class ToolLoopDetector {
 		}
 
 		const history = this.executionHistory.get(sessionId)!;
-		history.push({ key, timestamp, toolCall });
+		history.push({ key, timestamp });
 
 		// Keep history size manageable
 		if (history.length > this.maxHistorySize) {
@@ -56,16 +56,11 @@ export class ToolLoopDetector {
 	 * Get loop detection info for a tool call
 	 */
 	getLoopInfo(sessionId: string, toolCall: ToolCall): LoopDetectionInfo {
-		const key = this.getToolCallKey(toolCall);
-		const history = this.executionHistory.get(sessionId) || [];
-
 		const recentIdenticalCalls = this.getRecentIdenticalCalls(sessionId, toolCall);
-		const consecutiveCalls = this.countConsecutiveCalls(history, key);
 
 		return {
 			isLoop: recentIdenticalCalls.length >= this.loopThreshold,
 			identicalCallCount: recentIdenticalCalls.length,
-			consecutiveCallCount: consecutiveCalls,
 			timeWindowMs: this.timeWindowMs,
 			lastCallTimestamp: recentIdenticalCalls[recentIdenticalCalls.length - 1]?.timestamp,
 		};
@@ -119,21 +114,6 @@ export class ToolLoopDetector {
 	}
 
 	/**
-	 * Count consecutive calls with the same key
-	 */
-	private countConsecutiveCalls(history: ToolExecutionRecord[], targetKey: string): number {
-		let count = 0;
-		for (let i = history.length - 1; i >= 0; i--) {
-			if (history[i].key === targetKey) {
-				count++;
-			} else {
-				break;
-			}
-		}
-		return count;
-	}
-
-	/**
 	 * Clean up entries older than the time window
 	 */
 	private cleanupOldEntries(sessionId: string) {
@@ -149,16 +129,20 @@ export class ToolLoopDetector {
 	}
 }
 
+/**
+ * One recorded call. Only the derived {@link key} and the timestamp are kept —
+ * matching and windowing are both done on those, so holding the original
+ * `ToolCall` (and its arguments) here would retain it for the life of the
+ * session's history for no reader.
+ */
 interface ToolExecutionRecord {
 	key: string;
 	timestamp: number;
-	toolCall: ToolCall;
 }
 
 export interface LoopDetectionInfo {
 	isLoop: boolean;
 	identicalCallCount: number;
-	consecutiveCallCount: number;
 	timeWindowMs: number;
 	lastCallTimestamp?: number;
 }

--- a/test/tools/loop-detector.test.ts
+++ b/test/tools/loop-detector.test.ts
@@ -154,7 +154,6 @@ describe('ToolLoopDetector', () => {
 
 		expect(info.isLoop).toBe(false);
 		expect(info.identicalCallCount).toBe(2);
-		expect(info.consecutiveCallCount).toBe(2);
 		expect(info.timeWindowMs).toBe(60000);
 		expect(info.lastCallTimestamp).toBeDefined();
 	});


### PR DESCRIPTION
## Summary

`audit-architecture` nightly sweep flagged: **dead surface** in `src/tools/loop-detector.ts`.

Two pieces of `ToolLoopDetector` state are written and never read.

`LoopDetectionInfo.consecutiveCallCount` is recomputed on every `getLoopInfo()` call via the private `countConsecutiveCalls` walk. The only production consumer is `ToolExecutionEngine.executeTool`, which reads `isLoop`, `identicalCallCount`, and `timeWindowMs` — nothing anywhere in `src/` reads `consecutiveCallCount`. `ToolExecutionRecord.toolCall` is the same shape: pushed on every recorded call, never accessed. Matching and windowing both run off the derived `key`, so that field only served to pin the full tool arguments in the session's history array for the life of the session.

Neither is visible to `npm run knip`: both are class/interface *members* rather than exports, and `LoopDetectionInfo` is re-exported through the `src/index.ts` barrel, which exempts it anyway (see #1356).

Deletion only — no behavior change. The remaining `LoopDetectionInfo` fields, the threshold/window config, and every public method on the detector are untouched, and the one test assertion on the removed field is dropped with it.

Related to the wider dead-member sweep this run filed separately; `ToolLoopDetector.isLoopDetected` (a public method with no production caller but 16 test call sites) is deliberately **not** touched here — collapsing it into `getLoopInfo().isLoop` would rewrite most of `test/tools/loop-detector.test.ts`, which is a judgment call, not a mechanical one.

## Changes

- `src/tools/loop-detector.ts` — remove `consecutiveCallCount` from `LoopDetectionInfo`, remove the private `countConsecutiveCalls` helper, and remove the unread `toolCall` field from `ToolExecutionRecord` (documenting why the record keeps only `key` + `timestamp`).
- `test/tools/loop-detector.test.ts` — drop the single assertion on the removed field.

## Screenshots / Screencast

N/A — no UI surface is touched.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: filed directly by the nightly `audit-architecture` sweep as a mechanical dead-code deletion, not from an approved issue.
- [x] All CI checks pass — verified locally: `npm run format-check`, `npm run lint` (0 errors), `npm run build`, `npm run typecheck:test`, `npm test` (171 files, 3804 tests passing).
- [ ] I have tested this change on Desktop — N/A: deletion-only change to unreachable state, with no runtime surface to exercise; covered by the unit suite.
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — no platform-specific API is involved.
- [ ] Documentation has been updated (if applicable) — N/A: internal-only, no user-facing behavior, settings, or documented API changes.
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (`audit-architecture` skill)
- [x] I have reviewed and understand all AI-generated code in this PR

---

_Filed by the `audit-architecture` skill._

---
_Generated by [Claude Code](https://claude.ai/code/session_0111BY6wfCPT4Pp4Wm4z6YSQ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved loop detection by consistently identifying repeated tool calls.
  - Simplified loop status reporting to focus on recent identical calls.
  - Removed outdated consecutive-call information from loop details.

- **Documentation**
  - Clarified the information retained for tool execution history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->