### PR TITLE
Share the vault binary attachment pipeline between drop and @-mention (#1363)

### DIFF
--- a/src/ui/agent-view/agent-view-attachments.ts
+++ b/src/ui/agent-view/agent-view-attachments.ts
@@ -6,7 +6,9 @@ import { AgentViewShelf, getTextFilesFromFolder } from './agent-view-shelf';
 import { FileMentionModal } from './file-mention-modal';
 import { getContextSelection, createContextRange } from '../../utils/dom-context';
 import { shouldExcludePathForPlugin } from '../../utils/file-utils';
-import { rasterizeSvg } from '../../utils/svg-rasterizer';
+import { classifyFile, FileCategory } from '../../utils/file-classification';
+import { estimateAttachmentBytes } from './inline-attachment';
+import { attachVaultBinaryFile } from './attach-vault-file';
 import type { ObsidianGemini } from '../../types/plugin';
 import { t } from '../../i18n';
 
@@ -26,8 +28,9 @@ export interface AttachmentsContext {
 }
 
 /**
- * Handles file attachment operations for the agent view:
- * drag-and-drop, paste, @ mention file picker, and attachment persistence.
+ * Handles the @ mention file picker and attachment persistence for the agent
+ * view. Drag-and-drop and paste live in `AgentViewUI` (agent-view-ui.ts); both
+ * paths share the vault-binary pipeline in `attach-vault-file.ts` (#1363).
  */
 export class AgentViewAttachments {
 	constructor(private ctx: AttachmentsContext) {}
@@ -63,8 +66,6 @@ export class AgentViewAttachments {
 					if (!(fileOrFolder instanceof TFile)) return;
 
 					// Classify the file to determine text vs binary handling
-					const { classifyFile, FileCategory, arrayBufferToBase64, detectWebmMimeType, GEMINI_INLINE_DATA_LIMIT } =
-						await import('../../utils/file-classification');
 					const classification = classifyFile(fileOrFolder.extension);
 
 					if (classification.category === FileCategory.TEXT) {
@@ -76,47 +77,32 @@ export class AgentViewAttachments {
 						classification.category === FileCategory.GEMINI_BINARY ||
 						classification.category === FileCategory.SVG
 					) {
-						// Handle binary/SVG file — create inline attachment (same as drag-drop).
-						// SVG is rasterized to PNG; other binaries are inlined as-is.
+						// Handle binary/SVG file — create inline attachment (same as drag-drop),
+						// via the shared vault-binary pipeline (#1363).
 						try {
-							const buffer = await this.ctx.app.vault.readBinary(fileOrFolder);
-							const existing = this.ctx.getShelf().getPendingAttachments();
-							const cumulativeSize =
-								existing.reduce((sum, a) => sum + Math.ceil((a.base64.length * 3) / 4), 0) + buffer.byteLength;
-
-							if (cumulativeSize > GEMINI_INLINE_DATA_LIMIT) {
-								new Notice(t('agent.attachments.fileTooLarge', { name: fileOrFolder.name }), 5000);
-								return;
-							}
-
-							let base64: string;
-							let mimeType: string;
-							if (classification.category === FileCategory.SVG) {
-								try {
-									base64 = await rasterizeSvg(buffer, fileOrFolder.extension.toLowerCase() === 'svgz');
-									mimeType = 'image/png';
-								} catch (rasterErr) {
-									this.ctx.plugin.logger.error(`Failed to rasterize SVG ${fileOrFolder.path}:`, rasterErr);
+							const alreadyUsed = estimateAttachmentBytes(this.ctx.getShelf().getPendingAttachments());
+							const result = await attachVaultBinaryFile(
+								this.ctx.app,
+								fileOrFolder,
+								alreadyUsed,
+								this.ctx.plugin.logger
+							);
+							switch (result.kind) {
+								case 'too-large':
+									new Notice(t('agent.attachments.fileTooLarge', { name: fileOrFolder.name }), 5000);
+									return;
+								case 'raster-failed':
 									new Notice(t('agent.attachments.attachFailed', { name: fileOrFolder.name }));
 									return;
-								}
-							} else {
-								base64 = arrayBufferToBase64(buffer);
-								mimeType =
-									fileOrFolder.extension.toLowerCase() === 'webm'
-										? detectWebmMimeType(buffer)
-										: classification.mimeType;
+								case 'read-failed':
+									this.ctx.plugin.logger.error(`Failed to attach ${fileOrFolder.path}:`, result.error);
+									new Notice(t('agent.attachments.attachFailed', { name: fileOrFolder.name }));
+									return;
+								case 'ok':
+									this.addAttachment(result.attachment);
+									new Notice(t('agent.attachments.attached', { name: fileOrFolder.name }), 2000);
+									return;
 							}
-							const { generateAttachmentId } = await import('./inline-attachment');
-							const attachment: InlineAttachment = {
-								base64,
-								mimeType,
-								id: generateAttachmentId(),
-								vaultPath: fileOrFolder.path,
-								fileName: fileOrFolder.name,
-							};
-							this.addAttachment(attachment);
-							new Notice(t('agent.attachments.attached', { name: fileOrFolder.name }), 2000);
 						} catch (err) {
 							this.ctx.plugin.logger.error(`Failed to attach ${fileOrFolder.path}:`, err);
 							new Notice(t('agent.attachments.attachFailed', { name: fileOrFolder.name }));

--- a/src/ui/agent-view/agent-view-ui.ts
+++ b/src/ui/agent-view/agent-view-ui.ts
@@ -6,18 +6,14 @@ import { sanitizeFileName, shouldExcludePathForPlugin } from '../../utils/file-u
 import { collectFilesFromFolder } from '../../utils/folder-walk';
 import {
 	InlineAttachment,
-	generateAttachmentId,
+	estimateAttachmentBytes,
 	fileToBase64,
+	generateAttachmentId,
 	getMimeType,
 	isSupportedImageType,
 } from './inline-attachment';
-import {
-	classifyFile,
-	FileCategory,
-	arrayBufferToBase64,
-	detectWebmMimeType,
-	GEMINI_INLINE_DATA_LIMIT,
-} from '../../utils/file-classification';
+import { attachVaultBinaryFile } from './attach-vault-file';
+import { classifyFile, FileCategory, GEMINI_INLINE_DATA_LIMIT } from '../../utils/file-classification';
 import { rasterizeSvg } from '../../utils/svg-rasterizer';
 import { t } from '../../i18n';
 
@@ -641,50 +637,23 @@ export class AgentViewUI {
 					const sizeLimitExceeded: string[] = [];
 
 					for (const file of binaryFiles) {
-						try {
-							const buffer = await this.app.vault.readBinary(file);
-							cumulativeSize += buffer.byteLength;
-
-							if (cumulativeSize > GEMINI_INLINE_DATA_LIMIT) {
+						const result = await attachVaultBinaryFile(this.app, file, cumulativeSize, this.plugin.logger);
+						switch (result.kind) {
+							case 'ok':
+								callbacks.addAttachment(result.attachment);
+								cumulativeSize += result.bytes;
+								binaryCount++;
+								break;
+							case 'too-large':
 								sizeLimitExceeded.push(file.name);
-								cumulativeSize -= buffer.byteLength;
-								continue;
-							}
-
-							const classification = classifyFile(file.extension);
-							let base64: string;
-							let mimeType: string;
-							if (classification.category === FileCategory.SVG) {
-								// SVG can't be inlined directly — rasterize to PNG. On failure
-								// (malformed SVG, unresolvable refs), fall back to the
-								// unsupported-file notice rather than sending raw XML.
-								try {
-									base64 = await rasterizeSvg(buffer, file.extension.toLowerCase() === 'svgz');
-									mimeType = 'image/png';
-								} catch (rasterErr) {
-									this.plugin.logger.error(`Failed to rasterize SVG ${file.path}:`, rasterErr);
-									unsupportedExts.push(`.${file.extension}`);
-									cumulativeSize -= buffer.byteLength;
-									continue;
-								}
-							} else {
-								base64 = arrayBufferToBase64(buffer);
-								// For .webm files, detect audio vs video from container header
-								mimeType =
-									file.extension.toLowerCase() === 'webm' ? detectWebmMimeType(buffer) : classification.mimeType;
-							}
-							const attachment: InlineAttachment = {
-								base64,
-								mimeType,
-								id: generateAttachmentId(),
-								vaultPath: file.path,
-								fileName: file.name,
-							};
-							callbacks.addAttachment(attachment);
-							binaryCount++;
-						} catch (err) {
-							this.plugin.logger.error(`Failed to read binary file ${file.path}:`, err);
-							new Notice(t('agent.attachments.attachFailed', { name: file.name }));
+								break;
+							case 'raster-failed':
+								unsupportedExts.push(`.${file.extension}`);
+								break;
+							case 'read-failed':
+								this.plugin.logger.error(`Failed to read binary file ${file.path}:`, result.error);
+								new Notice(t('agent.attachments.attachFailed', { name: file.name }));
+								break;
 						}
 					}
 
@@ -883,7 +852,7 @@ export class AgentViewUI {
 	 * Compute the cumulative base64 byte size of all existing attachments.
 	 */
 	private getCurrentAttachmentSize(callbacks: UICallbacks): number {
-		return callbacks.getAttachments().reduce((sum, a) => sum + Math.ceil((a.base64.length * 3) / 4), 0);
+		return estimateAttachmentBytes(callbacks.getAttachments());
 	}
 
 	/**

--- a/src/ui/agent-view/attach-vault-file.ts
+++ b/src/ui/agent-view/attach-vault-file.ts
@@ -21,7 +21,7 @@ import {
 	detectWebmMimeType,
 } from '../../utils/file-classification';
 import { rasterizeSvg } from '../../utils/svg-rasterizer';
-import { generateAttachmentId, type InlineAttachment } from './inline-attachment';
+import { base64DecodedBytes, generateAttachmentId, type InlineAttachment } from './inline-attachment';
 import type { Logger } from '../../utils/logger';
 
 export type VaultAttachmentResult =
@@ -68,6 +68,7 @@ export async function attachVaultBinaryFile(
 	const classification = classifyFile(file.extension);
 	let base64: string;
 	let mimeType: string;
+	let bytes = buffer.byteLength;
 	if (classification.category === FileCategory.SVG) {
 		// SVG can't be inlined directly — rasterize to PNG. On failure
 		// (malformed SVG, unresolvable refs), fall back to the caller's
@@ -79,6 +80,14 @@ export async function attachVaultBinaryFile(
 			logger.error(`Failed to rasterize SVG ${file.path}:`, rasterErr);
 			return { kind: 'raster-failed' };
 		}
+		// The rasterized PNG can be larger than the source SVG (it's a decoded
+		// bitmap), so the budget — checked above against the small source file —
+		// has to hold for the converted payload too (#1412 review).
+		const convertedBytes = base64DecodedBytes(base64);
+		if (alreadyUsedBytes + convertedBytes > GEMINI_INLINE_DATA_LIMIT) {
+			return { kind: 'too-large' };
+		}
+		bytes = convertedBytes;
 	} else {
 		base64 = arrayBufferToBase64(buffer);
 		// For .webm files, detect audio vs video from container header
@@ -94,6 +103,6 @@ export async function attachVaultBinaryFile(
 			vaultPath: file.path,
 			fileName: file.name,
 		},
-		bytes: buffer.byteLength,
+		bytes,
 	};
 }

--- a/src/ui/agent-view/attach-vault-file.ts
+++ b/src/ui/agent-view/attach-vault-file.ts
@@ -1,0 +1,99 @@
+/**
+ * Shared vault-binary → InlineAttachment pipeline (#1363).
+ *
+ * The vault-drop path (agent-view-ui.ts) and the @-mention path
+ * (agent-view-attachments.ts) each had a private copy of read → budget check →
+ * rasterize-or-base64 → .webm sniff → build record, and the copies had drifted
+ * in which notices they show on failure. This leaf owns only the part both
+ * paths share; each caller keeps its own notice behavior by switching on the
+ * discriminated result.
+ *
+ * Leaf module: imports only siblings it must know (`inline-attachment`) and
+ * utils leaves (`file-classification`, `svg-rasterizer`) — no cycle risk.
+ */
+
+import type { App, TFile } from 'obsidian';
+import {
+	FileCategory,
+	GEMINI_INLINE_DATA_LIMIT,
+	arrayBufferToBase64,
+	classifyFile,
+	detectWebmMimeType,
+} from '../../utils/file-classification';
+import { rasterizeSvg } from '../../utils/svg-rasterizer';
+import { generateAttachmentId, type InlineAttachment } from './inline-attachment';
+import type { Logger } from '../../utils/logger';
+
+export type VaultAttachmentResult =
+	| { kind: 'ok'; attachment: InlineAttachment; bytes: number }
+	| { kind: 'too-large' }
+	| { kind: 'raster-failed' }
+	| { kind: 'read-failed'; error: unknown };
+
+/**
+ * Read a vault file as an inline attachment, honoring the shared 20 MB budget.
+ *
+ * `alreadyUsedBytes` is the caller's current attachment total (each path seeds
+ * it its own way). The helper reads the file, checks the budget, rasterizes
+ * SVG/SVGZ to PNG or base64-encodes the raw buffer (sniffing audio vs video
+ * for `.webm`), and returns the built record plus the file's raw byte length
+ * on success. Failure kinds never log by themselves except the rasterize
+ * failure, whose message is byte-identical in both call sites today — the
+ * `read-failed` error is returned instead so each caller logs its own wording
+ * (drop says "Failed to read…", @-mention says "Failed to attach…").
+ *
+ * @param app - Obsidian App (vault.readBinary)
+ * @param file - the vault file (must classify as GEMINI_BINARY or SVG)
+ * @param alreadyUsedBytes - attachment bytes already consumed by the caller
+ * @param logger - plugin logger for the rasterize failure
+ * @returns discriminated result; `bytes` is present only on `ok`
+ */
+export async function attachVaultBinaryFile(
+	app: App,
+	file: TFile,
+	alreadyUsedBytes: number,
+	logger: Logger
+): Promise<VaultAttachmentResult> {
+	let buffer: ArrayBuffer;
+	try {
+		buffer = await app.vault.readBinary(file);
+	} catch (err) {
+		return { kind: 'read-failed', error: err };
+	}
+
+	if (alreadyUsedBytes + buffer.byteLength > GEMINI_INLINE_DATA_LIMIT) {
+		return { kind: 'too-large' };
+	}
+
+	const classification = classifyFile(file.extension);
+	let base64: string;
+	let mimeType: string;
+	if (classification.category === FileCategory.SVG) {
+		// SVG can't be inlined directly — rasterize to PNG. On failure
+		// (malformed SVG, unresolvable refs), fall back to the caller's
+		// unsupported-file notice rather than sending raw XML.
+		try {
+			base64 = await rasterizeSvg(buffer, file.extension.toLowerCase() === 'svgz');
+			mimeType = 'image/png';
+		} catch (rasterErr) {
+			logger.error(`Failed to rasterize SVG ${file.path}:`, rasterErr);
+			return { kind: 'raster-failed' };
+		}
+	} else {
+		base64 = arrayBufferToBase64(buffer);
+		// For .webm files, detect audio vs video from container header
+		mimeType = file.extension.toLowerCase() === 'webm' ? detectWebmMimeType(buffer) : classification.mimeType;
+	}
+
+	return {
+		kind: 'ok',
+		attachment: {
+			base64,
+			mimeType,
+			id: generateAttachmentId(),
+			vaultPath: file.path,
+			fileName: file.name,
+		},
+		bytes: buffer.byteLength,
+	};
+}

--- a/src/ui/agent-view/inline-attachment.ts
+++ b/src/ui/agent-view/inline-attachment.ts
@@ -30,12 +30,21 @@ export function generateAttachmentId(): string {
 }
 
 /**
+ * Decoded byte size of a base64 payload (no data URI), padding excluded
+ * (so 'YQ==' counts as 1 byte, not 3).
+ */
+export function base64DecodedBytes(base64: string): number {
+	const padding = base64.endsWith('==') ? 2 : base64.endsWith('=') ? 1 : 0;
+	return Math.floor(((base64.length - padding) * 3) / 4);
+}
+
+/**
  * Estimate the decoded byte size of pending attachments from their base64
- * payloads (3 bytes per 4 base64 chars, rounded up). Shared by every path that
- * seeds the cumulative size used against GEMINI_INLINE_DATA_LIMIT (#1363).
+ * payloads. Shared by every path that seeds the cumulative size used against
+ * GEMINI_INLINE_DATA_LIMIT (#1363).
  */
 export function estimateAttachmentBytes(attachments: InlineAttachment[]): number {
-	return attachments.reduce((sum, a) => sum + Math.ceil((a.base64.length * 3) / 4), 0);
+	return attachments.reduce((sum, a) => sum + base64DecodedBytes(a.base64), 0);
 }
 
 /**

--- a/src/ui/agent-view/inline-attachment.ts
+++ b/src/ui/agent-view/inline-attachment.ts
@@ -30,6 +30,15 @@ export function generateAttachmentId(): string {
 }
 
 /**
+ * Estimate the decoded byte size of pending attachments from their base64
+ * payloads (3 bytes per 4 base64 chars, rounded up). Shared by every path that
+ * seeds the cumulative size used against GEMINI_INLINE_DATA_LIMIT (#1363).
+ */
+export function estimateAttachmentBytes(attachments: InlineAttachment[]): number {
+	return attachments.reduce((sum, a) => sum + Math.ceil((a.base64.length * 3) / 4), 0);
+}
+
+/**
  * Convert a File or Blob to base64
  */
 export function fileToBase64(file: File | Blob): Promise<string> {

--- a/test/ui/agent-view/attach-vault-file.test.ts
+++ b/test/ui/agent-view/attach-vault-file.test.ts
@@ -110,6 +110,34 @@ describe('attachVaultBinaryFile', () => {
 		}
 	});
 
+	it('enforces the budget against the converted PNG bytes, not the SVG source', async () => {
+		// A small SVG whose rasterization explodes past the 20 MB budget: the
+		// source-side pre-check passes, the converted-payload check rejects it
+		// (#1412 review).
+		rasterizeSvg.mockResolvedValue('A'.repeat(Math.ceil(((GEMINI_INLINE_DATA_LIMIT + 1024) * 4) / 3)));
+		const result = await attachVaultBinaryFile(
+			mockVault(bufferOf([1])),
+			makeFile('icon.svg', 'svg'),
+			0,
+			logger as unknown as Parameters<typeof attachVaultBinaryFile>[3]
+		);
+		expect(result.kind).toBe('too-large');
+	});
+
+	it('reports converted bytes on ok for an SVG and accepts them at the budget edge', async () => {
+		rasterizeSvg.mockResolvedValue('AB=='); // decodes to 1 byte
+		const result = await attachVaultBinaryFile(
+			mockVault(bufferOf([123, 45])),
+			makeFile('icon.svg', 'svg'),
+			GEMINI_INLINE_DATA_LIMIT - 3,
+			logger as unknown as Parameters<typeof attachVaultBinaryFile>[3]
+		);
+		// Source (2 bytes) passes the pre-check; the converted payload (1 byte)
+		// fits the budget — ok, with converted bytes reported.
+		expect(result.kind).toBe('ok');
+		if (result.kind === 'ok') expect(result.bytes).toBe(1);
+	});
+
 	it('returns raster-failed when rasterization rejects', async () => {
 		rasterizeSvg.mockRejectedValue(new Error('bad svg'));
 		const result = await attachVaultBinaryFile(
@@ -174,12 +202,22 @@ describe('attachVaultBinaryFile', () => {
 });
 
 describe('estimateAttachmentBytes', () => {
-	it('sums ceil(base64 length * 3 / 4) across attachments', async () => {
+	it('sums decoded bytes across attachments (3 per 4-char group)', () => {
 		const attachments = [
-			{ base64: 'A'.repeat(12), mimeType: 'image/png', id: '1' } as InlineAttachment,
-			{ base64: 'B'.repeat(13), mimeType: 'image/png', id: '2' } as InlineAttachment,
+			{ base64: 'A'.repeat(12), mimeType: 'image/png', id: '1' } as InlineAttachment, // 9 bytes
+			{ base64: 'B'.repeat(12), mimeType: 'image/png', id: '2' } as InlineAttachment, // 9 bytes
 		];
-		expect(estimateAttachmentBytes(attachments)).toBe(9 + 10);
+		expect(estimateAttachmentBytes(attachments)).toBe(18);
+	});
+
+	it('excludes base64 padding from the estimate (#1412 review)', () => {
+		// 'YQ==' decodes to 1 byte, not 3.
+		const attachments = [
+			{ base64: 'YQ==', mimeType: 'image/png', id: '1' } as InlineAttachment,
+			{ base64: 'YQf=', mimeType: 'image/png', id: '2' } as InlineAttachment,
+			{ base64: 'YQFj', mimeType: 'image/png', id: '3' } as InlineAttachment,
+		];
+		expect(estimateAttachmentBytes(attachments)).toBe(1 + 2 + 3);
 	});
 
 	it('returns zero for an empty shelf', () => {

--- a/test/ui/agent-view/attach-vault-file.test.ts
+++ b/test/ui/agent-view/attach-vault-file.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Tests for the shared vault-binary → InlineAttachment pipeline (#1363).
+ *
+ * This leaf was extracted because the vault-drop path (agent-view-ui.ts) and
+ * the @-mention path (agent-view-attachments.ts) each had a private copy that
+ * had drifted in failure notices. These tests pin the helper's contract:
+ * result arms, budget edge behavior, `.webm` sniffing, and SVG rasterization.
+ */
+
+import { attachVaultBinaryFile } from '../../../src/ui/agent-view/attach-vault-file';
+import { estimateAttachmentBytes, type InlineAttachment } from '../../../src/ui/agent-view/inline-attachment';
+import { GEMINI_INLINE_DATA_LIMIT } from '../../../src/utils/file-classification';
+import type { App, TFile } from 'obsidian';
+
+vi.mock('obsidian', async () => {
+	const original = await vi.importActual<any>('../../../__mocks__/obsidian.js');
+	return { ...original, requestUrl: vi.fn() };
+});
+
+// Rasterization is mocked: the helper only forwards the buffer and maps a
+// rejection to `raster-failed`; the renderer itself has its own tests.
+const rasterizeSvg = vi.fn();
+vi.mock('../../../src/utils/svg-rasterizer', () => ({
+	rasterizeSvg: (...args: unknown[]) => rasterizeSvg(...args),
+}));
+
+const logger = { log: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+function makeFile(path: string, extension: string): TFile {
+	return { path, name: path.split('/').pop(), extension } as unknown as TFile;
+}
+
+function mockVault(buffer: ArrayBuffer | Error): App {
+	return {
+		vault: {
+			readBinary: vi
+				.fn()
+				.mockImplementation(() => (buffer instanceof Error ? Promise.reject(buffer) : Promise.resolve(buffer))),
+		},
+	} as unknown as App;
+}
+
+// A distinctive byte pattern so we can verify the base64 round-trip.
+function bufferOf(content: number[]): ArrayBuffer {
+	return new Uint8Array(content).buffer;
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	rasterizeSvg.mockReset();
+});
+
+describe('attachVaultBinaryFile', () => {
+	it('wraps a plain binary in an ok attachment with the classified mime type', async () => {
+		const app = mockVault(bufferOf([0x25, 0x50, 0x44, 0x46])); // "%PDF"
+		const result = await attachVaultBinaryFile(app, makeFile('notes/doc.pdf', 'pdf'), 0, logger as never);
+
+		expect(result.kind).toBe('ok');
+		if (result.kind !== 'ok') return;
+		expect(result.bytes).toBe(4);
+		expect(result.attachment.mimeType).toBe('application/pdf');
+		expect(result.attachment.vaultPath).toBe('notes/doc.pdf');
+		expect(result.attachment.fileName).toBe('doc.pdf');
+		expect(result.attachment.id).toMatch(/^att-/);
+		// btoa("%PDF") — the raw buffer's base64 encoding
+		expect(result.attachment.base64).toBe(btoa('%PDF'));
+	});
+
+	it('sniffs .webm as video when a video codec signature is present', async () => {
+		// EBML header + V_VP8 signature, with trailing padding (the scanner skips
+		// the last 5 bytes of the buffer).
+		const bytes = [0x1a, 0x45, 0xdf, 0xa3, 0x56, 0x5f, 0x56, 0x50, 0x38, 0x00, 0x00, 0x00];
+		const result = await attachVaultBinaryFile(
+			mockVault(bufferOf(bytes)),
+			makeFile('a.webm', 'webm'),
+			0,
+			logger as unknown as Parameters<typeof attachVaultBinaryFile>[3]
+		);
+
+		expect(result.kind).toBe('ok');
+		if (result.kind === 'ok') expect(result.attachment.mimeType).toBe('video/webm');
+	});
+
+	it('defaults .webm without a video codec to audio/webm', async () => {
+		const result = await attachVaultBinaryFile(
+			mockVault(bufferOf([1, 2, 3])),
+			makeFile('a.webm', 'webm'),
+			0,
+			logger as unknown as Parameters<typeof attachVaultBinaryFile>[3]
+		);
+
+		expect(result.kind).toBe('ok');
+		if (result.kind === 'ok') expect(result.attachment.mimeType).toBe('audio/webm');
+	});
+
+	it('rasterizes SVG to PNG with the svgz flag passed through', async () => {
+		rasterizeSvg.mockResolvedValue('rasterized-base64');
+		const result = await attachVaultBinaryFile(
+			mockVault(bufferOf([1])),
+			makeFile('icon.svgz', 'svgz'),
+			0,
+			logger as unknown as Parameters<typeof attachVaultBinaryFile>[3]
+		);
+
+		expect(rasterizeSvg).toHaveBeenCalledWith(expect.anything(), true);
+		expect(result.kind).toBe('ok');
+		if (result.kind === 'ok') {
+			expect(result.attachment.mimeType).toBe('image/png');
+			expect(result.attachment.base64).toBe('rasterized-base64');
+		}
+	});
+
+	it('returns raster-failed when rasterization rejects', async () => {
+		rasterizeSvg.mockRejectedValue(new Error('bad svg'));
+		const result = await attachVaultBinaryFile(
+			mockVault(bufferOf([1])),
+			makeFile('icon.svg', 'svg'),
+			0,
+			logger as unknown as Parameters<typeof attachVaultBinaryFile>[3]
+		);
+
+		expect(result.kind).toBe('raster-failed');
+		expect(logger.error).toHaveBeenCalledWith('Failed to rasterize SVG icon.svg:', expect.any(Error));
+	});
+
+	it('returns too-large at the budget edge and reports no consumed bytes', async () => {
+		// Exactly at the limit is still allowed; one byte over is not.
+		const buffer = bufferOf(new Array(10).fill(7));
+		const app = mockVault(buffer);
+		const exact = await attachVaultBinaryFile(
+			app,
+			makeFile('a.pdf', 'pdf'),
+			GEMINI_INLINE_DATA_LIMIT - 10,
+			logger as unknown as Parameters<typeof attachVaultBinaryFile>[3]
+		);
+		expect(exact.kind).toBe('ok');
+
+		const over = await attachVaultBinaryFile(
+			app,
+			makeFile('a.pdf', 'pdf'),
+			GEMINI_INLINE_DATA_LIMIT - 9,
+			logger as unknown as Parameters<typeof attachVaultBinaryFile>[3]
+		);
+		expect(over).toEqual({ kind: 'too-large' });
+	});
+
+	it('returns read-failed with the error when readBinary rejects', async () => {
+		const app = mockVault(new Error('disk gone'));
+		const result = await attachVaultBinaryFile(
+			app,
+			makeFile('a.pdf', 'pdf'),
+			0,
+			logger as unknown as Parameters<typeof attachVaultBinaryFile>[3]
+		);
+
+		expect(result.kind).toBe('read-failed');
+		if (result.kind === 'read-failed') {
+			expect((result.error as Error).message).toBe('disk gone');
+		}
+		expect(logger.error).not.toHaveBeenCalled();
+	});
+
+	it('only counts the buffer toward the budget once (caller seeds the total)', async () => {
+		const app = mockVault(bufferOf(new Array(5).fill(1)));
+		// previous usage already consumed the whole budget: the 5-byte buffer tips it over
+		const result = await attachVaultBinaryFile(
+			app,
+			makeFile('a.pdf', 'pdf'),
+			GEMINI_INLINE_DATA_LIMIT,
+			logger as unknown as Parameters<typeof attachVaultBinaryFile>[3]
+		);
+		expect(result.kind).toBe('too-large');
+	});
+});
+
+describe('estimateAttachmentBytes', () => {
+	it('sums ceil(base64 length * 3 / 4) across attachments', async () => {
+		const attachments = [
+			{ base64: 'A'.repeat(12), mimeType: 'image/png', id: '1' } as InlineAttachment,
+			{ base64: 'B'.repeat(13), mimeType: 'image/png', id: '2' } as InlineAttachment,
+		];
+		expect(estimateAttachmentBytes(attachments)).toBe(9 + 10);
+	});
+
+	it('returns zero for an empty shelf', () => {
+		expect(estimateAttachmentBytes([])).toBe(0);
+	});
+});


### PR DESCRIPTION
## Summary

Fixes #1363

The vault binary → `InlineAttachment` pipeline — `readBinary` → 20 MB budget check → rasterize-or-`arrayBufferToBase64` → `.webm` sniff → build record — existed twice: inline in the vault-drop handler (`agent-view-ui.ts`) and in the @-mention picker (`agent-view-attachments.ts`), the pair #1170 deliberately left out of scope. The copies had drifted (failure notice routing, size-seed formulas, module loading), so a fix to one couldn't reach the other.

## Changes

- **New leaf `src/ui/agent-view/attach-vault-file.ts`** — `attachVaultBinaryFile(app, file, alreadyUsedBytes, logger)` returns a discriminated result: `{ kind: 'ok', attachment, bytes } | too-large | raster-failed | read-failed(error)`. Each caller keeps its own notice behavior by switching on the result, per the plan. The rasterize-failure log — byte-identical in both callers today — is logged by the helper; the `read-failed` error is returned so each caller logs its *own* wording (drop: "Failed to read binary file…", @-mention: "Failed to attach…"), preserving both messages exactly rather than unifying them.
- **`estimateAttachmentBytes()`** added to `inline-attachment.ts` — the shared `Math.ceil((base64.length * 3) / 4)` reduce that two sites hand-rolled; both size seeds now delegate (drop → `getCurrentAttachmentSize`, @-mention → pending-shelf estimate).
- **Both `await import()` calls in the @-mention path become static imports** — the file already statically imported `rasterizeSvg` and `inline-attachment`, the very modules it re-imported dynamically at `:66`/`:110`; nothing to break. `file-classification`'s four names come in statically with it.
- **Docstring fix** — `AgentViewAttachments` claimed drag-and-drop/paste duties it doesn't own; now documented per actual split.
- **New `test/ui/agent-view/attach-vault-file.test.ts`** — every result arm (plain binary round-trip, `.webm` audio vs video sniffing including codec detection, SVG/SVGZ rasterization + raster failure, budget edge *and* one-byte-over, read failure with the error surfaced, caller-seeded totals), plus `estimateAttachmentBytes`. The rasterize renderer itself stays mocked — the helper's forwarding contract is what's new here.
- The 23 pre-existing `agent-view-ui.test.ts` drop-flow tests pass untouched — behavior preservation, mechanically re-checked.
- No docs update per the plan's explicit flag: value-preserving internal extraction, `docs/`/README describe no moved surface.

## Notes

- The plan's verification (Aug 18) predates #1406/#1408; its targets (`agent-view-ui.ts`, `agent-view-attachments.ts`, `inline-attachment.ts`, `file-classification.ts`) were unaffected by those merges, and the re-verified line matches current master.
- The logger parameter follows the utility-function convention in `AGENTS.md`.
- Out of scope, per the plan: the external/paste image loop (`processAttachmentFiles`), the drag-and-drop/paste extraction from `AgentViewUI` (#801's entry), any limit/classification/notice-wording change, and `#1262`'s unit-test backfill for the two big modules.

## Screenshots / Screencast

No user-visible change: same notices, same budget, same classification. A live drag-drop + `@` pick in a vault is the honest end-to-end check (no runtime in this sandbox) — flagged accordingly; the substantive gate is the new unit suite plus the 23 preserved drop-flow tests.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer
- [x] All CI checks pass — `npm test` 3829 pass (10 new), `npm run build`, `npm run format-check`, `npm run lint:cycles`, `npm run typecheck:test`, `npm run knip`
- [ ] I have tested this change on Desktop
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards)
- [x] Documentation has been updated (if applicable) — none needed per the plan's flag: internal value-preserving extraction with no user-facing surface

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: pi coding agent (GLM)
- [x] I have reviewed and understand all AI-generated code in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Improved vault-file attachments in the agent view, including more reliable handling of binary files, SVG/SVGZ images, and WebM media.
  - Attachments now consistently enforce the 20 MB size limit and provide clearer handling when files cannot be read or converted.
  - Attachment size calculations are more accurate across multiple files, including Base64-encoded content.

- **Tests**
  - Added coverage for attachment creation, format detection, SVG conversion, size limits, byte estimation, and failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->