### PR TITLE
chore(daily): 2026-08-25 daily update

### DIFF
--- a/planning/changelog/2026-08-24.md
+++ b/planning/changelog/2026-08-24.md
@@ -1,0 +1,16 @@
+# Daily changelog — August 24, 2026
+
+**Date:** 2026-08-24
+**PRs merged:** 1
+
+---
+
+## Summary
+
+Quiet day — a single mechanical dry-violation fix from the automated architecture sweep.
+
+## What shipped
+
+### [#1390 refactor(hooks): share the hook default constants via the leaf module](https://github.com/allenhutchison/obsidian-gemini/pull/1390)
+
+The `audit-architecture` nightly sweep found `DEFAULT_DEBOUNCE_MS` and `DEFAULT_COOLDOWN_MS` declared twice — once in `HookManager`, which applies them, and once in `HookManagementModal`, which used the same numbers to seed its form defaults, placeholder, and description text. Nothing linked the two copies, so changing one would have left the settings UI advertising a default the manager didn't actually use. Both constants now live in the leaf module `src/services/hook-types.ts`, with `hook-manager.ts` and `hook-management-modal.ts` importing from there instead of each declaring their own. Purely a compile-time constant move — no behavior change.


### PR DESCRIPTION
## Summary

Daily housekeeping run: writes the changelog entry for yesterday's merged PRs. No doc drift or unlabeled issues found today.

## Changes

- `daily-changelog`: added `planning/changelog/2026-08-24.md` covering the 1 PR merged that day (#1390 — a mechanical dedup of duplicated hook-timing constants into a leaf module, filed by the `audit-architecture` sweep).
- `audit-product-docs`: audited `docs/guide/`, `docs/reference/`, `README.md`, and `AGENTS.md` against `src/` (settings defaults, command IDs, tool names, provider capability matrix, MCP timeouts, context-compaction constants, etc.) — no drift found, no new docs warranted.
- `triage-issues`: checked for unlabeled open issues — none found.

## Screenshots / Screencast

N/A — docs/changelog-only change, no UI impact.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: routine automated daily-housekeeping run, not tied to a specific issue.
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — plus `npm run lint` (0 errors) and `npm run typecheck:test`. 3804 tests across 171 files pass.
- [ ] I have tested this change on Desktop — N/A: adds a markdown changelog file only, no runtime behavior.
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — no code changes, markdown-only.
- [ ] Documentation has been updated (if applicable) — N/A: this PR *is* the documentation/changelog update; the docs audit itself found nothing to change.
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (`daily-update` meta-skill)
- [x] I have reviewed and understand all AI-generated code in this PR


---
_Generated by [Claude Code](https://claude.ai/code/session_01HMm6Bw2r3Ddvem4YUoXSeJ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added the August 24, 2026 daily changelog entry.
  * Documented the latest maintenance update and confirmed there are no changes to runtime behavior or publicly available features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->