### PR TITLE
Fix invariant drift: three-provider capability routing; main.js is not committed

### DIFF
--- a/.claude/guidelines/invariants.md
+++ b/.claude/guidelines/invariants.md
@@ -3,17 +3,29 @@
 Repo-specific invariants that CI **doesn't** fully catch and that a reviewer/audit must check a
 diff against. Breaking one of these is a correctness or architecture regression, not a style nit.
 
-## API layer: Factory + Decorator
+## API layer: Factory + Decorator, capability-routed
 
 ```
-src/main.ts → ModelClientFactory.createFromPlugin() → GeminiClient | OllamaClient → RetryDecorator → ModelApi
+src/main.ts → ModelClientFactory.createFromPlugin() → GeminiClient | OllamaClient | OpenAIClient → RetryDecorator → ModelApi
 ```
 
-- The factory (`src/api/factory.ts`) branches on `settings.provider` to instantiate a `GeminiClient`
-  or `OllamaClient`, wrapped by `RetryDecorator` (exponential backoff) for resilience.
+- Each call resolves its provider **independently** via `resolveProviderOrDefault(settings, useCase)`
+  (`src/api/provider-routing.ts`), which consults `settings.providerOverrides[useCase]` before
+  falling back to the primary `settings.provider`. The factory (`src/api/factory.ts`) instantiates a
+  `GeminiClient`, `OllamaClient`, or `OpenAIClient` from the resolved provider, wrapped by
+  `RetryDecorator` (exponential backoff) for resilience.
+- **Routing never silently substitutes a different provider.** Capability-gated features resolve via
+  `resolveProvider`, and a `null` result means the feature stays **off** — substituting a cloud
+  provider for a local one (or vice versa) would send vault data somewhere the user never opted
+  into. `resolveProviderOrDefault` exists only for the use cases every provider supports (chat,
+  summary, completions, rewrite).
 - All provider implementations conform to the `ModelApi` interface; provider-specific code stays
-  encapsulated under `src/api/providers/{gemini,ollama}/`. Don't leak provider specifics upward.
-- The factory serves distinct use cases (chat, summary, completions, rewrite) — keep them distinct.
+  encapsulated under `src/api/providers/{gemini,ollama,openai}/`. Don't leak provider specifics
+  upward: the capability matrix (which provider can serve which use case) lives in the leaf module
+  `src/api/providers/registry.ts`, and the routing helpers in the leaf module
+  `src/api/provider-routing.ts` — consume them instead of branching on provider name literals.
+- The factory serves distinct use cases (chat, summary, completions, rewrite, webSearch, rag,
+  imageGen) — keep them distinct.
 
 ## Session-history parser invariant
 
@@ -56,9 +68,10 @@ otherwise).
 
 ## Generated artifacts & state layout
 
-- `main.js`, `manifest.json`, `styles.css` are committed at the **repo root** for Obsidian —
-  commit them alongside source changes. Version fields in `package.json` / `manifest.json` /
-  `versions.json` are managed by `npm version` only (see `release.md`) — never hand-edit.
+- `manifest.json` and `styles.css` are committed at the **repo root** for Obsidian. `main.js` is a
+  build output and is **gitignored** — never commit it. Version fields in `package.json` /
+  `manifest.json` / `versions.json` are managed by `npm version` only (see `release.md`) — never
+  hand-edit.
 - `src/services/generated-help-references.ts` is auto-generated at build from `docs/guide/` and
   `docs/reference/`; adding/removing a markdown file there updates the bundled help skill
   automatically — never hand-edit the generated file.

--- a/.claude/guidelines/invariants.md
+++ b/.claude/guidelines/invariants.md
@@ -5,7 +5,7 @@ diff against. Breaking one of these is a correctness or architecture regression,
 
 ## API layer: Factory + Decorator, capability-routed
 
-```
+```text
 src/main.ts → ModelClientFactory.createFromPlugin() → GeminiClient | OllamaClient | OpenAIClient → RetryDecorator → ModelApi
 ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -328,7 +328,7 @@ The maintainer's half of the pipeline (reviewing plans, approving, answering que
 For creating pull requests, use the **create-pr** skill which enforces the PR template and runs all pre-flight checks.
 
 - Write concise, imperative commit subjects (`Fix agent session cleanup`, `Improve prompt builder`); reference issues/PRs with `#123`
-- Commit generated artifacts (`main.js`, `manifest.json`, `versions.json`) alongside source changes; use `npm run version` for releases
+- Commit generated artifacts (`manifest.json`, `styles.css`, `versions.json`) alongside source changes; `main.js` is a gitignored build output and is never committed. Use `npm run version` for releases
 - **MANDATORY**: Include documentation updates in the same PR/commit as code changes (see Documentation Maintenance section)
 - PRs should explain motivation, highlight user-visible impact, list automated/manual tests, and attach screenshots or vault clips for UI tweaks
 - Flag reviewers who own the affected area and mention required follow-up or rollout notes


### PR DESCRIPTION
## Summary

Fixes #1302

`.claude/guidelines/invariants.md` is the contract reviewers and the audit skills check diffs against, and two of its sections were stale:

1. **API layer**: still described the pre-#704 two-provider factory that "branches on `settings.provider`". With #1237/#1286 (OpenAI-compatible provider) and #1266 (per-use-case routing) landed, the load-bearing invariant is now about per-call provider resolution and single-substitution prevention, and neither `registry.ts` nor `provider-routing.ts` was named as a boundary.
2. **Generated artifacts**: instructed contributors to commit `main.js`, which `.gitignore` excludes and git refuses — the clause told the next person to do an impossible thing.

## Changes

- Rewrite the "API layer" section: three providers in the diagram, per-call routing via `resolveProviderOrDefault(settings, useCase)`, and the invariant that actually has consequences — **routing never silently substitutes a different provider**; a `null` from `resolveProvider` means the capability-gated feature stays off (`resolveProviderOrDefault` exists only for the four universally-supported use cases).
- Name `src/api/providers/registry.ts` (capability matrix) and `src/api/provider-routing.ts` (routing helpers) as the leaf modules to consume instead of branching on provider-name literals.
- Fix the artifacts clause: `manifest.json`, `styles.css` committed; `main.js` gitignored, never committed.
- One-line consistency fix in `AGENTS.md` (line 331), which carried the same "commit `main.js`" instruction — the issue marks AGENTS.md out of scope, but its proposed cross-check said to keep the two docs consistent, and this claim was factually wrong there too (`git ls-files` confirms: `manifest.json`/`styles.css`/`versions.json` tracked, `main.js` ignored).

## Screenshots / Screencast

Documentation-only change; nothing user-facing.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer
- [x] All CI checks pass — no code change; `npm run build`, `npm run format-check` pass
- [ ] I have tested this change on Desktop — N/A, documentation only
- [ ] I have verified this change does not break Mobile — N/A, documentation only
- [x] Documentation has been updated (if applicable) — this PR *is* the documentation update

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: pi coding agent (GLM)
- [x] I have reviewed and understand all AI-generated code in this PR

## Documentation updated

- `.claude/guidelines/invariants.md` — API layer section rewritten to three-provider capability-routed reality; generated-artifacts clause corrected
- `AGENTS.md` — same "commit generated artifacts" clause corrected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified provider routing and capability support, including OpenAI and use-case-specific overrides.
  * Documented expected behavior when requested capabilities are unsupported.
  * Updated guidance on committed files and generated build artifacts, including which files are tracked and which are excluded from version control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->