### PR TITLE
refactor(types): delete two born-dead optional wiring fields

### DIFF
--- a/src/services/model-manager.ts
+++ b/src/services/model-manager.ts
@@ -16,7 +16,6 @@ import { ParameterValidationService, ParameterRanges } from './parameter-validat
 
 export interface ModelUpdateOptions {
 	forceRefresh?: boolean;
-	preserveUserCustomizations?: boolean;
 }
 
 export class ModelManager {

--- a/src/tools/rag-search-tool.ts
+++ b/src/tools/rag-search-tool.ts
@@ -11,7 +11,6 @@ import { resolveGenerateContentModel } from '../models';
 interface RagSearchResult {
 	path?: string;
 	excerpt: string;
-	relevance?: number;
 }
 
 /**


### PR DESCRIPTION
## Summary

audit-architecture nightly sweep flagged: **dead surface** in `src/services/model-manager.ts` and `src/tools/rag-search-tool.ts`.

Two optional interface fields are declared but never populated and never read:

- `ModelUpdateOptions.preserveUserCustomizations` — the sibling `forceRefresh` is live at seven sites; this field has exactly one reference in the repo, its own declaration. `getAvailableModels` / `updateModels` never destructure it.
- `RagSearchResult.relevance` — the interface has a single construction site (`rag-search-tool.ts:243`) which sets `excerpt` and conditionally `path`, never `relevance`. Nothing reads it.

Neither field has ever had a consumer. `npm run knip` cannot see either one: knip resolves symbols, not per-field reachability through an object literal, so a field can be born dead and stay dead with every check green. This is the pattern tracked in #1303.

Deletion is safe: both fields are optional, so no construction site needs to change, and no reader exists to break. `ModelUpdateOptions` is re-exported through the `src/index.ts` barrel, but removing an optional field nobody sets is not a behavioral change to that surface.

Deliberately **not** included: `UsageMetadata.thoughtsTokenCount` in `src/services/context-manager.ts` is also unread, but removing it is the wrong call in isolation — it is evidence of a type-drift problem filed separately as its own issue, where the question is whether to plumb reasoning tokens through or drop the field. The two unread fields on `OllamaTagsModel` (`modified_at`, `remote_model`) are also excluded: that interface documents Ollama's `/api/tags` wire format, where declaring a field you do not consume is defensible.

## Changes

- `src/services/model-manager.ts` — drop `preserveUserCustomizations` from `ModelUpdateOptions`.
- `src/tools/rag-search-tool.ts` — drop `relevance` from `RagSearchResult`.

## Screenshots / Screencast

N/A — no UI change; this is a type-only deletion with no runtime effect.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: filed directly by the `audit-architecture` sweep, which routes mechanically-safe fixes to a PR rather than an issue. The governing pattern is #1303.
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [ ] I have tested this change on Desktop — N/A: type-only deletion, no emitted JS change and no runtime behavior to exercise.
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — no platform-specific code touched.
- [ ] Documentation has been updated (if applicable) — N/A: neither field is user-facing, documented, or referenced in `docs/`.
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (`audit-architecture` skill)
- [x] I have reviewed and understand all AI-generated code in this PR

## Test plan

- [x] `npm run format-check` clean
- [x] `npm run lint` clean (0 errors; the 40 warnings are pre-existing in `test/`)
- [x] `npm run build` clean (`tsc -noEmit` passes — confirms no reader of either field)
- [x] `npm run typecheck:test` clean
- [x] `npm test` — 176 files, 3925 tests passed

---

_Filed by the `audit-architecture` skill._

---
_Generated by [Claude Code](https://claude.ai/code/session_01TCfgT1mgAgTrViVee5TQkG)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified model update configuration by removing an unsupported customization option.
  * Removed unused search result metadata from internal processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->