### PR TITLE
refactor(ui): extract populateTabs in RagStatusModal (#1293)

### DIFF
--- a/src/ui/rag-status-modal.ts
+++ b/src/ui/rag-status-modal.ts
@@ -65,7 +65,14 @@ export class RagStatusModal extends Modal {
 
 	private renderTabs(container: HTMLElement): void {
 		const tabsEl = container.createDiv({ cls: 'rag-status-tabs' });
+		this.populateTabs(tabsEl);
+	}
 
+	/**
+	 * Fills an already-placed tab strip with the three tabs. Shared by the initial render and the
+	 * refresh path, which differ only in where the container is placed.
+	 */
+	private populateTabs(tabsEl: HTMLElement): void {
 		// Overview tab
 		this.createTab(tabsEl, 'overview', t('ragStatus.tabOverview'));
 
@@ -178,21 +185,7 @@ export class RagStatusModal extends Modal {
 		if (header) {
 			const tabsEl = contentEl.createDiv({ cls: 'rag-status-tabs' });
 			header.insertAdjacentElement('afterend', tabsEl);
-
-			// Overview tab
-			this.createTab(tabsEl, 'overview', t('ragStatus.tabOverview'));
-
-			// Files tab with count
-			this.createTab(
-				tabsEl,
-				'files',
-				t('ragStatus.tabFiles', { count: this.statusInfo.indexedCount.toLocaleString() })
-			);
-
-			// Failures tab with count
-			if (this.statusInfo.failedCount > 0) {
-				this.createTab(tabsEl, 'failures', t('ragStatus.tabFailures', { count: this.statusInfo.failedCount }));
-			}
+			this.populateTabs(tabsEl);
 		}
 
 		if (contentContainer) {

--- a/test/ui/rag-status-modal.test.ts
+++ b/test/ui/rag-status-modal.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Tests for RagStatusModal's tab strip.
+ *
+ * The modal builds its tabs from two different places — the initial render appends the strip to the
+ * content element, the refresh path re-creates it after the header — and #1293 flagged the two as
+ * near-verbatim twins that would drift. These tests pin the invariant that both paths produce the
+ * same tabs, so an extraction (or a future fourth tab added to only one site) is caught.
+ */
+
+import type { App } from 'obsidian';
+import type { RagDetailedStatus } from '../../src/services/rag-types';
+
+vi.mock('obsidian', () => {
+	const applyOptions = (element: HTMLElement, options?: any) => {
+		if (options?.text) element.textContent = options.text;
+		if (options?.cls) {
+			for (const cls of String(options.cls).split(/\s+/).filter(Boolean)) {
+				element.classList.add(cls);
+			}
+		}
+		if (options?.attr) {
+			for (const [name, value] of Object.entries(options.attr)) {
+				element.setAttribute(name, String(value));
+			}
+		}
+		return element;
+	};
+
+	const decorate = (element: HTMLElement): HTMLElement => {
+		(element as any).empty = function () {
+			this.replaceChildren();
+			return this;
+		};
+		(element as any).addClass = function (cls: string) {
+			this.classList.add(cls);
+			return this;
+		};
+		(element as any).createEl = function (tag: string, options?: any) {
+			const el = decorate(document.createElement(tag));
+			applyOptions(el, options);
+			this.appendChild(el);
+			return el;
+		};
+		(element as any).createDiv = function (options?: any) {
+			return this.createEl('div', options);
+		};
+		(element as any).createSpan = function (options?: any) {
+			return this.createEl('span', options);
+		};
+		return element;
+	};
+
+	return {
+		getLanguage: () => 'en',
+		setIcon: () => {},
+		Modal: class Modal {
+			app: any;
+			contentEl: HTMLElement;
+			modalEl: HTMLElement;
+
+			constructor(app: any) {
+				this.app = app;
+				this.contentEl = decorate(document.createElement('div'));
+				this.modalEl = decorate(document.createElement('div'));
+			}
+
+			open() {}
+			close() {}
+		},
+	};
+});
+
+// The tab strip is what's under test; the panel bodies are covered by rag-status-panel.test.ts.
+vi.mock('../../src/ui/components/rag-status-panel', () => ({
+	renderRagOverview: vi.fn(),
+	renderRagFileList: vi.fn(),
+	renderRagFailures: vi.fn(),
+}));
+
+import { RagStatusModal } from '../../src/ui/rag-status-modal';
+
+function makeStatus(overrides: Partial<RagDetailedStatus> = {}): RagDetailedStatus {
+	return {
+		status: 'idle',
+		indexedCount: 12,
+		failedCount: 0,
+		...overrides,
+	} as RagDetailedStatus;
+}
+
+function openModal(status: RagDetailedStatus): RagStatusModal {
+	const modal = new RagStatusModal(
+		{} as App,
+		status,
+		() => {},
+		() => {},
+		async () => true
+	);
+	modal.onOpen();
+	return modal;
+}
+
+function tabLabels(modal: RagStatusModal): string[] {
+	return Array.from((modal as any).contentEl.querySelectorAll('.rag-status-tab')).map(
+		(el) => (el as HTMLElement).textContent ?? ''
+	);
+}
+
+/** Clicking a tab is the only public way to reach the refresh re-render path. */
+function clickTab(modal: RagStatusModal, label: string): void {
+	const tab = Array.from((modal as any).contentEl.querySelectorAll('.rag-status-tab')).find(
+		(el) => (el as HTMLElement).textContent === label
+	) as HTMLElement | undefined;
+	if (!tab) throw new Error(`No tab labelled "${label}"`);
+	tab.click();
+}
+
+describe('RagStatusModal tabs', () => {
+	beforeEach(() => {
+		document.body.innerHTML = '';
+	});
+
+	it('renders the same tabs on the initial render and after a refresh', () => {
+		const modal = openModal(makeStatus({ failedCount: 3 }));
+		const initial = tabLabels(modal);
+		expect(initial).toHaveLength(3);
+
+		clickTab(modal, initial[1]);
+
+		expect(tabLabels(modal)).toEqual(initial);
+	});
+
+	it('omits the failures tab on both paths when there are no failures', () => {
+		const modal = openModal(makeStatus({ failedCount: 0 }));
+		const initial = tabLabels(modal);
+		expect(initial).toHaveLength(2);
+
+		clickTab(modal, initial[1]);
+
+		const afterRefresh = tabLabels(modal);
+		expect(afterRefresh).toEqual(initial);
+		expect(afterRefresh).toHaveLength(2);
+	});
+
+	it('keeps exactly one tab strip after refreshing', () => {
+		const modal = openModal(makeStatus({ failedCount: 1 }));
+
+		clickTab(modal, tabLabels(modal)[1]);
+
+		expect((modal as any).contentEl.querySelectorAll('.rag-status-tabs')).toHaveLength(1);
+	});
+
+	it('marks the clicked tab active after the refresh re-render', () => {
+		const modal = openModal(makeStatus({ failedCount: 0 }));
+		const filesLabel = tabLabels(modal)[1];
+
+		clickTab(modal, filesLabel);
+
+		const active = (modal as any).contentEl.querySelectorAll('.rag-status-tab-active');
+		expect(active).toHaveLength(1);
+		expect((active[0] as HTMLElement).textContent).toBe(filesLabel);
+	});
+});


### PR DESCRIPTION
<!-- auto-dev -->

## Summary

`src/ui/rag-status-modal.ts` built its three-tab strip in two places: `renderTabs()` on the initial
render, and again inside `refresh()` when the strip is rebuilt after a tab click. Both issued the
same three `createTab` calls behind the same `failedCount > 0` guard; the only real difference is
placement (append to the container vs. `insertAdjacentElement('afterend', …)`). Adding a fourth tab
meant editing both sites, and nothing in CI would have caught it if only one were updated.

This extracts a private `populateTabs(tabsEl)` holding the three calls and the guard. Each call site
keeps its own placement and then delegates. Pure extraction — no behaviour change, no new module,
the helper stays private to the file.

This is **entry 1 of the four** listed on #1293, taken on its own per the issue's explicit
instruction ("file one sub-issue per entry (or pick them off individually), don't bundle them into
one PR") and the maintainer's approval of the first slice. Entries 2–4 are untouched, so #1293 stays
open — the `Fixes` link below is deliberately omitted for that reason.

Related: #1293 (entry 1 of 4).

## Changes

- `src/ui/rag-status-modal.ts` — add private `populateTabs(tabsEl: HTMLElement)`; repoint
  `renderTabs()` and the `refresh()` re-render at it. Net ~14 lines removed.
- `test/ui/rag-status-modal.test.ts` (new) — the module had no test file at all, so the extraction
  would otherwise have landed guarded only by `build` / `typecheck:test`, neither of which can catch
  a tab going missing from one of the two paths. Four assertions drive both render paths through the
  public surface (a tab click is the only way to reach `refresh()`) and pin that they agree,
  including the `failedCount === 0` case where the failures tab must be absent from both.

## Screenshots / Screencast

N/A — no visual change. The rendered tab markup is byte-identical before and after; only the
construction path is shared.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer
      (#1293, plan approved for the first slice)
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — run locally:
      `format-check` clean, `lint` 0 errors (40 pre-existing warnings), `build` clean,
      `typecheck:test` clean, `test` 3823 passed / 172 files, `lint:cycles` clean
- [ ] I have tested this change on Desktop — **N/A in this environment.** No live Obsidian instance
      is available in the sandbox, so the modal was not driven by hand. Instead both render paths are
      exercised at the DOM level by the new test; to confirm it actually has teeth, the refresh path
      was temporarily reverted to a drifted two-tab copy and the test failed as intended, then the
      change was restored.
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) —
      no platform-specific API is touched; the change is a private method extraction.
- [ ] Documentation has been updated (if applicable) — **N/A.** `populateTabs` is private, the
      rendered output is unchanged, and nothing in `docs/` or `README.md` describes the tab
      internals. Checked rather than assumed.
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this
      PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (auto-dev pipeline, built from the plan approved on #1293)
- [x] I have reviewed and understand all AI-generated code in this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01T85s7C9scmBGcvsu5vi2KE)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved status modal refresh behavior to keep tabs consistent.
  * Preserved the selected tab when refreshing.
  * Prevented duplicate tab strips from appearing.
  * Maintained conditional display of failure information.

* **Tests**
  * Added coverage for tab consistency during initial display and refresh, including scenarios with and without failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->