### PR TITLE
Normalize state-folder setting at the settings boundary (#1374)

### DIFF
--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -82,6 +82,7 @@ UI sections without a dedicated topic in this reference: _Vault search index_ (c
 - **Type**: String
 - **Default**: `gemini-scribe`
 - **Description**: Folder where plugin stores history, prompts, and sessions
+- **Notes**: The value is normalized on load and when saved (via `normalizePath` semantics) — a hand-typed trailing, leading, or duplicate slash is corrected automatically, so folder exclusion and subfolder paths never break on a malformed state-folder path.
 - **Structure**:
   ```text
   gemini-scribe/

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,7 +9,7 @@ import { GeminiHistory } from './history/history';
 import { GeminiCompletions } from './completions';
 import { Notice } from 'obsidian';
 import { getDefaultModelForRole, migrateOllamaModelSetting } from './models';
-import { migrateInteractionsApiDefault } from './utils/settings-migrations';
+import { migrateInteractionsApiDefault, normalizeStateFolderPath } from './utils/settings-migrations';
 import { isProviderActive, routingKey, sanitizeProviderOverrides } from './api/provider-routing';
 import { getCapabilities } from './api/providers/registry';
 import { ModelManager } from './services/model-manager';
@@ -417,6 +417,15 @@ export default class ObsidianGemini extends Plugin implements ObsidianGeminiApi 
 		// the module-level default. sanitizeProviderOverrides always returns a
 		// fresh object, and drops anything a hand-edited data.json got wrong.
 		this.settings.providerOverrides = sanitizeProviderOverrides(this.settings.providerOverrides);
+
+		// The state folder comes from a free-text field, so a hand-typed trailing
+		// (or duplicate/leading) slash can persist to data.json — and it silently
+		// defeats every exclusion and subfolder path built on historyFolder
+		// (#1374). Repair it once on load so the stored value is always clean.
+		if (normalizeStateFolderPath(this.settings)) {
+			await this.saveData(this.settings);
+			this.logger?.log('Normalized the state folder setting (historyFolder)');
+		}
 
 		// One-time migration: split the Ollama model out of the shared chatModelName
 		// field so switching providers no longer clobbers either choice. See

--- a/src/ui/settings-general.ts
+++ b/src/ui/settings-general.ts
@@ -11,6 +11,7 @@ import { getErrorMessage } from '../utils/error-utils';
 import { t, type TranslationKey } from '../i18n';
 import type { SettingsSectionContext } from './settings-helpers';
 import { getOllamaModelForRole, remoteHostForModel, type ModelProvider, type ModelRole } from '../models';
+import { normalizeStateFolderPath } from '../utils/settings-migrations';
 import {
 	activeProviders,
 	isProviderActive,
@@ -161,6 +162,9 @@ async function renderGeneralSection(
 		.addText((text) => {
 			new FolderSuggest(app, text.inputEl, (folder) => {
 				plugin.settings.historyFolder = folder;
+				// FolderSuggest writes clean TFolder paths, but hand-typed text can
+				// still reach this callback; normalize before it persists (#1374).
+				normalizeStateFolderPath(plugin.settings);
 				debouncedSave();
 			});
 			text.setValue(plugin.settings.historyFolder);

--- a/src/utils/settings-migrations.ts
+++ b/src/utils/settings-migrations.ts
@@ -8,6 +8,8 @@
  * merged settings, whose defaults already backfill new fields.
  */
 
+import { normalizePath } from 'obsidian';
+
 /**
  * Default-on rollout for the Interactions API transport (#1017).
  *
@@ -31,4 +33,40 @@ export function migrateInteractionsApiDefault(
 		return true;
 	}
 	return false;
+}
+
+/**
+ * Normalize the state-folder setting (`settings.historyFolder`) at the settings
+ * boundary (#1374).
+ *
+ * The state folder is set from a free-text field and is the argument
+ * `isPathInFolder` is built on: `path === folder || path.startsWith(folder + '/')`.
+ * A persisted trailing (or duplicate/leading) slash makes both arms dead —
+ * containment reports that nothing lives inside the folder — so every exclusion
+ * built on the setting silently stops excluding (file mention modal, tool
+ * guards) and every `${historyFolder}/...` path doubles its slash.
+ *
+ * Normalizing here (not inside `isPathInFolder`) keeps the predicate pure and
+ * fixes both the containment checks and the path building in one place; the
+ * load-time call covers vaults that already persisted a malformed value.
+ *
+ * @param settings - settings object with the `historyFolder` field (mutated in place)
+ * @returns true if the value was malformed and has been rewritten
+ */
+export function normalizeStateFolderPath(settings: { historyFolder: string }): boolean {
+	if (!settings.historyFolder) {
+		return false;
+	}
+	// normalizePath leaves surrounding whitespace untouched on some inputs;
+	// trim explicitly so the result is unambiguous.
+	const candidate = settings.historyFolder.trim();
+	if (!candidate) {
+		return false;
+	}
+	const normalized = normalizePath(candidate);
+	if (normalized === settings.historyFolder) {
+		return false;
+	}
+	settings.historyFolder = normalized;
+	return true;
 }

--- a/test/utils/settings-migrations.test.ts
+++ b/test/utils/settings-migrations.test.ts
@@ -1,4 +1,5 @@
-import { migrateInteractionsApiDefault } from '../../src/utils/settings-migrations';
+import { migrateInteractionsApiDefault, normalizeStateFolderPath } from '../../src/utils/settings-migrations';
+import { shouldExcludePath } from '../../src/utils/file-utils';
 
 describe('migrateInteractionsApiDefault', () => {
 	it('flips an existing opt-in-era install (persisted false, no marker) to on and marks it', () => {
@@ -40,5 +41,52 @@ describe('migrateInteractionsApiDefault', () => {
 		expect(migrateInteractionsApiDefault(settings, {})).toBe(false);
 		expect(migrateInteractionsApiDefault(settings, null)).toBe(false);
 		expect(migrateInteractionsApiDefault(settings, undefined)).toBe(false);
+	});
+});
+
+describe('normalizeStateFolderPath', () => {
+	it('strips a hand-typed trailing slash', () => {
+		const settings = { historyFolder: 'gemini-scribe/' };
+		expect(normalizeStateFolderPath(settings)).toBe(true);
+		expect(settings.historyFolder).toBe('gemini-scribe');
+	});
+
+	it('collapses duplicate internal slashes', () => {
+		const settings = { historyFolder: 'gemini-scribe//Agent-Sessions' };
+		expect(normalizeStateFolderPath(settings)).toBe(true);
+		expect(settings.historyFolder).toBe('gemini-scribe/Agent-Sessions');
+	});
+
+	it('strips a leading slash and trims whitespace', () => {
+		const settings = { historyFolder: '  /gemini-scribe/ ' };
+		expect(normalizeStateFolderPath(settings)).toBe(true);
+		expect(settings.historyFolder).toBe('gemini-scribe');
+	});
+
+	it('leaves a clean value untouched', () => {
+		const settings = { historyFolder: 'gemini-scribe' };
+		expect(normalizeStateFolderPath(settings)).toBe(false);
+		expect(settings.historyFolder).toBe('gemini-scribe');
+	});
+
+	it('leaves an empty value alone (broader validation is out of scope, #1374)', () => {
+		const settings = { historyFolder: '' };
+		expect(normalizeStateFolderPath(settings)).toBe(false);
+
+		const whitespaceOnly = { historyFolder: '   ' };
+		expect(normalizeStateFolderPath(whitespaceOnly)).toBe(false);
+	});
+
+	it('a repaired setting regains exclusion (#1374 end-to-end)', () => {
+		// The failure mode: a trailing-slash folder defeats isPathInFolder's
+		// prefix check, so nothing is "inside" the state folder and exclusions
+		// fail open. After the load boundary repairs the value, exclusion works.
+		const before = { historyFolder: 'gemini-scribe/' };
+		expect(shouldExcludePath('gemini-scribe/Agent-Sessions/run.md', before.historyFolder, '.obsidian')).toBe(false);
+
+		normalizeStateFolderPath(before);
+		expect(shouldExcludePath('gemini-scribe/Agent-Sessions/run.md', before.historyFolder, '.obsidian')).toBe(true);
+		expect(shouldExcludePath('gemini-scribe', before.historyFolder, '.obsidian')).toBe(true);
+		expect(shouldExcludePath('gemini-scribe-backup', before.historyFolder, '.obsidian')).toBe(false);
 	});
 });


### PR DESCRIPTION
## Summary

Fixes #1374

`settings.historyFolder` is a free-text field. A hand-typed trailing slash (e.g. `gemini-scribe/`) persisted verbatim and silently broke `isPathInFolder`'s containment check — `path.startsWith(folder + '/')` never matches, so every exclusion built on the state folder failed open: the file-mention modal offered session-history files as context, `createFileFilter()` stopped filtering, and the vault tools' `shouldExcludePathForPlugin()` guard opened up. Every `${historyFolder}/...` subfolder path also doubled its slash.

Per the issue's proposal, the fix lives at the **settings boundary** (not inside `isPathInFolder`, which stays a pure predicate), covering both the containment checks and the path building in one place.

## Changes

- Add `normalizeStateFolderPath()` to `src/utils/settings-migrations.ts` — pure helper, mutates in place, returns whether it rewrote (same pattern as the other migrations)
- `loadSettings()` backs it: a value already persisted malformed in `data.json` is repaired on load and saved back (`main.ts`)
- The settings UI write normalizes before persisting (`settings-general.ts`)
- Regression coverage in `test/utils/settings-migrations.test.ts`: trailing/leading/duplicate slashes, whitespace, clean and empty values, plus an end-to-end case asserting a repaired setting regains exclusion via `shouldExcludePath`
- No visible behavior change for correctly-set folders; empty-string validation remains out of scope per the issue

## Screenshots / Screencast

Not a UI change — the normalization is invisible when the setting is well-formed.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer
- [x] All CI checks pass (`npm test` 3699 pass, `npm run build`, `npm run format-check`, `npm run lint:cycles`, `npm run typecheck:test`)
- [ ] I have tested this change on Desktop
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards)
- [x] Documentation has been updated (if applicable)

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: pi coding agent (GLM)
- [x] I have reviewed and understand all AI-generated code in this PR

## Documentation updated

- `docs/reference/settings.md` — Plugin state folder section: notes that the value is normalized on load/save

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Automatically cleans up history-folder paths by removing extra whitespace, duplicate slashes, and leading or trailing slashes.
  * Applies consistent path formatting when settings are loaded, selected, or manually entered.
  * Preserves empty and already-correct paths without changes.

* **Documentation**
  * Updated settings documentation to describe path normalization behavior.

* **Tests**
  * Added coverage for path cleanup, unchanged values, and path exclusion behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->