### PR TITLE
chore(daily): 2026-08-28 daily update

### DIFF
--- a/planning/changelog/2026-08-28.md
+++ b/planning/changelog/2026-08-28.md
@@ -16,7 +16,7 @@ architecture/dedup cleanups feeding off recently-closed issues (#1310, #1292, #1
 
 ### Housekeeping backlog
 
-- [#1394](https://github.com/allenhutchison/obsidian-gemini/pull/1394), [#1397](https://github.com/allenhutchison/obsidian-gemini/pull/1397), [#1399](https://github.com/allenhutchison/obsidian-gemini/pull/1399), [#1403](https://github.com/allenhutchison/obsidian-gemini/pull/1403) — the daily-update PRs for August 25, 26, 27, and 28 all merged together this afternoon after sitting queued for review; each carries only that day's own changelog/audit output.
+- [#1394](https://github.com/allenhutchison/obsidian-gemini/pull/1394), [#1397](https://github.com/allenhutchison/obsidian-gemini/pull/1397), [#1399](https://github.com/allenhutchison/obsidian-gemini/pull/1399), [#1403](https://github.com/allenhutchison/obsidian-gemini/pull/1403) — the daily-update PRs for August 25, 26, 27, and 28 all merged this afternoon after sitting queued for review; each carries only that day's own changelog/audit output.
 
 ### Architecture cleanups (audit-architecture sweep)
 
@@ -69,3 +69,10 @@ Fixes #1309. `settings.streamingEnabled` was threaded through the model-client f
 ### [#1411 Prune the four spuriously-plumbed capability flags](https://github.com/allenhutchison/obsidian-gemini/pull/1411)
 
 Fixes #1298. Four of fifteen `ProviderCapabilities` fields (`costMetrics`, `vision`, `promptCache`, `interactionsApi`) were declared and filled in for all three providers but consulted by no code path. Deleted; `perUseCaseModels` — the one field with a real consumer — is kept and now documented as descriptive rather than load-bearing.
+
+## Other housekeeping
+
+The daily-update run's other two roster sub-skills touch GitHub directly rather than the working tree:
+
+- **audit-product-docs**: no drift found in the user-facing docs. While cross-checking provider defaults, spotted a likely code bug worth a maintainer look — `DEFAULT_SETTINGS.openaiModelName` (`src/main.ts`) is `'gpt-5.6'`, but the curated OpenAI catalog only recognizes `'gpt-5.6-sol'` as the chat-role id. Not fixed here; flagged for a separate, reviewed change.
+- **triage-issues**: labeled the one unlabeled open issue, [#1414](https://github.com/allenhutchison/obsidian-gemini/issues/1414), `bug` + `tool-execution`.

--- a/planning/changelog/2026-08-28.md
+++ b/planning/changelog/2026-08-28.md
@@ -1,0 +1,71 @@
+# Daily changelog — August 28, 2026
+
+**Date:** 2026-08-28
+**PRs merged:** 16
+
+---
+
+## Summary
+
+The busiest day in over a week: a backlog of `audit-architecture` mechanical refactors and four queued
+daily-update housekeeping PRs cleared in the early afternoon, then a second wave in the evening landed a
+real user-facing bug fix (state-folder path normalization), an invariants-doc correction, and a run of
+architecture/dedup cleanups feeding off recently-closed issues (#1310, #1292, #1379, #1387, #1309, #1298).
+
+## What shipped
+
+### Housekeeping backlog
+
+- [#1394](https://github.com/allenhutchison/obsidian-gemini/pull/1394), [#1397](https://github.com/allenhutchison/obsidian-gemini/pull/1397), [#1399](https://github.com/allenhutchison/obsidian-gemini/pull/1399), [#1403](https://github.com/allenhutchison/obsidian-gemini/pull/1403) — the daily-update PRs for August 25, 26, 27, and 28 all merged together this afternoon after sitting queued for review; each carries only that day's own changelog/audit output.
+
+### Architecture cleanups (audit-architecture sweep)
+
+### [#1392 refactor(vault-analyzer): reuse the shared system-path exclusion helper](https://github.com/allenhutchison/obsidian-gemini/pull/1392)
+
+`VaultAnalyzer.isSystemPath` was a verbatim reimplementation of the shared `shouldExcludePathForPlugin` predicate, with a third hand-rolled spelling of the same check in `buildFolderStructure`. Both now delegate to the canonical helper — a like-for-like substitution with no behavior change.
+
+### [#1393 refactor(settings): stop resurrecting the migrated alwaysAllowReadWrite key](https://github.com/allenhutchison/obsidian-gemini/pull/1393)
+
+The deprecated `alwaysAllowReadWrite` setting was still declared in `ObsidianGeminiSettings` and seeded in `DEFAULT_SETTINGS`, so every load resurrected the key the migration had just deleted, and every save persisted it again. Dropped it from both, following the pattern already used for the other deprecated fields.
+
+### [#1395 refactor(agent-view): share the usage-metadata emit between both send paths](https://github.com/allenhutchison/obsidian-gemini/pull/1395)
+
+The streaming and non-streaming arms of `sendMessage()` each carried an identical eight-line block for emitting `apiResponseReceived`, differing only by a log prefix. Extracted into a shared private `emitUsageMetadata()` helper.
+
+### [#1400 refactor(paths): use isPathInFolder for five inline containment checks](https://github.com/allenhutchison/obsidian-gemini/pull/1400)
+
+Five call sites (`deep-research.ts`, `image-generation.ts`, `obsidian-file-adapter.ts`, `project-manager.ts`, `read-file-tool.ts`) re-expanded the canonical `isPathInFolder()` predicate inline instead of calling it, meaning fixes to the shared helper (like #1404 below) couldn't reach them. All five now call the shared function; no behavior change.
+
+### Evening: bug fix, doc correction, and more dedup
+
+### [#1404 Normalize state-folder setting at the settings boundary](https://github.com/allenhutchison/obsidian-gemini/pull/1404)
+
+Fixes #1374. A hand-typed trailing slash on the plugin state folder setting (e.g. `gemini-scribe/`) silently broke every containment check built on it — the file-mention modal stopped filtering out session-history files, and vault tools' system-path exclusion opened up. `normalizeStateFolderPath()` now repairs the value on load and on save from the settings UI.
+
+### [#1405 Fix invariant drift: three-provider capability routing; main.js is not committed](https://github.com/allenhutchison/obsidian-gemini/pull/1405)
+
+Fixes #1302. `.claude/guidelines/invariants.md` still described the old two-provider factory and told contributors to commit the gitignored `main.js`. Rewritten for the current three-provider, per-use-case capability-routed architecture, with a matching one-line fix in `AGENTS.md`.
+
+### [#1406 Close out the vault tools migration into src/tools/vault/](https://github.com/allenhutchison/obsidian-gemini/pull/1406)
+
+Fixes #1310. Moved `UpdateFrontmatterTool` and `AppendContentTool` out of the flat `vault-tools-extended.ts` into one-file-per-tool modules alongside their nine siblings — a pure move with no behavior, tool-id, or registration-order change.
+
+### [#1407 Share the 200-char confirmation preview truncation across tools](https://github.com/allenhutchison/obsidian-gemini/pull/1407)
+
+Fixes #1292. Four tools (`write_file`, `append_content`, `update_memory`, `create_skill`) each hand-rolled the same 200-character truncation-with-ellipsis logic for confirmation previews. Consolidated into `truncateForPreview()` in `format-utils.ts`; output is byte-identical.
+
+### [#1408 Fix double-spaced code blocks; unify the paragraph normalizer](https://github.com/allenhutchison/obsidian-gemini/pull/1408)
+
+Fixes #1379. The shared `formatModelMessage` helper had no code-fence tracking, so it inserted a blank line between every pair of consecutive code lines — every agent-view code block rendered double-spaced. Fixed, and the selection-response modal's separate `normalizeNewlines` fork (which had drifted in five other ways, including missing wikilink unescaping) was deleted in favor of the shared, now-fixed function.
+
+### [#1409 Delete the write-only tool execution history store; wire loop-detector teardown](https://github.com/allenhutchison/obsidian-gemini/pull/1409)
+
+Fixes #1387. `ToolExecutionEngine` kept an unbounded, never-cleared `Map` of every successful tool call's full parameters and result — a monotonic memory leak with no reader in production code. Deleted the store; the one load-bearing behavior behind it (clearing a session's loop-detector records) is now its own method, wired into session deletion.
+
+### [#1410 Delete the never-read streamingEnabled client plumbing](https://github.com/allenhutchison/obsidian-gemini/pull/1410)
+
+Fixes #1309. `settings.streamingEnabled` was threaded through the model-client factory into all three providers' configs but read by none of them — the actual streaming decision happens directly against `plugin.settings` in the agent view. Removed the inert plumbing; the setting and its UI toggle are unchanged.
+
+### [#1411 Prune the four spuriously-plumbed capability flags](https://github.com/allenhutchison/obsidian-gemini/pull/1411)
+
+Fixes #1298. Four of fifteen `ProviderCapabilities` fields (`costMetrics`, `vision`, `promptCache`, `interactionsApi`) were declared and filled in for all three providers but consulted by no code path. Deleted; `perUseCaseModels` — the one field with a real consumer — is kept and now documented as descriptive rather than load-bearing.


### PR DESCRIPTION
## Summary

Daily housekeeping run for 2026-08-28 (the roster from `.claude/maintainerd.json`'s `dailyUpdate.subSkills`: `daily-changelog`, `audit-product-docs`, `triage-issues`).

## Changes

- **daily-changelog**: added `planning/changelog/2026-08-28.md` covering the day's 16 merged PRs — a backlog of four queued daily-update PRs plus a batch of `audit-architecture` refactors that afternoon, then a state-folder bug fix (#1374), an invariants-doc correction (#1302), and a run of dedup/dead-code cleanups (#1310, #1292, #1379, #1387, #1309, #1298) that evening.
- **audit-product-docs**: no documentation drift found. The areas touched by today's merges (state-folder normalization, provider capability flags) are already documented accurately. While cross-checking, spotted a likely **code bug** worth a maintainer look: `DEFAULT_SETTINGS.openaiModelName` in `src/main.ts` is `'gpt-5.6'`, but the curated OpenAI model catalog (`src/services/openai-models-service.ts`) only recognizes `'gpt-5.6-sol'` as the chat-role id (matching the `-terra`/`-luna` siblings for summary/completions). A fresh install routed to OpenAI for chat would request a model id that isn't in the known catalog. Not fixed here — this PR only carries doc/triage output, and code fixes belong in their own reviewed change.
- **triage-issues**: one unlabeled open issue found and labeled — [#1414](https://github.com/allenhutchison/obsidian-gemini/issues/1414) → `bug` + `tool-execution` (documents a no-op contract that `ToolPolicyEditor.setValue()` doesn't implement, causing avoidable UI rebuilds).

## Screenshots / Screencast

N/A — no UI change; this PR is documentation/changelog only.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A, scheduled daily-housekeeping run per `.claude/maintainerd.json`.
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — also ran `npm run lint` (0 errors, pre-existing warnings only) and `npm run typecheck:test`.
- [ ] I have tested this change on Desktop — N/A, no runtime behavior change.
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A, markdown-only change.
- [x] Documentation has been updated (if applicable) — this PR *is* the daily changelog; no product-doc drift was found to fix.
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (scheduled `daily-update` meta-skill run)
- [x] I have reviewed and understand all AI-generated code in this PR


---
_Generated by [Claude Code](https://claude.ai/code/session_012qj3PGxygsAAJEZn552asw)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added the August 28, 2026 daily changelog.
  * Recorded 16 merged updates covering settings and path handling, usage metadata, preview and formatting improvements, vault-tool changes, loop detection, documentation updates, and product issue triage.
  * Confirmed that no exported or public interfaces changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->