### PR TITLE
refactor(types): delete the dead ChatMessage / ToolExecution surface

### DIFF
--- a/src/agent/session-history.ts
+++ b/src/agent/session-history.ts
@@ -124,7 +124,6 @@ export class SessionHistory {
 			temperature: entry.metadata?.temperature,
 			topP: entry.metadata?.topP,
 			customPrompt: entry.metadata?.customPrompt,
-			toolsUsed: [], // TODO: Add tool support later
 			isDefined: (value: unknown) => value !== undefined,
 		});
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,8 +21,6 @@ export type {
 	AgentContext,
 	SessionModelConfig,
 	ChatSession,
-	ChatMessage,
-	ToolExecution,
 } from './types/agent';
 
 // Tool System Types

--- a/src/types/agent.ts
+++ b/src/types/agent.ts
@@ -150,55 +150,6 @@ export interface SessionMetadata {
 }
 
 /**
- * Message within a chat session
- */
-export interface ChatMessage {
-	/** Unique message ID */
-	id: string;
-
-	/** Message role */
-	role: 'user' | 'assistant' | 'system';
-
-	/** Message content */
-	content: string;
-
-	/** Timestamp */
-	timestamp: Date;
-
-	/** Tools used in this message (for assistant messages) */
-	toolsUsed?: ToolExecution[];
-
-	/** Context that was active when this message was sent */
-	contextSnapshot?: {
-		files: string[]; // File paths
-	};
-}
-
-/**
- * Information about a tool execution
- */
-export interface ToolExecution {
-	/** Tool name/identifier */
-	name: string;
-
-	/** Tool category */
-	category: ToolCategory;
-
-	/** Parameters passed to the tool */
-	parameters: Record<string, unknown>;
-
-	/** Tool execution result */
-	result?: unknown;
-
-	/** Any error that occurred */
-	error?: string;
-
-	/** Whether user confirmation was required/given */
-	confirmationRequired?: boolean;
-	confirmationGiven?: boolean;
-}
-
-/**
  * Default agent contexts for different use cases
  */
 export const DEFAULT_CONTEXTS = {


### PR DESCRIPTION
## Summary

`audit-architecture` nightly sweep flagged: **dead surface** in `src/types/agent.ts`.

`ChatMessage` and the `ToolExecution` interface declared alongside it have no production reader or writer anywhere in `src/` or `test/`. They survive only because `src/index.ts` re-exports them — the "public API" barrel that is itself unreachable (#1356) and therefore exempts them from `npm run knip`. Deleting them is safe: nothing constructs a `ChatMessage`, nothing annotates with it, and the `ChatMessage` identifier that *is* live (`src/api/providers/openai/client.ts:47`) is an unrelated file-local alias for `OpenAI.ChatCompletionMessageParam`.

Two details worth calling out:

- `ChatMessage.contextSnapshot`'s declaration is the **only** occurrence of that identifier in the repo — it was never populated or read.
- The removal also clears a name collision. The `ToolExecution` that `ToolExecutionEngine.formatToolResult` actually consumes is a differently-shaped interface in `src/tools/types.ts`. The barrel re-exported the dead one, so a consumer of the declared public API got the wrong shape for that name.

Separately, `SessionHistory.appendHistoryEntry` passed a hardcoded `toolsUsed: []` (with a `// TODO: Add tool support later`) into `historyEntry.hbs`. That template has no `toolsUsed` placeholder, so the argument was inert; it goes with the field. Rendered history output is byte-for-byte unchanged — the session-history round-trip tests confirm it.

This is scoped to the dead declarations only. It does not touch the `src/index.ts` barrel's reachability, which is #1356's subject.

Fixes: n/a — filed directly by the audit, no tracking issue.

## Changes

- `src/types/agent.ts` — remove the unused `ChatMessage` and `ToolExecution` interfaces (49 lines). `ToolCategory`, declared in the same file and used by ~10 modules, is untouched.
- `src/index.ts` — drop `ChatMessage` and `ToolExecution` from the type re-export list.
- `src/agent/session-history.ts` — drop the inert `toolsUsed: []` template argument.

## Screenshots / Screencast

N/A — no UI surface is touched; this removes type declarations and one dead template argument.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: opened directly by the `audit-architecture` sweep, which files a PR rather than an issue for mechanically-safe deletions.
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — also verified `npm run lint`, `npm run typecheck:test`, and `npm run knip` locally. 171 test files / 3819 tests pass.
- [ ] I have tested this change on Desktop — N/A: type-only deletion plus one inert template argument; there is no runtime behavior to exercise. Verified by build + typecheck + the full suite instead.
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — no platform-specific code involved.
- [ ] Documentation has been updated (if applicable) — N/A: purely internal, no user-facing behavior or setting changes.
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (`audit-architecture` skill)
- [x] I have reviewed and understand all AI-generated code in this PR

---

_Filed by the `audit-architecture` skill._

---
_Generated by [Claude Code](https://claude.ai/code/session_01CKet1oV9EUeA92JAyexoH4)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Maintenance**
  - Streamlined session history handling by removing unused metadata.
  - Removed obsolete type definitions from the public API.
  - No changes to the application’s visible behavior or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->