### PR TITLE
refactor(vault-analyzer): reuse the shared system-path exclusion helper

### DIFF
--- a/src/services/vault-analyzer.ts
+++ b/src/services/vault-analyzer.ts
@@ -5,7 +5,7 @@ import { ModelClientFactory } from '../api';
 import { AgentsMemoryData } from './agents-memory';
 import { VaultAnalysisModal } from '../ui/vault-analysis-modal';
 import { collectFilesFromFolder } from '../utils/folder-walk';
-import { isPathInFolder } from '../utils/file-utils';
+import { shouldExcludePathForPlugin } from '../utils/file-utils';
 import { t } from '../i18n';
 import { asRecord, getRawErrorMessageOr } from '../utils/error-utils';
 
@@ -258,8 +258,7 @@ export class VaultAnalyzer {
 		let structure = '';
 
 		// Skip system folders (the Obsidian config dir may be renamed from `.obsidian`)
-		const skipFolders = [this.plugin.app.vault.configDir, this.plugin.settings.historyFolder];
-		if (skipFolders.includes(folder.path)) {
+		if (this.isSystemPath(folder.path)) {
 			return '';
 		}
 
@@ -312,13 +311,12 @@ export class VaultAnalyzer {
 	 * configuration directory — neither is user content, so neither belongs in
 	 * anything we count, fingerprint, or show the model.
 	 *
-	 * Root-anchored containment so a sibling like `gemini-scribe-backup/` or a
-	 * renamed `_obsidian-notes/` is not wrongly excluded by a bare prefix match.
+	 * Delegates to the shared helper so the containment semantics (root-anchored,
+	 * so a sibling like `gemini-scribe-backup/` or a renamed `_obsidian-notes/` is
+	 * not wrongly excluded by a bare prefix match) live in exactly one place.
 	 */
 	private isSystemPath(path: string): boolean {
-		return (
-			isPathInFolder(path, this.plugin.settings.historyFolder) || isPathInFolder(path, this.plugin.app.vault.configDir)
-		);
+		return shouldExcludePathForPlugin(path, this.plugin);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

`audit-architecture` nightly sweep flagged: **dry-violation** in `src/services/vault-analyzer.ts`.

`VaultAnalyzer.isSystemPath` was a verbatim reimplementation of `shouldExcludePathForPlugin` (`src/utils/file-utils.ts`) — the same "inside the plugin state folder or inside `vault.configDir`, root-anchored" predicate, with the two copies kept in step by a comment rather than by construction. `buildFolderStructure` carried a *third* spelling of the same intent in the same file, as an exact-equality check against a `[configDir, historyFolder]` array.

The shared helper is what the vault tools, `FileMentionModal`, `AgentView`, and `HookManager` already call; `vault-analyzer.ts` was the one holdout. Routing both sites through it is a substitution, not a behaviour change: `shouldExcludePath` runs the same two `isPathInFolder` checks (in the other order, which is irrelevant to an `||`) and additionally guards against an empty `excludeFolder`, so it is a strict superset of the local copy. Swapping `buildFolderStructure`'s exact-equality check for `isSystemPath` widens it from "this folder is the system folder" to "this folder is at or under it"; the recursion is top-down from the vault root, so every system folder was already caught by its own exact match and the reachable outcome is unchanged.

This is deliberately narrow. The state-folder *layout* duplication is #1382, which puts the exclusion helpers explicitly out of scope; the `isPathInFolder` trailing-slash question is #1374. Neither is touched here.

Fixes N/A — no tracking issue; filed directly by the audit.

## Changes

- `src/services/vault-analyzer.ts` — `isSystemPath` now delegates to `shouldExcludePathForPlugin`; `buildFolderStructure` calls `isSystemPath` instead of hand-rolling a `skipFolders.includes(...)` check; import swapped from `isPathInFolder` to `shouldExcludePathForPlugin`.

## Screenshots / Screencast

N/A — internal refactor with no UI surface.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A, opened by the `audit-architecture` sweep, which files a PR directly for mechanical fixes.
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [ ] I have tested this change on Desktop — N/A, not manually exercised; covered by the automated suite (171 files / 3804 tests green) and by the change being a like-for-like substitution.
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — no platform-specific API is involved; `shouldExcludePathForPlugin` is pure string comparison.
- [ ] Documentation has been updated (if applicable) — N/A, no user-facing behaviour, settings, or docs surface changes.
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (`audit-architecture` skill)
- [x] I have reviewed and understand all AI-generated code in this PR

---

_Filed by the `audit-architecture` skill._

---
_Generated by [Claude Code](https://claude.ai/code/session_01GKVfgG9nc8Rw51Y8mg4ekR)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved folder analysis by consistently excluding system-managed paths, including history and configuration folders.
  * Prevented system paths from being included during folder traversal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->