### PR TITLE
refactor(agent-view): share the usage-metadata emit between both send paths

### DIFF
--- a/src/ui/agent-view/agent-view-send.ts
+++ b/src/ui/agent-view/agent-view-send.ts
@@ -572,15 +572,7 @@ To reference an attachment in your response, use the path shown above.`;
 						const response = await streamResponse.complete;
 						this.currentStreamingResponse = null;
 
-						// Emit usage metadata via event bus (contextManager subscribes)
-						if (response.usageMetadata) {
-							await this.ctx.plugin.agentEventBus?.emit('apiResponseReceived', {
-								usageMetadata: response.usageMetadata,
-								modelName,
-							});
-						} else {
-							this.ctx.plugin.logger.debug('[AgentView] Streaming response had no usageMetadata');
-						}
+						await this.emitUsageMetadata(response, modelName, 'Streaming');
 
 						// Model reasoning for this turn — prefer the completed response's
 						// thoughts; fall back to whatever streamed into the progress bar.
@@ -664,15 +656,7 @@ To reference an attachment in your response, use the path shown above.`;
 					this.ctx.plugin.logger.log('Agent view using non-streaming API');
 					const response = await modelApi.generateModelResponse(request);
 
-					// Emit usage metadata via event bus (contextManager subscribes)
-					if (response.usageMetadata) {
-						await this.ctx.plugin.agentEventBus?.emit('apiResponseReceived', {
-							usageMetadata: response.usageMetadata,
-							modelName,
-						});
-					} else {
-						this.ctx.plugin.logger.debug('[AgentView] Non-streaming response had no usageMetadata');
-					}
+					await this.emitUsageMetadata(response, modelName, 'Non-streaming');
 
 					// Update progress to show response received
 					this.ctx.progress.update(t('agent.progress.processing'), 'waiting');
@@ -732,6 +716,31 @@ To reference an attachment in your response, use the path shown above.`;
 
 			// Always update token usage display after any message completion
 			await this.ctx.updateTokenUsage();
+		}
+	}
+
+	/**
+	 * Publish a model response's usage metadata on the event bus (contextManager
+	 * subscribes) so the token display reflects the turn. Shared by the streaming
+	 * and non-streaming send paths, which previously carried the same eight-line
+	 * emit-or-debug-log block with only the log prefix differing.
+	 *
+	 * `pathLabel` names the send path in the debug log ('Streaming' /
+	 * 'Non-streaming'); it is logger output, so it stays English per the i18n rule
+	 * in `.claude/guidelines/coding.md`.
+	 */
+	private async emitUsageMetadata(
+		response: Pick<ModelResponse, 'usageMetadata'>,
+		modelName: string,
+		pathLabel: string
+	): Promise<void> {
+		if (response.usageMetadata) {
+			await this.ctx.plugin.agentEventBus?.emit('apiResponseReceived', {
+				usageMetadata: response.usageMetadata,
+				modelName,
+			});
+		} else {
+			this.ctx.plugin.logger.debug(`[AgentView] ${pathLabel} response had no usageMetadata`);
 		}
 	}
 


### PR DESCRIPTION
## Summary

`audit-architecture` nightly sweep flagged: **dry-violation** in `src/ui/agent-view/agent-view-send.ts`.

The streaming and non-streaming arms of `AgentViewSend.sendMessage()` each carried the same eight-line block — emit `apiResponseReceived` on the agent event bus when the response has `usageMetadata`, otherwise write a debug log line. The only difference between the two copies was the log prefix (`Streaming` vs `Non-streaming`), so keeping the emitted event payload and the log shape consistent was a manual job. The clone sits below jscpd's 12-line bar and differs by a string literal, so neither the existing duplicate scans nor CI would ever surface it.

This extracts a private `emitUsageMetadata(response, modelName, pathLabel)` and calls it from both arms, with the debug prefix passed in as `pathLabel`. Pure extraction: the emitted event, its payload, the `?.` guard on `agentEventBus`, and the awaited ordering relative to the surrounding code are all unchanged. `pathLabel` is logger output, so it stays English per the i18n rule in `.claude/guidelines/coding.md`.

This does not attempt to shrink `sendMessage()` itself, which is ~505 lines and is filed separately as a design-level finding by the same sweep.

Fixes N/A — filed directly by the audit sweep, no pre-existing issue.

## Changes

- `src/ui/agent-view/agent-view-send.ts` — add private `emitUsageMetadata(response, modelName, pathLabel)`; replace the duplicated emit-or-log block in the streaming arm and the non-streaming arm with a call to it.

## Screenshots / Screencast

N/A — no UI change. The refactor is internal to the send path; nothing rendered changes.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: opened directly by the `audit-architecture` nightly sweep, which routes mechanical, well-scoped findings to a PR rather than an issue.
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — run locally before pushing: `npm run format-check` clean, `npm run lint` 0 errors (40 pre-existing warnings, all in `test/`), `npm run build` clean, `npm run typecheck:test` clean, `npm test` 3804 passed / 171 files.
- [ ] I have tested this change on Desktop — not run in a live vault. This is a pure extraction with no behavior change, covered by the existing suite; a reviewer wanting a live check should exercise a chat turn on both the streaming and non-streaming paths and confirm the token-usage display still updates.
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — no platform-specific API is touched; the moved code is event-bus and logger calls only.
- [ ] Documentation has been updated (if applicable) — N/A: internal refactor with no user-facing behavior, settings, or command surface change.
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (`audit-architecture` skill)
- [x] I have reviewed and understand all AI-generated code in this PR

---

_Filed by the `audit-architecture` skill._

---
_Generated by [Claude Code](https://claude.ai/code/session_01XVtcrwrrGqnVp2ohkfzdhN)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Usage metadata is now consistently reported for both streaming and standard responses.
  - Model and usage details are captured across response delivery paths, improving the accuracy of usage tracking.
  - Additional diagnostic messages are available when usage information cannot be published.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->