### PR TITLE
chore(daily): 2026-08-30 daily update

### DIFF
--- a/planning/changelog/2026-08-30.md
+++ b/planning/changelog/2026-08-30.md
@@ -1,0 +1,57 @@
+# Daily changelog — August 30, 2026
+
+**Date:** 2026-08-30
+**PRs merged:** 11
+
+---
+
+## Summary
+
+A backlog-clearing evening: two queued daily-update housekeeping PRs (for August 28 and August 30)
+and two dependency bumps merged first, then a run of `audit-architecture` and `auto-dev` PRs closed
+out behind them — a real bug fix for the `ToolPolicyEditor` no-op (#1414), a DRY fix for session-file
+renaming that had drifted into two divergently-broken copies, a dead-type deletion, and three UI
+refactors/test-coverage additions.
+
+## What shipped
+
+### Housekeeping backlog
+
+- [#1426](https://github.com/allenhutchison/obsidian-gemini/pull/1426), [#1419](https://github.com/allenhutchison/obsidian-gemini/pull/1419) — the daily-update PRs for August 30 and August 28 merged after sitting queued for review; each carries only that day's own changelog/audit output.
+- [#1421](https://github.com/allenhutchison/obsidian-gemini/pull/1421) — `chore(deps)`: bump `openai` 7.5.0 → 7.6.0 in the production-dependencies group.
+- [#1422](https://github.com/allenhutchison/obsidian-gemini/pull/1422) — `chore(deps-dev)`: bump the dev-dependencies group with 7 updates.
+
+### [#1427 fix(ui): honor the documented setValue no-op in ToolPolicyEditor](https://github.com/allenhutchison/obsidian-gemini/pull/1427)
+
+Fixes #1414. `ToolPolicyEditor.setValue()` documented a structural-equality no-op it never implemented — every call reassigned state and called `render()`, rebuilding the inherit checkbox, preset dropdown, and every per-tool override dropdown, which would steal focus and close an open dropdown on a host-modal refresh. Adds `policiesEqual()` and an early return so the guard is real; no production caller reaches `setValue` yet, so no behavior changes for current users.
+
+### [#1423 fix(agent-view): share the session history rename between auto-label and manual title edit](https://github.com/allenhutchison/obsidian-gemini/pull/1423)
+
+The `audit-architecture` sweep flagged a DRY violation where two copies of "rename a session's history file to match its title" had drifted in opposite directions: the auto-label path had collision handling but no session-identity guard, and the manual title-edit path had the guard but no collision handling — the latter meant a rename collision silently reverted a user's title edit with no notice. Both now route through a shared `session-rename.ts` helper, and the auto-label flow is pinned to a session captured before its first `await` so switching sessions mid-flight can no longer apply a generated title to the wrong session.
+
+### [#1420 refactor(ui): extract populateTabs in RagStatusModal (#1293)](https://github.com/allenhutchison/obsidian-gemini/pull/1420)
+
+Entry 1 of 4 from #1293, taken as its own PR per the issue's instruction to pick off entries individually. `RagStatusModal` built its three-tab strip in two places — initial render and the refresh after a tab click — that could silently diverge; both now delegate to one private `populateTabs()`. The module gets its first test file in the same PR.
+
+### [#1418 refactor(ui): delete the legacy read-only ScheduledTasksModal (#1284)](https://github.com/allenhutchison/obsidian-gemini/pull/1418)
+
+Fixes #1284. Deleted `ScheduledTasksModal`, a read-only subset of `SchedulerManagementModal`'s list view whose own command registration comment called it "read-only legacy — kept for backwards compatibility." The `view-scheduled-tasks` command now opens the full manager on its list view, keeping the same command id so existing hotkey bindings survive. Also removes the 14 `scheduledTasks.*` i18n keys across all locale files and the modal's dedicated CSS.
+
+### [#1415 refactor(types): delete the dead ChatMessage / ToolExecution surface](https://github.com/allenhutchison/obsidian-gemini/pull/1415)
+
+`audit-architecture` flagged dead declarations in `src/types/agent.ts`: `ChatMessage` and a same-named `ToolExecution` interface had no reader or writer anywhere, kept alive only by an unreachable barrel re-export (#1356) — and the re-exported `ToolExecution` shadowed the differently-shaped interface the tool-execution engine actually uses, so a consumer of the "public" API would have gotten the wrong shape for that name. Also drops an inert `toolsUsed: []` argument that had no corresponding template placeholder.
+
+### [#1413 test(ui): cover the two permission-gating UI surfaces (#1262)](https://github.com/allenhutchison/obsidian-gemini/pull/1413)
+
+Slice 2 of the #1262 missing-tests umbrella: adds direct coverage for `tool-policy-editor.ts` and `yolo-confirmation-modal.ts`, the two remaining Priority-1 modules that had zero direct tests. Tests only, no source changes — though the rebase onto #1427 folded in that PR's equal-value no-op cases and restored one assertion the rebase had weakened.
+
+### [#1412 Share the vault binary attachment pipeline between drop and @-mention (#1363)](https://github.com/allenhutchison/obsidian-gemini/pull/1412)
+
+Fixes #1363. The vault-binary → `InlineAttachment` pipeline (`readBinary` → 20 MB budget check → rasterize-or-base64 → format sniff → build record) existed twice — inline in the drag-drop handler and again in the @-mention picker — and the two copies had drifted in failure-notice routing and size-seed formulas. Extracted into a shared `attachVaultBinaryFile()` helper that returns a discriminated result, so each caller keeps its own notice wording while the underlying logic can no longer diverge.
+
+## Other housekeeping
+
+The daily-update run's other two roster sub-skills touch GitHub directly rather than the working tree:
+
+- **audit-product-docs**: no documentation drift found; no new docs warranted.
+- **triage-issues**: no unlabeled open issues found. No-op.


### PR DESCRIPTION
## Summary

Automated daily-update run bundling the repo's per-day housekeeping skills for 2026-08-30.

## Changes

- **daily-changelog**: wrote `planning/changelog/2026-08-30.md` covering the day's 11 merged PRs — a backlog of two queued daily-update PRs (Aug 28, Aug 30) plus two dependency bumps merged first, then a run of `audit-architecture`/`auto-dev` PRs: a real bug fix for the `ToolPolicyEditor` `setValue` no-op (#1414), a DRY fix for session-history renaming that had drifted into two divergently-broken copies, a dead `ChatMessage`/`ToolExecution` type deletion, the legacy `ScheduledTasksModal` removal, a `RagStatusModal` tab-rendering extraction, new test coverage for two permission-gating UI modules, and a shared vault binary-attachment-pipeline helper.
- **audit-product-docs**: full audit of all `docs/guide/*.md`, `docs/reference/*.md`, `README.md`, and `AGENTS.md` against `src/` — settings/defaults, command IDs, tool names, frontmatter schemas, schedule-format parsing, hook trigger/action enums, MCP timeouts, loop-detection thresholds, file-classification limits, tool-policy resolution order, and the provider capability matrix. No drift found, no new docs warranted.
- **triage-issues**: no unlabeled open issues found — all 36 open issues already carry labels. No-op.

## Screenshots / Screencast

N/A — no UI changes; this PR is changelog-only.

## Checklist

### Required

- [x] I have read and agree to the Contributing Guidelines
- [x] I have read and agree to the AI Policy
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A, this is the recurring automated daily-update run, not tied to a single issue
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — also ran `npm run lint` (0 errors, 40 pre-existing warnings) and `npm run typecheck:test`; 176 files / 3903 tests passed
- [ ] I have tested this change on Desktop — N/A, docs/changelog-only change with no runtime code path
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A, no code changes
- [x] Documentation has been updated (if applicable) — N/A, this PR *is* the documentation/changelog update; the audit found no drift needing a fix

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude (scheduled maintainerd daily-update agent)
- [x] I have reviewed and understand all AI-generated code in this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01AwGGNH6cUxebQQnkggFZw3)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved handling of shared vault-binary attachments.
  * Session file renames are now handled consistently.
* **Bug Fixes**
  * Fixed unnecessary updates when tool policy settings remain unchanged.
  * Improved permission-gated interface behavior.
  * Removed the legacy scheduled-tasks interface.
* **Maintenance**
  * Streamlined chat and tool functionality.
  * Updated dependencies and completed routine housekeeping.
  * Added coverage for status display and permission behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->