### PR TITLE
Fix double-spaced code blocks; unify the paragraph normalizer (#1379)

### DIFF
--- a/src/ui/selection-response-modal.ts
+++ b/src/ui/selection-response-modal.ts
@@ -2,81 +2,7 @@ import { App, Modal, MarkdownRenderer, Editor, Notice, setIcon } from 'obsidian'
 import type { ObsidianGemini } from '../types/plugin';
 import { t } from '../i18n';
 import { getRawErrorMessageOr } from '../utils/error-utils';
-
-/**
- * Normalize newlines in AI responses for proper Markdown rendering.
- * Converts single newlines to double newlines while preserving tables and code blocks.
- */
-function normalizeNewlines(text: string): string {
-	const lines = text.split('\n');
-	const formattedLines: string[] = [];
-	let inTable = false;
-	let inCodeBlock = false;
-	let previousLineWasEmpty = true;
-
-	for (let i = 0; i < lines.length; i++) {
-		const line = lines[i];
-		const nextLine = lines[i + 1];
-		const trimmedLine = line.trim();
-
-		// Track code blocks (fenced with ``` or ~~~)
-		if (trimmedLine.startsWith('```') || trimmedLine.startsWith('~~~')) {
-			inCodeBlock = !inCodeBlock;
-			formattedLines.push(line);
-			previousLineWasEmpty = false;
-			continue;
-		}
-
-		// Don't modify content inside code blocks
-		if (inCodeBlock) {
-			formattedLines.push(line);
-			previousLineWasEmpty = trimmedLine === '';
-			continue;
-		}
-
-		// Improved table detection
-		const hasUnescapedPipe = line.split('\\|').join('').includes('|');
-		const isTableDivider = /^\s*\|?\s*[:-]+\s*\|/.test(line);
-		const isTableRow = hasUnescapedPipe && !isTableDivider && trimmedLine !== '|';
-
-		// Check if we're starting a table
-		if ((isTableRow || isTableDivider) && !inTable) {
-			inTable = true;
-			if (!previousLineWasEmpty && formattedLines.length > 0) {
-				formattedLines.push('');
-			}
-		}
-
-		// Add the current line
-		formattedLines.push(line);
-
-		// Check if we're ending a table
-		if (inTable && !hasUnescapedPipe && trimmedLine !== '') {
-			inTable = false;
-			formattedLines.push('');
-		} else if (inTable && trimmedLine === '') {
-			inTable = false;
-		}
-
-		// For non-table content, add empty line between paragraphs
-		if (
-			!inTable &&
-			!hasUnescapedPipe &&
-			trimmedLine !== '' &&
-			nextLine &&
-			nextLine.trim() !== '' &&
-			!nextLine.includes('|') &&
-			!nextLine.trim().startsWith('```') &&
-			!nextLine.trim().startsWith('~~~')
-		) {
-			formattedLines.push('');
-		}
-
-		previousLineWasEmpty = trimmedLine === '';
-	}
-
-	return formattedLines.join('\n');
-}
+import { formatModelMessage } from '../utils/markdown-formatting';
 
 /**
  * Modal that displays an AI response to a selection and allows inserting it as a callout.
@@ -163,8 +89,9 @@ export class SelectionResponseModal extends Modal {
 		this.responseContainer.show();
 		this.actionsContainer.show();
 
-		// Normalize newlines for proper Markdown rendering
-		const normalizedResponse = normalizeNewlines(response);
+		// Normalize newlines for proper Markdown rendering (shared with the agent
+		// view; see markdown-formatting.ts)
+		const normalizedResponse = formatModelMessage(response);
 
 		// Render markdown response
 		this.responseContainer.empty();
@@ -192,7 +119,7 @@ export class SelectionResponseModal extends Modal {
 		if (!this.response) return;
 
 		// Normalize newlines for consistent formatting in the callout
-		const normalizedResponse = normalizeNewlines(this.response);
+		const normalizedResponse = formatModelMessage(this.response);
 
 		// Format response as a callout
 		const calloutLines = normalizedResponse.split('\n').map((line) => `> ${line}`);

--- a/src/utils/markdown-formatting.ts
+++ b/src/utils/markdown-formatting.ts
@@ -15,6 +15,25 @@
 /** Matches a markdown table divider line (e.g. | --- | :---: |). */
 const tableDividerRe = /^[\s|]*[:?-]+\s*\|/;
 
+/**
+ * The fence run starting `trimmedLine`, if any (three or more backticks or
+ * tildes). An opening fence may carry an info string after the run.
+ */
+function fenceRun(trimmedLine: string): string | null {
+	return trimmedLine.match(/^(`{3,}|~{3,})/)?.[1] ?? null;
+}
+
+/**
+ * True when `trimmedLine` closes the fence opened with `marker`, per
+ * CommonMark: the same character, an equal-or-longer run, and whitespace only
+ * after it — so a '```ts' line inside a ```-fence is content, a longer run
+ * closes a shorter opener, and a shorter run does not close a longer opener.
+ */
+function isFenceClose(trimmedLine: string, marker: string): boolean {
+	const closeMatch = trimmedLine.match(/^(`{3,}|~{3,})\s*$/);
+	return closeMatch !== null && closeMatch[1][0] === marker[0] && closeMatch[1].length >= marker.length;
+}
+
 /** Returns true if the line contains at least one unescaped pipe character. */
 function hasUnescapedPipe(line: string): boolean {
 	return line.split('\\|').join('').includes('|');
@@ -48,9 +67,7 @@ export function formatModelMessage(text: string): string {
 		// equal-or-longer run followed by whitespace only — a '```ts' or
 		// '~~~text' line inside a fence stays content.
 		if (fenceMarker) {
-			const closeMatch = trimmedLine.match(/^(`{3,}|~{3,})\s*$/);
-			const isClosing =
-				closeMatch !== null && closeMatch[1][0] === fenceMarker[0] && closeMatch[1].length >= fenceMarker.length;
+			const isClosing = isFenceClose(trimmedLine, fenceMarker);
 			formattedLines.push(line);
 			if (isClosing) {
 				fenceMarker = null;
@@ -64,11 +81,11 @@ export function formatModelMessage(text: string): string {
 			continue;
 		}
 
-		const fenceOpen = trimmedLine.match(/^(`{3,}|~{3,})/);
+		const fenceOpen = fenceRun(trimmedLine);
 		if (fenceOpen) {
 			inTable = false; // a fence can never be part of a table
 			formattedLines.push(line);
-			fenceMarker = fenceOpen[1];
+			fenceMarker = fenceOpen;
 			previousLineWasEmpty = false;
 			continue;
 		}
@@ -133,9 +150,41 @@ export function formatModelMessage(text: string): string {
 export function unescapeWikiLinks(text: string): string {
 	if (!text) return text;
 
-	// Split on fenced code blocks (``` … ``` or ~~~ … ~~~), preserving delimiters.
-	// Odd-indexed segments are inside code fences.
-	const parts = text.split(/((?:`{3,}|~{3,})[\s\S]*?(?:`{3,}|~{3,}))/);
+	// Segment the text around fenced code blocks, preserving delimiters and
+	// using the same CommonMark open/close rules as formatModelMessage (same
+	// character, equal-or-longer run, whitespace-only trailer) so an embedded
+	// mismatched run can't split a fence and leak later content out of it.
+	// Even-indexed segments are outside code fences; odd-indexed are inside.
+	const parts: string[] = [];
+	let current = '';
+	let fenceMarker: string | null = null;
+	const lines = text.split('\n');
+	for (let idx = 0; idx < lines.length; idx++) {
+		const sep = idx < lines.length - 1 ? '\n' : '';
+		const line = lines[idx];
+		const trimmedLine = line.trim();
+		if (fenceMarker) {
+			if (isFenceClose(trimmedLine, fenceMarker)) {
+				fenceMarker = null;
+				parts.push(current + line + sep);
+				current = '';
+				continue;
+			}
+			current += line + sep;
+			continue;
+		}
+		const openRun = fenceRun(trimmedLine);
+		if (openRun) {
+			// Flush the outside-fence text so far; the fence from its opening
+			// delimiter through the close is one fenced segment.
+			parts.push(current);
+			current = line + sep;
+			fenceMarker = openRun;
+			continue;
+		}
+		current += line + sep;
+	}
+	parts.push(current);
 
 	for (let i = 0; i < parts.length; i++) {
 		if (i % 2 !== 0) continue; // Skip fenced code blocks

--- a/src/utils/markdown-formatting.ts
+++ b/src/utils/markdown-formatting.ts
@@ -4,7 +4,8 @@
  * Gemini returns text with single newlines between paragraphs, but Obsidian's
  * markdown renderer requires double newlines for paragraph breaks. This module
  * converts single newlines to double newlines while preserving table formatting,
- * which relies on single newlines between rows.
+ * which relies on single newlines between rows, and fenced code blocks, whose
+ * content must pass through verbatim (#1379).
  *
  * Also handles unescaping of WikiLinks that Gemini sometimes wraps in backtick
  * code spans or backslash-escapes, which prevents Obsidian from rendering them
@@ -29,12 +30,43 @@ export function formatModelMessage(text: string): string {
 	const lines = text.split('\n');
 	const formattedLines: string[] = [];
 	let inTable = false;
+	// Set to the marker that opened the fence ('```' or '~~~'); the fence only
+	// closes on the same marker, so a ``` line inside a ~~~ fence stays content.
+	let fenceMarker: '```' | '~~~' | null = null;
 	let previousLineWasEmpty = true;
 
 	for (let i = 0; i < lines.length; i++) {
 		const line = lines[i];
 		const nextLine = lines[i + 1];
 		const trimmedLine = line.trim();
+
+		// Track fenced code blocks: fenced content passes through verbatim —
+		// blank-line insertion inside a fence double-spaces every code line. A
+		// fence only closes on the marker that opened it, so a ``` line inside a
+		// ~~~ fence stays fence content.
+		const fenceMarkerLine = trimmedLine.startsWith('~~~')
+			? ('~~~' as const)
+			: trimmedLine.startsWith('```')
+				? ('```' as const)
+				: null;
+		if (fenceMarker || fenceMarkerLine) {
+			const isClosing = fenceMarker !== null && fenceMarkerLine === fenceMarker;
+			const isOpening = fenceMarker === null && fenceMarkerLine !== null;
+			formattedLines.push(line);
+			if (isClosing) {
+				fenceMarker = null;
+				// Blank line after a closing fence when followed by text — mirrors
+				// the paragraph-break rule so the next line starts its own block.
+				if (nextLine && nextLine.trim() !== '' && formattedLines[formattedLines.length - 1] !== '') {
+					formattedLines.push('');
+				}
+			} else if (isOpening) {
+				inTable = false; // a fence can never be part of a table
+				fenceMarker = fenceMarkerLine;
+			}
+			previousLineWasEmpty = trimmedLine === '';
+			continue;
+		}
 
 		const lineHasPipe = hasUnescapedPipe(line);
 		const isTableDivider = tableDividerRe.test(line);
@@ -44,18 +76,17 @@ export function formatModelMessage(text: string): string {
 		if ((isTableRow || isTableDivider) && !inTable) {
 			inTable = true;
 			// Add empty line before table if needed
-			if (!previousLineWasEmpty && formattedLines.length > 0) {
+			if (!previousLineWasEmpty && formattedLines.length > 0 && formattedLines[formattedLines.length - 1] !== '') {
 				formattedLines.push('');
 			}
 		}
 
-		// Add the current line
-		formattedLines.push(line);
-
-		// Check if we're ending a table
+		// Check if we're ending a table: the first non-empty line without a pipe
+		// ends it, and the separating blank line goes BEFORE that line — so the
+		// table closes as its own block and never leaves a trailing newline at
+		// end of message.
 		if (inTable && !lineHasPipe && trimmedLine !== '') {
 			inTable = false;
-			// Add empty line after table if not already blank
 			if (formattedLines[formattedLines.length - 1] !== '') {
 				formattedLines.push('');
 			}
@@ -63,6 +94,9 @@ export function formatModelMessage(text: string): string {
 			// Empty line also ends a table
 			inTable = false;
 		}
+
+		// Add the current line
+		formattedLines.push(line);
 
 		// For non-table content, add empty line between paragraphs
 		if (

--- a/src/utils/markdown-formatting.ts
+++ b/src/utils/markdown-formatting.ts
@@ -30,9 +30,11 @@ export function formatModelMessage(text: string): string {
 	const lines = text.split('\n');
 	const formattedLines: string[] = [];
 	let inTable = false;
-	// Set to the marker that opened the fence ('```' or '~~~'); the fence only
-	// closes on the same marker, so a ``` line inside a ~~~ fence stays content.
-	let fenceMarker: '```' | '~~~' | null = null;
+	// Set to the fence run that opened the block ('```', '```…', '~~~'…): the
+	// fence only closes on the same character with an equal-or-longer run
+	// followed by whitespace only, per CommonMark — so a '```ts' line inside a
+	// ```-fence stays content (#1379).
+	let fenceMarker: string | null = null;
 	let previousLineWasEmpty = true;
 
 	for (let i = 0; i < lines.length; i++) {
@@ -41,17 +43,14 @@ export function formatModelMessage(text: string): string {
 		const trimmedLine = line.trim();
 
 		// Track fenced code blocks: fenced content passes through verbatim —
-		// blank-line insertion inside a fence double-spaces every code line. A
-		// fence only closes on the marker that opened it, so a ``` line inside a
-		// ~~~ fence stays fence content.
-		const fenceMarkerLine = trimmedLine.startsWith('~~~')
-			? ('~~~' as const)
-			: trimmedLine.startsWith('```')
-				? ('```' as const)
-				: null;
-		if (fenceMarker || fenceMarkerLine) {
-			const isClosing = fenceMarker !== null && fenceMarkerLine === fenceMarker;
-			const isOpening = fenceMarker === null && fenceMarkerLine !== null;
+		// blank-line insertion inside a fence double-spaces every code line. Per
+		// CommonMark the fence closes on the same character with an
+		// equal-or-longer run followed by whitespace only — a '```ts' or
+		// '~~~text' line inside a fence stays content.
+		if (fenceMarker) {
+			const closeMatch = trimmedLine.match(/^(`{3,}|~{3,})\s*$/);
+			const isClosing =
+				closeMatch !== null && closeMatch[1][0] === fenceMarker[0] && closeMatch[1].length >= fenceMarker.length;
 			formattedLines.push(line);
 			if (isClosing) {
 				fenceMarker = null;
@@ -60,11 +59,17 @@ export function formatModelMessage(text: string): string {
 				if (nextLine && nextLine.trim() !== '' && formattedLines[formattedLines.length - 1] !== '') {
 					formattedLines.push('');
 				}
-			} else if (isOpening) {
-				inTable = false; // a fence can never be part of a table
-				fenceMarker = fenceMarkerLine;
 			}
 			previousLineWasEmpty = trimmedLine === '';
+			continue;
+		}
+
+		const fenceOpen = trimmedLine.match(/^(`{3,}|~{3,})/);
+		if (fenceOpen) {
+			inTable = false; // a fence can never be part of a table
+			formattedLines.push(line);
+			fenceMarker = fenceOpen[1];
+			previousLineWasEmpty = false;
 			continue;
 		}
 

--- a/test/utils/markdown-formatting.test.ts
+++ b/test/utils/markdown-formatting.test.ts
@@ -176,6 +176,19 @@ describe('unescapeWikiLinks', () => {
 		expect(unescapeWikiLinks(input)).toBe(input);
 	});
 
+	it('a mismatched fence run inside a fence does not split it (unescape pairing)', () => {
+		// Old splitter tilted on the first ~~~ run and let the escaped link be
+		// rewritten outside the still-open ``` fence; the strict parser keeps
+		// the whole block fenced.
+		const input = '```\n~~~\n\\[\\[a\\]\\]\n~~~\n```';
+		expect(unescapeWikiLinks(input)).toBe(input);
+	});
+
+	it('an escaped wikilink after a properly closed fence is still unescaped', () => {
+		const input = '```\ncode\n```\n\\[\\[real\\]\\]';
+		expect(unescapeWikiLinks(input)).toBe('```\ncode\n```\n[[real]]');
+	});
+
 	// --- Backslash escaping ---
 	it('fixes fully backslash-escaped wikilinks', () => {
 		expect(unescapeWikiLinks('See \\[\\[My Note\\]\\] for details')).toBe('See [[My Note]] for details');

--- a/test/utils/markdown-formatting.test.ts
+++ b/test/utils/markdown-formatting.test.ts
@@ -113,6 +113,21 @@ describe('formatModelMessage', () => {
 		expect(output).toBe('~~~\ntext\n```inline\ntext2\n~~~\n\nAfter');
 	});
 
+	it('a closing fence may not carry trailing text (```nope stays content, CommonMark)', () => {
+		const input = '```\ncode\n```nope\nmore\n```';
+		expect(formatModelMessage(input)).toBe('```\ncode\n```nope\nmore\n```');
+	});
+
+	it('a longer closing run inside a shorter fence still closes (CommonMark)', () => {
+		const input = '```\ncode\n`````\nAfter';
+		expect(formatModelMessage(input)).toBe('```\ncode\n`````\n\nAfter');
+	});
+
+	it('a shorter closing run does not close a longer fence (CommonMark)', () => {
+		const input = '````\ncode\n```\nmore\n````';
+		expect(formatModelMessage(input)).toBe('````\ncode\n```\nmore\n````');
+	});
+
 	it('does not double-space table rows that appear between two fences', () => {
 		const input = '```\npre\n```\n| A | B |\n| --- | --- |\n```\npost\n```';
 		const output = formatModelMessage(input);

--- a/test/utils/markdown-formatting.test.ts
+++ b/test/utils/markdown-formatting.test.ts
@@ -36,8 +36,11 @@ describe('formatModelMessage', () => {
 	it('adds blank line after a table when followed by text', () => {
 		const input = '| A | B |\n| --- | --- |\n| 1 | 2 |\nSome text after';
 		const result = formatModelMessage(input);
-		// The first non-pipe line ends the table; a blank line is inserted after it
-		expect(result).toContain('| 1 | 2 |\nSome text after\n');
+		// The first non-pipe line ends the table; the separating blank line sits
+		// between the table and the following text (#1379: previously the blank
+		// landed after the first non-table line, leaving a trailing newline when
+		// the text was the last line of the message).
+		expect(result).toBe('| A | B |\n| --- | --- |\n| 1 | 2 |\n\nSome text after');
 	});
 
 	it('handles table with leading whitespace in divider', () => {
@@ -78,6 +81,51 @@ describe('formatModelMessage', () => {
 		formatModelMessage(' '.repeat(50000) + 'x');
 		const elapsed = Date.now() - start;
 		expect(elapsed).toBeLessThan(1000);
+	});
+
+	// --- Fenced code blocks (#1379) ---
+	it('leaves fenced code content untouched (no double-spacing inside fences)', () => {
+		const input = 'Here is code:\n```ts\nconst a = 1;\nconst b = 2;\n```\nDone.';
+		// Paragraph break before the fence, blank between paragraphs — but the
+		// code lines themselves are never touched.
+		expect(formatModelMessage(input)).toBe('Here is code:\n\n```ts\nconst a = 1;\nconst b = 2;\n```\n\nDone.');
+	});
+
+	it('leaves tilde-fenced content untouched', () => {
+		const input = 'Text:\n~~~\nconst a = 1;\nconst b = 2;\n~~~\nAfter';
+		expect(formatModelMessage(input)).toBe('Text:\n\n~~~\nconst a = 1;\nconst b = 2;\n~~~\n\nAfter');
+	});
+
+	it('does not treat fence content as table rows (pipes inside fences)', () => {
+		const input = '~~~\n| fake | table |\n| --- | --- |\n~~~';
+		expect(formatModelMessage(input)).toBe('~~~\n| fake | table |\n| --- | --- |\n~~~');
+	});
+
+	it('fence immediately after a paragraph line still gets its opening paragraph break', () => {
+		const input = 'Here is code:\n```ts\nconst a = 1;\n```';
+		expect(formatModelMessage(input)).toBe('Here is code:\n\n```ts\nconst a = 1;\n```');
+	});
+
+	it('a fence does not close on a mismatched marker (``` inside ~~~)', () => {
+		const input = '~~~\ntext\n```inline\ntext2\n~~~\nAfter';
+		const output = formatModelMessage(input);
+		// Everything inside the ~~~ fence stays verbatim, including the ``` line
+		expect(output).toBe('~~~\ntext\n```inline\ntext2\n~~~\n\nAfter');
+	});
+
+	it('does not double-space table rows that appear between two fences', () => {
+		const input = '```\npre\n```\n| A | B |\n| --- | --- |\n```\npost\n```';
+		const output = formatModelMessage(input);
+		expect(output).toContain('| A | B |\n| --- | --- |');
+		expect(output).not.toContain('| A | B |\n\n| --- |');
+	});
+
+	// --- Table-end single blank line (modal fork drift) ---
+	it('emits exactly one blank line after a table followed by text', () => {
+		const input = '| A | B |\n| --- | --- |\n| 1 | 2 |\nTail';
+		const output = formatModelMessage(input);
+		expect(output).not.toContain('\n\n\n');
+		expect(output.endsWith('Tail')).toBe(true);
 	});
 
 	// --- WikiLink unescaping integration ---


### PR DESCRIPTION
## Summary

Fixes #1379

Two bodies of "turn a model response into markdown that Obsidian renders with paragraph breaks" existed: the tested `formatModelMessage` (`src/utils/markdown-formatting.ts`, six call sites in the agent view) and a private `normalizeNewlines` fork in the selection-response modal. They had drifted in six ways — one of which was a **live rendering defect in the shared copy** used by the agent view.

## The defect (the highest-value part)

`formatModelMessage` had no code-fence state, so it inserted a blank line between every pair of consecutive code lines — every agent-view code block (assistant messages, reasoning, plans, streamed markdown) rendered double-spaced:

```
Before:  ```ts\n\nconst a = 1;\n\nconst b = 2;\n```
After:   ```ts\nconst a = 1;\nconst b = 2;\n```
```

Fence tracking now wraps the walk (ported from the modal's fork, hardened): fenced content passes through verbatim, and a fence only closes on the marker that opened it (`'```'` vs `'~~~'` — a ` ``` ` line inside a ` ~~~ ` fence stays content). A blank line is emitted after a *closing* fence when followed by text, mirroring the paragraph-break rule.

## Per-difference decisions (the other five drifts)

1. **WikiLink unescaping** — the modal now gets it. `unescapeWikiLinks` makes Gemini's defensively-wrapped `[[links]]` clickable; the inserted callout in the user's note now carries live links, matching the agent view's behavior. (The issue's alternative — modal keeps raw wikilinks by splitting the shared fn — rejected: fewer layers, consistent model-output rendering across surfaces.)
2. **Table-divider regex** — shared (tested) regex stays canonical.
3. **Blank line after a table** — shared's guarded push wins. While porting, also fixed the placement: the separator moved **before** the first non-table line (it landed *after* it, producing a trailing newline when a table was followed by text at end-of-message). One existing test pinned the old placement and was updated with a comment.
4. **Next-line pipe test** — shared `hasUnescapedPipe(nextLine)` (escape-aware) wins over the modal's raw `includes('|')`.
5. **Inlined `hasUnescapedPipe`** — deleted along with the fork.

## Changes

- `src/utils/markdown-formatting.ts` — fence tracking + table-end placement fix
- `src/ui/selection-response-modal.ts` — `normalizeNewlines` deleted; both call sites use `formatModelMessage`; no change to how the callout is built or inserted
- `test/utils/markdown-formatting.test.ts` — 8 new fence/drift tests (backtick + tilde fences, fences with pipes inside, fence-after-paragraph, mismatched markers, tables between fences, single blank after table); one pre-existing table-end test updated to the now-correct placement
- `npx jscpd src --min-lines 6 --min-tokens 45` no longer reports the pair

## Screenshots / Screencast

Code blocks in the agent view stop double-spacing. Selection-response modal gains fence handling, wikilink unescaping, and the table-blank guard — all rendering improvements, no UI structure change.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer
- [x] All CI checks pass — `npm test` 3810 pass, `npm run build`, `npm run format-check`, `npm run lint:cycles`, `npm run typecheck:test`, jscpd re-run clean
- [ ] I have tested this change on Desktop
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards)
- [x] Documentation has been updated (if applicable) — module header updated; no user guide mentions the normalization internals

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: pi coding agent (GLM)
- [x] I have reviewed and understand all AI-generated code in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Markdown rendering in selection response dialogs.
  * Preserved fenced code blocks, including tilde fences and content containing pipe characters.
  * Improved spacing between code blocks, tables, and surrounding text.
  * Ensured mismatched code fences are handled correctly.

* **Tests**
  * Added coverage for code fences, tables, and their boundaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->