### PR TITLE
Delete the write-only tool execution history store; wire loop-detector teardown (#1387)

### DIFF
--- a/src/tools/execution-engine.ts
+++ b/src/tools/execution-engine.ts
@@ -19,7 +19,6 @@ import type { ObsidianGemini } from '../types/plugin';
 export class ToolExecutionEngine {
 	private plugin: ObsidianGemini;
 	private registry: ToolRegistry;
-	private executionHistory: Map<string, ToolExecution[]> = new Map();
 	private loopDetector: ToolLoopDetector;
 
 	constructor(plugin: ObsidianGemini, registry: ToolRegistry) {
@@ -153,17 +152,6 @@ export class ToolExecutionEngine {
 			// Execute the tool
 			const result = await tool.execute(toolCall.arguments, context);
 
-			// Record execution in history
-			const execution: ToolExecution = {
-				toolName: tool.name,
-				parameters: toolCall.arguments,
-				result: result,
-				timestamp: new Date(),
-				confirmed: requiresConfirmation,
-			};
-
-			this.addToHistory(context.session.id, execution);
-
 			return result;
 		} catch (error) {
 			const errorMessage = getRawErrorMessageOr(error, 'Unknown error');
@@ -218,26 +206,13 @@ export class ToolExecutionEngine {
 	}
 
 	/**
-	 * Add execution to history
+	 * Release per-session state for a session that is being deleted.
+	 *
+	 * Clears the tool loop detector's recorded calls for the session so its key
+	 * does not live on for the rest of the plugin process (#1387). Called from
+	 * the session-deletion path (`SessionListModal.deleteSession`).
 	 */
-	private addToHistory(sessionId: string, execution: ToolExecution) {
-		const history = this.executionHistory.get(sessionId) || [];
-		history.push(execution);
-		this.executionHistory.set(sessionId, history);
-	}
-
-	/**
-	 * Get execution history for a session
-	 */
-	getExecutionHistory(sessionId: string): ToolExecution[] {
-		return this.executionHistory.get(sessionId) || [];
-	}
-
-	/**
-	 * Clear execution history for a session
-	 */
-	clearExecutionHistory(sessionId: string) {
-		this.executionHistory.delete(sessionId);
+	clearLoopDetectorSession(sessionId: string): void {
 		this.loopDetector.clearSession(sessionId);
 	}
 

--- a/src/tools/loop-detector.ts
+++ b/src/tools/loop-detector.ts
@@ -125,7 +125,13 @@ export class ToolLoopDetector {
 			(record) => now - record.timestamp < this.timeWindowMs * 2 // Keep 2x window for analysis
 		);
 
-		this.executionHistory.set(sessionId, filtered);
+		// When everything expires, drop the key entirely instead of parking an
+		// empty array under it — otherwise a dead session's key lives forever.
+		if (filtered.length === 0) {
+			this.executionHistory.delete(sessionId);
+		} else {
+			this.executionHistory.set(sessionId, filtered);
+		}
 	}
 }
 

--- a/src/ui/agent-view/session-list-modal.ts
+++ b/src/ui/agent-view/session-list-modal.ts
@@ -343,6 +343,10 @@ export class SessionListModal extends Modal {
 		try {
 			const file = this.app.vault.getAbstractFileByPath(session.historyPath);
 			if (file) {
+				// Release per-session engine state (tool-loop detector records) so
+				// the deleted session's key does not linger for the process lifetime (#1387)
+				this.plugin.toolExecutionEngine.clearLoopDetectorSession(session.id);
+
 				await this.app.fileManager.trashFile(file);
 				new Notice(t('agent.sessionList.deleted', { title: session.title }));
 

--- a/src/ui/agent-view/session-list-modal.ts
+++ b/src/ui/agent-view/session-list-modal.ts
@@ -343,11 +343,11 @@ export class SessionListModal extends Modal {
 		try {
 			const file = this.app.vault.getAbstractFileByPath(session.historyPath);
 			if (file) {
-				// Release per-session engine state (tool-loop detector records) so
-				// the deleted session's key does not linger for the process lifetime (#1387)
-				this.plugin.toolExecutionEngine.clearLoopDetectorSession(session.id);
-
 				await this.app.fileManager.trashFile(file);
+				// Release per-session engine state (tool-loop detector records) only
+				// after the file deletion succeeded — if trashing failed the session
+				// remains, so its detection state must survive too (#1387).
+				this.plugin.toolExecutionEngine.clearLoopDetectorSession(session.id);
 				new Notice(t('agent.sessionList.deleted', { title: session.title }));
 
 				// Reload the list and refresh filter state

--- a/src/ui/selection-response-modal.ts
+++ b/src/ui/selection-response-modal.ts
@@ -2,81 +2,7 @@ import { App, Modal, MarkdownRenderer, Editor, Notice, setIcon } from 'obsidian'
 import type { ObsidianGemini } from '../types/plugin';
 import { t } from '../i18n';
 import { getRawErrorMessageOr } from '../utils/error-utils';
-
-/**
- * Normalize newlines in AI responses for proper Markdown rendering.
- * Converts single newlines to double newlines while preserving tables and code blocks.
- */
-function normalizeNewlines(text: string): string {
-	const lines = text.split('\n');
-	const formattedLines: string[] = [];
-	let inTable = false;
-	let inCodeBlock = false;
-	let previousLineWasEmpty = true;
-
-	for (let i = 0; i < lines.length; i++) {
-		const line = lines[i];
-		const nextLine = lines[i + 1];
-		const trimmedLine = line.trim();
-
-		// Track code blocks (fenced with ``` or ~~~)
-		if (trimmedLine.startsWith('```') || trimmedLine.startsWith('~~~')) {
-			inCodeBlock = !inCodeBlock;
-			formattedLines.push(line);
-			previousLineWasEmpty = false;
-			continue;
-		}
-
-		// Don't modify content inside code blocks
-		if (inCodeBlock) {
-			formattedLines.push(line);
-			previousLineWasEmpty = trimmedLine === '';
-			continue;
-		}
-
-		// Improved table detection
-		const hasUnescapedPipe = line.split('\\|').join('').includes('|');
-		const isTableDivider = /^\s*\|?\s*[:-]+\s*\|/.test(line);
-		const isTableRow = hasUnescapedPipe && !isTableDivider && trimmedLine !== '|';
-
-		// Check if we're starting a table
-		if ((isTableRow || isTableDivider) && !inTable) {
-			inTable = true;
-			if (!previousLineWasEmpty && formattedLines.length > 0) {
-				formattedLines.push('');
-			}
-		}
-
-		// Add the current line
-		formattedLines.push(line);
-
-		// Check if we're ending a table
-		if (inTable && !hasUnescapedPipe && trimmedLine !== '') {
-			inTable = false;
-			formattedLines.push('');
-		} else if (inTable && trimmedLine === '') {
-			inTable = false;
-		}
-
-		// For non-table content, add empty line between paragraphs
-		if (
-			!inTable &&
-			!hasUnescapedPipe &&
-			trimmedLine !== '' &&
-			nextLine &&
-			nextLine.trim() !== '' &&
-			!nextLine.includes('|') &&
-			!nextLine.trim().startsWith('```') &&
-			!nextLine.trim().startsWith('~~~')
-		) {
-			formattedLines.push('');
-		}
-
-		previousLineWasEmpty = trimmedLine === '';
-	}
-
-	return formattedLines.join('\n');
-}
+import { formatModelMessage } from '../utils/markdown-formatting';
 
 /**
  * Modal that displays an AI response to a selection and allows inserting it as a callout.
@@ -163,8 +89,9 @@ export class SelectionResponseModal extends Modal {
 		this.responseContainer.show();
 		this.actionsContainer.show();
 
-		// Normalize newlines for proper Markdown rendering
-		const normalizedResponse = normalizeNewlines(response);
+		// Normalize newlines for proper Markdown rendering (shared with the agent
+		// view; see markdown-formatting.ts)
+		const normalizedResponse = formatModelMessage(response);
 
 		// Render markdown response
 		this.responseContainer.empty();
@@ -192,7 +119,7 @@ export class SelectionResponseModal extends Modal {
 		if (!this.response) return;
 
 		// Normalize newlines for consistent formatting in the callout
-		const normalizedResponse = normalizeNewlines(this.response);
+		const normalizedResponse = formatModelMessage(this.response);
 
 		// Format response as a callout
 		const calloutLines = normalizedResponse.split('\n').map((line) => `> ${line}`);

--- a/src/utils/markdown-formatting.ts
+++ b/src/utils/markdown-formatting.ts
@@ -15,6 +15,25 @@
 /** Matches a markdown table divider line (e.g. | --- | :---: |). */
 const tableDividerRe = /^[\s|]*[:?-]+\s*\|/;
 
+/**
+ * The fence run starting `trimmedLine`, if any (three or more backticks or
+ * tildes). An opening fence may carry an info string after the run.
+ */
+function fenceRun(trimmedLine: string): string | null {
+	return trimmedLine.match(/^(`{3,}|~{3,})/)?.[1] ?? null;
+}
+
+/**
+ * True when `trimmedLine` closes the fence opened with `marker`, per
+ * CommonMark: the same character, an equal-or-longer run, and whitespace only
+ * after it — so a '```ts' line inside a ```-fence is content, a longer run
+ * closes a shorter opener, and a shorter run does not close a longer opener.
+ */
+function isFenceClose(trimmedLine: string, marker: string): boolean {
+	const closeMatch = trimmedLine.match(/^(`{3,}|~{3,})\s*$/);
+	return closeMatch !== null && closeMatch[1][0] === marker[0] && closeMatch[1].length >= marker.length;
+}
+
 /** Returns true if the line contains at least one unescaped pipe character. */
 function hasUnescapedPipe(line: string): boolean {
 	return line.split('\\|').join('').includes('|');
@@ -48,9 +67,7 @@ export function formatModelMessage(text: string): string {
 		// equal-or-longer run followed by whitespace only — a '```ts' or
 		// '~~~text' line inside a fence stays content.
 		if (fenceMarker) {
-			const closeMatch = trimmedLine.match(/^(`{3,}|~{3,})\s*$/);
-			const isClosing =
-				closeMatch !== null && closeMatch[1][0] === fenceMarker[0] && closeMatch[1].length >= fenceMarker.length;
+			const isClosing = isFenceClose(trimmedLine, fenceMarker);
 			formattedLines.push(line);
 			if (isClosing) {
 				fenceMarker = null;
@@ -64,11 +81,11 @@ export function formatModelMessage(text: string): string {
 			continue;
 		}
 
-		const fenceOpen = trimmedLine.match(/^(`{3,}|~{3,})/);
+		const fenceOpen = fenceRun(trimmedLine);
 		if (fenceOpen) {
 			inTable = false; // a fence can never be part of a table
 			formattedLines.push(line);
-			fenceMarker = fenceOpen[1];
+			fenceMarker = fenceOpen;
 			previousLineWasEmpty = false;
 			continue;
 		}
@@ -133,9 +150,41 @@ export function formatModelMessage(text: string): string {
 export function unescapeWikiLinks(text: string): string {
 	if (!text) return text;
 
-	// Split on fenced code blocks (``` … ``` or ~~~ … ~~~), preserving delimiters.
-	// Odd-indexed segments are inside code fences.
-	const parts = text.split(/((?:`{3,}|~{3,})[\s\S]*?(?:`{3,}|~{3,}))/);
+	// Segment the text around fenced code blocks, preserving delimiters and
+	// using the same CommonMark open/close rules as formatModelMessage (same
+	// character, equal-or-longer run, whitespace-only trailer) so an embedded
+	// mismatched run can't split a fence and leak later content out of it.
+	// Even-indexed segments are outside code fences; odd-indexed are inside.
+	const parts: string[] = [];
+	let current = '';
+	let fenceMarker: string | null = null;
+	const lines = text.split('\n');
+	for (let idx = 0; idx < lines.length; idx++) {
+		const sep = idx < lines.length - 1 ? '\n' : '';
+		const line = lines[idx];
+		const trimmedLine = line.trim();
+		if (fenceMarker) {
+			if (isFenceClose(trimmedLine, fenceMarker)) {
+				fenceMarker = null;
+				parts.push(current + line + sep);
+				current = '';
+				continue;
+			}
+			current += line + sep;
+			continue;
+		}
+		const openRun = fenceRun(trimmedLine);
+		if (openRun) {
+			// Flush the outside-fence text so far; the fence from its opening
+			// delimiter through the close is one fenced segment.
+			parts.push(current);
+			current = line + sep;
+			fenceMarker = openRun;
+			continue;
+		}
+		current += line + sep;
+	}
+	parts.push(current);
 
 	for (let i = 0; i < parts.length; i++) {
 		if (i % 2 !== 0) continue; // Skip fenced code blocks

--- a/src/utils/markdown-formatting.ts
+++ b/src/utils/markdown-formatting.ts
@@ -4,7 +4,8 @@
  * Gemini returns text with single newlines between paragraphs, but Obsidian's
  * markdown renderer requires double newlines for paragraph breaks. This module
  * converts single newlines to double newlines while preserving table formatting,
- * which relies on single newlines between rows.
+ * which relies on single newlines between rows, and fenced code blocks, whose
+ * content must pass through verbatim (#1379).
  *
  * Also handles unescaping of WikiLinks that Gemini sometimes wraps in backtick
  * code spans or backslash-escapes, which prevents Obsidian from rendering them
@@ -29,12 +30,43 @@ export function formatModelMessage(text: string): string {
 	const lines = text.split('\n');
 	const formattedLines: string[] = [];
 	let inTable = false;
+	// Set to the marker that opened the fence ('```' or '~~~'); the fence only
+	// closes on the same marker, so a ``` line inside a ~~~ fence stays content.
+	let fenceMarker: '```' | '~~~' | null = null;
 	let previousLineWasEmpty = true;
 
 	for (let i = 0; i < lines.length; i++) {
 		const line = lines[i];
 		const nextLine = lines[i + 1];
 		const trimmedLine = line.trim();
+
+		// Track fenced code blocks: fenced content passes through verbatim —
+		// blank-line insertion inside a fence double-spaces every code line. A
+		// fence only closes on the marker that opened it, so a ``` line inside a
+		// ~~~ fence stays fence content.
+		const fenceMarkerLine = trimmedLine.startsWith('~~~')
+			? ('~~~' as const)
+			: trimmedLine.startsWith('```')
+				? ('```' as const)
+				: null;
+		if (fenceMarker || fenceMarkerLine) {
+			const isClosing = fenceMarker !== null && fenceMarkerLine === fenceMarker;
+			const isOpening = fenceMarker === null && fenceMarkerLine !== null;
+			formattedLines.push(line);
+			if (isClosing) {
+				fenceMarker = null;
+				// Blank line after a closing fence when followed by text — mirrors
+				// the paragraph-break rule so the next line starts its own block.
+				if (nextLine && nextLine.trim() !== '' && formattedLines[formattedLines.length - 1] !== '') {
+					formattedLines.push('');
+				}
+			} else if (isOpening) {
+				inTable = false; // a fence can never be part of a table
+				fenceMarker = fenceMarkerLine;
+			}
+			previousLineWasEmpty = trimmedLine === '';
+			continue;
+		}
 
 		const lineHasPipe = hasUnescapedPipe(line);
 		const isTableDivider = tableDividerRe.test(line);
@@ -44,18 +76,17 @@ export function formatModelMessage(text: string): string {
 		if ((isTableRow || isTableDivider) && !inTable) {
 			inTable = true;
 			// Add empty line before table if needed
-			if (!previousLineWasEmpty && formattedLines.length > 0) {
+			if (!previousLineWasEmpty && formattedLines.length > 0 && formattedLines[formattedLines.length - 1] !== '') {
 				formattedLines.push('');
 			}
 		}
 
-		// Add the current line
-		formattedLines.push(line);
-
-		// Check if we're ending a table
+		// Check if we're ending a table: the first non-empty line without a pipe
+		// ends it, and the separating blank line goes BEFORE that line — so the
+		// table closes as its own block and never leaves a trailing newline at
+		// end of message.
 		if (inTable && !lineHasPipe && trimmedLine !== '') {
 			inTable = false;
-			// Add empty line after table if not already blank
 			if (formattedLines[formattedLines.length - 1] !== '') {
 				formattedLines.push('');
 			}
@@ -63,6 +94,9 @@ export function formatModelMessage(text: string): string {
 			// Empty line also ends a table
 			inTable = false;
 		}
+
+		// Add the current line
+		formattedLines.push(line);
 
 		// For non-table content, add empty line between paragraphs
 		if (

--- a/src/utils/markdown-formatting.ts
+++ b/src/utils/markdown-formatting.ts
@@ -30,9 +30,11 @@ export function formatModelMessage(text: string): string {
 	const lines = text.split('\n');
 	const formattedLines: string[] = [];
 	let inTable = false;
-	// Set to the marker that opened the fence ('```' or '~~~'); the fence only
-	// closes on the same marker, so a ``` line inside a ~~~ fence stays content.
-	let fenceMarker: '```' | '~~~' | null = null;
+	// Set to the fence run that opened the block ('```', '```…', '~~~'…): the
+	// fence only closes on the same character with an equal-or-longer run
+	// followed by whitespace only, per CommonMark — so a '```ts' line inside a
+	// ```-fence stays content (#1379).
+	let fenceMarker: string | null = null;
 	let previousLineWasEmpty = true;
 
 	for (let i = 0; i < lines.length; i++) {
@@ -41,17 +43,14 @@ export function formatModelMessage(text: string): string {
 		const trimmedLine = line.trim();
 
 		// Track fenced code blocks: fenced content passes through verbatim —
-		// blank-line insertion inside a fence double-spaces every code line. A
-		// fence only closes on the marker that opened it, so a ``` line inside a
-		// ~~~ fence stays fence content.
-		const fenceMarkerLine = trimmedLine.startsWith('~~~')
-			? ('~~~' as const)
-			: trimmedLine.startsWith('```')
-				? ('```' as const)
-				: null;
-		if (fenceMarker || fenceMarkerLine) {
-			const isClosing = fenceMarker !== null && fenceMarkerLine === fenceMarker;
-			const isOpening = fenceMarker === null && fenceMarkerLine !== null;
+		// blank-line insertion inside a fence double-spaces every code line. Per
+		// CommonMark the fence closes on the same character with an
+		// equal-or-longer run followed by whitespace only — a '```ts' or
+		// '~~~text' line inside a fence stays content.
+		if (fenceMarker) {
+			const closeMatch = trimmedLine.match(/^(`{3,}|~{3,})\s*$/);
+			const isClosing =
+				closeMatch !== null && closeMatch[1][0] === fenceMarker[0] && closeMatch[1].length >= fenceMarker.length;
 			formattedLines.push(line);
 			if (isClosing) {
 				fenceMarker = null;
@@ -60,11 +59,17 @@ export function formatModelMessage(text: string): string {
 				if (nextLine && nextLine.trim() !== '' && formattedLines[formattedLines.length - 1] !== '') {
 					formattedLines.push('');
 				}
-			} else if (isOpening) {
-				inTable = false; // a fence can never be part of a table
-				fenceMarker = fenceMarkerLine;
 			}
 			previousLineWasEmpty = trimmedLine === '';
+			continue;
+		}
+
+		const fenceOpen = trimmedLine.match(/^(`{3,}|~{3,})/);
+		if (fenceOpen) {
+			inTable = false; // a fence can never be part of a table
+			formattedLines.push(line);
+			fenceMarker = fenceOpen[1];
+			previousLineWasEmpty = false;
 			continue;
 		}
 

--- a/test/tools/execution-engine.test.ts
+++ b/test/tools/execution-engine.test.ts
@@ -887,7 +887,7 @@ describe('ToolExecutionEngine - getAvailableToolsDescription', () => {
 	});
 });
 
-describe('ToolExecutionEngine - Execution History Management', () => {
+describe('ToolExecutionEngine - Session state lifecycle (#1387)', () => {
 	let plugin: any;
 	let registry: ToolRegistry;
 	let engine: ToolExecutionEngine;
@@ -897,14 +897,19 @@ describe('ToolExecutionEngine - Execution History Management', () => {
 		description: 'noop',
 		category: ToolCategory.READ_ONLY,
 		classification: ToolClassification.READ,
-		parameters: { type: 'object' as const, properties: {}, required: [] },
+		parameters: {
+			type: 'object' as const,
+			properties: { a: { type: 'number' as const, description: 'loop detector probe' } },
+			required: [],
+		},
 		execute: vi.fn().mockResolvedValue({ success: true, data: {} }),
 	};
 
 	beforeEach(() => {
 		plugin = {
 			settings: {
-				loopDetectionThreshold: 99,
+				loopDetectionEnabled: true,
+				loopDetectionThreshold: 2,
 				loopDetectionTimeWindowSeconds: 60,
 			},
 			logger: { log: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() },
@@ -919,15 +924,11 @@ describe('ToolExecutionEngine - Execution History Management', () => {
 		vi.clearAllMocks();
 	});
 
-	it('returns empty array for unknown session', () => {
-		expect(engine.getExecutionHistory('unknown-session')).toEqual([]);
-	});
-
-	it('records execution history and retrieves it', async () => {
-		const context = {
+	const sessionContext = (id: string) =>
+		({
 			plugin,
 			session: {
-				id: 'history-session',
+				id,
 				type: 'agent-session',
 				context: {
 					contextFiles: [],
@@ -936,38 +937,29 @@ describe('ToolExecutionEngine - Execution History Management', () => {
 					requireConfirmation: [],
 				},
 			},
-		} as any;
+		}) as any;
 
-		await engine.executeTool({ name: 'noop', arguments: {} }, context, denyProvider);
-		await engine.executeTool({ name: 'noop', arguments: {} }, context, denyProvider);
+	const identicalCall = { name: 'noop', arguments: { a: 1 } };
 
-		const history = engine.getExecutionHistory('history-session');
-		expect(history).toHaveLength(2);
-		expect(history[0].toolName).toBe('noop');
-		expect(history[0].result.success).toBe(true);
-		expect(history[0].timestamp).toBeInstanceOf(Date);
+	it('flags a loop once identical calls reach the threshold', async () => {
+		await engine.executeTool(identicalCall, sessionContext('flag-session'), denyProvider);
+		await engine.executeTool(identicalCall, sessionContext('flag-session'), denyProvider);
+		const flagged = await engine.executeTool(identicalCall, sessionContext('flag-session'), denyProvider);
+		expect(flagged.success).toBe(false);
+		expect(flagged.loopDetected).toBe(true);
 	});
 
-	it('clears execution history for a session', async () => {
-		const context = {
-			plugin,
-			session: {
-				id: 'clear-session',
-				type: 'agent-session',
-				context: {
-					contextFiles: [],
-					contextDepth: 2,
-					enabledTools: [ToolCategory.READ_ONLY],
-					requireConfirmation: [],
-				},
-			},
-		} as any;
+	it('clearLoopDetectorSession drops the recorded calls so detection restarts (#1387)', async () => {
+		const context = sessionContext('shrink-session');
+		await engine.executeTool(identicalCall, context, denyProvider);
+		await engine.executeTool(identicalCall, context, denyProvider);
+		engine.clearLoopDetectorSession('shrink-session');
 
-		await engine.executeTool({ name: 'noop', arguments: {} }, context, denyProvider);
-		expect(engine.getExecutionHistory('clear-session')).toHaveLength(1);
-
-		engine.clearExecutionHistory('clear-session');
-		expect(engine.getExecutionHistory('clear-session')).toEqual([]);
+		// Without the clear, the next identical call would be flagged at the
+		// threshold; with the session state released it runs again.
+		const result = await engine.executeTool(identicalCall, context, denyProvider);
+		expect(result.success).toBe(true);
+		expect(result.loopDetected).toBeUndefined();
 	});
 });
 

--- a/test/tools/loop-detector.test.ts
+++ b/test/tools/loop-detector.test.ts
@@ -197,3 +197,30 @@ describe('ToolLoopDetector', () => {
 		expect(detector.isLoopDetected(sessionId, toolCall)).toBe(true);
 	});
 });
+
+describe('ToolLoopDetector - key cleanup (#1387)', () => {
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('deletes the session key when cleanup empties it, instead of parking an empty array', () => {
+		// A zero-second window means nothing survives cleanup: the just-recorded
+		// entry is already expired, so the key is dropped entirely rather than
+		// left as an empty array the session's lifetime would keep alive.
+		const detector = new ToolLoopDetector(2, 0);
+		detector.recordExecution('s1', { name: 'read_file', arguments: {} });
+
+		const internal = detector as unknown as { executionHistory: Map<string, unknown[]> };
+		expect(internal.executionHistory.has('s1')).toBe(false);
+	});
+
+	it('keeps the session key while at least one entry is still within the window', () => {
+		vi.useFakeTimers();
+		const detector = new ToolLoopDetector(2, 60);
+		detector.recordExecution('s1', { name: 'read_file', arguments: {} });
+
+		const internal = detector as unknown as { executionHistory: Map<string, unknown[]> };
+		expect(internal.executionHistory.has('s1')).toBe(true);
+		expect(internal.executionHistory.get('s1')).toHaveLength(1);
+	});
+});

--- a/test/ui/agent-view/session-list-confirm.test.ts
+++ b/test/ui/agent-view/session-list-confirm.test.ts
@@ -97,6 +97,7 @@ interface Harness {
 	trashFile: ReturnType<typeof vi.fn>;
 	onSelect: ReturnType<typeof vi.fn>;
 	onDelete: ReturnType<typeof vi.fn>;
+	clearLoopDetectorSession: ReturnType<typeof vi.fn>;
 	contentEl: HTMLElement;
 }
 
@@ -120,8 +121,10 @@ async function openModal(sessions: ChatSession[]): Promise<Harness> {
 		fileManager: { trashFile },
 	} as unknown as App;
 
+	const clearLoopDetectorSession = vi.fn();
 	const plugin = {
 		settings: { historyFolder: 'gemini-scribe' },
+		toolExecutionEngine: { clearLoopDetectorSession },
 		sessionManager: {
 			loadSession: vi.fn((path: string) => Promise.resolve(sessions.find((s) => s.historyPath === path) ?? null)),
 			createAgentSession: vi.fn(),
@@ -135,7 +138,7 @@ async function openModal(sessions: ChatSession[]): Promise<Harness> {
 	const modal = new SessionListModal(app, plugin, { onSelect, onDelete }, null);
 	await modal.onOpen();
 
-	return { modal, trashFile, onSelect, onDelete, contentEl: (modal as any).contentEl };
+	return { modal, trashFile, onSelect, onDelete, clearLoopDetectorSession, contentEl: (modal as any).contentEl };
 }
 
 /** The rendered rows, in display order. */
@@ -192,6 +195,23 @@ describe('SessionListModal inline delete confirmation', () => {
 		} finally {
 			vi.unstubAllGlobals();
 		}
+	});
+
+	it('releases the tool-loop detector records when the session is deleted (#1387)', async () => {
+		const { contentEl, clearLoopDetectorSession } = await openModal([makeSession('a', 'Alpha')]);
+		const row = rows(contentEl)[0];
+		click(deleteButton(row));
+		click(confirmButton(row)!);
+		await vi.waitFor(() => expect(clearLoopDetectorSession).toHaveBeenCalledWith('a'));
+	});
+
+	it('does not release loop-detector state when cancelled (#1387)', async () => {
+		const { contentEl, clearLoopDetectorSession } = await openModal([makeSession('a', 'Alpha')]);
+		const row = rows(contentEl)[0];
+		click(deleteButton(row));
+		click(cancelButton(row)!);
+		await new Promise((resolve) => window.setTimeout(resolve, 0));
+		expect(clearLoopDetectorSession).not.toHaveBeenCalled();
 	});
 
 	it('deletes only after the confirm button is clicked', async () => {

--- a/test/ui/agent-view/session-list-confirm.test.ts
+++ b/test/ui/agent-view/session-list-confirm.test.ts
@@ -205,6 +205,18 @@ describe('SessionListModal inline delete confirmation', () => {
 		await vi.waitFor(() => expect(clearLoopDetectorSession).toHaveBeenCalledWith('a'));
 	});
 
+	it('does not release loop-detector state when trashing fails (#1387 review regression)', async () => {
+		const { contentEl, trashFile, clearLoopDetectorSession } = await openModal([makeSession('a', 'Alpha')]);
+		trashFile.mockRejectedValueOnce(new Error('trash failed'));
+		const row = rows(contentEl)[0];
+		click(deleteButton(row));
+		click(confirmButton(row)!);
+		await vi.waitFor(() => expect(trashFile).toHaveBeenCalled());
+		// Give the rejected promise a tick to surface in deleteSession's catch.
+		await new Promise((resolve) => window.setTimeout(resolve, 0));
+		expect(clearLoopDetectorSession).not.toHaveBeenCalled();
+	});
+
 	it('does not release loop-detector state when cancelled (#1387)', async () => {
 		const { contentEl, clearLoopDetectorSession } = await openModal([makeSession('a', 'Alpha')]);
 		const row = rows(contentEl)[0];

--- a/test/utils/markdown-formatting.test.ts
+++ b/test/utils/markdown-formatting.test.ts
@@ -176,6 +176,19 @@ describe('unescapeWikiLinks', () => {
 		expect(unescapeWikiLinks(input)).toBe(input);
 	});
 
+	it('a mismatched fence run inside a fence does not split it (unescape pairing)', () => {
+		// Old splitter tilted on the first ~~~ run and let the escaped link be
+		// rewritten outside the still-open ``` fence; the strict parser keeps
+		// the whole block fenced.
+		const input = '```\n~~~\n\\[\\[a\\]\\]\n~~~\n```';
+		expect(unescapeWikiLinks(input)).toBe(input);
+	});
+
+	it('an escaped wikilink after a properly closed fence is still unescaped', () => {
+		const input = '```\ncode\n```\n\\[\\[real\\]\\]';
+		expect(unescapeWikiLinks(input)).toBe('```\ncode\n```\n[[real]]');
+	});
+
 	// --- Backslash escaping ---
 	it('fixes fully backslash-escaped wikilinks', () => {
 		expect(unescapeWikiLinks('See \\[\\[My Note\\]\\] for details')).toBe('See [[My Note]] for details');

--- a/test/utils/markdown-formatting.test.ts
+++ b/test/utils/markdown-formatting.test.ts
@@ -113,6 +113,21 @@ describe('formatModelMessage', () => {
 		expect(output).toBe('~~~\ntext\n```inline\ntext2\n~~~\n\nAfter');
 	});
 
+	it('a closing fence may not carry trailing text (```nope stays content, CommonMark)', () => {
+		const input = '```\ncode\n```nope\nmore\n```';
+		expect(formatModelMessage(input)).toBe('```\ncode\n```nope\nmore\n```');
+	});
+
+	it('a longer closing run inside a shorter fence still closes (CommonMark)', () => {
+		const input = '```\ncode\n`````\nAfter';
+		expect(formatModelMessage(input)).toBe('```\ncode\n`````\n\nAfter');
+	});
+
+	it('a shorter closing run does not close a longer fence (CommonMark)', () => {
+		const input = '````\ncode\n```\nmore\n````';
+		expect(formatModelMessage(input)).toBe('````\ncode\n```\nmore\n````');
+	});
+
 	it('does not double-space table rows that appear between two fences', () => {
 		const input = '```\npre\n```\n| A | B |\n| --- | --- |\n```\npost\n```';
 		const output = formatModelMessage(input);

--- a/test/utils/markdown-formatting.test.ts
+++ b/test/utils/markdown-formatting.test.ts
@@ -36,8 +36,11 @@ describe('formatModelMessage', () => {
 	it('adds blank line after a table when followed by text', () => {
 		const input = '| A | B |\n| --- | --- |\n| 1 | 2 |\nSome text after';
 		const result = formatModelMessage(input);
-		// The first non-pipe line ends the table; a blank line is inserted after it
-		expect(result).toContain('| 1 | 2 |\nSome text after\n');
+		// The first non-pipe line ends the table; the separating blank line sits
+		// between the table and the following text (#1379: previously the blank
+		// landed after the first non-table line, leaving a trailing newline when
+		// the text was the last line of the message).
+		expect(result).toBe('| A | B |\n| --- | --- |\n| 1 | 2 |\n\nSome text after');
 	});
 
 	it('handles table with leading whitespace in divider', () => {
@@ -78,6 +81,51 @@ describe('formatModelMessage', () => {
 		formatModelMessage(' '.repeat(50000) + 'x');
 		const elapsed = Date.now() - start;
 		expect(elapsed).toBeLessThan(1000);
+	});
+
+	// --- Fenced code blocks (#1379) ---
+	it('leaves fenced code content untouched (no double-spacing inside fences)', () => {
+		const input = 'Here is code:\n```ts\nconst a = 1;\nconst b = 2;\n```\nDone.';
+		// Paragraph break before the fence, blank between paragraphs — but the
+		// code lines themselves are never touched.
+		expect(formatModelMessage(input)).toBe('Here is code:\n\n```ts\nconst a = 1;\nconst b = 2;\n```\n\nDone.');
+	});
+
+	it('leaves tilde-fenced content untouched', () => {
+		const input = 'Text:\n~~~\nconst a = 1;\nconst b = 2;\n~~~\nAfter';
+		expect(formatModelMessage(input)).toBe('Text:\n\n~~~\nconst a = 1;\nconst b = 2;\n~~~\n\nAfter');
+	});
+
+	it('does not treat fence content as table rows (pipes inside fences)', () => {
+		const input = '~~~\n| fake | table |\n| --- | --- |\n~~~';
+		expect(formatModelMessage(input)).toBe('~~~\n| fake | table |\n| --- | --- |\n~~~');
+	});
+
+	it('fence immediately after a paragraph line still gets its opening paragraph break', () => {
+		const input = 'Here is code:\n```ts\nconst a = 1;\n```';
+		expect(formatModelMessage(input)).toBe('Here is code:\n\n```ts\nconst a = 1;\n```');
+	});
+
+	it('a fence does not close on a mismatched marker (``` inside ~~~)', () => {
+		const input = '~~~\ntext\n```inline\ntext2\n~~~\nAfter';
+		const output = formatModelMessage(input);
+		// Everything inside the ~~~ fence stays verbatim, including the ``` line
+		expect(output).toBe('~~~\ntext\n```inline\ntext2\n~~~\n\nAfter');
+	});
+
+	it('does not double-space table rows that appear between two fences', () => {
+		const input = '```\npre\n```\n| A | B |\n| --- | --- |\n```\npost\n```';
+		const output = formatModelMessage(input);
+		expect(output).toContain('| A | B |\n| --- | --- |');
+		expect(output).not.toContain('| A | B |\n\n| --- |');
+	});
+
+	// --- Table-end single blank line (modal fork drift) ---
+	it('emits exactly one blank line after a table followed by text', () => {
+		const input = '| A | B |\n| --- | --- |\n| 1 | 2 |\nTail';
+		const output = formatModelMessage(input);
+		expect(output).not.toContain('\n\n\n');
+		expect(output.endsWith('Tail')).toBe(true);
 	});
 
 	// --- WikiLink unescaping integration ---


### PR DESCRIPTION
## Summary

Fixes #1387 (Option A — delete the store)

`ToolExecutionEngine` kept a `Map<sessionId, ToolExecution[]>` that was appended to on **every successful tool call** but never read, never size-capped, and never cleared — a monotonic memory leak holding every tool call's full parameters and result payload for the plugin process's lifetime. No production code read it (`getExecutionHistory`/`clearExecutionHistory` were test-only).

## Changes

- **Delete the store**: remove `executionHistory`, `addToHistory`, `getExecutionHistory`, `clearExecutionHistory`, and the `addToHistory` call in `executeTool` (the `ToolExecution` type stays — `AgentSession.toolsUsed` uses it).
- **Replace the one load-bearing behavior**: `clearExecutionHistory` was the only caller of `ToolLoopDetector.clearSession`, so the engine now exposes `clearLoopDetectorSession(sessionId)` with the same responsibility.
- **Wire session teardown** (the leak's actual fix): `SessionListModal.deleteSession` calls it before trashing the session file, so a deleted session's loop-detector records don't linger for the process lifetime.
- **`ToolLoopDetector.cleanupOldEntries`**: `delete` the key when the filtered array is empty instead of parking an empty array under it (note: reachable only when cleanup runs with an already-expired record set — defensive against future callers — since `recordExecution` always re-pushes first).
- **Tests**: the three dead-surface engine tests are gone, replaced with behavioral lifecycle tests at threshold 2 (identical calls flag a loop; after `clearLoopDetectorSession` the next identical call runs again). Modal tests assert the teardown fires on delete-confirm and does *not* fire on cancel. New loop-detector tests pin the delete-vs-empty-array branch both ways.

## Screenshots / Screencast

No user-visible change — pure lifecycle/memory fix, plus loop-detection restart parity after a session is deleted.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer
- [x] All CI checks pass — `npm test` 3813 pass, `npm run build`, `npm run format-check`, `npm run lint:cycles`, `npm run typecheck:test`, `npm run knip`
- [ ] I have tested this change on Desktop
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards)
- [x] Documentation has been updated (if applicable) — no user-facing surface; engine JSDoc documents the teardown contract

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: pi coding agent (GLM)
- [x] I have reviewed and understand all AI-generated code in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Markdown formatting for fenced code blocks, tables, and paragraphs.
  - Preserved code fences accurately, including tilde-based fences and embedded pipes.
  - Ensured deleted sessions no longer retain loop-detection state.
  - Improved cleanup of expired loop-detection records.
- **Improvements**
  - Loop detection now resets correctly when a session is cleared, allowing tool execution to resume as expected.
  - Standardized response and callout formatting for more consistent display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->