### PR TITLE
test(ui): cover the two permission-gating UI surfaces (#1262)

### DIFF
--- a/test/ui/components/tool-policy-editor.test.ts
+++ b/test/ui/components/tool-policy-editor.test.ts
@@ -469,11 +469,16 @@ describe('ToolPolicyEditor', () => {
 			expect(mount.querySelector('.gemini-tool-policy-editor-preset-row')).toBeNull();
 		});
 
-		it('still does not emit on a genuine rebuild', () => {
+		it('does not emit when the value is equal, and still does not emit on a genuine rebuild', () => {
 			makeEditor({ preset: PolicyPreset.CAUTIOUS });
 
-			editor!.setValue({ preset: PolicyPreset.YOLO });
+			// The early return must not emit...
+			editor!.setValue({ preset: PolicyPreset.CAUTIOUS });
+			expect(onChange).not.toHaveBeenCalled();
 
+			// ...and neither does a real rebuild: setValue is a programmatic
+			// refresh, not a user edit, whichever branch it takes.
+			editor!.setValue({ preset: PolicyPreset.YOLO });
 			expect(onChange).not.toHaveBeenCalled();
 		});
 

--- a/test/ui/components/tool-policy-editor.test.ts
+++ b/test/ui/components/tool-policy-editor.test.ts
@@ -1,16 +1,13 @@
 /**
- * Regression tests for the ToolPolicyEditor.setValue equal-value no-op (#1414).
+ * Tests for ToolPolicyEditor — the shared per-feature tool-policy picker used by
+ * the scheduled-task, hook, and project forms.
  *
- * The full editor suite lives in test/ui/components/tool-policy-editor.test.ts,
- * added by PR #1413 — this file pins only the setValue semantics that PR
- * deliberately left unpinned because the docstring and the behavior disagreed:
- * setValue must not rebuild the editor when the incoming policy is structurally
- * equal to the current state (focus loss / closed dropdowns on host-modal
- * re-renders), and must rebuild when it differs.
- *
- * The editor is a plain class (not a Modal), driven against a detached jsdom
- * container with the Obsidian DOM sugar added per-test, mirroring the harness
- * conventions of test/ui/agent-view/agent-view-tool-display.test.ts.
+ * `ToolPolicyEditor` is a plain class (not a `Modal`), so it can be driven directly
+ * against a detached container. Per #1262's guidance these assert the **policy
+ * decisions** the editor emits — what `onChange` receives for a given interaction —
+ * rather than the markup it renders. The DOM is only the input device: real jsdom
+ * `<select>`/`<input>` elements are used so `change` events exercise the same
+ * listeners a user would.
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from 'vitest';
@@ -20,7 +17,9 @@ import type { ObsidianGemini } from '../../../src/types/plugin';
 
 /**
  * Add the Obsidian DOM sugar (createEl/createDiv/createSpan/empty) that jsdom lacks.
- * The global vitest setup patches hide/show/toggle/toggleClass onto the prototype.
+ * The global vitest setup patches hide/show/toggle/toggleClass onto the prototype; the
+ * element-factory helpers with cls/text/attr options stay per-test, mirroring
+ * test/ui/agent-view/agent-view-tool-display.test.ts.
  */
 function addObsidianMethods(el: HTMLElement): HTMLElement {
 	const anyEl = el as any;
@@ -49,37 +48,44 @@ function addObsidianMethods(el: HTMLElement): HTMLElement {
 	return el;
 }
 
+/** One tool per classification, so the grouped overrides table renders every section. */
 const TOOLS = [
 	{ name: 'read_file', displayName: 'Read File', classification: ToolClassification.READ },
+	{ name: 'write_file', displayName: 'Write File', classification: ToolClassification.WRITE },
 	{ name: 'delete_file', displayName: 'Delete File', classification: ToolClassification.DESTRUCTIVE },
+	{ name: 'web_fetch', displayName: 'Web Fetch', classification: ToolClassification.EXTERNAL },
 ];
 
-describe('ToolPolicyEditor.setValue equal-value no-op (#1414)', () => {
+describe('ToolPolicyEditor', () => {
 	let mount: HTMLElement;
 	let onChange: Mock<(next: FeatureToolPolicy | undefined) => void>;
 	let plugin: ObsidianGemini;
 	let editor: ToolPolicyEditor | undefined;
 
-	function makeEditor(value: FeatureToolPolicy | undefined): ToolPolicyEditor {
+	/** Build the editor and keep a handle so afterEach can tear it down. */
+	function makeEditor(value: FeatureToolPolicy | undefined, tools: unknown[] = TOOLS): ToolPolicyEditor {
 		plugin = {
-			toolRegistry: { getAllTools: () => TOOLS },
+			toolRegistry: { getAllTools: () => tools },
 		} as unknown as ObsidianGemini;
 		editor = new ToolPolicyEditor(plugin, mount, { value, onChange });
 		return editor;
 	}
 
+	/** The single "inherit global policy" checkbox. */
 	function inheritCheckbox(): HTMLInputElement {
 		const cb = mount.querySelector<HTMLInputElement>('.gemini-tool-policy-editor-inherit input');
 		if (!cb) throw new Error('inherit checkbox not rendered');
 		return cb;
 	}
 
+	/** The preset dropdown (absent while "inherit global policy" is on). */
 	function presetSelect(): HTMLSelectElement {
 		const sel = mount.querySelector<HTMLSelectElement>('.gemini-tool-policy-editor-preset-row select');
 		if (!sel) throw new Error('preset select not rendered');
 		return sel;
 	}
 
+	/** The per-tool override dropdown for `toolName`, located via its row's name span. */
 	function toolSelect(toolName: string): HTMLSelectElement {
 		const label = TOOLS.find((t) => t.name === toolName)?.displayName ?? toolName;
 		const rows = Array.from(mount.querySelectorAll('.gemini-tool-policy-editor-tool-row'));
@@ -87,6 +93,25 @@ describe('ToolPolicyEditor.setValue equal-value no-op (#1414)', () => {
 		const sel = row?.querySelector('select');
 		if (!sel) throw new Error(`override select for ${toolName} not rendered`);
 		return sel;
+	}
+
+	/** Set a <select>'s value and fire the `change` event the editor listens for. */
+	function choose(select: HTMLSelectElement, value: string): void {
+		select.value = value;
+		select.dispatchEvent(new Event('change'));
+	}
+
+	/** Toggle the checkbox and fire its `change` event. */
+	function toggleInherit(checked: boolean): void {
+		const cb = inheritCheckbox();
+		cb.checked = checked;
+		cb.dispatchEvent(new Event('change'));
+	}
+
+	/** The value handed to the most recent onChange call. */
+	function lastEmitted(): FeatureToolPolicy | undefined {
+		expect(onChange).toHaveBeenCalled();
+		return onChange.mock.calls[onChange.mock.calls.length - 1][0];
 	}
 
 	beforeEach(() => {
@@ -102,93 +127,472 @@ describe('ToolPolicyEditor.setValue equal-value no-op (#1414)', () => {
 		document.body.innerHTML = '';
 	});
 
-	it('does not rebuild the DOM when the new value is structurally equal', () => {
-		const initial: FeatureToolPolicy = {
-			preset: PolicyPreset.CAUTIOUS,
-			overrides: { delete_file: ToolPermission.DENY },
-		};
-		makeEditor(initial);
-		const checkboxBefore = inheritCheckbox();
-		const presetBefore = presetSelect();
-		const toolBefore = toolSelect('delete_file');
+	// ── Initial value → rendered state ────────────────────────────────────────
 
-		// A structurally-equal (but freshly allocated) policy — this is what a
-		// host-modal refresh hands over when nothing about the policy changed.
-		editor!.setValue({ preset: PolicyPreset.CAUTIOUS, overrides: { delete_file: ToolPermission.DENY } });
+	describe('initial value', () => {
+		it('renders the inherit-global state for an undefined policy and hides the body', () => {
+			makeEditor(undefined);
 
-		// The very same DOM nodes survive: no container.empty() + rebuild.
-		expect(inheritCheckbox()).toBe(checkboxBefore);
-		expect(presetSelect()).toBe(presetBefore);
-		expect(toolSelect('delete_file')).toBe(toolBefore);
+			expect(inheritCheckbox().checked).toBe(true);
+			expect(mount.querySelector('.gemini-tool-policy-editor-preset-row')).toBeNull();
+			expect(mount.querySelectorAll('.gemini-tool-policy-editor-tool-row')).toHaveLength(0);
+			// Rendering alone must never emit — onChange means "the user changed something".
+			expect(onChange).not.toHaveBeenCalled();
+		});
+
+		it('reflects an explicit preset and per-tool overrides in the controls', () => {
+			makeEditor({
+				preset: PolicyPreset.READ_ONLY,
+				overrides: { delete_file: ToolPermission.DENY },
+			});
+
+			expect(inheritCheckbox().checked).toBe(false);
+			expect(presetSelect().value).toBe(PolicyPreset.READ_ONLY);
+			expect(toolSelect('delete_file').value).toBe(ToolPermission.DENY);
+			// Tools with no override sit on the inherit sentinel.
+			expect(toolSelect('read_file').value).toBe('__inherit__');
+			expect(onChange).not.toHaveBeenCalled();
+		});
+
+		it('shows the preset row with no preset selected when only overrides are set', () => {
+			makeEditor({ overrides: { web_fetch: ToolPermission.APPROVE } });
+
+			expect(inheritCheckbox().checked).toBe(false);
+			expect(presetSelect().value).toBe('__inherit__');
+			expect(toolSelect('web_fetch').value).toBe(ToolPermission.APPROVE);
+		});
+
+		it('does not alias the caller value — mutating the editor leaves the input untouched', () => {
+			const original: FeatureToolPolicy = {
+				preset: PolicyPreset.CAUTIOUS,
+				overrides: { read_file: ToolPermission.APPROVE },
+			};
+			makeEditor(original);
+
+			choose(toolSelect('delete_file'), ToolPermission.DENY);
+
+			expect(original).toEqual({
+				preset: PolicyPreset.CAUTIOUS,
+				overrides: { read_file: ToolPermission.APPROVE },
+			});
+			// ...and the emitted overrides map is a copy too, not the editor's own state.
+			const emitted = lastEmitted();
+			expect(emitted?.overrides).toEqual({
+				read_file: ToolPermission.APPROVE,
+				delete_file: ToolPermission.DENY,
+			});
+			expect(emitted?.overrides).not.toBe(original.overrides);
+		});
 	});
 
-	it('does not rebuild when both values are undefined', () => {
-		makeEditor(undefined);
-		const checkboxBefore = inheritCheckbox();
+	// ── The inherit toggle ────────────────────────────────────────────────────
 
-		editor!.setValue(undefined);
+	describe('inherit toggle', () => {
+		it('emits undefined and reveals the body when inheriting is turned off', () => {
+			makeEditor(undefined);
 
-		expect(inheritCheckbox()).toBe(checkboxBefore);
+			toggleInherit(false);
+
+			// An empty custom policy normalizes to undefined — there is nothing to
+			// persist until the user actually picks a preset or an override.
+			expect(lastEmitted()).toBeUndefined();
+			expect(inheritCheckbox().checked).toBe(false);
+			expect(presetSelect()).toBeTruthy();
+			expect(mount.querySelectorAll('.gemini-tool-policy-editor-tool-row')).toHaveLength(TOOLS.length);
+		});
+
+		it('discards a configured policy and emits undefined when inheriting is turned back on', () => {
+			makeEditor({ preset: PolicyPreset.YOLO, overrides: { delete_file: ToolPermission.DENY } });
+
+			toggleInherit(true);
+
+			expect(lastEmitted()).toBeUndefined();
+			expect(mount.querySelector('.gemini-tool-policy-editor-preset-row')).toBeNull();
+		});
 	});
 
-	it('does not rebuild when the only difference is absent vs empty overrides', () => {
-		makeEditor({ preset: PolicyPreset.YOLO });
-		const presetBefore = presetSelect();
+	// ── Preset selection ──────────────────────────────────────────────────────
 
-		editor!.setValue({ preset: PolicyPreset.YOLO, overrides: {} });
+	describe('preset selection', () => {
+		it('emits the chosen preset', () => {
+			makeEditor({});
 
-		expect(presetSelect()).toBe(presetBefore);
+			choose(presetSelect(), PolicyPreset.EDIT_MODE);
+
+			expect(lastEmitted()).toEqual({ preset: PolicyPreset.EDIT_MODE });
+		});
+
+		it('offers every preset except CUSTOM, plus the no-preset sentinel', () => {
+			makeEditor({});
+
+			const values = Array.from(presetSelect().options).map((o) => o.value);
+			expect(values).toEqual([
+				'__inherit__',
+				PolicyPreset.READ_ONLY,
+				PolicyPreset.CAUTIOUS,
+				PolicyPreset.EDIT_MODE,
+				PolicyPreset.YOLO,
+			]);
+			expect(values).not.toContain(PolicyPreset.CUSTOM);
+		});
+
+		it('clearing the preset drops it and normalizes an otherwise-empty policy to undefined', () => {
+			makeEditor({ preset: PolicyPreset.READ_ONLY });
+
+			choose(presetSelect(), '__inherit__');
+
+			expect(lastEmitted()).toBeUndefined();
+		});
+
+		it('clearing the preset keeps surviving overrides', () => {
+			makeEditor({ preset: PolicyPreset.READ_ONLY, overrides: { web_fetch: ToolPermission.DENY } });
+
+			choose(presetSelect(), '__inherit__');
+
+			expect(lastEmitted()).toEqual({ overrides: { web_fetch: ToolPermission.DENY } });
+		});
 	});
 
-	it('rebuilds and reflects the new value when the policy differs', () => {
-		makeEditor({ preset: PolicyPreset.CAUTIOUS });
-		const presetBefore = presetSelect();
+	// ── Per-tool overrides ────────────────────────────────────────────────────
 
-		editor!.setValue({ preset: PolicyPreset.READ_ONLY, overrides: { delete_file: ToolPermission.ASK_USER } });
+	describe('per-tool overrides', () => {
+		it('emits an override for the tool that changed', () => {
+			makeEditor({});
 
-		// New nodes were built (the old select was torn down) and carry the new value.
-		expect(presetSelect()).not.toBe(presetBefore);
-		expect(presetSelect().value).toBe(PolicyPreset.READ_ONLY);
-		expect(toolSelect('delete_file').value).toBe(ToolPermission.ASK_USER);
+			choose(toolSelect('delete_file'), ToolPermission.DENY);
+
+			expect(lastEmitted()).toEqual({ overrides: { delete_file: ToolPermission.DENY } });
+		});
+
+		it('layers overrides on top of the preset rather than replacing it', () => {
+			makeEditor({ preset: PolicyPreset.EDIT_MODE });
+
+			choose(toolSelect('delete_file'), ToolPermission.DENY);
+
+			expect(lastEmitted()).toEqual({
+				preset: PolicyPreset.EDIT_MODE,
+				overrides: { delete_file: ToolPermission.DENY },
+			});
+		});
+
+		it('accumulates overrides across several tools', () => {
+			makeEditor({});
+
+			choose(toolSelect('delete_file'), ToolPermission.DENY);
+			choose(toolSelect('write_file'), ToolPermission.ASK_USER);
+			choose(toolSelect('read_file'), ToolPermission.APPROVE);
+
+			expect(lastEmitted()).toEqual({
+				overrides: {
+					delete_file: ToolPermission.DENY,
+					write_file: ToolPermission.ASK_USER,
+					read_file: ToolPermission.APPROVE,
+				},
+			});
+		});
+
+		it('resetting a tool to inherit removes just that override', () => {
+			makeEditor({
+				overrides: { delete_file: ToolPermission.DENY, web_fetch: ToolPermission.APPROVE },
+			});
+
+			choose(toolSelect('delete_file'), '__inherit__');
+
+			expect(lastEmitted()).toEqual({ overrides: { web_fetch: ToolPermission.APPROVE } });
+		});
+
+		it('normalizes to undefined once the last override is cleared', () => {
+			makeEditor({ overrides: { delete_file: ToolPermission.DENY } });
+
+			choose(toolSelect('delete_file'), '__inherit__');
+
+			expect(lastEmitted()).toBeUndefined();
+		});
+
+		it('offers every permission plus the inherit sentinel for each tool', () => {
+			makeEditor({});
+
+			const values = Array.from(toolSelect('write_file').options).map((o) => o.value);
+			expect(values).toEqual(['__inherit__', ToolPermission.DENY, ToolPermission.ASK_USER, ToolPermission.APPROVE]);
+		});
+
+		it('renders a row per registered tool, grouped by classification order', () => {
+			makeEditor({});
+
+			const names = Array.from(mount.querySelectorAll('.gemini-tool-policy-editor-tool-name')).map(
+				(el) => el.textContent
+			);
+			// Object.values(ToolClassification) order: read, write, destructive, external.
+			expect(names).toEqual(['Read File', 'Write File', 'Delete File', 'Web Fetch']);
+		});
+
+		it('falls back to the tool name when a tool has no display name', () => {
+			makeEditor({}, [{ name: 'bare_tool', displayName: '', classification: ToolClassification.READ }]);
+
+			const names = Array.from(mount.querySelectorAll('.gemini-tool-policy-editor-tool-name')).map(
+				(el) => el.textContent
+			);
+			expect(names).toEqual(['bare_tool']);
+		});
+
+		it('renders an empty-state message instead of a table when no tools are registered', () => {
+			makeEditor({}, []);
+
+			expect(mount.querySelectorAll('.gemini-tool-policy-editor-tool-row')).toHaveLength(0);
+			expect(mount.querySelector('.gemini-tool-policy-editor-overrides')?.textContent).toContain('No tools registered');
+			// The preset row still renders — the policy is editable without tools.
+			expect(presetSelect()).toBeTruthy();
+		});
+
+		it('survives a plugin with no tool registry at all', () => {
+			plugin = {} as unknown as ObsidianGemini;
+			editor = new ToolPolicyEditor(plugin, mount, { value: {}, onChange });
+
+			expect(mount.querySelectorAll('.gemini-tool-policy-editor-tool-row')).toHaveLength(0);
+			expect(presetSelect()).toBeTruthy();
+		});
 	});
 
-	it('rebuilds when the value changes from undefined to a policy and back', () => {
-		makeEditor(undefined);
-		expect(mount.querySelector('.gemini-tool-policy-editor-preset-row')).toBeNull();
+	// ── setValue ──────────────────────────────────────────────────────────────
 
-		editor!.setValue({ preset: PolicyPreset.YOLO });
-		expect(inheritCheckbox().checked).toBe(false);
-		expect(presetSelect().value).toBe(PolicyPreset.YOLO);
+	describe('setValue', () => {
+		it('round-trips a policy into the controls without emitting', () => {
+			makeEditor(undefined);
 
-		editor!.setValue(undefined);
-		expect(inheritCheckbox().checked).toBe(true);
-		expect(mount.querySelector('.gemini-tool-policy-editor-preset-row')).toBeNull();
+			editor!.setValue({ preset: PolicyPreset.CAUTIOUS, overrides: { web_fetch: ToolPermission.DENY } });
+
+			expect(inheritCheckbox().checked).toBe(false);
+			expect(presetSelect().value).toBe(PolicyPreset.CAUTIOUS);
+			expect(toolSelect('web_fetch').value).toBe(ToolPermission.DENY);
+			// setValue is a programmatic refresh, not a user edit.
+			expect(onChange).not.toHaveBeenCalled();
+		});
+
+		it('round-trips undefined back to the inherit-global state', () => {
+			makeEditor({ preset: PolicyPreset.YOLO });
+
+			editor!.setValue(undefined);
+
+			expect(inheritCheckbox().checked).toBe(true);
+			expect(mount.querySelector('.gemini-tool-policy-editor-preset-row')).toBeNull();
+			expect(onChange).not.toHaveBeenCalled();
+		});
+
+		it('does not alias the value passed to it', () => {
+			makeEditor(undefined);
+			const next: FeatureToolPolicy = { overrides: { read_file: ToolPermission.APPROVE } };
+
+			editor!.setValue(next);
+			choose(toolSelect('write_file'), ToolPermission.DENY);
+
+			expect(next).toEqual({ overrides: { read_file: ToolPermission.APPROVE } });
+		});
+
+		it('edits after setValue emit from the new value, not the old one', () => {
+			makeEditor({ preset: PolicyPreset.YOLO, overrides: { delete_file: ToolPermission.APPROVE } });
+
+			editor!.setValue({ preset: PolicyPreset.READ_ONLY });
+			choose(toolSelect('web_fetch'), ToolPermission.DENY);
+
+			expect(lastEmitted()).toEqual({
+				preset: PolicyPreset.READ_ONLY,
+				overrides: { web_fetch: ToolPermission.DENY },
+			});
+		});
+
+		// ── The equal-value no-op (#1414) ────────────────────────────────────
+		//
+		// setValue's docstring promises "no-op if the new value is structurally
+		// equal to the current state" — the tests below pin that the DOM is not
+		// rebuilt (same nodes survive) and that no emission fires.
+
+		it('does not rebuild the DOM when the new value is structurally equal', () => {
+			const initial: FeatureToolPolicy = {
+				preset: PolicyPreset.CAUTIOUS,
+				overrides: { delete_file: ToolPermission.DENY },
+			};
+			makeEditor(initial);
+			const checkboxBefore = inheritCheckbox();
+			const presetBefore = presetSelect();
+			const toolBefore = toolSelect('delete_file');
+
+			// A structurally-equal (but freshly allocated) policy — this is what a
+			// host-modal refresh hands over when nothing about the policy changed.
+			editor!.setValue({ preset: PolicyPreset.CAUTIOUS, overrides: { delete_file: ToolPermission.DENY } });
+
+			// The very same DOM nodes survive: no container.empty() + rebuild.
+			expect(inheritCheckbox()).toBe(checkboxBefore);
+			expect(presetSelect()).toBe(presetBefore);
+			expect(toolSelect('delete_file')).toBe(toolBefore);
+		});
+
+		it('does not rebuild when both values are undefined', () => {
+			makeEditor(undefined);
+			const checkboxBefore = inheritCheckbox();
+
+			editor!.setValue(undefined);
+
+			expect(inheritCheckbox()).toBe(checkboxBefore);
+		});
+
+		it('does not rebuild when the only difference is absent vs empty overrides', () => {
+			makeEditor({ preset: PolicyPreset.YOLO });
+			const presetBefore = presetSelect();
+
+			editor!.setValue({ preset: PolicyPreset.YOLO, overrides: {} });
+
+			expect(presetSelect()).toBe(presetBefore);
+		});
+
+		it('rebuilds and reflects the new value when the policy differs', () => {
+			makeEditor({ preset: PolicyPreset.CAUTIOUS });
+			const presetBefore = presetSelect();
+
+			editor!.setValue({ preset: PolicyPreset.READ_ONLY, overrides: { delete_file: ToolPermission.ASK_USER } });
+
+			// New nodes were built (the old select was torn down) and carry the new value.
+			expect(presetSelect()).not.toBe(presetBefore);
+			expect(presetSelect().value).toBe(PolicyPreset.READ_ONLY);
+			expect(toolSelect('delete_file').value).toBe(ToolPermission.ASK_USER);
+		});
+
+		it('rebuilds when the value changes from undefined to a policy and back', () => {
+			makeEditor(undefined);
+			expect(mount.querySelector('.gemini-tool-policy-editor-preset-row')).toBeNull();
+
+			editor!.setValue({ preset: PolicyPreset.YOLO });
+			expect(inheritCheckbox().checked).toBe(false);
+			expect(presetSelect().value).toBe(PolicyPreset.YOLO);
+
+			editor!.setValue(undefined);
+			expect(inheritCheckbox().checked).toBe(true);
+			expect(mount.querySelector('.gemini-tool-policy-editor-preset-row')).toBeNull();
+		});
+
+		it('still does not emit on a genuine rebuild', () => {
+			makeEditor({ preset: PolicyPreset.CAUTIOUS });
+
+			editor!.setValue({ preset: PolicyPreset.YOLO });
+
+			expect(onChange).not.toHaveBeenCalled();
+		});
+
+		it('keeps the editor editable after an equal-value setValue', () => {
+			makeEditor({ preset: PolicyPreset.CAUTIOUS, overrides: { delete_file: ToolPermission.DENY } });
+
+			editor!.setValue({ preset: PolicyPreset.CAUTIOUS, overrides: { delete_file: ToolPermission.DENY } });
+
+			// The surviving controls still respond: picks emit from the current state.
+			const select = toolSelect('read_file');
+			select.value = ToolPermission.APPROVE;
+			select.dispatchEvent(new Event('change'));
+
+			expect(onChange).toHaveBeenCalledTimes(1);
+			expect(onChange).toHaveBeenCalledWith({
+				preset: PolicyPreset.CAUTIOUS,
+				overrides: { delete_file: ToolPermission.DENY, read_file: ToolPermission.APPROVE },
+			});
+		});
 	});
 
-	it('does not emit when the value is equal, and still does not emit on a genuine rebuild', () => {
-		makeEditor({ preset: PolicyPreset.CAUTIOUS });
+	// ── Rendering options ─────────────────────────────────────────────────────
 
-		editor!.setValue({ preset: PolicyPreset.CAUTIOUS });
-		expect(onChange).not.toHaveBeenCalled();
+	describe('rendering options', () => {
+		it('uses the default title and omits the description when neither is supplied', () => {
+			makeEditor({});
 
-		editor!.setValue({ preset: PolicyPreset.YOLO });
-		expect(onChange).not.toHaveBeenCalled();
+			expect(mount.querySelector('.gemini-tool-policy-editor-title')?.textContent).toBe('Tool access');
+			expect(mount.querySelector('.gemini-tool-policy-editor-desc')).toBeNull();
+		});
+
+		it('suppresses the heading entirely for an empty title', () => {
+			plugin = { toolRegistry: { getAllTools: () => TOOLS } } as unknown as ObsidianGemini;
+			editor = new ToolPolicyEditor(plugin, mount, { value: {}, onChange, title: '' });
+
+			expect(mount.querySelector('.gemini-tool-policy-editor-title')).toBeNull();
+		});
+
+		it('renders a custom title and description', () => {
+			plugin = { toolRegistry: { getAllTools: () => TOOLS } } as unknown as ObsidianGemini;
+			editor = new ToolPolicyEditor(plugin, mount, {
+				value: {},
+				onChange,
+				title: 'Hook tools',
+				description: 'When off, inherits the global plugin tool policy.',
+			});
+
+			expect(mount.querySelector('.gemini-tool-policy-editor-title')?.textContent).toBe('Hook tools');
+			expect(mount.querySelector('.gemini-tool-policy-editor-desc')?.textContent).toBe(
+				'When off, inherits the global plugin tool policy.'
+			);
+		});
+
+		it('gives each instance a unique checkbox id so coexisting editors stay independently labelled', () => {
+			const first = addObsidianMethods(document.createElement('div'));
+			const second = addObsidianMethods(document.createElement('div'));
+			document.body.append(first, second);
+			const stub = { toolRegistry: { getAllTools: () => TOOLS } } as unknown as ObsidianGemini;
+
+			const a = new ToolPolicyEditor(stub, first, { value: undefined, onChange });
+			const b = new ToolPolicyEditor(stub, second, { value: undefined, onChange });
+
+			const idA = first.querySelector('input')?.id;
+			const idB = second.querySelector('input')?.id;
+			expect(idA).toBeTruthy();
+			expect(idA).not.toBe(idB);
+			// The label is bound to its own checkbox, not the other editor's.
+			expect(first.querySelector('label')?.getAttribute('for')).toBe(idA);
+			expect(second.querySelector('label')?.getAttribute('for')).toBe(idB);
+
+			a.destroy();
+			b.destroy();
+		});
 	});
 
-	it('keeps the editor editable after an equal-value setValue', () => {
-		makeEditor({ preset: PolicyPreset.CAUTIOUS, overrides: { delete_file: ToolPermission.DENY } });
+	// ── destroy ───────────────────────────────────────────────────────────────
 
-		editor!.setValue({ preset: PolicyPreset.CAUTIOUS, overrides: { delete_file: ToolPermission.DENY } });
+	describe('destroy', () => {
+		it('detaches the editor DOM from the mount and the document', () => {
+			makeEditor({ preset: PolicyPreset.CAUTIOUS });
+			expect(mount.querySelector('.gemini-tool-policy-editor')).toBeTruthy();
 
-		// The surviving controls still respond: picks emit from the current state.
-		const select = toolSelect('read_file');
-		select.value = ToolPermission.APPROVE;
-		select.dispatchEvent(new Event('change'));
+			editor!.destroy();
 
-		expect(onChange).toHaveBeenCalledTimes(1);
-		expect(onChange).toHaveBeenCalledWith({
-			preset: PolicyPreset.CAUTIOUS,
-			overrides: { delete_file: ToolPermission.DENY, read_file: ToolPermission.APPROVE },
+			expect(mount.querySelector('.gemini-tool-policy-editor')).toBeNull();
+			expect(mount.children).toHaveLength(0);
+			expect(document.querySelector('.gemini-tool-policy-editor')).toBeNull();
+		});
+
+		it('leaves no control behind that could emit, and does not emit on the way out', () => {
+			makeEditor({ preset: PolicyPreset.CAUTIOUS, overrides: { delete_file: ToolPermission.DENY } });
+
+			editor!.destroy();
+
+			// Nothing interactive survives under the mount, so no further user
+			// interaction can reach the editor's listeners.
+			expect(mount.querySelectorAll('select')).toHaveLength(0);
+			expect(mount.querySelectorAll('input')).toHaveLength(0);
+			expect(onChange).not.toHaveBeenCalled();
+		});
+
+		it('is safe to call twice', () => {
+			makeEditor({});
+
+			editor!.destroy();
+			expect(() => editor!.destroy()).not.toThrow();
+			expect(onChange).not.toHaveBeenCalled();
+		});
+
+		it('does not disturb sibling content already in the mount', () => {
+			const sibling = document.createElement('p');
+			sibling.textContent = 'kept';
+			mount.appendChild(sibling);
+			makeEditor({});
+
+			editor!.destroy();
+
+			expect(mount.contains(sibling)).toBe(true);
+			expect(mount.querySelector('.gemini-tool-policy-editor')).toBeNull();
 		});
 	});
 });

--- a/test/ui/yolo-confirmation-modal.test.ts
+++ b/test/ui/yolo-confirmation-modal.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Tests for YoloConfirmationModal — the bypass-confirmations gate.
+ *
+ * YOLO mode auto-approves every tool call, including destructive and external
+ * ones, so what matters here is the *gate's semantics*, not its copy: which
+ * boolean reaches `onConfirm`, and that it reaches it exactly once no matter how
+ * the modal is dismissed. Per #1262 this follows the
+ * `test/ui/management-modal-base.test.ts` pattern — construct against the
+ * `__mocks__/obsidian` `Modal`, call `onOpen()`, drive the captured buttons.
+ */
+
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import type { App } from 'obsidian';
+
+/** Button specs captured from `new Setting(contentEl).addButton(...)`, in order. */
+const buttonSpecs: Array<{ text: string; warning: boolean; click?: () => void }> = [];
+
+vi.mock('obsidian', async () => {
+	const original = await vi.importActual<any>('../../__mocks__/obsidian.js');
+
+	/**
+	 * Give the modal a real jsdom `contentEl` (with the Obsidian element-factory
+	 * sugar) and make `close()` invoke `onClose()`, as Obsidian does — that is what
+	 * makes the "fires exactly once" guarantee meaningful rather than vacuous.
+	 */
+	class Modal extends original.Modal {
+		constructor(app: any) {
+			super(app);
+			this.contentEl = addObsidianMethods(document.createElement('div'));
+			this.closeCalls = 0;
+		}
+		open() {
+			this.onOpen?.();
+		}
+		close() {
+			this.closeCalls++;
+			this.onClose?.();
+		}
+	}
+
+	class Setting extends original.Setting {
+		addButton(cb: (b: any) => void) {
+			const spec = { text: '', warning: false, click: undefined as undefined | (() => void) };
+			const btn = {
+				setButtonText(text: string) {
+					spec.text = text;
+					return btn;
+				},
+				setWarning() {
+					spec.warning = true;
+					return btn;
+				},
+				setCta() {
+					return btn;
+				},
+				onClick(fn: () => void) {
+					spec.click = fn;
+					return btn;
+				},
+			};
+			cb(btn);
+			buttonSpecs.push(spec);
+			return this;
+		}
+	}
+
+	return { ...original, Modal, Setting };
+});
+
+/** Obsidian's element-factory sugar over a real jsdom node. */
+function addObsidianMethods(el: HTMLElement): HTMLElement {
+	const anyEl = el as any;
+	anyEl.createEl = function (tag: string, opts?: any) {
+		const elem = document.createElement(tag);
+		if (opts?.cls) elem.className = opts.cls;
+		if (opts?.text !== undefined) elem.textContent = opts.text;
+		addObsidianMethods(elem);
+		this.appendChild(elem);
+		return elem;
+	};
+	anyEl.createDiv = function (opts?: any) {
+		return this.createEl('div', opts);
+	};
+	anyEl.empty = function () {
+		this.innerHTML = '';
+	};
+	return el;
+}
+
+// vi.mock is hoisted, so this static import already sees the shimmed Modal/Setting.
+import { YoloConfirmationModal } from '../../src/ui/yolo-confirmation-modal';
+
+describe('YoloConfirmationModal', () => {
+	let onConfirm: Mock<(confirmed: boolean) => void>;
+	let modal: any;
+
+	/** The Cancel button — registered first. */
+	function cancelButton() {
+		return buttonSpecs[0];
+	}
+	/** The Enable (destructive) button — registered second. */
+	function enableButton() {
+		return buttonSpecs[1];
+	}
+
+	beforeEach(() => {
+		buttonSpecs.length = 0;
+		onConfirm = vi.fn<(confirmed: boolean) => void>();
+		modal = new YoloConfirmationModal({} as App, onConfirm);
+		modal.onOpen();
+	});
+
+	// ── The gate's two explicit answers ───────────────────────────────────────
+
+	it('confirms with true when the user enables YOLO mode', () => {
+		enableButton().click!();
+
+		expect(onConfirm).toHaveBeenCalledTimes(1);
+		expect(onConfirm).toHaveBeenCalledWith(true);
+	});
+
+	it('confirms with false when the user cancels', () => {
+		cancelButton().click!();
+
+		expect(onConfirm).toHaveBeenCalledTimes(1);
+		expect(onConfirm).toHaveBeenCalledWith(false);
+	});
+
+	it('closes the modal on either answer', () => {
+		enableButton().click!();
+		expect(modal.closeCalls).toBe(1);
+
+		buttonSpecs.length = 0;
+		onConfirm.mockClear();
+		const second = new YoloConfirmationModal({} as App, onConfirm);
+		second.onOpen();
+		cancelButton().click!();
+		expect((second as unknown as { closeCalls: number }).closeCalls).toBe(1);
+	});
+
+	// ── Dismissal without choosing ────────────────────────────────────────────
+
+	it('treats dismissal without a choice as a decline rather than hanging', () => {
+		// Escape / click-outside routes through close() → onClose().
+		modal.close();
+
+		expect(onConfirm).toHaveBeenCalledTimes(1);
+		expect(onConfirm).toHaveBeenCalledWith(false);
+	});
+
+	it('resolves false when onClose fires directly, never leaving the caller pending', () => {
+		modal.onClose();
+
+		expect(onConfirm).toHaveBeenCalledTimes(1);
+		expect(onConfirm).toHaveBeenCalledWith(false);
+	});
+
+	// ── The `resolved` guard: exactly once, whatever the sequence ─────────────
+
+	it('fires exactly once when enabling — the close it triggers must not double-resolve', () => {
+		enableButton().click!();
+		// A stray onClose (Obsidian fires it as the modal tears down) must be a no-op.
+		modal.onClose();
+
+		expect(onConfirm).toHaveBeenCalledTimes(1);
+		expect(onConfirm).toHaveBeenCalledWith(true);
+	});
+
+	it('fires exactly once when cancelling, even followed by a close', () => {
+		cancelButton().click!();
+		modal.close();
+
+		expect(onConfirm).toHaveBeenCalledTimes(1);
+		expect(onConfirm).toHaveBeenCalledWith(false);
+	});
+
+	it('never upgrades a decline to an approval when close follows cancel', () => {
+		cancelButton().click!();
+		modal.onClose();
+
+		expect(onConfirm).toHaveBeenCalledTimes(1);
+		expect(onConfirm.mock.calls[0][0]).toBe(false);
+	});
+
+	it('resets the guard on reopen, so a dismissal after an earlier answer still declines', () => {
+		// Answering leaves the guard set; without a reset on reopen, the next
+		// dismissal would be silently swallowed and the caller left pending.
+		enableButton().click!();
+		expect(onConfirm).toHaveBeenCalledTimes(1);
+
+		buttonSpecs.length = 0;
+		modal.onOpen();
+		modal.close();
+
+		expect(onConfirm).toHaveBeenCalledTimes(2);
+		expect(onConfirm.mock.calls[1][0]).toBe(false);
+	});
+
+	// ── Structure the gate depends on ─────────────────────────────────────────
+
+	it('offers exactly two choices, with the enabling one marked destructive', () => {
+		expect(buttonSpecs).toHaveLength(2);
+		expect(cancelButton().warning).toBe(false);
+		expect(enableButton().warning).toBe(true);
+		expect(cancelButton().text).toBeTruthy();
+		expect(enableButton().text).toBeTruthy();
+	});
+
+	it('renders the risk warning copy so the user is told what they are approving', () => {
+		expect(modal.contentEl.querySelector('h2')).toBeTruthy();
+		expect(modal.contentEl.querySelector('.gemini-warning-text')).toBeTruthy();
+		expect(modal.contentEl.querySelectorAll('p').length).toBeGreaterThanOrEqual(3);
+	});
+
+	it('clears its content on close rather than leaving the warning copy mounted', () => {
+		expect(modal.contentEl.childElementCount).toBeGreaterThan(0);
+
+		modal.onClose();
+
+		expect(modal.contentEl.childElementCount).toBe(0);
+	});
+
+	it('does not stack duplicate copy across a close/reopen cycle', () => {
+		const paragraphs = modal.contentEl.querySelectorAll('p').length;
+
+		modal.onClose();
+		modal.onOpen();
+
+		expect(modal.contentEl.querySelectorAll('p').length).toBe(paragraphs);
+	});
+});


### PR DESCRIPTION
<!-- auto-dev -->

## Summary

Refs #1262

Slice 2 of the #1262 missing-tests umbrella, built from the plan approved on that issue. It covers the two remaining **Priority-1** modules that gate *permission* decisions — `src/ui/components/tool-policy-editor.ts` and `src/ui/yolo-confirmation-modal.ts`. Both had zero direct coverage when this branch opened.

Tests only — no source changes.

**Deliberately `Refs`, not `Fixes`.** The umbrella tracks 20 modules; #1270 covered 5 and this covers 2 more. Closing the tracker now would lose the remaining 13. Same convention #1270 used.

## Rebased onto the #1414 fix

This branch was rebased onto current `master`, which now contains #1427 (`fix(ui): honor the documented setValue no-op in ToolPolicyEditor`). That changes the picture from the original description:

- **#1414 is fixed and merged.** `setValue` now early-returns via `policiesEqual()` when the incoming policy is structurally equal, so the documented no-op is real. The original version of this PR deliberately left that path uncovered because the docstring and the implementation disagreed; that disagreement is gone.
- **#1427's seven equal-value tests now live in this file**, merged in by the rebase under an "equal-value no-op (#1414)" heading — DOM-identity checks that the same nodes survive, the undefined/undefined and absent-vs-empty-overrides cases, the genuine-rebuild cases, and that the editor stays editable afterwards.
- **One assertion was dropped by the rebase and is restored here** (`6ac0040`). Master's `'does not emit when the value is equal, and still does not emit on a genuine rebuild'` had been folded down to only its second half, losing the check that the early-return branch itself does not emit — a net regression against master. Restored in full; deleting the `policiesEqual` guard now fails 3 tests in this file, up from 2 without it.

## Changes

- **`test/ui/components/tool-policy-editor.test.ts`** — `ToolPolicyEditor` is a plain class, not a `Modal`, so it is driven directly against a detached container built from real jsdom nodes plus the Obsidian element-factory sugar. Real select and input elements are used, so `change` events exercise the same listeners a user would. Assertions are on the **policy decisions** emitted through `onChange`, not the markup, per the issue's guidance:
  - initial value to control state, including the "only overrides, no preset" and inherit-global shapes;
  - the inherit toggle in both directions, and the normalization that turns an empty custom policy back into `undefined`;
  - preset selection, clearing a preset, and clearing it while overrides survive;
  - per-tool overrides — set, accumulate, reset one, reset the last — and the layering that keeps preset and overrides together rather than replacing;
  - `setValue()` round-trips a policy and `undefined` without emitting, later edits build on the new value, and the equal-value no-op path above;
  - the editor never aliases caller state: neither the constructor value nor the `setValue` argument is mutated, and emitted override maps are copies;
  - `destroy()` detaches from mount and document, leaves no control behind that could emit, is idempotent, and spares sibling content;
  - empty/absent tool registry, `displayName` fallback, title/description options, and unique checkbox ids across coexisting instances.
- **`test/ui/yolo-confirmation-modal.test.ts`** (new) — follows `test/ui/management-modal-base.test.ts`: construct against the `__mocks__/obsidian` `Modal`, call `onOpen()`, drive the captured buttons. The local `Modal` shim makes `close()` invoke `onClose()` **as Obsidian does**, so the "fires exactly once" guarantee is actually tested rather than assumed vacuously:
  - enable resolves `true`, cancel resolves `false`, both close the modal;
  - dismissal without a choice resolves `false` instead of leaving the caller pending;
  - the `resolved` guard holds across every button-then-close ordering, so a decline is never upgraded to an approval and nothing double-fires;
  - `onOpen` resets the guard, so a dismissal after an earlier answer still declines;
  - two choices are offered with the enabling one marked destructive, and `onClose` clears `contentEl`.

### One honest limitation

The `destroy()` assertions pin **DOM detachment**, not listener removal. `destroy()` calls `container.empty()` + `container.remove()`; the `change` listeners still live on the now-detached nodes, so a test that dispatched on a retained reference would still see `onChange` fire. What the editor actually guarantees — and what these tests assert — is that nothing interactive survives under the mount or in the document, so no further user interaction can reach it. Asserting "no `onChange` ever again" would have been a false claim about the code.

## Verification

Each module was mutated in turn to confirm the tests fail when the source breaks — a test that passes against a broken module is worse than no test. Twelve mutations on the original slice, all caught:

| Module | Mutations |
| --- | --- |
| `tool-policy-editor.ts` | constructor aliases the caller value instead of cloning; `emit()` skips normalization; clearing an override stops deleting it; `setValue()` stops re-rendering; `destroy()` empties but does not remove |
| `yolo-confirmation-modal.ts` | `resolved` guard dropped on the enable path; `onClose` resolves `true`; `onClose` never resolves; `onOpen` does not reset the guard; cancel confirms `true`; `setWarning()` dropped; `onClose` stops clearing `contentEl` |

Three of those (the `onOpen` guard reset, the cancel button's value, the `onClose` clear) **initially survived** — the first-draft assertions were weaker than intended. The tests were tightened until all twelve fail. A thirteenth mutation, deleting the `policiesEqual` guard, was used to check the restored assertion above.

Pre-flight on the rebased head: `npm test` (174 files, 3886 tests), `npm run build`, `npm run format-check`, `npm run lint` (0 errors), `npm run typecheck:test`, `npm run lint:cycles` (0 cycles), `npm run knip`.

No behavioral/runtime verification applies: this is a tests-only diff with no runnable surface of its own.

## Screenshots / Screencast

N/A — tests only, no user-visible change.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer — plan approved on #1262 ("Approved for slice 2 as scoped")
- [x] All CI checks pass — see the pre-flight list above, re-run on the rebased head
- [x] I have tested this change on Desktop — N/A: tests only, no runtime behavior to exercise in a vault; the deliverable is the suite itself, run locally and mutation-checked
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A: no source change, no platform-sensitive code added
- [x] Documentation has been updated (if applicable) — N/A per the plan: no user-facing behavior or public surface changes
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (auto-dev pipeline)
- [x] I have reviewed and understand all AI-generated code in this PR

---

Produced by the auto-dev pipeline from the plan approved on #1262.