### PR TITLE
refactor(paths): use isPathInFolder for five inline containment checks

### DIFF
--- a/src/services/deep-research.ts
+++ b/src/services/deep-research.ts
@@ -363,8 +363,7 @@ export class DeepResearchService {
 		if (historyFolder) {
 			const normalizedHistoryFolder = normalizePath(historyFolder);
 			const backgroundTasksFolder = normalizePath(`${normalizedHistoryFolder}/Background-Tasks`);
-			const insideStateFolder =
-				normalizedPath === normalizedHistoryFolder || normalizedPath.startsWith(normalizedHistoryFolder + '/');
+			const insideStateFolder = isPathInFolder(normalizedPath, normalizedHistoryFolder);
 			const insideBackgroundTasks = normalizedPath.startsWith(backgroundTasksFolder + '/');
 			if (insideStateFolder && !insideBackgroundTasks) {
 				throw new Error(

--- a/src/services/image-generation.ts
+++ b/src/services/image-generation.ts
@@ -293,8 +293,7 @@ export class ImageGeneration {
 		if (historyFolder) {
 			const normalizedHistoryFolder = normalizePath(historyFolder);
 			const backgroundTasksFolder = normalizePath(`${normalizedHistoryFolder}/Background-Tasks`);
-			const insideStateFolder =
-				normalizedFilePath === normalizedHistoryFolder || normalizedFilePath.startsWith(normalizedHistoryFolder + '/');
+			const insideStateFolder = isPathInFolder(normalizedFilePath, normalizedHistoryFolder);
 			const insideBackgroundTasks = normalizedFilePath.startsWith(backgroundTasksFolder + '/');
 			if (insideStateFolder && !insideBackgroundTasks) {
 				throw new Error(`Output path cannot be inside the plugin state folder: "${outputPath}"`);

--- a/src/services/obsidian-file-adapter.ts
+++ b/src/services/obsidian-file-adapter.ts
@@ -229,7 +229,7 @@ export class ObsidianVaultAdapter implements FileSystemAdapter {
 
 		// Check user-configured exclude folders
 		for (const folder of this.excludeFolders) {
-			if (filePath.startsWith(folder + '/') || filePath === folder) {
+			if (isPathInFolder(filePath, folder)) {
 				return false;
 			}
 		}

--- a/src/services/project-manager.ts
+++ b/src/services/project-manager.ts
@@ -8,6 +8,7 @@ import {
 	parseToolPolicyFrontmatter,
 	serializeToolPolicy,
 } from '../types/tool-policy';
+import { isPathInFolder } from '../utils/file-utils';
 
 /** Regex to strip dataview/dataviewjs/bases fenced code blocks from body text */
 const UNSUPPORTED_CODE_BLOCK_RE = /```(?:dataview|dataviewjs|bases?)[\s\S]*?```/g;
@@ -93,8 +94,8 @@ export class ProjectManager {
 
 		for (const project of this.projectCache.values()) {
 			const root = project.rootPath;
-			// Root '' matches everything; otherwise check prefix with trailing /
-			const isMatch = root === '' ? true : path.startsWith(root + '/') || path === root;
+			// Root '' matches everything; otherwise require root-anchored containment
+			const isMatch = root === '' ? true : isPathInFolder(path, root);
 			if (isMatch && root.length > bestLength) {
 				bestMatch = project;
 				bestLength = root.length;

--- a/src/tools/vault/read-file-tool.ts
+++ b/src/tools/vault/read-file-tool.ts
@@ -52,8 +52,7 @@ export class ReadFileTool implements Tool {
 
 			// Allow reading agent session history files (needed by recall_sessions tool)
 			const agentSessionsFolder = normalizePath(`${plugin.settings.historyFolder}/Agent-Sessions`);
-			const isAgentSessionPath =
-				normalizedPath === agentSessionsFolder || normalizedPath.startsWith(agentSessionsFolder + '/');
+			const isAgentSessionPath = isPathInFolder(normalizedPath, agentSessionsFolder);
 			const isObsidianPath = isPathInFolder(normalizedPath, plugin.app.vault.configDir);
 
 			// Check if path is excluded (allow agent session files, but never the Obsidian config dir)


### PR DESCRIPTION
## Summary

`audit-architecture` nightly sweep flagged: **dry-violation** — `isPathInFolder()` in `src/utils/file-utils.ts` is the repo's canonical root-anchored path-containment predicate, but five call sites re-expand its exact body inline (`p === f || p.startsWith(f + '/')`) rather than calling it.

That matters because the predicate is a live fix surface. #1372 landed root-anchored containment for two folder checks and #1374 tracks a trailing-slash bug in `isPathInFolder` itself — neither a landed nor a pending fix to the canonical helper can reach a site that re-implements it. Every inline copy has to be found and fixed by hand.

This is a pure de-duplication: at each of the five sites the replaced expression and `isPathInFolder(path, folder)` compute the same boolean, so there is no behaviour change to review — only the coupling changes.

Not included, deliberately: the *strict-prefix-only* variants elsewhere in `src/` (`p.startsWith(f + '/')` with no `p === f` arm — `obsidian-file-adapter.ts:226`, `skill-manager.ts:263`, `session-list-modal.ts:116`, `tools/vault/utils.ts:28`, `list-files-tool.ts:83`, and the `Background-Tasks` arms in the two write-path validators). Routing those through `isPathInFolder` would add a `p === f` match, which is a real behaviour change and needs a per-site decision. They are being filed as a separate issue rather than smuggled into a no-op refactor.

## Changes

- `src/services/deep-research.ts` — `insideStateFolder` now calls `isPathInFolder` (import already present)
- `src/services/image-generation.ts` — same for `insideStateFolder` (import already present)
- `src/services/obsidian-file-adapter.ts` — the user-configured `excludeFolders` loop now calls `isPathInFolder` (import already present)
- `src/services/project-manager.ts` — `getProjectForPath`'s non-empty-root arm now calls `isPathInFolder`; adds the `file-utils` import and updates the now-stale comment above it
- `src/tools/vault/read-file-tool.ts` — `isAgentSessionPath` now calls `isPathInFolder` (import already present)

## Screenshots / Screencast

N/A — no UI surface is touched.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: filed by the nightly `audit-architecture` sweep, which routes mechanical no-op findings straight to a PR. Close it if the coupling is preferred as-is.
- [x] All CI checks pass — run locally before pushing: `npm run format-check`, `npm run lint` (0 errors), `npm run build`, `npm run typecheck:test`, `npm run lint:cycles` (0 cycles), `npm test` (171 files / 3804 tests passing)
- [ ] I have tested this change on Desktop — N/A: no runtime behaviour changes, and the five sites are covered by the existing suite (`test/services/project-manager.test.ts`, `test/services/deep-research.test.ts`, `test/services/image-generation.test.ts`, `test/tools/read-file-tool.test.ts`)
- [x] I have verified this change does not break Mobile — no platform-specific API is touched; `isPathInFolder` is pure string logic
- [ ] Documentation has been updated (if applicable) — N/A: internal refactor, no user-facing behaviour or settings change
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (`audit-architecture` skill)
- [x] I have reviewed and understand all AI-generated code in this PR

---

_Filed by the `audit-architecture` skill._

---
_Generated by [Claude Code](https://claude.ai/code/session_01BrPkotDSF1Cnh1SjuPBbXo)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file and folder path validation across research, image generation, project management, file indexing, and file reading.
  * Correctly handles both exact folder matches and nested paths.
  * Prevents similarly named folders from being incorrectly treated as contained paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->