### PR TITLE
refactor(hooks): share the hook default constants via the leaf module

### DIFF
--- a/src/services/hook-manager.ts
+++ b/src/services/hook-manager.ts
@@ -49,7 +49,7 @@ export type {
 	HookTrigger,
 	HookUpdateParams,
 } from './hook-types';
-export { DEFAULT_COOLDOWN_MS, DEFAULT_DEBOUNCE_MS, renderPrompt } from './hook-types';
+export { renderPrompt } from './hook-types';
 
 // Hook slugs become file basenames inside `Hooks/`, so we mirror the same
 // constraints the skills system uses: lowercase ASCII letters/digits/hyphens,

--- a/src/services/hook-manager.ts
+++ b/src/services/hook-manager.ts
@@ -12,6 +12,7 @@ import type {
 	HookTrigger,
 	HookUpdateParams,
 } from './hook-types';
+import { DEFAULT_COOLDOWN_MS, DEFAULT_DEBOUNCE_MS } from './hook-types';
 import {
 	extractMarkdownBody,
 	migrateLegacyEnabledTools,
@@ -26,16 +27,6 @@ import { matchesFrontmatterFilter, matchesGlob } from './hook-matcher';
 
 const HOOKS_FOLDER = 'Hooks';
 const STATE_FILE = 'hooks-state.json';
-
-/** Default per-(hook, file) debounce window (ms). Resets on every matching event. */
-const DEFAULT_DEBOUNCE_MS = 5000;
-
-/**
- * Default cooldown after a hook fire completes — further (hook, file) events
- * within this window are suppressed to prevent self-retrigger when the hook's
- * agent run wrote to the same file that triggered it.
- */
-const DEFAULT_COOLDOWN_MS = 30_000;
 
 /** Hard loop ceiling: max fires per (hook, file) inside the loop window. */
 const HARD_LOOP_LIMIT = 5;
@@ -58,7 +49,7 @@ export type {
 	HookTrigger,
 	HookUpdateParams,
 } from './hook-types';
-export { renderPrompt } from './hook-types';
+export { DEFAULT_COOLDOWN_MS, DEFAULT_DEBOUNCE_MS, renderPrompt } from './hook-types';
 
 // Hook slugs become file basenames inside `Hooks/`, so we mirror the same
 // constraints the skills system uses: lowercase ASCII letters/digits/hyphens,

--- a/src/services/hook-types.ts
+++ b/src/services/hook-types.ts
@@ -6,6 +6,25 @@ import type { FeatureToolPolicy } from '../types/tool-policy';
  * depend on them without importing each other (see #1155). hook-manager.ts
  * re-exports everything here, so external import paths are unchanged.
  */
+// ─── Defaults ─────────────────────────────────────────────────────────────────
+//
+// These live in the leaf (rather than in hook-manager.ts) because both the
+// manager and the management modal need them: the manager applies them when
+// creating/parsing a hook, and the modal seeds its form, placeholder, and
+// field description from the same numbers. A second copy in the UI would let
+// the two drift, so the modal shows one default while the manager writes
+// another.
+
+/** Default per-(hook, file) debounce window (ms). Resets on every matching event. */
+export const DEFAULT_DEBOUNCE_MS = 5000;
+
+/**
+ * Default cooldown after a hook fire completes — further (hook, file) events
+ * within this window are suppressed to prevent self-retrigger when the hook's
+ * agent run wrote to the same file that triggered it.
+ */
+export const DEFAULT_COOLDOWN_MS = 30_000;
+
 // ─── Public types ─────────────────────────────────────────────────────────────
 
 export type HookTrigger = 'file-created' | 'file-modified' | 'file-deleted' | 'file-renamed';

--- a/src/ui/hook-management-modal.ts
+++ b/src/ui/hook-management-modal.ts
@@ -1,5 +1,6 @@
 import { Notice, Setting, setIcon } from 'obsidian';
 import type { Hook, HookAction, HookCreateParams, HookState, HookTrigger, HooksState } from '../services/hook-manager';
+import { DEFAULT_COOLDOWN_MS, DEFAULT_DEBOUNCE_MS } from '../services/hook-types';
 import type { FeatureToolPolicy } from '../types/tool-policy';
 import { DEFAULT_HEADLESS_MAX_ITERATIONS } from '../agent/agent-loop';
 import { ManagementModalBase } from './components/management-modal-base';
@@ -20,9 +21,6 @@ const ACTION_OPTIONS = [
 	{ value: 'rewrite', labelKey: 'hooks.actionRewrite' },
 	{ value: 'command', labelKey: 'hooks.actionCommand' },
 ] as const;
-
-const DEFAULT_DEBOUNCE_MS = 5000;
-const DEFAULT_COOLDOWN_MS = 30_000;
 
 /**
  * Full CRUD management modal for lifecycle hooks. Extends the shared


### PR DESCRIPTION
## Summary

`audit-architecture` nightly sweep flagged a **dry-violation** in `src/services/hook-manager.ts` / `src/ui/hook-management-modal.ts`.

`DEFAULT_DEBOUNCE_MS` (`5000`) and `DEFAULT_COOLDOWN_MS` (`30_000`) are each declared twice — once in `HookManager`, which applies them when creating and parsing hooks, and once in `HookManagementModal`, which seeds its blank form, its text-field placeholder, and the `{default}` interpolated into `hooks.debounceDesc` / `hooks.cooldownDesc` from the same numbers. Nothing links the two copies, so changing one would leave the settings UI advertising and writing a default the manager does not apply.

The fix moves both constants down into `src/services/hook-types.ts` — the leaf module `coding.md` names for exactly this case ("when a manager and a sibling module need the same type or helper, put it in a leaf module both import"), and the module `hook-manager.ts` already sources its hook types from. Both `hook-manager.ts` and `hook-management-modal.ts` now import them from there.

This is a pure value-preserving move: both literals were already identical, so no behaviour changes. It is not linked to an approved issue, but it does clear a prerequisite that #1315 already anticipated in its proposed unit of work ("The default constants (`DEFAULT_DEBOUNCE_MS`, `DEFAULT_COOLDOWN_MS`) will need to move down into the leaf, or into a constants module both import"). #1315 itself explicitly treats `hook-management-modal.ts` as out of scope, so the duplication against the modal is not covered there and is fixed here.

## Changes

- `src/services/hook-types.ts` — add a `Defaults` section exporting `DEFAULT_DEBOUNCE_MS` and `DEFAULT_COOLDOWN_MS`, carrying over the original doc comments plus a note on why they live in the leaf.
- `src/services/hook-manager.ts` — drop the local declarations, import both from `./hook-types`.
- `src/ui/hook-management-modal.ts` — drop the local declarations and import both from `../services/hook-types`.

Unlike the sibling hook *types*, the two constants are deliberately **not** re-exported from `hook-manager.ts`. Nothing imports them from there, and a re-export with no consumer is a dead export — the first push of this PR added one for symmetry and the `Dead-code & unused-deps` check correctly failed it (`Unused exports (2)`). The second commit removes it; `renderPrompt` keeps its re-export because it does have consumers routed that way.

## Screenshots / Screencast

N/A — no rendered output changes. The modal's form defaults, placeholder, and description interpolation resolve to the same numbers as before.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: filed by the automated architecture sweep, which opens single-unit mechanical fixes directly. Related context in #1315.
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — plus `npm run lint` (0 errors), `npm run knip`, `npm run typecheck:test`, and `npm run lint:cycles` (still 0 cycles). 3804 tests across 171 files pass. All re-run after the knip fix.
- [ ] I have tested this change on Desktop — N/A: no runtime behaviour to exercise; the change is a compile-time constant move verified by the type checker and the existing hook test suite.
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — no new platform-specific API use; `hook-types.ts` is a plain leaf module with no Node/Electron imports.
- [ ] Documentation has been updated (if applicable) — N/A: purely internal refactor with no user-facing behaviour, settings, or defaults change.
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (`audit-architecture` skill)
- [x] I have reviewed and understand all AI-generated code in this PR

---

_Filed by the `audit-architecture` skill._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Standardized default timing settings across hook-related features.
  * Hook debounce timing is now set to 5 seconds.
  * Hook cooldown timing is now set to 30 seconds.
  * These defaults are applied consistently wherever hook timing is configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->