### PR TITLE
Prune the four spuriously-plumbed capability flags (#1298)

### DIFF
--- a/src/api/providers/registry.ts
+++ b/src/api/providers/registry.ts
@@ -55,28 +55,18 @@ export interface ProviderCapabilities {
 	rag: boolean;
 	imageGen: boolean;
 
-	// --- Behavioural traits ---
-	/**
-	 * `'always'` — every model accepts image input.
-	 * `'auto-detect'` — varies per model, probed at runtime.
-	 * `'never'` — text only.
-	 */
-	vision: 'always' | 'auto-detect' | 'never';
+	// --- Behavioural traits with live readers ---
 	/** Exposes a real token-counting endpoint (otherwise we estimate chars-per-token). */
 	nativeTokenCount: boolean;
-	/** Reports cached-prompt token counts in usage metadata. */
-	promptCache: boolean;
-	/** Requests have a per-token cost worth reporting. */
-	costMetrics: boolean;
-	/** Supports the Interactions API transport. */
-	interactionsApi: boolean;
 	/** Honours the `customBaseUrl` setting. */
 	customBaseUrl: boolean;
 	/**
-	 * Different models can be configured per use case without a runtime penalty.
-	 * False for Ollama, which keeps a single model resident — diverging models
-	 * thrashes RAM/VRAM on every switch (#1077), so its per-use-case model
-	 * fields default to inheriting the chat model.
+	 * Descriptive-only until #703 wires the settings ladder through this flag:
+	 * a real consumer exists (the per-use-case model pickers and their model
+	 * defaults) but currently branches on the provider name (#1298). False for
+	 * Ollama, which keeps a single model resident — diverging models thrash
+	 * RAM/VRAM on every switch (#1077), so its per-use-case model fields
+	 * default to inheriting the chat model.
 	 */
 	perUseCaseModels: boolean;
 	/** Requests need an API key before the provider can be initialized. */
@@ -104,11 +94,7 @@ export const PROVIDERS: Record<ModelProvider, ProviderDefinition> = {
 			webSearch: true,
 			rag: true,
 			imageGen: true,
-			vision: 'always',
 			nativeTokenCount: true,
-			promptCache: true,
-			costMetrics: true,
-			interactionsApi: true,
 			customBaseUrl: true,
 			perUseCaseModels: true,
 			requiresApiKey: true,
@@ -127,11 +113,7 @@ export const PROVIDERS: Record<ModelProvider, ProviderDefinition> = {
 			webSearch: false,
 			rag: false,
 			imageGen: false,
-			vision: 'auto-detect',
 			nativeTokenCount: false,
-			promptCache: false,
-			costMetrics: false,
-			interactionsApi: false,
 			customBaseUrl: false,
 			perUseCaseModels: false,
 			requiresApiKey: false,
@@ -156,11 +138,7 @@ export const PROVIDERS: Record<ModelProvider, ProviderDefinition> = {
 			webSearch: false,
 			rag: false,
 			imageGen: false,
-			vision: 'auto-detect',
 			nativeTokenCount: false,
-			promptCache: false,
-			costMetrics: false,
-			interactionsApi: false,
 			customBaseUrl: true,
 			perUseCaseModels: true,
 			requiresApiKey: true,

--- a/test/api/provider-registry.test.ts
+++ b/test/api/provider-registry.test.ts
@@ -27,7 +27,6 @@ describe('capability matrix', () => {
 		expect(caps.imageGen).toBe(true);
 		expect(caps.requiresApiKey).toBe(true);
 		expect(caps.nativeTokenCount).toBe(true);
-		expect(caps.interactionsApi).toBe(true);
 		expect(caps.customBaseUrl).toBe(true);
 	});
 
@@ -44,7 +43,6 @@ describe('capability matrix', () => {
 		expect(caps.imageGen).toBe(false);
 		expect(caps.requiresApiKey).toBe(false);
 		expect(caps.nativeTokenCount).toBe(false);
-		expect(caps.vision).toBe('auto-detect');
 		// One resident model at a time (#1077).
 		expect(caps.perUseCaseModels).toBe(false);
 	});
@@ -61,10 +59,6 @@ describe('capability matrix', () => {
 		expect(caps.imageGen).toBe(false);
 		expect(caps.requiresApiKey).toBe(true);
 		expect(caps.nativeTokenCount).toBe(false);
-		expect(caps.promptCache).toBe(false);
-		expect(caps.costMetrics).toBe(false);
-		expect(caps.interactionsApi).toBe(false);
-		expect(caps.vision).toBe('auto-detect');
 		expect(caps.customBaseUrl).toBe(true);
 		// Each use case keeps its own model — no single-resident-model constraint.
 		expect(caps.perUseCaseModels).toBe(true);


### PR DESCRIPTION
## Summary

Fixes #1298

Five of the fifteen `ProviderCapabilities` fields were declared, filled in for all three providers, and "**mirrored** into the docs" — but read by **no code path anywhere**. Half the matrix was documentation wearing a type. This PR applies the issue's per-field dispositions.

## Per-field decisions

| Field | Disposition | Why |
|---|---|---|
| `costMetrics` | **Deleted** | No cost-reporting surface exists in the plugin at all; the flag gates nothing and inviting wiring to a never-validated flag is the failure mode the issue warns about |
| `vision` | **Deleted** | The live answer is per-model `supportsVision` (`models.ts`, probed by `ollama-models-service` / `openai-models-service`); provider grain was the wrong granularity, and the issue's alternative (re-wiring the services to read it) would add indirection without a consumer |
| `promptCache` | **Deleted** | Non-Gemini clients degrade on their own (no `cachedContentTokenCount` in usage; the agent view keys off `usage.cachedTokens > 0`) |
| `interactionsApi` | **Deleted** | Gated by `settings.useInteractionsApi` + the per-model `interactionsOnly` flag; Ollama/OpenAI simply don't implement the transport |
| `perUseCaseModels` | **Kept, marked descriptive** | The issue: "worth wiring rather than deleting, since a real consumer exists today — do it as part of #703's sub-task, not here." Now documented as such. |

## Changes

- `src/api/providers/registry.ts` — the four fields deleted from the interface and all three provider definitions; the traits section now separates **load-bearing** fields (`nativeTokenCount`, `customBaseUrl`, `requiresApiKey`, `defaultInputTokenLimit`) from the one descriptive field, per the issue's "make the file honest" ask
- `test/api/provider-registry.test.ts` — the six assertions over deleted fields removed; every remaining assertion is a live check (all suites still pass)
- No `src/` code consulted any of the four fields (verified by grep — only comments); `docs/reference/provider-capabilities.md` documents user-visible *behavior*, not these flags — its Vision note (per-model auto-detection) is still exactly right, so no rows move

## Screenshots / Screencast

No user-visible change — the deleted flags had no readers; routing (`providerSupports` over the seven use-case booleans) is untouched.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer
- [x] All CI checks pass — `npm test` 3803 pass, `npm run build`, `npm run format-check`, `npm run lint:cycles`, `npm run typecheck:test`, `npm run knip`
- [ ] I have tested this change on Desktop
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards)
- [x] Documentation has been updated (if applicable) — audited `docs/reference/provider-capabilities.md`; it never carried rows for the deleted flags (they only ever existed in the registry), so no doc rows move

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: pi coding agent (GLM)
- [x] I have reviewed and understand all AI-generated code in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified provider capability information by removing several no-longer-used capability indicators.
  * Retained support details for native token counting, custom base URLs, and per-use-case model selection.
  * Updated provider capability definitions and validation accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->