### PR TITLE
refactor(settings): stop resurrecting the migrated alwaysAllowReadWrite key

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -99,8 +99,6 @@ const DEFAULT_SETTINGS: ObsidianGeminiSettings = {
 	loopDetectionEnabled: true,
 	loopDetectionThreshold: 3,
 	loopDetectionTimeWindowSeconds: 30,
-	// Trusted Mode (legacy — migrated to toolPolicy)
-	alwaysAllowReadWrite: false,
 	// Tool policy settings
 	toolPolicy: { ...DEFAULT_TOOL_POLICY },
 	// Version tracking for update notifications
@@ -510,19 +508,25 @@ export default class ObsidianGemini extends Plugin implements ObsidianGeminiApi 
 		// after ModelListProvider has loaded the cached remote model list. Running it here
 		// against DEFAULT_GEMINI_MODELS would use a stale list.
 
-		// Migrate legacy alwaysAllowReadWrite → toolPolicy
+		// Migrate legacy alwaysAllowReadWrite → toolPolicy, then drop the key.
+		// The removal is deliberately outside the `!data.toolPolicy` guard: a
+		// migrated install that still carries the key (written back before the key
+		// was dropped from DEFAULT_SETTINGS) must be cleaned up too, or it lingers
+		// and can re-drive the preset if `toolPolicy` ever goes missing.
 		const legacyAllowReadWrite = data.alwaysAllowReadWrite;
-		if (legacyAllowReadWrite !== undefined && !data.toolPolicy) {
-			this.settings.toolPolicy = {
-				activePreset: legacyAllowReadWrite ? PolicyPreset.EDIT_MODE : PolicyPreset.CAUTIOUS,
-				toolPermissions: {},
-			};
+		if (legacyAllowReadWrite !== undefined) {
+			if (!data.toolPolicy) {
+				this.settings.toolPolicy = {
+					activePreset: legacyAllowReadWrite ? PolicyPreset.EDIT_MODE : PolicyPreset.CAUTIOUS,
+					toolPermissions: {},
+				};
+				this.logger?.log(
+					`Migrated alwaysAllowReadWrite=${legacyAllowReadWrite ? 'true' : 'false'} → toolPolicy.activePreset=${this.settings.toolPolicy.activePreset}`
+				);
+			}
 			// Clear the legacy setting
 			delete (this.settings as { alwaysAllowReadWrite?: unknown }).alwaysAllowReadWrite;
 			await this.saveData(this.settings);
-			this.logger?.log(
-				`Migrated alwaysAllowReadWrite=${legacyAllowReadWrite ? 'true' : 'false'} → toolPolicy.activePreset=${this.settings.toolPolicy.activePreset}`
-			);
 		}
 	}
 

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -99,8 +99,6 @@ export interface ObsidianGeminiSettings {
 	loopDetectionEnabled: boolean;
 	loopDetectionThreshold: number;
 	loopDetectionTimeWindowSeconds: number;
-	// Trusted Mode (legacy — migrated to toolPolicy)
-	alwaysAllowReadWrite: boolean;
 	// Tool policy settings
 	toolPolicy: ToolPolicySettings;
 	// Version tracking for update notifications


### PR DESCRIPTION
## Summary

`audit-architecture` nightly sweep flagged: **dead surface** in `src/types/settings.ts` / `src/main.ts`.

`alwaysAllowReadWrite` is a deprecated setting. Its migration (`src/main.ts:511`) reads the persisted value, folds it into `toolPolicy.activePreset`, deletes the key from `this.settings`, and saves. But the field was *also* still declared as a required member of `ObsidianGeminiSettings` and still seeded in `DEFAULT_SETTINGS` — so the deletion never stuck:

1. Migration deletes the key and saves. `data.json` is clean.
2. Next `loadSettings` runs `Object.assign({}, DEFAULT_SETTINGS, data)` → `alwaysAllowReadWrite: false` comes back from the defaults.
3. The migration guard is `data.alwaysAllowReadWrite !== undefined`, and `data` (the raw persisted record) no longer has it, so the migration does not re-fire.
4. The next `saveSettings()` writes the key back to `data.json`, permanently.

Fresh installs get it too — they write a key they never had. `alwaysAllowReadWrite` has no reader anywhere in `src/` outside the migration itself, so the field is pure dead surface being re-persisted on every save.

There is also a narrow correctness path behind it: because the key is resurrected as `false`, an install that ever loses `toolPolicy` from `data.json` (hand-edit, sync conflict, downgrade-then-upgrade) would re-run the migration against the resurrected `false` and be forced to `PolicyPreset.CAUTIOUS` — silently downgrading a user who had chosen `EDIT_MODE`. Removing the seed closes that path as well.

The fix follows the pattern the same function already uses two blocks above for `apiKey`, `modelDiscovery`, and `modelDiscoveryCache`: those are absent from both the interface and `DEFAULT_SETTINGS`, and are read off the raw `asRecord(rawData)` during migration only. `alwaysAllowReadWrite` was the one deprecated field that never got that treatment.

Fixes N/A — no tracking issue; filed directly by the audit.

## Changes

- `src/types/settings.ts` — drop the deprecated `alwaysAllowReadWrite` member from `ObsidianGeminiSettings`.
- `src/main.ts` — drop `alwaysAllowReadWrite: false` from `DEFAULT_SETTINGS`.
- `src/main.ts` — hoist the delete-and-save out of the `!data.toolPolicy` guard, so an install that already carries the resurrected key is cleaned up on next load rather than only on the one-time preset migration. The preset migration itself (and its log line) stays gated on `!data.toolPolicy` exactly as before.

The migration continues to read `data.alwaysAllowReadWrite` off the raw record, which is typed `Record<string, unknown>` via `asRecord` — so removing the interface member does not change how the legacy value is read, and real legacy installs migrate exactly as they did.

## Screenshots / Screencast

N/A — no UI surface. `alwaysAllowReadWrite` has had no settings control since the `toolPolicy` migration landed.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A, opened by the `audit-architecture` sweep, which files a PR directly for mechanical fixes.
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — also `npm run lint`, `npm run typecheck:test`, `npm run knip`, and `npm run lint:cycles`.
- [ ] I have tested this change on Desktop — N/A, not manually exercised in a vault. Disclosed as a known gap: `loadSettings` has no test harness today (`test/main.test.ts` only asserts type shapes), so no regression test was added either. The guard that replaces it is the type system: `DEFAULT_SETTINGS` is annotated `ObsidianGeminiSettings`, so re-adding the field to the defaults without re-adding it to the interface is now a compile error — the same mechanism the sibling deprecated fields rely on. Building a `loadSettings` harness (mocking `Plugin`, `loadData`/`saveData`, `secretStorage`) is real work and belongs in its own change, not bolted onto a four-line removal.
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — no platform-specific API involved; the touched code is plain object/settings handling.
- [ ] Documentation has been updated (if applicable) — N/A. `alwaysAllowReadWrite` appears nowhere in `docs/` or `README.md`; it was already undocumented as a deprecated internal key.
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (`audit-architecture` skill)
- [x] I have reviewed and understand all AI-generated code in this PR

---

_Filed by the `audit-architecture` skill._

---
_Generated by [Claude Code](https://claude.ai/code/session_01GKVfgG9nc8Rw51Y8mg4ekR)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved migration of legacy permission settings.
  - Legacy settings are now cleared reliably, including when newer tool permission settings already exist.
  - Preset conversion continues only when no tool permission configuration has been saved.

- **Refactor**
  - Consolidated tool permission management under the current tool policy settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->