### PR TITLE
fix(rag): retry the RAG search SDK call like every other call site

### DIFF
--- a/src/tools/rag-search-tool.ts
+++ b/src/tools/rag-search-tool.ts
@@ -2,6 +2,7 @@ import { Tool, ToolResult, ToolExecutionContext } from './types';
 import { ToolCategory } from '../types/agent';
 import { ToolClassification } from '../types/tool-policy';
 import { getRawErrorMessage } from '../utils/error-utils';
+import { executeWithRetry } from '../utils/retry';
 import { resolveGenerateContentModel } from '../models';
 
 /**
@@ -205,17 +206,26 @@ export class RagSearchTool implements Tool {
 			// Use the configured chat model for consistency; an interactions-only
 			// chat model falls back to the bundled default since File Search runs
 			// on generateContent.
-			const response = await ai.models.generateContent({
-				model: resolveGenerateContentModel(plugin.settings.chatModelName),
-				contents: `Search for information about: ${params.query}\n\nProvide a summary of the most relevant findings from the indexed documents. Include specific file references when available.`,
-				config: {
-					tools: [
-						{
-							fileSearch: fileSearchConfig,
+			//
+			// Wrapped in executeWithRetry like every other direct SDK call site
+			// (web-fetch, the grounding tools, the RAG vault scanner): a transient
+			// 429/5xx here otherwise fails the tool call outright.
+			const response = await executeWithRetry(
+				() =>
+					ai.models.generateContent({
+						model: resolveGenerateContentModel(plugin.settings.chatModelName),
+						contents: `Search for information about: ${params.query}\n\nProvide a summary of the most relevant findings from the indexed documents. Include specific file references when available.`,
+						config: {
+							tools: [
+								{
+									fileSearch: fileSearchConfig,
+								},
+							],
 						},
-					],
-				},
-			});
+					}),
+				undefined,
+				{ operationName: 'RagSearchTool.generateContent', logger: plugin.logger }
+			);
 
 			// Extract results from response
 			const results: RagSearchResult[] = [];

--- a/test/tools/rag-search-tool.test.ts
+++ b/test/tools/rag-search-tool.test.ts
@@ -1,5 +1,19 @@
 import { RagSearchTool, getRagTools } from '../../src/tools/rag-search-tool';
 import { ToolExecutionContext } from '../../src/tools/types';
+import { executeWithRetry } from '../../src/utils/retry';
+
+// Run the wrapped operation with near-zero backoff so the retry test stays fast
+// and deterministic, matching the convention in grounding-tool-runner.test.ts.
+vi.mock('../../src/utils/retry', async () => {
+	const actual = await vi.importActual<any>('../../src/utils/retry');
+	return {
+		...actual,
+		executeWithRetry: vi.fn().mockImplementation((operation, _config, options) => {
+			const fastConfig = { maxRetries: 2, initialDelayMs: 1, maxDelayMs: 1, jitter: false };
+			return actual.executeWithRetry(operation, fastConfig, options);
+		}),
+	};
+});
 
 describe('RagSearchTool', () => {
 	let tool: RagSearchTool;
@@ -310,6 +324,34 @@ describe('RagSearchTool', () => {
 					],
 				},
 			});
+		});
+
+		it('should route the search through executeWithRetry', async () => {
+			mockAi.models.generateContent.mockResolvedValue({
+				text: 'Search results',
+				candidates: [{ groundingMetadata: { groundingChunks: [] } }],
+			});
+
+			await tool.execute({ query: 'test' }, mockContext);
+
+			expect(executeWithRetry).toHaveBeenCalledWith(
+				expect.any(Function),
+				undefined,
+				expect.objectContaining({ operationName: 'RagSearchTool.generateContent' })
+			);
+		});
+
+		it('should retry a transient API failure and succeed', async () => {
+			const transient = Object.assign(new Error('Service Unavailable'), { status: 503 });
+			mockAi.models.generateContent.mockRejectedValueOnce(transient).mockResolvedValue({
+				text: 'Search results',
+				candidates: [{ groundingMetadata: { groundingChunks: [] } }],
+			});
+
+			const result = await tool.execute({ query: 'test' }, mockContext);
+
+			expect(mockAi.models.generateContent).toHaveBeenCalledTimes(2);
+			expect(result.success).toBe(true);
 		});
 
 		it('should execute search with folder filter', async () => {


### PR DESCRIPTION
## Summary

audit-architecture nightly sweep flagged: **repo-invariant drift** in `src/tools/rag-search-tool.ts`.

`RagSearchTool.execute` (the `vault_semantic_search` tool) called `ai.models.generateContent` directly with no retry wrapper. Every other direct SDK call site in the plugin goes through `executeWithRetry` — `web-fetch-tool.ts` (both the URL-context path and the fallback), `grounding-tool-runner.ts` (Google Search / Maps), `rag-vault-scanner.ts` (store create/delete), `context-manager.ts` (`countTokens`) — and the provider clients get the same resilience from `RetryDecorator`. #753 applied retry/backoff to the non-chat SDK call sites, but this one was missed, so a transient 429/5xx failed the tool call outright instead of backing off and retrying.

The fix wraps the existing call in `executeWithRetry` using the same argument shape the sibling call sites use (`undefined` config → `DEFAULT_RETRY_CONFIG`, plus `operationName` and `logger`). The request payload itself is unchanged, so a successful search behaves exactly as before.

Fixes nothing tracked — filed directly as a PR because the fix is mechanical and local.

## Changes

- `src/tools/rag-search-tool.ts` — wrap the `ai.models.generateContent` call in `executeWithRetry` with `operationName: 'RagSearchTool.generateContent'`; import `executeWithRetry` from `../utils/retry`.
- `test/tools/rag-search-tool.test.ts` — mock `../../src/utils/retry` with a near-zero backoff config (the convention already used in `grounding-tool-runner.test.ts`) so the retry path stays fast; add two tests: the call is routed through `executeWithRetry` with the expected `operationName`, and a transient 503 is retried and then succeeds.

## Screenshots / Screencast

N/A — no UI change. The only user-visible difference is that a transient API failure during semantic search now retries instead of surfacing an error.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: filed directly by the `audit-architecture` sweep as a mechanical fix; the routing rule sends sub-150-line, single-concern fixes to a PR rather than an issue.
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — run locally: `npm run format-check` clean, `npm run lint` 0 errors (40 pre-existing warnings in unrelated test files), `npm run build` clean, `npm run typecheck:test` clean, `npm test` 3905 passed / 176 files.
- [ ] I have tested this change on Desktop — not manually exercised against a live vault; covered by the unit tests above. Triggering the original failure needs a real transient API error.
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — no platform-specific API involved; `executeWithRetry` is already used on mobile-loaded paths.
- [ ] Documentation has been updated (if applicable) — N/A: internal resilience change, no user-facing behavior, setting, or feature surface to document.
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (`audit-architecture` skill)
- [x] I have reviewed and understand all AI-generated code in this PR

---

_Filed by the `audit-architecture` skill._

---
_Generated by [Claude Code](https://claude.ai/code/session_01RyH9hT6E5ZiXkCzCbbDJ5B)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved RAG search reliability by automatically retrying after temporary service failures.
  * Search requests now recover from transient API errors instead of failing immediately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->