### PR TITLE
fix(ui): honor the documented setValue no-op in ToolPolicyEditor

### DIFF
--- a/src/types/tool-policy.ts
+++ b/src/types/tool-policy.ts
@@ -307,6 +307,24 @@ export function clonePolicy(policy: FeatureToolPolicy | undefined): FeatureToolP
 }
 
 /**
+ * Structurally compare two FeatureToolPolicy values. Absent vs. empty
+ * `overrides` count as equal (they serialize identically); everything else is
+ * compared field-by-field. Used by ToolPolicyEditor.setValue to skip
+ * re-renders when the host modal re-applies an unchanged policy.
+ */
+export function policiesEqual(a: FeatureToolPolicy | undefined, b: FeatureToolPolicy | undefined): boolean {
+	if (a === b) return true;
+	if (!a || !b) return false;
+	if (a.preset !== b.preset) return false;
+	const aOverrides = a.overrides ?? {};
+	const bOverrides = b.overrides ?? {};
+	const aKeys = Object.keys(aOverrides);
+	const bKeys = Object.keys(bOverrides);
+	if (aKeys.length !== bKeys.length) return false;
+	return aKeys.every((key) => aOverrides[key] === bOverrides[key]);
+}
+
+/**
  * Serialize a FeatureToolPolicy back to a plain frontmatter-friendly object.
  * Returns undefined when the policy is effectively empty.
  */

--- a/src/ui/components/tool-policy-editor.ts
+++ b/src/ui/components/tool-policy-editor.ts
@@ -9,6 +9,7 @@ import {
 	ToolClassification,
 	ToolPermission,
 	clonePolicy,
+	policiesEqual,
 } from '../../types/tool-policy';
 import { t } from '../../i18n';
 
@@ -79,6 +80,7 @@ export class ToolPolicyEditor {
 	 * No-op if the new value is structurally equal to the current state.
 	 */
 	setValue(next: FeatureToolPolicy | undefined): void {
+		if (policiesEqual(this.state, next)) return;
 		this.state = clonePolicy(next);
 		this.render();
 	}

--- a/test/types/tool-policy.test.ts
+++ b/test/types/tool-policy.test.ts
@@ -13,6 +13,7 @@ import {
 	parseToolPolicyFrontmatter,
 	serializeToolPolicy,
 	clonePolicy,
+	policiesEqual,
 	FeatureToolPolicy,
 	ToolPolicySettings,
 } from '../../src/types/tool-policy';
@@ -312,6 +313,44 @@ describe('tool-policy types', () => {
 
 		it('returns undefined for undefined input', () => {
 			expect(clonePolicy(undefined)).toBeUndefined();
+		});
+	});
+
+	describe('policiesEqual', () => {
+		it('treats undefined as equal only to undefined', () => {
+			expect(policiesEqual(undefined, undefined)).toBe(true);
+			expect(policiesEqual(undefined, {})).toBe(false);
+			expect(policiesEqual({}, undefined)).toBe(false);
+		});
+
+		it('compares presets', () => {
+			expect(policiesEqual({ preset: PolicyPreset.YOLO }, { preset: PolicyPreset.YOLO })).toBe(true);
+			expect(policiesEqual({ preset: PolicyPreset.YOLO }, { preset: PolicyPreset.CAUTIOUS })).toBe(false);
+			expect(policiesEqual({ preset: PolicyPreset.YOLO }, {})).toBe(false);
+		});
+
+		it('treats absent and empty overrides as equal', () => {
+			expect(policiesEqual({}, { overrides: {} })).toBe(true);
+			expect(policiesEqual({ overrides: {} }, {})).toBe(true);
+		});
+
+		it('compares overrides key-by-key, order-insensitive', () => {
+			const a: FeatureToolPolicy = {
+				overrides: { read_file: ToolPermission.APPROVE, delete_file: ToolPermission.DENY },
+			};
+			const b: FeatureToolPolicy = {
+				overrides: { delete_file: ToolPermission.DENY, read_file: ToolPermission.APPROVE },
+			};
+			expect(policiesEqual(a, b)).toBe(true);
+		});
+
+		it('detects added, removed, and changed override entries', () => {
+			const base: FeatureToolPolicy = { overrides: { read_file: ToolPermission.APPROVE } };
+			expect(policiesEqual(base, { overrides: { read_file: ToolPermission.DENY } })).toBe(false);
+			expect(policiesEqual(base, { overrides: {} })).toBe(false);
+			expect(
+				policiesEqual(base, { overrides: { read_file: ToolPermission.APPROVE, web_fetch: ToolPermission.DENY } })
+			).toBe(false);
 		});
 	});
 });

--- a/test/ui/components/tool-policy-editor.test.ts
+++ b/test/ui/components/tool-policy-editor.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Regression tests for the ToolPolicyEditor.setValue equal-value no-op (#1414).
+ *
+ * The full editor suite lives in test/ui/components/tool-policy-editor.test.ts,
+ * added by PR #1413 — this file pins only the setValue semantics that PR
+ * deliberately left unpinned because the docstring and the behavior disagreed:
+ * setValue must not rebuild the editor when the incoming policy is structurally
+ * equal to the current state (focus loss / closed dropdowns on host-modal
+ * re-renders), and must rebuild when it differs.
+ *
+ * The editor is a plain class (not a Modal), driven against a detached jsdom
+ * container with the Obsidian DOM sugar added per-test, mirroring the harness
+ * conventions of test/ui/agent-view/agent-view-tool-display.test.ts.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from 'vitest';
+import { ToolPolicyEditor } from '../../../src/ui/components/tool-policy-editor';
+import { FeatureToolPolicy, PolicyPreset, ToolClassification, ToolPermission } from '../../../src/types/tool-policy';
+import type { ObsidianGemini } from '../../../src/types/plugin';
+
+/**
+ * Add the Obsidian DOM sugar (createEl/createDiv/createSpan/empty) that jsdom lacks.
+ * The global vitest setup patches hide/show/toggle/toggleClass onto the prototype.
+ */
+function addObsidianMethods(el: HTMLElement): HTMLElement {
+	const anyEl = el as any;
+	anyEl.createEl = function (tag: string, opts?: any) {
+		const elem = document.createElement(tag);
+		if (opts?.cls) elem.className = opts.cls;
+		if (opts?.text !== undefined) elem.textContent = opts.text;
+		if (opts?.attr) {
+			for (const [key, val] of Object.entries(opts.attr)) {
+				elem.setAttribute(key, val as string);
+			}
+		}
+		addObsidianMethods(elem);
+		this.appendChild(elem);
+		return elem;
+	};
+	anyEl.createDiv = function (opts?: any) {
+		return this.createEl('div', opts);
+	};
+	anyEl.createSpan = function (opts?: any) {
+		return this.createEl('span', opts);
+	};
+	anyEl.empty = function () {
+		this.innerHTML = '';
+	};
+	return el;
+}
+
+const TOOLS = [
+	{ name: 'read_file', displayName: 'Read File', classification: ToolClassification.READ },
+	{ name: 'delete_file', displayName: 'Delete File', classification: ToolClassification.DESTRUCTIVE },
+];
+
+describe('ToolPolicyEditor.setValue equal-value no-op (#1414)', () => {
+	let mount: HTMLElement;
+	let onChange: Mock<(next: FeatureToolPolicy | undefined) => void>;
+	let plugin: ObsidianGemini;
+	let editor: ToolPolicyEditor | undefined;
+
+	function makeEditor(value: FeatureToolPolicy | undefined): ToolPolicyEditor {
+		plugin = {
+			toolRegistry: { getAllTools: () => TOOLS },
+		} as unknown as ObsidianGemini;
+		editor = new ToolPolicyEditor(plugin, mount, { value, onChange });
+		return editor;
+	}
+
+	function inheritCheckbox(): HTMLInputElement {
+		const cb = mount.querySelector<HTMLInputElement>('.gemini-tool-policy-editor-inherit input');
+		if (!cb) throw new Error('inherit checkbox not rendered');
+		return cb;
+	}
+
+	function presetSelect(): HTMLSelectElement {
+		const sel = mount.querySelector<HTMLSelectElement>('.gemini-tool-policy-editor-preset-row select');
+		if (!sel) throw new Error('preset select not rendered');
+		return sel;
+	}
+
+	function toolSelect(toolName: string): HTMLSelectElement {
+		const label = TOOLS.find((t) => t.name === toolName)?.displayName ?? toolName;
+		const rows = Array.from(mount.querySelectorAll('.gemini-tool-policy-editor-tool-row'));
+		const row = rows.find((r) => r.querySelector('.gemini-tool-policy-editor-tool-name')?.textContent === label);
+		const sel = row?.querySelector('select');
+		if (!sel) throw new Error(`override select for ${toolName} not rendered`);
+		return sel;
+	}
+
+	beforeEach(() => {
+		document.body.innerHTML = '';
+		mount = addObsidianMethods(document.createElement('div'));
+		document.body.appendChild(mount);
+		onChange = vi.fn<(next: FeatureToolPolicy | undefined) => void>();
+	});
+
+	afterEach(() => {
+		editor?.destroy();
+		editor = undefined;
+		document.body.innerHTML = '';
+	});
+
+	it('does not rebuild the DOM when the new value is structurally equal', () => {
+		const initial: FeatureToolPolicy = {
+			preset: PolicyPreset.CAUTIOUS,
+			overrides: { delete_file: ToolPermission.DENY },
+		};
+		makeEditor(initial);
+		const checkboxBefore = inheritCheckbox();
+		const presetBefore = presetSelect();
+		const toolBefore = toolSelect('delete_file');
+
+		// A structurally-equal (but freshly allocated) policy — this is what a
+		// host-modal refresh hands over when nothing about the policy changed.
+		editor!.setValue({ preset: PolicyPreset.CAUTIOUS, overrides: { delete_file: ToolPermission.DENY } });
+
+		// The very same DOM nodes survive: no container.empty() + rebuild.
+		expect(inheritCheckbox()).toBe(checkboxBefore);
+		expect(presetSelect()).toBe(presetBefore);
+		expect(toolSelect('delete_file')).toBe(toolBefore);
+	});
+
+	it('does not rebuild when both values are undefined', () => {
+		makeEditor(undefined);
+		const checkboxBefore = inheritCheckbox();
+
+		editor!.setValue(undefined);
+
+		expect(inheritCheckbox()).toBe(checkboxBefore);
+	});
+
+	it('does not rebuild when the only difference is absent vs empty overrides', () => {
+		makeEditor({ preset: PolicyPreset.YOLO });
+		const presetBefore = presetSelect();
+
+		editor!.setValue({ preset: PolicyPreset.YOLO, overrides: {} });
+
+		expect(presetSelect()).toBe(presetBefore);
+	});
+
+	it('rebuilds and reflects the new value when the policy differs', () => {
+		makeEditor({ preset: PolicyPreset.CAUTIOUS });
+		const presetBefore = presetSelect();
+
+		editor!.setValue({ preset: PolicyPreset.READ_ONLY, overrides: { delete_file: ToolPermission.ASK_USER } });
+
+		// New nodes were built (the old select was torn down) and carry the new value.
+		expect(presetSelect()).not.toBe(presetBefore);
+		expect(presetSelect().value).toBe(PolicyPreset.READ_ONLY);
+		expect(toolSelect('delete_file').value).toBe(ToolPermission.ASK_USER);
+	});
+
+	it('rebuilds when the value changes from undefined to a policy and back', () => {
+		makeEditor(undefined);
+		expect(mount.querySelector('.gemini-tool-policy-editor-preset-row')).toBeNull();
+
+		editor!.setValue({ preset: PolicyPreset.YOLO });
+		expect(inheritCheckbox().checked).toBe(false);
+		expect(presetSelect().value).toBe(PolicyPreset.YOLO);
+
+		editor!.setValue(undefined);
+		expect(inheritCheckbox().checked).toBe(true);
+		expect(mount.querySelector('.gemini-tool-policy-editor-preset-row')).toBeNull();
+	});
+
+	it('does not emit when the value is equal, and still does not emit on a genuine rebuild', () => {
+		makeEditor({ preset: PolicyPreset.CAUTIOUS });
+
+		editor!.setValue({ preset: PolicyPreset.CAUTIOUS });
+		expect(onChange).not.toHaveBeenCalled();
+
+		editor!.setValue({ preset: PolicyPreset.YOLO });
+		expect(onChange).not.toHaveBeenCalled();
+	});
+
+	it('keeps the editor editable after an equal-value setValue', () => {
+		makeEditor({ preset: PolicyPreset.CAUTIOUS, overrides: { delete_file: ToolPermission.DENY } });
+
+		editor!.setValue({ preset: PolicyPreset.CAUTIOUS, overrides: { delete_file: ToolPermission.DENY } });
+
+		// The surviving controls still respond: picks emit from the current state.
+		const select = toolSelect('read_file');
+		select.value = ToolPermission.APPROVE;
+		select.dispatchEvent(new Event('change'));
+
+		expect(onChange).toHaveBeenCalledTimes(1);
+		expect(onChange).toHaveBeenCalledWith({
+			preset: PolicyPreset.CAUTIOUS,
+			overrides: { delete_file: ToolPermission.DENY, read_file: ToolPermission.APPROVE },
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Fixes #1414

`ToolPolicyEditor.setValue()` documented a structural-equality no-op it never implemented — every call reassigned state and called `render()`, which does `container.empty()` and rebuilds the inherit checkbox, the preset dropdown, and every per-tool override dropdown. The docstring names the exact scenario this hurts ("after a re-render in the host modal"), where the rebuild would steal focus and close an open dropdown whenever a host modal refreshed its form with an unchanged policy.

This makes the documented contract true: `setValue` now early-returns when the incoming policy is structurally equal to the current state. No production caller invokes `setValue` today (both host modals dispose and recreate the editor), so no behavior changes for existing users — the guard is ahead of the refresh-based call pattern the method was written for.

## Changes

- `src/types/tool-policy.ts`: new exported `policiesEqual(a, b)` — structural comparison for `FeatureToolPolicy`; absent vs. empty `overrides` count as equal (they serialize identically via `serializeToolPolicy`), and key comparison is order-insensitive.
- `src/ui/components/tool-policy-editor.ts`: `setValue` early-returns when `policiesEqual(this.state, next)`; otherwise the existing clone-and-render path is unchanged.
- `test/types/tool-policy.test.ts`: unit tests for `policiesEqual` (undefined vs. empty, preset mismatch, absent-vs-empty overrides, order-insensitive key comparison, added/removed/changed override detection).
- `test/ui/components/tool-policy-editor.test.ts` (new): DOM-identity regression tests pinning the no-op — an equal-value `setValue` keeps the *same* DOM nodes (checkbox, preset select, tool selects are reference-identical), a changed value rebuilds and reflects the new policy, and the surviving controls remain editable afterwards. This is a separate file from the general editor suite PR #1413 adds, which deliberately left the equal-value path unpinned because the docstring and behavior disagreed; merging the two files later is a plain block move.

## Screenshots / Screencast

N/A — no visual change; the fix removes a rebuild (and its focus loss) from a path with no current production caller.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [ ] I have tested this change on Desktop
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards)
- [x] Documentation has been updated (if applicable)
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

Notes on the unticked items:

- **Desktop testing**: not performed — no production caller reaches `setValue`, so there is no user-visible surface to exercise; the change is verified by the regression tests instead (45 targeted tests, full suite 3831/3831 green).
- **Mobile**: the touched code paths (`policiesEqual`, `setValue` guard) contain no platform-specific API and run identically on Mobile.
- **Documentation**: the `setValue` contract is documented only in its docstring, which this PR makes true; grep over `docs/` finds no other reference to `ToolPolicyEditor` or the `setValue` contract, so no doc updates apply (internal fix, no user-facing behavior change).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tool policy editing to avoid unnecessary re-rendering when values have not changed.
  * Preserved editor state and interactions when equivalent policies are applied.
  * Correctly handles missing and empty policy overrides as equivalent.
* **Tests**
  * Added coverage for policy comparisons, reordered overrides, and policy transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->