### PR TITLE
refactor(utils): give parent-path derivation a home in file-utils

### DIFF
--- a/src/services/headless-run-output.ts
+++ b/src/services/headless-run-output.ts
@@ -1,5 +1,5 @@
 import { Vault, normalizePath } from 'obsidian';
-import { ensureFolderExists } from '../utils/file-utils';
+import { ensureParentFolderExists } from '../utils/file-utils';
 import { getRawErrorMessage } from '../utils/error-utils';
 import type { Logger } from '../utils/logger';
 
@@ -117,10 +117,7 @@ export interface WriteHeadlessOutputParams {
 export async function writeHeadlessOutput(params: WriteHeadlessOutputParams): Promise<string> {
 	const { vault, outputPath, header, content, folderLabel, logger, retry } = params;
 
-	const parentPath = outputPath.includes('/') ? outputPath.slice(0, outputPath.lastIndexOf('/')) : null;
-	if (parentPath) {
-		await ensureFolderExists(vault, parentPath, folderLabel, logger);
-	}
+	await ensureParentFolderExists(vault, outputPath, folderLabel, logger);
 
 	const fullContent = header + content;
 

--- a/src/services/image-generation.ts
+++ b/src/services/image-generation.ts
@@ -3,7 +3,7 @@ import { Notice, App, MarkdownView, Modal, Setting, TextAreaComponent, TFile, no
 import { BaseModelRequest, GeminiClient, ModelClientFactory } from '../api';
 import { GeminiPrompts } from '../prompts';
 import { getErrorMessage, getRawErrorMessageOr } from '../utils/error-utils';
-import { ensureFolderExists, isPathInFolder } from '../utils/file-utils';
+import { ensureParentFolderExists, isPathInFolder } from '../utils/file-utils';
 import { t } from '../i18n';
 
 export class ImageGeneration {
@@ -333,10 +333,7 @@ export class ImageGeneration {
 
 			// Ensure the parent folder exists before writing — createBinary will fail
 			// if any intermediate directory in the path is missing.
-			const parentPath = resolvedPath.includes('/') ? resolvedPath.slice(0, resolvedPath.lastIndexOf('/')) : null;
-			if (parentPath) {
-				await ensureFolderExists(this.plugin.app.vault, parentPath, 'image output folder', this.plugin.logger);
-			}
+			await ensureParentFolderExists(this.plugin.app.vault, resolvedPath, 'image output folder', this.plugin.logger);
 		} else {
 			resolvedPath = await this.resolveDefaultOutputPath(prompt);
 		}

--- a/src/services/obsidian-file-adapter.ts
+++ b/src/services/obsidian-file-adapter.ts
@@ -4,7 +4,7 @@ import type { FileSystemAdapter, FileInfo, FileContent } from '@allenhutchison/g
 // The MIME helpers are runtime values — import them from the built-in-free
 // `/mime` subpath so this module never pulls Node built-ins at load (#1154).
 import { getMimeTypeWithFallback, isExtensionSupportedWithFallback } from '@allenhutchison/gemini-utils/mime';
-import { isPathInFolder } from '../utils/file-utils';
+import { getFileName, isPathInFolder } from '../utils/file-utils';
 
 /**
  * Obsidian Vault adapter for the gemini-utils FileSystemAdapter interface.
@@ -199,7 +199,7 @@ export class ObsidianVaultAdapter implements FileSystemAdapter {
 		if (this.includeAttachments) {
 			// Extract extension safely - handle files without extensions or dotfiles
 			// Use the filename part only to avoid matching dots in folder paths
-			const filename = filePath.substring(filePath.lastIndexOf('/') + 1);
+			const filename = getFileName(filePath);
 			const dotIdx = filename.lastIndexOf('.');
 			if (dotIdx <= 0) {
 				// No extension (dotIdx === -1) or dotfile (dotIdx === 0) - not indexable

--- a/src/tools/deep-research-tool.ts
+++ b/src/tools/deep-research-tool.ts
@@ -4,7 +4,7 @@ import { ToolCategory } from '../types/agent';
 import { ToolClassification } from '../types/tool-policy';
 import { ResearchScope } from '../services/deep-research';
 import { formatLocalDate } from '../utils/format-utils';
-import { sanitizeFileName, ensureFolderExists } from '../utils/file-utils';
+import { sanitizeFileName, ensureParentFolderExists } from '../utils/file-utils';
 import { t } from '../i18n';
 import { getRawErrorMessageOr } from '../utils/error-utils';
 
@@ -125,10 +125,7 @@ export class DeepResearchTool implements Tool {
 					if (isCancelled()) return undefined;
 
 					// Ensure the parent folder exists before conductResearch tries to save there.
-					const folder = resolvedOutputFile.includes('/') ? resolvedOutputFile.split('/').slice(0, -1).join('/') : null;
-					if (folder) {
-						await ensureFolderExists(plugin.app.vault, folder, 'output directory', plugin.logger);
-					}
+					await ensureParentFolderExists(plugin.app.vault, resolvedOutputFile, 'output directory', plugin.logger);
 
 					// Poll for cancellation every 2 s and signal the API if the task is cancelled.
 					const cancelPoller = window.setInterval(() => {

--- a/src/tools/vault/move-file-tool.ts
+++ b/src/tools/vault/move-file-tool.ts
@@ -2,7 +2,7 @@ import { Tool, ToolResult, ToolExecutionContext } from '../types';
 import { ToolCategory } from '../../types/agent';
 import { ToolClassification } from '../../types/tool-policy';
 import { normalizePath } from 'obsidian';
-import { ensureFolderExists } from '../../utils/file-utils';
+import { ensureParentFolderExists } from '../../utils/file-utils';
 import { guardExcludedPath, resolvePathToFileOrFolder } from './utils';
 import { t } from '../../i18n';
 import { getRawErrorMessageOr } from '../../utils/error-utils';
@@ -100,10 +100,7 @@ export class MoveFileTool implements Tool {
 			}
 
 			// Ensure target directory exists (for files and folders)
-			const targetDir = targetNormalizedPath.substring(0, targetNormalizedPath.lastIndexOf('/'));
-			if (targetDir) {
-				await ensureFolderExists(plugin.app.vault, targetDir, 'target directory', plugin.logger);
-			}
+			await ensureParentFolderExists(plugin.app.vault, targetNormalizedPath, 'target directory', plugin.logger);
 
 			// Perform the rename/move (use fileManager to update internal links)
 			await plugin.app.fileManager.renameFile(sourceItem, targetNormalizedPath);

--- a/src/tools/vault/write-file-tool.ts
+++ b/src/tools/vault/write-file-tool.ts
@@ -3,7 +3,7 @@ import { ToolCategory } from '../../types/agent';
 import { ToolClassification } from '../../types/tool-policy';
 import { TFile, normalizePath } from 'obsidian';
 import { truncateForPreview } from '../../utils/format-utils';
-import { ensureFolderExists, shouldExcludePathForPlugin } from '../../utils/file-utils';
+import { ensureParentFolderExists, shouldExcludePathForPlugin } from '../../utils/file-utils';
 import { guardExcludedPath, safeReadFileForDiff } from './utils';
 import { t } from '../../i18n';
 import { getRawErrorMessageOr } from '../../utils/error-utils';
@@ -106,18 +106,8 @@ export class WriteFileTool implements Tool {
 				// File exists, modify it
 				await plugin.app.vault.modify(file, params.content);
 			} else {
-				// File doesn't exist, create it
-				// First ensure parent directory exists
-				const lastSlashIndex = normalizedPath.lastIndexOf('/');
-				if (lastSlashIndex > 0) {
-					const parentDir = normalizedPath.substring(0, lastSlashIndex);
-					const parentExists = await plugin.app.vault.adapter.exists(parentDir);
-					if (!parentExists) {
-						// Create parent directory (this will create all intermediate directories)
-						plugin.logger.debug(`Creating parent directory: ${parentDir}`);
-						await ensureFolderExists(plugin.app.vault, parentDir, 'parent directory', plugin.logger);
-					}
-				}
+				// File doesn't exist, create it — first ensure parent directory exists
+				await ensureParentFolderExists(plugin.app.vault, normalizedPath, 'parent directory', plugin.logger);
 
 				await plugin.app.vault.create(normalizedPath, params.content);
 				// Get the newly created file

--- a/src/utils/accessed-files.ts
+++ b/src/utils/accessed-files.ts
@@ -1,4 +1,5 @@
 import { ToolResult } from '../tools/types';
+import { getFileName } from './file-utils';
 
 /** Tools where result.data.path represents a targeted file access */
 const TRACKED_TOOLS = new Set([
@@ -62,7 +63,7 @@ export function extractAccessedPaths(toolResults: readonly ToolResultEntry[]): s
  * Non-md files keep their extension: images/photo.png → [[photo.png]]
  */
 export function pathToWikilink(path: string): string {
-	const filename = path.substring(path.lastIndexOf('/') + 1);
+	const filename = getFileName(path);
 	const basename = filename.endsWith('.md') ? filename.slice(0, -3) : filename;
 	return `[[${basename}]]`;
 }

--- a/src/utils/file-utils.ts
+++ b/src/utils/file-utils.ts
@@ -159,6 +159,45 @@ export async function ensureFolderExists(
 }
 
 /**
+ * Derive the parent folder of a file path, or `null` at the vault root.
+ *
+ * The null-at-root contract is the edge case every former inline copy of this
+ * operation re-decided (five sites, four spellings — see #1425); it lives here
+ * now. No trailing slash is produced, and a folder name containing a dot
+ * (`my.notes/README.md`) is not mistaken for an extension boundary.
+ */
+export function getParentPath(path: string): string | null {
+	const lastSlash = path.lastIndexOf('/');
+	return lastSlash > 0 ? path.substring(0, lastSlash) : null;
+}
+
+/**
+ * Derive the final path segment — the file name with no folder prefix.
+ * Returns the input unchanged when it contains no slash (already a root file).
+ */
+export function getFileName(path: string): string {
+	const lastSlash = path.lastIndexOf('/');
+	return lastSlash >= 0 ? path.substring(lastSlash + 1) : path;
+}
+
+/**
+ * Ensure the parent folder of `filePath` exists, creating it (and any
+ * intermediate folders) if needed. The shared operation every write path
+ * performs before its first write to a vault path; a no-op for root-level
+ * paths (`out.md`) where there is no parent to create.
+ */
+export async function ensureParentFolderExists(
+	vault: Vault,
+	filePath: string,
+	context?: string,
+	logger?: Logger
+): Promise<void> {
+	const parentPath = getParentPath(filePath);
+	if (!parentPath) return;
+	await ensureFolderExists(vault, parentPath, context, logger);
+}
+
+/**
  * Sanitize a string for use as a file name by removing or replacing
  * characters forbidden on most operating systems.
  */

--- a/test/services/headless-run-output.test.ts
+++ b/test/services/headless-run-output.test.ts
@@ -17,11 +17,13 @@ vi.mock('obsidian', () => ({
 
 // vi.mock factories are hoisted above the file body, so the spy must be created
 // in a hoisted scope (and mock-prefixed) for the factory to reference it safely.
-const { mockEnsureFolderExists } = vi.hoisted(() => ({
+const { mockEnsureFolderExists, mockEnsureParentFolderExists } = vi.hoisted(() => ({
 	mockEnsureFolderExists: vi.fn().mockResolvedValue(undefined),
+	mockEnsureParentFolderExists: vi.fn().mockResolvedValue(undefined),
 }));
 vi.mock('../../src/utils/file-utils', () => ({
 	ensureFolderExists: mockEnsureFolderExists,
+	ensureParentFolderExists: mockEnsureParentFolderExists,
 }));
 
 /** Build a minimal Vault stub with controllable existence + create behavior. */
@@ -35,6 +37,7 @@ function makeVault(opts?: { exists?: (path: string) => boolean; create?: Mock })
 
 beforeEach(() => {
 	mockEnsureFolderExists.mockClear();
+	mockEnsureParentFolderExists.mockClear();
 });
 
 describe('resolveOutputPath', () => {
@@ -136,7 +139,15 @@ describe('writeHeadlessOutput — no retry (scheduled-task shape)', () => {
 		});
 
 		expect(written).toBe('Runs/task/2026-04-18.md');
-		expect(mockEnsureFolderExists).toHaveBeenCalledWith(vault, 'Runs/task', 'scheduled task output folder', undefined);
+		// The write path hands the full file path to the shared helper; the
+		// parent derivation it performs internally is unit-tested in
+		// test/utils/file-utils.test.ts.
+		expect(mockEnsureParentFolderExists).toHaveBeenCalledWith(
+			vault,
+			'Runs/task/2026-04-18.md',
+			'scheduled task output folder',
+			undefined
+		);
 		expect(create).toHaveBeenCalledWith('Runs/task/2026-04-18.md', '---\nscheduled_task: "task"\n---\n\nBody text');
 	});
 
@@ -156,10 +167,13 @@ describe('writeHeadlessOutput — no retry (scheduled-task shape)', () => {
 		expect(create).toHaveBeenCalledWith('Runs/task/2026-04-18-1.md', 'H\nB');
 	});
 
-	it('skips folder creation for a top-level (folderless) path', async () => {
+	it('hands the path to ensureParentFolderExists even at the vault root', async () => {
 		const vault = makeVault({ exists: () => false });
 		await writeHeadlessOutput({ vault, outputPath: 'out.md', header: 'H\n', content: 'B', folderLabel: 'x' });
-		expect(mockEnsureFolderExists).not.toHaveBeenCalled();
+		// The root-level no-op lives inside the shared helper now (unit-tested
+		// in test/utils/file-utils.test.ts); what this test pins is that the
+		// write path always routes through it with the full file path.
+		expect(mockEnsureParentFolderExists).toHaveBeenCalledWith(vault, 'out.md', 'x', undefined);
 	});
 
 	it('propagates a non-"already exists" create error unchanged', async () => {

--- a/test/services/hook-runner.test.ts
+++ b/test/services/hook-runner.test.ts
@@ -24,6 +24,7 @@ vi.mock('obsidian', () => ({
 
 vi.mock('../../src/utils/file-utils', () => ({
 	ensureFolderExists: vi.fn().mockResolvedValue(undefined),
+	ensureParentFolderExists: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock('../../src/utils/format-utils', () => ({

--- a/test/services/image-generation.test.ts
+++ b/test/services/image-generation.test.ts
@@ -40,6 +40,7 @@ vi.mock('../../src/prompts', () => ({
 vi.mock('../../src/utils/file-utils', async (importOriginal) => ({
 	...(await importOriginal<typeof import('../../src/utils/file-utils')>()),
 	ensureFolderExists: vi.fn().mockResolvedValue(undefined),
+	ensureParentFolderExists: vi.fn().mockResolvedValue(undefined),
 }));
 
 import { Notice } from 'obsidian';
@@ -429,16 +430,16 @@ describe('ImageGeneration.saveImageToVault (private)', () => {
 		await expect(save(emptyBase64, 'test')).rejects.toThrow(/Invalid base64 image data.*Empty image data/);
 	});
 
-	it('calls validateOutputPath and ensureFolderExists when an explicit outputPath is provided', async () => {
-		const { ensureFolderExists } = await import('../../src/utils/file-utils');
+	it('calls validateOutputPath and ensureParentFolderExists when an explicit outputPath is provided', async () => {
+		const { ensureParentFolderExists } = await import('../../src/utils/file-utils');
 		const validBase64 = btoa('fake-png-data');
 
 		const result = await save(validBase64, 'test', 'images/subfolder/out.jpg');
 
 		expect(result).toBe('images/subfolder/out.png');
-		expect(ensureFolderExists).toHaveBeenCalledWith(
+		expect(ensureParentFolderExists).toHaveBeenCalledWith(
 			mockPlugin.app.vault,
-			'images/subfolder',
+			'images/subfolder/out.png',
 			'image output folder',
 			mockPlugin.logger
 		);
@@ -453,13 +454,21 @@ describe('ImageGeneration.saveImageToVault (private)', () => {
 		expect(createBinaryMock).toHaveBeenCalled();
 	});
 
-	it('does NOT call ensureFolderExists when file is in the vault root (no slash in path)', async () => {
-		const { ensureFolderExists } = await import('../../src/utils/file-utils');
+	it('routes a vault-root path through ensureParentFolderExists, which no-ops it', async () => {
+		const { ensureParentFolderExists } = await import('../../src/utils/file-utils');
 		const validBase64 = btoa('fake-png-data');
 
 		await save(validBase64, 'test', 'root-image.png');
 
-		expect(ensureFolderExists).not.toHaveBeenCalled();
+		// The root-level no-op decision lives inside the shared helper now
+		// (unit-tested in test/utils/file-utils.test.ts); the write path
+		// unconditionally delegates to it.
+		expect(ensureParentFolderExists).toHaveBeenCalledWith(
+			mockPlugin.app.vault,
+			'root-image.png',
+			'image output folder',
+			mockPlugin.logger
+		);
 		expect(createBinaryMock).toHaveBeenCalledWith('root-image.png', expect.any(ArrayBuffer));
 	});
 });

--- a/test/services/scheduled-task-manager.test.ts
+++ b/test/services/scheduled-task-manager.test.ts
@@ -67,6 +67,7 @@ vi.mock('obsidian', () => ({
 // ensureFolderExists is a no-op in tests
 vi.mock('../../src/utils/file-utils', () => ({
 	ensureFolderExists: vi.fn().mockResolvedValue(undefined),
+	ensureParentFolderExists: vi.fn().mockResolvedValue(undefined),
 }));
 
 // findFrontmatterEndOffset — return undefined (no frontmatter in test content)

--- a/test/services/scheduled-task-runner.test.ts
+++ b/test/services/scheduled-task-runner.test.ts
@@ -13,6 +13,7 @@ vi.mock('obsidian', () => ({
 
 vi.mock('../../src/utils/file-utils', () => ({
 	ensureFolderExists: vi.fn().mockResolvedValue(undefined),
+	ensureParentFolderExists: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock('../../src/utils/format-utils', () => ({

--- a/test/tools/deep-research-tool.test.ts
+++ b/test/tools/deep-research-tool.test.ts
@@ -25,6 +25,7 @@ const mockEnsureFolderExists = vi.fn().mockResolvedValue(undefined);
 vi.mock('../../src/utils/file-utils', async () => ({
 	...(await vi.importActual<any>('../../src/utils/file-utils')),
 	ensureFolderExists: (...args: any[]) => mockEnsureFolderExists(...args),
+	ensureParentFolderExists: vi.fn().mockResolvedValue(undefined),
 	sanitizeFileName: (name: string) =>
 		name
 			.replace(/[\\/:*?"<>|]/g, '-')

--- a/test/utils/file-utils.test.ts
+++ b/test/utils/file-utils.test.ts
@@ -4,6 +4,9 @@ import {
 	shouldExcludePathForPlugin,
 	createFileFilter,
 	ensureFolderExists,
+	ensureParentFolderExists,
+	getFileName,
+	getParentPath,
 	isPathInFolder,
 } from '../../src/utils/file-utils';
 import { TFile, TFolder, Vault, Notice, normalizePath } from 'obsidian';
@@ -301,6 +304,87 @@ describe('file-utils', () => {
 
 			// normalizePath mock just returns the input, but verifies it was called
 			expect(normalizePath).toHaveBeenCalledWith('normalized/path');
+		});
+	});
+
+	describe('getParentPath', () => {
+		it('returns the folder prefix for nested paths', () => {
+			expect(getParentPath('a/b/c.md')).toBe('a/b');
+			expect(getParentPath('folder/note.md')).toBe('folder');
+		});
+
+		it('returns null at the vault root', () => {
+			expect(getParentPath('out.md')).toBeNull();
+			expect(getParentPath('README')).toBeNull();
+		});
+
+		it('produces no trailing slash for a top-level folder', () => {
+			expect(getParentPath('folder/sub/file.md')).toBe('folder/sub');
+			expect(getParentPath('x/file.md')).toBe('x');
+		});
+
+		it('is not confused by a dot inside a folder name', () => {
+			expect(getParentPath('my.notes/README.md')).toBe('my.notes');
+			expect(getParentPath('v1.2/notes/a.md')).toBe('v1.2/notes');
+		});
+	});
+
+	describe('getFileName', () => {
+		it('returns the final path segment', () => {
+			expect(getFileName('folder/sub/note.md')).toBe('note.md');
+			expect(getFileName('a/b.png')).toBe('b.png');
+		});
+
+		it('returns the input unchanged for root-level paths', () => {
+			expect(getFileName('out.md')).toBe('out.md');
+			expect(getFileName('README')).toBe('README');
+		});
+
+		it('keeps dotfiles intact', () => {
+			expect(getFileName('folder/.obsidian.app.css')).toBe('.obsidian.app.css');
+		});
+	});
+
+	describe('ensureParentFolderExists', () => {
+		let mockVault: {
+			getAbstractFileByPath: Mock;
+			createFolder: Mock;
+			adapter: { exists: Mock };
+		};
+
+		beforeEach(() => {
+			mockVault = {
+				getAbstractFileByPath: vi.fn(),
+				createFolder: vi.fn(),
+				adapter: { exists: vi.fn().mockResolvedValue(false) },
+			};
+		});
+
+		it('is a no-op for a root-level path — no existence checks, no create', async () => {
+			await ensureParentFolderExists(mockVault as unknown as Vault, 'out.md');
+
+			expect(mockVault.getAbstractFileByPath).not.toHaveBeenCalled();
+			expect(mockVault.adapter.exists).not.toHaveBeenCalled();
+			expect(mockVault.createFolder).not.toHaveBeenCalled();
+		});
+
+		it('delegates to ensureFolderExists with the derived parent', async () => {
+			const folder = Object.assign(new TFolder(), { path: 'folder' });
+			mockVault.getAbstractFileByPath.mockReturnValue(folder);
+
+			await ensureParentFolderExists(mockVault as unknown as Vault, 'folder/out.md', 'parent directory');
+
+			expect(mockVault.getAbstractFileByPath).toHaveBeenCalledWith('folder');
+			expect(mockVault.createFolder).not.toHaveBeenCalled();
+		});
+
+		it('creates a missing nested parent and propagates context and errors', async () => {
+			mockVault.getAbstractFileByPath.mockReturnValue(null);
+			mockVault.createFolder.mockRejectedValue(new Error('Disk full'));
+
+			await expect(
+				ensureParentFolderExists(mockVault as unknown as Vault, 'a/b/out.md', 'image output folder')
+			).rejects.toThrow('Failed to create folder "a/b" (image output folder): Disk full');
 		});
 	});
 });


### PR DESCRIPTION
## Summary

Fixes #1425

"Ensure the parent folder exists before writing" was hand-rolled at five write paths in four spellings, each re-deciding the vault-root edge case inline, each followed by the same shared `ensureFolderExists` call. This gives the operation a single home in `file-utils.ts` and routes every site through it. Value-preserving: identical derived parents at all inputs, identical root-level no-op behavior, identical context labels in error messages.

## Changes

- `src/utils/file-utils.ts` — three new exports beside `ensureFolderExists`:
  - `getParentPath(path)` — parent folder or `null` at the vault root; no trailing slash; a dot in a folder name (`my.notes/README.md`) is not mistaken for an extension boundary.
  - `getFileName(path)` — final path segment, input unchanged for root-level paths.
  - `ensureParentFolderExists(vault, filePath, context?, logger?)` — the composed operation: derives the parent and delegates to `ensureFolderExists`; no-op at the vault root.
- Five write paths converted to `ensureParentFolderExists`, each keeping its context label: `write-file-tool.ts`, `move-file-tool.ts`, `image-generation.ts`, `headless-run-output.ts`, `deep-research-tool.ts`.
- `write-file-tool.ts` — the redundant `adapter.exists(parentDir)` pre-check is dropped; `ensureFolderExists` already performs that check with a metadata-cache fast path plus a create-race retry.
- Two basename sites converted to `getFileName`: `obsidian-file-adapter.ts` (extension extraction), `accessed-files.ts` (wikilink basename).
- `test/utils/file-utils.test.ts` — 12 new unit tests: both helpers at the vault root / subfolder / nested folder / dotted folder name, dotfile handling, and `ensureParentFolderExists` delegation (no-op at root with zero vault calls; parent derivation with label; error propagation through the shared context labeling).
- Test mock updates in five files (`headless-run-output`, `image-generation`, `hook-runner`, `scheduled-task-runner`, `scheduled-task-manager`, `deep-research-tool`) — these `vi.mock` the `file-utils` module with explicit export lists; the converted sources now import `ensureParentFolderExists`, so the mocks define it. Two tests that previously asserted the inline parent-derivation at call sites now assert the delegation boundary (full file path handed to the helper); the derivation itself is pinned by the new unit tests. One pre-existing test name was updated to describe what it now pins.

## Screenshots / Screencast

N/A — internal refactor, no user-facing behavior change.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [ ] I have tested this change on Desktop
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards)
- [x] Documentation has been updated (if applicable)
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

Notes on the unticked items:

- **Desktop testing**: not performed — pure refactor with no user-visible surface; the full suite (3851 tests) plus per-site behavior tests cover the converted paths.
- **Mobile**: the touched code paths contain no platform-specific API.
- **Documentation**: the helpers are internal utilities referenced nowhere in `docs/` (verified by grep); no user-facing behavior changed, so no doc updates apply.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file and folder creation across output, image-generation, research, and vault workflows.
  * Nested parent folders are now created reliably before writing or moving files.
  * Root-level files are handled correctly without attempting unnecessary folder creation.
  * Filename and path handling is more consistent, including dotfiles and generated links.

* **Tests**
  * Expanded coverage for nested paths, root-level files, existing folders, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->