### PR TITLE
docs(guidelines): encode the "wiring interfaces carry only what is read" rule

### DIFF
--- a/.claude/guidelines/coding.md
+++ b/.claude/guidelines/coding.md
@@ -64,6 +64,18 @@ module both import — never import the manager back. See `invariants.md` for th
 `ToolExecutionContext.plugin` is already typed `ObsidianGemini` — use `context.plugin` directly,
 no cast.
 
+## Wiring interfaces carry only what is read
+
+When you add a field to a context, callback, or capability interface (`SendContext`,
+`UICallbacks`, `AgentViewContext` — aliased `ToolsContext` at its `agent-view.ts` import,
+`ProviderCapabilities`, …), wire it to a consumer in the same change. Don't populate a field
+speculatively for a caller that doesn't exist yet: `npm run knip` resolves exported symbols, not
+per-field reachability through an object literal, and both the interface and the method the field
+targets are live — so a field can be born dead and stay dead indefinitely with every check green.
+The reverse holds too: when you remove the last reader of a field, remove the field and its
+population site in the same change, or the next reader-less block of code (a modal, a handler)
+becomes unreachable without anything flagging it.
+
 ## Platform guards
 
 Desktop-only APIs (Electron, MCP, Node.js) must be guarded with Obsidian's `Platform` checks

--- a/.claude/guidelines/coding.md
+++ b/.claude/guidelines/coding.md
@@ -73,8 +73,9 @@ speculatively for a caller that doesn't exist yet: `npm run knip` resolves expor
 per-field reachability through an object literal, and both the interface and the method the field
 targets are live — so a field can be born dead and stay dead indefinitely with every check green.
 The reverse holds too: when you remove the last reader of a field, remove the field and its
-population site in the same change, or the next reader-less block of code (a modal, a handler)
-becomes unreachable without anything flagging it.
+population site in the same change. Otherwise the field stays reader-less, and whatever it fed —
+a modal, a handler — can be left unreachable with every check still green (#1301's orphaned
+170-line modal).
 
 ## Platform guards
 


### PR DESCRIPTION
<!-- auto-dev -->
## Summary

Encodes the pattern `audit-architecture` has filed three times in 90 days (#1298, #1300, #1301): a field is declared on a context / callback / capability interface and populated at its single construction site, but no consumer ever reads it.

The reason this class of dead code persists is structural rather than incidental. `knip` resolves exported symbols, not per-field reachability through an object literal, and both the containing interface and the method a field targets are live — so an unread field is invisible to every check and survives indefinitely. That is precisely the class #1294 (making the knip check blocking) will **not** catch, which is why the issue argues for a rule rather than more configuration.

Adds one section to `.claude/guidelines/coding.md`, placed after **Plugin type surface — never import `main.ts`**, which already governs how components are wired. Docs-only: no code, CI, or `knip.json` changes.

Produced by the auto-dev pipeline from the plan approved on the issue.

Fixes #1303

## Changes

- `.claude/guidelines/coding.md` — new section **Wiring interfaces carry only what is read**, inserted between the plugin-type-surface and platform-guards sections. It states the rule, grounds the *why* in knip's resolution model (a field can be born dead and stay dead with every check green), and keeps the removal half explicit: when the last reader of a field goes, the field and its population site go with it — the half that produced #1301's unreachable 170-line modal.

Two notes on how the wording departs from the issue's draft:

- The issue's draft lists `ToolsContext` among the wiring interfaces. No interface by that name exists — it is a local import alias (`import { AgentViewTools, AgentViewContext as ToolsContext } from './agent-view-tools'`, `src/ui/agent-view/agent-view.ts:16`); the declaration is `AgentViewContext` (`src/ui/agent-view/agent-view-tools.ts:19`). The section names `AgentViewContext` and mentions the alias, so the interface names in the rule are greppable — which is most of what makes the rule checkable by a reviewer or a later audit.
- The plan raised whether to mirror a one-line version into `AGENTS.md` (what an ordinary agent session loads) as well as `coding.md` (what the review/audit skills load). The approval did not take that option, so this PR keeps it to `coding.md` as the issue specified.

Every symbol and path the new section cites was re-verified against this branch rather than trusted from the plan: `SendContext` (`agent-view-send.ts:28`), `UICallbacks` (`agent-view-ui.ts:24`), `AgentViewContext` (`agent-view-tools.ts:19`), `ProviderCapabilities` (`api/providers/registry.ts:46`), the `ToolsContext` alias (`agent-view.ts:16`), `ignoreExportsUsedInFile` (`knip.json:6`), and the `knip` script (`package.json:26`).

## Screenshots / Screencast

N/A — no UI surface; the change is a guideline document.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer — #1303, plan approved 2026-08-29
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — run locally before pushing: `format-check` clean (Prettier does cover this file; `.prettierignore` excludes only `*.hbs` and four JSON/dist paths, so this is a real gate rather than a no-op), `lint` 0 errors / 40 pre-existing warnings, `build` clean, `typecheck:test` clean, 3915 tests in 176 files passing
- [ ] I have tested this change on Desktop — N/A, no runnable surface: the change is prose in a guideline file that no code reads
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A, no code change
- [x] Documentation has been updated (if applicable) — this PR *is* the documentation change; no user-facing behavior changed, so no `docs/` or `README.md` update applies
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

Behavioral verification (auto-dev step 3, item 6) is genuinely N/A here rather than skipped: a guideline-prose change has no runnable surface to exercise. The substantive check for this change is that every symbol and path the new section cites resolves in the tree — a stale citation being the failure mode a rule document actually has — and each was verified on this branch, as listed above.

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (auto-dev pipeline)
- [x] I have reviewed and understand all AI-generated code in this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01QTcp5WcbFiYGqzrii983FR)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance to keep wiring interfaces limited to data actively consumed.
  * Clarified that unused context, callback, and capability fields should be removed along with their final consumers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->