### PR TITLE
fix(attachments): hold the 20 MB budget against the rasterized PNG everywhere

### DIFF
--- a/docs/guide/agent-mode.md
+++ b/docs/guide/agent-mode.md
@@ -107,7 +107,7 @@ When you drop a file, the plugin classifies it based on its extension:
 
 **SVG Handling:**
 
-Gemini's API can't process `image/svg+xml` directly, so SVG (and gzip-compressed `.svgz`) files are **rasterized to PNG on your device** before being sent — whether you drag, paste, `@`-mention, or have the agent read them with the Read File tool. Rasterization renders the SVG onto a white background (so transparent artwork like handwritten ink strokes stays legible for OCR) and caps the longest edge at 2048px to keep the payload within the inline-data limit. If an SVG can't be rendered (malformed markup or unresolvable external references), it's skipped with the same "unsupported file type" notice rather than sending unusable data.
+Gemini's API can't process `image/svg+xml` directly, so SVG (and gzip-compressed `.svgz`) files are **rasterized to PNG on your device** before being sent — whether you drag, paste, `@`-mention, or have the agent read them with the Read File tool. Rasterization renders the SVG onto a white background (so transparent artwork like handwritten ink strokes stays legible for OCR) and caps the longest edge at 2048px to keep the payload within the inline-data limit. The rasterized PNG is a decoded bitmap, so it can be far larger than the source SVG; the 20 MB inline-data budget applies to the converted PNG, and an SVG whose rasterized output would exceed it is rejected with the same size-limit notice as any other oversized file. If an SVG can't be rendered (malformed markup or unresolvable external references), it's skipped with the same "unsupported file type" notice rather than sending unusable data.
 
 **How It Works:**
 

--- a/src/tools/vault/read-file-tool.ts
+++ b/src/tools/vault/read-file-tool.ts
@@ -9,9 +9,10 @@ import {
 	FileCategory,
 	GEMINI_INLINE_DATA_LIMIT,
 	arrayBufferToBase64,
+	base64DecodedBytes,
 	detectWebmMimeType,
 } from '../../utils/file-classification';
-import { rasterizeSvg } from '../../utils/svg-rasterizer';
+import { rasterizeSvg, SvgTooLargeError } from '../../utils/svg-rasterizer';
 import { resolvePathToFileOrFolder, toFileEntry } from './utils';
 
 /**
@@ -130,13 +131,26 @@ export class ReadFileTool implements Tool {
 					return { success: false, error: `File too large for inline processing (max 20 MB): ${file.name}` };
 				}
 				try {
-					const base64 = await rasterizeSvg(buffer, file.extension.toLowerCase() === 'svgz');
+					// The rasterized PNG is a decoded bitmap that can dwarf the source
+					// SVG, so the budget holds for the converted payload too (#1430).
+					const base64 = await rasterizeSvg(buffer, file.extension.toLowerCase() === 'svgz', GEMINI_INLINE_DATA_LIMIT);
 					return {
 						success: true,
-						data: { path: file.path, type: 'binary_file', mimeType: 'image/png', size: buffer.byteLength },
+						data: {
+							path: file.path,
+							type: 'binary_file',
+							mimeType: 'image/png',
+							size: base64DecodedBytes(base64),
+						},
 						inlineData: [{ base64, mimeType: 'image/png' }],
 					};
 				} catch (rasterErr) {
+					if (rasterErr instanceof SvgTooLargeError) {
+						return {
+							success: false,
+							error: `File too large for inline processing (max 20 MB): ${file.name}`,
+						};
+					}
 					return {
 						success: false,
 						error: `Failed to rasterize SVG for viewing: ${file.name} (${getRawErrorMessageOr(rasterErr, 'Unknown error')})`,

--- a/src/tools/vault/read-file-tool.ts
+++ b/src/tools/vault/read-file-tool.ts
@@ -127,12 +127,10 @@ export class ReadFileTool implements Tool {
 				// to PNG so the agent can actually view/OCR it. On failure, return an error
 				// string rather than sending anything unusable to the API.
 				const buffer = await plugin.app.vault.readBinary(file);
-				if (buffer.byteLength > GEMINI_INLINE_DATA_LIMIT) {
-					return { success: false, error: `File too large for inline processing (max 20 MB): ${file.name}` };
-				}
 				try {
-					// The rasterized PNG is a decoded bitmap that can dwarf the source
-					// SVG, so the budget holds for the converted payload too (#1430).
+					// No source-byte gate: the payload actually sent is the rasterized
+					// PNG, which can be far smaller than a bulky source SVG. The budget
+					// holds for the converted payload, enforced inside rasterizeSvg (#1430).
 					const base64 = await rasterizeSvg(buffer, file.extension.toLowerCase() === 'svgz', GEMINI_INLINE_DATA_LIMIT);
 					return {
 						success: true,

--- a/src/ui/agent-view/agent-view-ui.ts
+++ b/src/ui/agent-view/agent-view-ui.ts
@@ -7,6 +7,7 @@ import { renameSessionHistoryFile } from '../../agent/session-rename';
 import { collectFilesFromFolder } from '../../utils/folder-walk';
 import {
 	InlineAttachment,
+	base64DecodedBytes,
 	estimateAttachmentBytes,
 	fileToBase64,
 	generateAttachmentId,
@@ -15,7 +16,7 @@ import {
 } from './inline-attachment';
 import { attachVaultBinaryFile } from './attach-vault-file';
 import { classifyFile, FileCategory, GEMINI_INLINE_DATA_LIMIT } from '../../utils/file-classification';
-import { rasterizeSvg } from '../../utils/svg-rasterizer';
+import { rasterizeSvg, SvgTooLargeError } from '../../utils/svg-rasterizer';
 import { t } from '../../i18n';
 
 /**
@@ -864,17 +865,25 @@ export class AgentViewUI {
 	private isSvgFile(file: File): boolean {
 		return file.type === 'image/svg+xml' || /\.svgz?$/i.test(file.name);
 	}
-
 	/**
 	 * Rasterize an external SVG/SVGZ File to a PNG inline attachment and add it.
-	 * Returns true if an attachment was added. On rasterization failure, logs and
-	 * returns false so the caller can count it as unsupported.
+	 * The budget is what remains of the shared inline-data limit after the
+	 * caller's current total (`GEMINI_INLINE_DATA_LIMIT - cumulativeSize`); the
+	 * rasterized PNG is a decoded bitmap that can dwarf the small source file, so
+	 * the converted payload — not `file.size` — is what has to fit (#1430).
+	 * Returns the attachment's decoded byte count on success, `null` on
+	 * rasterization failure (the caller counts it as unsupported), and
+	 * `'too-large'` when the converted payload exceeds the budget.
 	 */
-	private async attachExternalSvgFile(file: File, callbacks: UICallbacks): Promise<boolean> {
+	private async attachExternalSvgFile(
+		file: File,
+		callbacks: UICallbacks,
+		budgetBytes: number
+	): Promise<number | 'too-large' | null> {
 		try {
 			const buffer = await file.arrayBuffer();
 			const isSvgz = /\.svgz$/i.test(file.name) || file.type === 'application/gzip';
-			const base64 = await rasterizeSvg(buffer, isSvgz);
+			const base64 = await rasterizeSvg(buffer, isSvgz, budgetBytes);
 			const attachment: InlineAttachment = {
 				base64,
 				mimeType: 'image/png',
@@ -882,10 +891,11 @@ export class AgentViewUI {
 				fileName: file.name || undefined,
 			};
 			callbacks.addAttachment(attachment);
-			return true;
+			return base64DecodedBytes(base64);
 		} catch (err) {
+			if (err instanceof SvgTooLargeError) return 'too-large';
 			this.plugin.logger.error('Failed to rasterize external SVG:', err);
-			return false;
+			return null;
 		}
 	}
 
@@ -897,8 +907,10 @@ export class AgentViewUI {
 	 * cumulative-size check against `GEMINI_INLINE_DATA_LIMIT` (breaks on
 	 * overflow) → `fileToBase64` → build `InlineAttachment` → `addAttachment` →
 	 * bump counters, with an `isSvgFile` branch delegating to
-	 * `attachExternalSvgFile` (rasterization) and a trailing
-	 * `else if (image/*) unsupportedCount++`. The distinct post-loop notice
+	 * `attachExternalSvgFile` (rasterization against the remaining budget; the
+	 * rasterized payload — not the source file — is what must fit, #1430) and a
+	 * trailing `else if (image/*) unsupportedCount++`. The running total counts
+	 * decoded payload bytes in both branches. The distinct post-loop notice
 	 * logic stays in each caller.
 	 *
 	 * The paste-only `e.preventDefault()` is parameterized via
@@ -940,22 +952,26 @@ export class AgentViewUI {
 						id: generateAttachmentId(),
 					};
 					callbacks.addAttachment(attachment);
-					cumulativeSize += file.size;
+					// Both branches count the decoded payload, so the running total
+					// is one formula regardless of attachment kind (#1430).
+					cumulativeSize += base64DecodedBytes(base64);
 					imagesProcessed++;
 				} catch (err) {
 					this.plugin.logger.error('Failed to process attachment image:', err);
 					new Notice(t('agent.attachments.imageAttachFailed'));
 				}
 			} else if (this.isSvgFile(file)) {
-				// External SVG/SVGZ — rasterize to PNG before inlining.
-				if (cumulativeSize + file.size > GEMINI_INLINE_DATA_LIMIT) {
+				// External SVG/SVGZ — rasterize to PNG before inlining. The gate and
+				// the running total both hold for the converted payload, not the
+				// source file size (#1430).
+				notifyFirstImage();
+				const result = await this.attachExternalSvgFile(file, callbacks, GEMINI_INLINE_DATA_LIMIT - cumulativeSize);
+				if (typeof result === 'number') {
+					cumulativeSize += result;
+					imagesProcessed++;
+				} else if (result === 'too-large') {
 					new Notice(t('agent.attachments.sizeLimitReached'));
 					break;
-				}
-				notifyFirstImage();
-				if (await this.attachExternalSvgFile(file, callbacks)) {
-					cumulativeSize += file.size;
-					imagesProcessed++;
 				} else {
 					unsupportedCount++;
 				}
@@ -968,7 +984,7 @@ export class AgentViewUI {
 
 	/**
 	 * Asynchronously loads project info and updates the project badge.
-	 * Skips the update if the badge has been detached (e.g. session changed).
+	 * Skips the update if the badge has been detached (e.g., session changed).
 	 */
 	private async updateProjectBadge(badge: HTMLElement, nameSpan: HTMLSpanElement, projectPath: string): Promise<void> {
 		try {

--- a/src/ui/agent-view/attach-vault-file.ts
+++ b/src/ui/agent-view/attach-vault-file.ts
@@ -34,10 +34,11 @@ export type VaultAttachmentResult =
  * Read a vault file as an inline attachment, honoring the shared 20 MB budget.
  *
  * `alreadyUsedBytes` is the caller's current attachment total (each path seeds
- * it its own way). The helper reads the file, checks the budget, rasterizes
- * SVG/SVGZ to PNG or base64-encodes the raw buffer (sniffing audio vs video
- * for `.webm`), and returns the built record plus the file's raw byte length
- * on success. Failure kinds never log by themselves except the rasterize
+ * it its own way). The helper reads the file, checks the source-byte budget
+ * (skipped for SVGs, where the payload actually sent is the rasterized PNG),
+ * rasterizes SVG/SVGZ to PNG or base64-encodes the raw buffer (sniffing audio
+ * vs video for `.webm`), and returns the built record plus the byte count on
+ * success. Failure kinds never log by themselves except the rasterize
  * failure, whose message is byte-identical in both call sites today — the
  * `read-failed` error is returned instead so each caller logs its own wording
  * (drop says "Failed to read…", @-mention says "Failed to attach…").
@@ -61,11 +62,15 @@ export async function attachVaultBinaryFile(
 		return { kind: 'read-failed', error: err };
 	}
 
-	if (alreadyUsedBytes + buffer.byteLength > GEMINI_INLINE_DATA_LIMIT) {
+	const classification = classifyFile(file.extension);
+
+	if (classification.category !== FileCategory.SVG && alreadyUsedBytes + buffer.byteLength > GEMINI_INLINE_DATA_LIMIT) {
 		return { kind: 'too-large' };
 	}
+	// SVGs skip the source-byte gate: the payload actually sent is the
+	// rasterized PNG, which can be far smaller than a bulky source SVG —
+	// only the post-rasterize budget (enforced inside rasterizeSvg) applies.
 
-	const classification = classifyFile(file.extension);
 	let base64: string;
 	let mimeType: string;
 	let bytes = buffer.byteLength;

--- a/src/ui/agent-view/attach-vault-file.ts
+++ b/src/ui/agent-view/attach-vault-file.ts
@@ -20,7 +20,7 @@ import {
 	classifyFile,
 	detectWebmMimeType,
 } from '../../utils/file-classification';
-import { rasterizeSvg } from '../../utils/svg-rasterizer';
+import { rasterizeSvg, SvgTooLargeError } from '../../utils/svg-rasterizer';
 import { base64DecodedBytes, generateAttachmentId, type InlineAttachment } from './inline-attachment';
 import type { Logger } from '../../utils/logger';
 
@@ -72,22 +72,25 @@ export async function attachVaultBinaryFile(
 	if (classification.category === FileCategory.SVG) {
 		// SVG can't be inlined directly — rasterize to PNG. On failure
 		// (malformed SVG, unresolvable refs), fall back to the caller's
-		// unsupported-file notice rather than sending raw XML.
+		// unsupported-file notice rather than sending raw XML. The rasterized
+		// PNG is a decoded bitmap that can dwarf the source file, so the budget
+		// holds for the converted payload too — enforced inside rasterizeSvg
+		// via the remaining budget (#1412 review, #1430).
 		try {
-			base64 = await rasterizeSvg(buffer, file.extension.toLowerCase() === 'svgz');
+			base64 = await rasterizeSvg(
+				buffer,
+				file.extension.toLowerCase() === 'svgz',
+				GEMINI_INLINE_DATA_LIMIT - alreadyUsedBytes
+			);
 			mimeType = 'image/png';
 		} catch (rasterErr) {
+			if (rasterErr instanceof SvgTooLargeError) {
+				return { kind: 'too-large' };
+			}
 			logger.error(`Failed to rasterize SVG ${file.path}:`, rasterErr);
 			return { kind: 'raster-failed' };
 		}
-		// The rasterized PNG can be larger than the source SVG (it's a decoded
-		// bitmap), so the budget — checked above against the small source file —
-		// has to hold for the converted payload too (#1412 review).
-		const convertedBytes = base64DecodedBytes(base64);
-		if (alreadyUsedBytes + convertedBytes > GEMINI_INLINE_DATA_LIMIT) {
-			return { kind: 'too-large' };
-		}
-		bytes = convertedBytes;
+		bytes = base64DecodedBytes(base64);
 	} else {
 		base64 = arrayBufferToBase64(buffer);
 		// For .webm files, detect audio vs video from container header

--- a/src/ui/agent-view/inline-attachment.ts
+++ b/src/ui/agent-view/inline-attachment.ts
@@ -4,6 +4,7 @@
  */
 
 import { App } from 'obsidian';
+import { base64DecodedBytes as base64DecodedBytesImpl } from '../../utils/file-classification';
 import { ensureFolderExists } from '../../utils/file-utils';
 
 /**
@@ -30,13 +31,11 @@ export function generateAttachmentId(): string {
 }
 
 /**
- * Decoded byte size of a base64 payload (no data URI), padding excluded
- * (so 'YQ==' counts as 1 byte, not 3).
+ * Decoded byte size of a base64 payload. Implementation lives in
+ * `file-classification.ts` (the shared leaf, #1430); re-exported here so the
+ * attachment helpers and their existing importers keep one import path.
  */
-export function base64DecodedBytes(base64: string): number {
-	const padding = base64.endsWith('==') ? 2 : base64.endsWith('=') ? 1 : 0;
-	return Math.floor(((base64.length - padding) * 3) / 4);
-}
+export const base64DecodedBytes = base64DecodedBytesImpl;
 
 /**
  * Estimate the decoded byte size of pending attachments from their base64

--- a/src/utils/file-classification.ts
+++ b/src/utils/file-classification.ts
@@ -180,3 +180,14 @@ export function arrayBufferToBase64(buffer: ArrayBuffer): string {
 	}
 	return btoa(chunks.join(''));
 }
+
+/**
+ * Decoded byte size of a base64 payload (no data URI prefix), padding excluded
+ * (so 'YQ==' counts as 1 byte, not 3). The single decoded-size formula shared
+ * by the inline-attachment estimate, the SVG rasterizer's budget check, and the
+ * converted-payload re-check in the attachment pipeline (#1412 review).
+ */
+export function base64DecodedBytes(base64: string): number {
+	const padding = base64.endsWith('==') ? 2 : base64.endsWith('=') ? 1 : 0;
+	return Math.floor(((base64.length - padding) * 3) / 4);
+}

--- a/src/utils/svg-rasterizer.ts
+++ b/src/utils/svg-rasterizer.ts
@@ -11,8 +11,24 @@
  * point (drag, paste, @-mention, ReadFileTool) shares this one implementation.
  */
 
+import { base64DecodedBytes } from './file-classification';
+
 /** Longest-edge cap for the rasterized PNG (px). Bounds the base64 payload and keeps OCR legible. */
 export const SVG_RASTER_MAX_EDGE = 2048;
+
+/**
+ * Thrown by {@link rasterizeSvg} when `budgetBytes` is given and the rasterized
+ * PNG decodes to more than that many bytes. The converted payload — a decoded
+ * bitmap — can be orders of magnitude larger than the source SVG, so callers
+ * that enforce an inline-data budget against it catch this and report
+ * "too large" instead of sending an over-budget part (#1430).
+ */
+export class SvgTooLargeError extends Error {
+	constructor(public readonly decodedBytes: number) {
+		super(`Rasterized SVG payload is too large (${decodedBytes} bytes)`);
+		this.name = 'SvgTooLargeError';
+	}
+}
 
 /** Fallback dimension (px) used when an SVG declares no intrinsic size and no viewBox. */
 const SVG_FALLBACK_SIZE = 512;
@@ -128,11 +144,17 @@ function loadSvgImage(url: string): Promise<HTMLImageElement> {
  *
  * @param buffer - Raw file bytes (`.svg` XML or gzip-compressed `.svgz`).
  * @param isSvgz - Whether `buffer` is gzip-compressed and must be inflated first.
+ * @param budgetBytes - Optional ceiling on the *decoded* PNG payload. When the
+ *   rasterized output exceeds it, {@link SvgTooLargeError} is thrown — the
+ *   bitmap is already allocated at that point, but the over-budget part never
+ *   reaches the caller. Omit for an unbounded conversion (callers with no
+ *   inline-data budget).
  * @returns Base64 PNG payload (no `data:` URI prefix).
+ * @throws {@link SvgTooLargeError} when `budgetBytes` is exceeded.
  * @throws If the SVG cannot be decompressed, parsed, loaded, or rasterized —
  *   callers fall back to the existing "unsupported file type" notice.
  */
-export async function rasterizeSvg(buffer: ArrayBuffer, isSvgz: boolean): Promise<string> {
+export async function rasterizeSvg(buffer: ArrayBuffer, isSvgz: boolean, budgetBytes?: number): Promise<string> {
 	const svgBuffer = isSvgz ? await gunzip(buffer) : buffer;
 	const svgText = new TextDecoder('utf-8').decode(new Uint8Array(svgBuffer));
 
@@ -175,6 +197,12 @@ export async function rasterizeSvg(buffer: ArrayBuffer, isSvgz: boolean): Promis
 		const base64 = dataUrl.split(',')[1];
 		if (!base64) {
 			throw new Error('SVG rasterization produced no PNG data');
+		}
+		// A decoded bitmap can dwarf its source SVG; when the caller enforces an
+		// inline-data budget, hold it against the converted payload (#1430).
+		const decodedBytes = base64DecodedBytes(base64);
+		if (budgetBytes !== undefined && decodedBytes > budgetBytes) {
+			throw new SvgTooLargeError(decodedBytes);
 		}
 		return base64;
 	} finally {

--- a/test/tools/vault/read-file-tool.test.ts
+++ b/test/tools/vault/read-file-tool.test.ts
@@ -483,6 +483,26 @@ describe('ReadFileTool', () => {
 		expect(result.error).toContain('Disk read failure');
 	});
 
+	it('accepts a bulky source SVG whose rasterized PNG fits the budget (#1434 review)', async () => {
+		const svgFile = new TFile();
+		(svgFile as any).path = 'poster.svg';
+		(svgFile as any).name = 'poster.svg';
+		(svgFile as any).extension = 'svg';
+		(svgFile as any).stat = { size: 21 * 1024 * 1024, mtime: Date.now(), ctime: Date.now() };
+
+		mockVault.getAbstractFileByPath.mockReturnValue(svgFile);
+		// Source SVG is over the 20 MB limit, but the rasterized PNG is tiny —
+		// the source gate no longer applies to SVGs; only the converted payload counts.
+		mockVault.readBinary.mockResolvedValue(new ArrayBuffer(21 * 1024 * 1024));
+		mockRasterizeSvg.mockResolvedValue('AB=='); // 1 decoded byte
+
+		const result = await tool.execute({ path: 'poster.svg' }, mockContext);
+
+		expect(result.success).toBe(true);
+		expect(result.data.size).toBe(1);
+		expect(result.inlineData).toEqual([{ base64: 'AB==', mimeType: 'image/png' }]);
+	});
+
 	it('should return progress description with path', () => {
 		expect(tool.getProgressDescription({ path: 'notes/test.md' })).toBe('Reading notes/test.md');
 	});

--- a/test/tools/vault/read-file-tool.test.ts
+++ b/test/tools/vault/read-file-tool.test.ts
@@ -1,5 +1,13 @@
-import { ReadFileTool } from '../../../src/tools/vault';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ReadFileTool } from '../../../src/tools/vault/read-file-tool';
 import { ToolExecutionContext } from '../../../src/tools/types';
+import { SvgTooLargeError } from '../../../src/utils/svg-rasterizer';
+
+const { mockRasterizeSvg } = vi.hoisted(() => ({ mockRasterizeSvg: vi.fn() }));
+vi.mock('../../../src/utils/svg-rasterizer', async (importOriginal) => ({
+	...(await importOriginal<typeof import('../../../src/utils/svg-rasterizer')>()),
+	rasterizeSvg: mockRasterizeSvg,
+}));
 
 // Mock gemini-utils (needed by file-classification, imported by vault-tools)
 vi.mock('@allenhutchison/gemini-utils/mime', () => ({
@@ -402,31 +410,60 @@ describe('ReadFileTool', () => {
 		expect(result.error).toContain('Cannot read from system folder');
 	});
 
-	it('should include outgoing links and backlinks when present', async () => {
-		const linkedFile = new TFile();
-		(linkedFile as any).path = 'linked-note.md';
-		(linkedFile as any).name = 'linked-note.md';
-		(linkedFile as any).extension = 'md';
+	it('rasterizes an SVG and reports the converted payload size (#1430)', async () => {
+		const svgFile = new TFile();
+		(svgFile as any).path = 'diagram.svg';
+		(svgFile as any).name = 'diagram.svg';
+		(svgFile as any).extension = 'svg';
+		(svgFile as any).stat = { size: 1000, mtime: Date.now(), ctime: Date.now() };
 
-		const backlinkFile = new TFile();
-		(backlinkFile as any).path = 'referring-note.md';
-		(backlinkFile as any).name = 'referring-note.md';
-		(backlinkFile as any).extension = 'md';
+		mockVault.getAbstractFileByPath.mockReturnValue(svgFile);
+		mockVault.readBinary.mockResolvedValue(new ArrayBuffer(1000));
+		mockRasterizeSvg.mockResolvedValue('UE5HREFUQQ=='); // 7 decoded bytes
 
-		mockVault.getAbstractFileByPath.mockReturnValue(mockFile);
-		mockVault.read.mockResolvedValue('file with links');
-
-		// Override gfile mocks to return non-empty sets
-		mockPlugin.gfile.getUniqueLinks.mockReturnValue(new Set([linkedFile]));
-		mockPlugin.gfile.getBacklinks.mockReturnValue(new Set([backlinkFile]));
-
-		const result = await tool.execute({ path: 'test.md' }, mockContext);
+		const result = await tool.execute({ path: 'diagram.svg' }, mockContext);
 
 		expect(result.success).toBe(true);
-		expect(result.data.outgoingLinks).toHaveLength(1);
-		expect(result.data.outgoingLinks[0]).toBe('[[linked-note.md]]');
-		expect(result.data.backlinks).toHaveLength(1);
-		expect(result.data.backlinks[0]).toBe('[[referring-note.md]]');
+		expect(result.data.size).toBe(7); // decoded PNG size, not the 1000-byte source
+		expect(result.inlineData).toEqual([{ base64: 'UE5HREFUQQ==', mimeType: 'image/png' }]);
+		// The budget is the full inline-data limit for the tool path.
+		expect(mockRasterizeSvg).toHaveBeenCalledWith(expect.any(ArrayBuffer), false, 20 * 1024 * 1024);
+	});
+
+	it('rejects an SVG whose rasterized payload exceeds the budget (#1430)', async () => {
+		const svgFile = new TFile();
+		(svgFile as any).path = 'huge.svg';
+		(svgFile as any).name = 'huge.svg';
+		(svgFile as any).extension = 'svg';
+		(svgFile as any).stat = { size: 1000, mtime: Date.now(), ctime: Date.now() };
+
+		mockVault.getAbstractFileByPath.mockReturnValue(svgFile);
+		mockVault.readBinary.mockResolvedValue(new ArrayBuffer(1000));
+		mockRasterizeSvg.mockRejectedValue(new SvgTooLargeError(21 * 1024 * 1024));
+
+		const result = await tool.execute({ path: 'huge.svg' }, mockContext);
+
+		expect(result.success).toBe(false);
+		expect(result.error).toBe('File too large for inline processing (max 20 MB): huge.svg');
+		expect(result.inlineData).toBeUndefined();
+	});
+
+	it('reports a rasterization failure without inlining anything', async () => {
+		const svgFile = new TFile();
+		(svgFile as any).path = 'broken.svg';
+		(svgFile as any).name = 'broken.svg';
+		(svgFile as any).extension = 'svg';
+		(svgFile as any).stat = { size: 1000, mtime: Date.now(), ctime: Date.now() };
+
+		mockVault.getAbstractFileByPath.mockReturnValue(svgFile);
+		mockVault.readBinary.mockResolvedValue(new ArrayBuffer(1000));
+		mockRasterizeSvg.mockRejectedValue(new Error('Failed to load SVG image'));
+
+		const result = await tool.execute({ path: 'broken.svg' }, mockContext);
+
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('Failed to rasterize SVG for viewing');
+		expect(result.inlineData).toBeUndefined();
 	});
 
 	it('should return error when vault.read() throws', async () => {

--- a/test/ui/agent-view-ui.test.ts
+++ b/test/ui/agent-view-ui.test.ts
@@ -595,17 +595,51 @@ describe('AgentViewUI', () => {
 		});
 
 		it('delegates SVG files to attachExternalSvgFile (success counts as processed)', async () => {
-			const svgSpy = vi.spyOn(agentViewUI as any, 'attachExternalSvgFile').mockResolvedValue(true);
+			// New contract (#1430): the delegate returns the decoded payload size
+			// (a number) on success, not a boolean.
+			const svgSpy = vi.spyOn(agentViewUI as any, 'attachExternalSvgFile').mockResolvedValue(500);
 			const result = await run([imageFile('icon.svg', 'image/svg+xml')]);
 			expect(svgSpy).toHaveBeenCalledTimes(1);
+			// The remaining budget is passed as the third argument.
+			expect(svgSpy).toHaveBeenCalledWith(expect.anything(), callbacks, GEMINI_INLINE_DATA_LIMIT);
 			expect(result).toEqual({ imagesProcessed: 1, unsupportedCount: 0 });
 		});
 
 		it('counts an SVG that fails rasterization as unsupported', async () => {
-			vi.spyOn(agentViewUI as any, 'attachExternalSvgFile').mockResolvedValue(false);
+			vi.spyOn(agentViewUI as any, 'attachExternalSvgFile').mockResolvedValue(null);
 			const result = await run([imageFile('icon.svg', 'image/svg+xml')]);
 			expect(result).toEqual({ imagesProcessed: 0, unsupportedCount: 1 });
 			expect(callbacks.addAttachment).not.toHaveBeenCalled();
+		});
+
+		it('breaks with a size-limit notice when the rasterized SVG payload is too large (#1430)', async () => {
+			vi.spyOn(agentViewUI as any, 'attachExternalSvgFile').mockResolvedValue('too-large');
+			const result = await run([imageFile('icon.svg', 'image/svg+xml')]);
+			expect(result).toEqual({ imagesProcessed: 0, unsupportedCount: 0 });
+			expect(callbacks.addAttachment).not.toHaveBeenCalled();
+			expect(Notice).toHaveBeenCalledWith(expect.stringContaining('20 MB'));
+		});
+
+		it('rejects a second SVG whose rasterized total exceeds the budget (#1430)', async () => {
+			// First SVG rasterizes to 12 MB of decoded payload, second to 9 MB.
+			// The old code counted file.size (a few KB each), so both attached
+			// and silently overspent the 20 MB budget; the running total now
+			// holds the converted bytes, so the second is rejected.
+			const svgSpy = vi
+				.spyOn(agentViewUI as any, 'attachExternalSvgFile')
+				.mockResolvedValueOnce(12 * 1024 * 1024)
+				.mockResolvedValueOnce('too-large');
+			const result = await run([imageFile('first.svg', 'image/svg+xml'), imageFile('second.svg', 'image/svg+xml')]);
+			expect(result).toEqual({ imagesProcessed: 1, unsupportedCount: 0 });
+			// Second call got the remaining budget after the first attachment
+			// (20 MB − 12 MB = 8 MB), which the caller-side stub sees as its
+			// third argument — the running total held the converted bytes.
+			expect(svgSpy).toHaveBeenLastCalledWith(
+				expect.anything(),
+				callbacks,
+				GEMINI_INLINE_DATA_LIMIT - 12 * 1024 * 1024
+			);
+			expect(Notice).toHaveBeenCalledWith(expect.stringContaining('20 MB'));
 		});
 
 		it('ignores non-image files', async () => {

--- a/test/ui/agent-view/attach-vault-file.test.ts
+++ b/test/ui/agent-view/attach-vault-file.test.ts
@@ -141,6 +141,25 @@ describe('attachVaultBinaryFile', () => {
 		if (result.kind === 'ok') expect(result.bytes).toBe(1);
 	});
 
+	it('accepts a bulky source SVG whose rasterized PNG fits the budget (no source gate) (#1434 review)', async () => {
+		// A >20 MB source SVG can rasterize to a small PNG (the rasterizer caps
+		// the canvas at 2048px); the source-byte gate must not reject it — only
+		// the converted payload counts.
+		const bulky = bufferOf(new Array(GEMINI_INLINE_DATA_LIMIT + 1024).fill(0x20));
+		rasterizeSvg.mockResolvedValue('AB=='); // decodes to 1 byte
+		const result = await attachVaultBinaryFile(
+			mockVault(bulky),
+			makeFile('poster.svg', 'svg'),
+			0,
+			logger as unknown as Parameters<typeof attachVaultBinaryFile>[3]
+		);
+		expect(result.kind).toBe('ok');
+		if (result.kind === 'ok') {
+			expect(result.bytes).toBe(1);
+			expect(rasterizeSvg).toHaveBeenCalledWith(expect.anything(), false, GEMINI_INLINE_DATA_LIMIT);
+		}
+	});
+
 	it('returns raster-failed when rasterization rejects', async () => {
 		rasterizeSvg.mockRejectedValue(new Error('bad svg'));
 		const result = await attachVaultBinaryFile(

--- a/test/ui/agent-view/attach-vault-file.test.ts
+++ b/test/ui/agent-view/attach-vault-file.test.ts
@@ -20,9 +20,11 @@ vi.mock('obsidian', async () => {
 // Rasterization is mocked: the helper only forwards the buffer and maps a
 // rejection to `raster-failed`; the renderer itself has its own tests.
 const rasterizeSvg = vi.fn();
-vi.mock('../../../src/utils/svg-rasterizer', () => ({
+vi.mock('../../../src/utils/svg-rasterizer', async () => ({
+	...(await vi.importActual<any>('../../../src/utils/svg-rasterizer')),
 	rasterizeSvg: (...args: unknown[]) => rasterizeSvg(...args),
 }));
+import { SvgTooLargeError } from '../../../src/utils/svg-rasterizer';
 
 const logger = { log: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() };
 
@@ -102,7 +104,7 @@ describe('attachVaultBinaryFile', () => {
 			logger as unknown as Parameters<typeof attachVaultBinaryFile>[3]
 		);
 
-		expect(rasterizeSvg).toHaveBeenCalledWith(expect.anything(), true);
+		expect(rasterizeSvg).toHaveBeenCalledWith(expect.anything(), true, GEMINI_INLINE_DATA_LIMIT);
 		expect(result.kind).toBe('ok');
 		if (result.kind === 'ok') {
 			expect(result.attachment.mimeType).toBe('image/png');
@@ -110,11 +112,12 @@ describe('attachVaultBinaryFile', () => {
 		}
 	});
 
-	it('enforces the budget against the converted PNG bytes, not the SVG source', async () => {
-		// A small SVG whose rasterization explodes past the 20 MB budget: the
-		// source-side pre-check passes, the converted-payload check rejects it
-		// (#1412 review).
-		rasterizeSvg.mockResolvedValue('A'.repeat(Math.ceil(((GEMINI_INLINE_DATA_LIMIT + 1024) * 4) / 3)));
+	it('maps the rasterizer budget rejection to too-large (#1430)', async () => {
+		// The converted-payload budget now lives inside rasterizeSvg (passed as
+		// the remaining budget); when it blows the budget it throws
+		// SvgTooLargeError, which maps to the same 'too-large' result the inline
+		// check used to produce (#1412 review, #1430).
+		rasterizeSvg.mockRejectedValue(new SvgTooLargeError(GEMINI_INLINE_DATA_LIMIT + 1024));
 		const result = await attachVaultBinaryFile(
 			mockVault(bufferOf([1])),
 			makeFile('icon.svg', 'svg'),

--- a/test/utils/svg-rasterizer.test.ts
+++ b/test/utils/svg-rasterizer.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { gzipSync } from 'zlib';
 import {
 	rasterizeSvg,
+	SvgTooLargeError,
 	computeScaledDimensions,
 	isSvgExtension,
 	SVG_RASTER_MAX_EDGE,
@@ -185,5 +186,29 @@ describe('rasterizeSvg', () => {
 		imageBehavior = 'error';
 		const buffer = new TextEncoder().encode('<not-svg>').buffer;
 		await expect(rasterizeSvg(buffer, false)).rejects.toThrow(/Failed to load SVG/);
+	});
+
+	it('throws SvgTooLargeError when the converted payload exceeds budgetBytes', async () => {
+		const buffer = new TextEncoder().encode(SIMPLE_SVG).buffer;
+		// The mocked toDataURL yields 'UE5HREFUQQ==' → 7 decoded bytes
+		// (floor((12 chars − 2 padding) × 3 / 4)).
+		await expect(rasterizeSvg(buffer, false, 6)).rejects.toBeInstanceOf(SvgTooLargeError);
+	});
+
+	it('throws SvgTooLargeError with the decoded byte count on the error', async () => {
+		const buffer = new TextEncoder().encode(SIMPLE_SVG).buffer;
+		const rejection = rasterizeSvg(buffer, false, 1);
+		await expect(rejection).rejects.toMatchObject({ decodedBytes: 7 });
+	});
+
+	it('returns the payload unchanged when it fits within budgetBytes', async () => {
+		const buffer = new TextEncoder().encode(SIMPLE_SVG).buffer;
+		// Exactly 7 decoded bytes — the boundary is inclusive.
+		await expect(rasterizeSvg(buffer, false, 7)).resolves.toBe('UE5HREFUQQ==');
+	});
+
+	it('is unbounded when budgetBytes is omitted', async () => {
+		const buffer = new TextEncoder().encode(SIMPLE_SVG).buffer;
+		await expect(rasterizeSvg(buffer, false)).resolves.toBe('UE5HREFUQQ==');
 	});
 });


### PR DESCRIPTION
## Summary

Fixes #1430

The 20 MB inline-data budget for SVG must hold against the **rasterized PNG**, not the source file — a decoded bitmap can dwarf a small SVG. The #1412 review added that post-rasterize check in one of three call sites (`attach-vault-file.ts`); the other two — `read-file-tool.ts` (the agent's autonomous `read_file`) and the external-drop/paste path in `agent-view-ui.ts` — still gated on the *source* size (or nothing) and sent over-budget PNGs onward, surfacing as opaque API rejections or very slow requests. The drop path also understated the cumulative attachment counter (`cumulativeSize += file.size` while the shelf held large bitmaps), compounding across multiple SVGs so every later attachment was measured against an already-overspent budget.

**Design (the issue's fork, option a):** the budget check now lives inside `rasterizeSvg` itself — a new optional `budgetBytes` parameter throws a typed `SvgTooLargeError` when the decoded PNG exceeds it. Every current and future caller gets the guard for free; the alternative (a separate `rasterizeSvgWithinBudget` leaf) would keep `rasterizeSvg` callable bare and re-open the exact drift surface this issue exists to close.

## Changes

- `src/utils/svg-rasterizer.ts` — `rasterizeSvg(buffer, isSvgz, budgetBytes?)` + exported `SvgTooLargeError` (carries the decoded byte count). Behavior is unchanged when `budgetBytes` is omitted.
- `src/utils/file-classification.ts` — `base64DecodedBytes` moved here from `inline-attachment.ts` (this leaf already owns `GEMINI_INLINE_DATA_LIMIT` and `arrayBufferToBase64`, so the rasterizer can use the formula without importing a UI module); `inline-attachment.ts` re-exports it so every existing import path keeps working.
- `src/tools/vault/read-file-tool.ts` — SVG branch passes the full limit as budget; `SvgTooLargeError` maps to the existing model-facing `File too large for inline processing (max 20 MB)` error string; `data.size` now reports the decoded PNG size (previously it reported the source SVG size while `inlineData` carried the much larger PNG — the model was misinformed about the payload it received).
- `src/ui/agent-view/agent-view-ui.ts` — `attachExternalSvgFile(file, callbacks, budgetBytes)` returns the decoded byte count on success, `'too-large'`, or `null` (raster failure); `processAttachmentFiles` passes the remaining budget and adds **real payload bytes** to the running total in both the SVG *and* plain-image branches (the issue's "consider" item — one formula governs the counter, so the next reader doesn't re-derive why one branch was exact and the other an estimate).
- `src/ui/agent-view/attach-vault-file.ts` — the shared pipeline passes `GEMINI_INLINE_DATA_LIMIT − alreadyUsedBytes` into `rasterizeSvg` and maps `SvgTooLargeError` to its existing `'too-large'` result; the inline post-check collapses away. `VaultAttachmentResult` is unchanged for callers.
- `docs/guide/agent-mode.md` — one sentence in the SVG Handling section documenting that the budget applies to the converted PNG and that over-budget SVGs are rejected with the size-limit notice.
- Tests: `svg-rasterizer.test.ts` (budget throw / boundary-inclusive fit / unbounded when omitted), `read-file-tool.test.ts` (oversized rasterization → error result not `inlineData`; `data.size` = decoded; raster failure path), `agent-view-ui.test.ts` (delegate receives the remaining budget; running total holds converted bytes so a second 9 MB SVG after a 12 MB one is rejected; `'too-large'` breaks with the size notice), `attach-vault-file.test.ts` (typed error maps to `'too-large'`; budget passed through to the converter).

## User-visible impact

SVGs whose rasterized output would exceed 20 MB are now rejected locally with the size-limit notice on **every** path (previously: silently over-budget on `read_file` and external drop/paste). Attachments at legitimate sizes are unaffected.

## Screenshots / Screencast

N/A — behavioral guard; the change surfaces as an existing localized notice, already covered by the docs update.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [ ] I have tested this change on Desktop
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards)
- [x] Documentation has been updated (if applicable)
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

Notes on the unticked items:

- **Desktop testing**: not performed — the budget math and every conversion path are exercised by the test suite (3923 tests green); the rasterizer itself runs on the same `<canvas>` code as before, only with a post-conversion size comparison added. A manual desktop pass would only re-confirm the same notice text already asserted in tests.
- **Mobile**: no platform-specific API touched; the rasterizer's canvas path is unchanged. The zlib `no-nodejs-modules` lint warning in `test/utils/svg-rasterizer.test.ts` is pre-existing (test-only, gated off in the `test/**` ESLint override).
- **Documentation**: `docs/guide/agent-mode.md` SVG Handling section updated — the budget-now-applies-to-the-converted-PNG rule is user-visible behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * SVG attachments now enforce the 20 MB limit against decoded rasterized PNG size.
  * Oversized SVG conversions display the standard file-size limit notice.
  * Inline attachment tracking accurately accounts for converted SVG output and cumulative limits.

* **Documentation**
  * Clarified that the 20 MB limit applies to rasterized PNG output rather than the original SVG file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->