### PR TITLE
chore(daily): 2026-08-27 daily update

### DIFF
--- a/planning/changelog/2026-08-26.md
+++ b/planning/changelog/2026-08-26.md
@@ -1,0 +1,14 @@
+# Daily changelog — August 26, 2026
+
+**Date:** 2026-08-26
+**PRs merged:** 0
+
+---
+
+## Summary
+
+Quiet day — no PRs merged.
+
+## What shipped
+
+Nothing merged today.


### PR DESCRIPTION
## Summary

Daily housekeeping run for 2026-08-27, produced by the `daily-update` meta-skill orchestrating the repo's configured sub-skill roster (`daily-changelog`, `audit-product-docs`, `triage-issues`).

## Changes

- **daily-changelog**: Wrote `planning/changelog/2026-08-26.md`. Quiet day — 0 PRs merged on 2026-08-26 (confirmed via `search_pull_requests` against the repo; the most recent merge before this run was #1390 on 2026-08-24).
- **audit-product-docs**: No drift found across `README.md`, `AGENTS.md`, `docs/guide/`, and `docs/reference/` — every checked settings name/default, command ID, folder path, schedule grammar, tool name, and frontmatter field matched the code. No new docs warranted (no zero-documented, load-bearing, user-visible features found; recent `src/` commits were internal refactors). No working-tree changes from this sub-skill.
- **triage-issues**: No unlabeled open issues — all 39 open issues already carry labels. No GitHub-side changes.

## Notes for the maintainer

- The doc audit surfaced one **code-level** (not doc) drift observation, out of scope for this skill to fix: `src/main.ts`'s `DEFAULT_SETTINGS.openaiModelName` is hardcoded to `'gpt-5.6'`, while every other reference (the model catalog in `src/services/openai-models-service.ts` and three doc files) uses `'gpt-5.6-sol'`. It's harmless today because `reconcileOpenAI` in `src/models.ts` self-heals the value at load time, but the literal default is effectively a typo worth fixing in its own PR.
- `config.paths.prTemplate` (`.github/PULL_REQUEST_TEMPLATE.md`) does not exist in the repo despite being set in `.claude/maintainerd.json`. This PR body falls back to the generic Summary/Changes structure; consider re-running `/bootstrap` to scaffold a template or clear the stale config key.

## Checklist

- [x] Format check (`npm run format-check`) passes
- [x] Lint (`npm run lint`) passes — 0 errors (40 pre-existing warnings, unrelated to this diff)
- [x] Build (`npm run build`) passes
- [x] Typecheck (`npm run typecheck:test`) passes
- [x] Tests (`npm test`) pass — 3804/3804
- [x] Circular-import check (`npm run lint:cycles`) passes
- [N/A] Documentation updates — this PR *is* the documentation/housekeeping update; no further docs needed
- [N/A] Screenshots — no UI changes

---
_Generated by [Claude Code](https://claude.ai/code/session_015Pc3143QKLozq7mZT6KEMj)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added the August 26, 2026 daily changelog.
  * Recorded that no pull requests were merged and no changes were shipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->