### PR TITLE
chore(daily): 2026-08-31 daily update

### DIFF
--- a/planning/changelog/2026-08-31.md
+++ b/planning/changelog/2026-08-31.md
@@ -1,0 +1,36 @@
+# Daily changelog — August 31, 2026
+
+**Date:** 2026-08-31
+**PRs merged:** 6
+
+---
+
+## Summary
+
+A cleanup-heavy day: the prior day's daily-update PR merged first, followed by a run of refactors that continue chasing down repo-invariant drift — a missing retry wrapper on the RAG search tool, a shared home for parent-path derivation, and a shared leaf for frontmatter-offset scanning. The one user-visible fix closes a real gap in the 20 MB attachment budget for rasterized SVGs, and the day closed with the automated Gemini model-list refresh.
+
+## What shipped
+
+### [#1431 chore(daily): 2026-08-30 daily update](https://github.com/allenhutchison/obsidian-gemini/pull/1431)
+
+The automated daily-update run for 2026-08-30: wrote that day's changelog, ran a docs audit that found no drift, and a triage pass that found no unlabeled issues.
+
+### [#1429 fix(rag): retry the RAG search SDK call like every other call site](https://github.com/allenhutchison/obsidian-gemini/pull/1429)
+
+An `audit-architecture` sweep found that `RagSearchTool.execute` (the `vault_semantic_search` tool) called `ai.models.generateContent` directly with no retry wrapper, unlike every other direct SDK call site in the plugin. Wraps the call in `executeWithRetry` so a transient 429/5xx backs off and retries instead of failing the tool call outright.
+
+### [#1428 refactor(utils): give parent-path derivation a home in file-utils](https://github.com/allenhutchison/obsidian-gemini/pull/1428)
+
+"Ensure the parent folder exists before writing" had been hand-rolled at five write paths in four spellings. Adds `getParentPath`, `getFileName`, and `ensureParentFolderExists` to `file-utils.ts` and routes every site through them, dropping a redundant existence pre-check in `write-file-tool.ts` along the way. Value-preserving refactor, no behavior change.
+
+### [#1434 fix(attachments): hold the 20 MB budget against the rasterized PNG everywhere](https://github.com/allenhutchison/obsidian-gemini/pull/1434)
+
+Fixes #1430. The 20 MB inline-data budget for SVG attachments must hold against the rasterized PNG, not the source file, since a decoded bitmap can dwarf a small SVG. A prior fix (#1412) added that check at one of three call sites; this closes the other two (`read_file` and the external drop/paste path), and fixes a drop-path bug where the cumulative attachment counter was measured against source size instead of actual payload bytes. Over-budget SVGs are now rejected locally with the existing size-limit notice on every path.
+
+### [#1432 chore: Update available Gemini models](https://github.com/allenhutchison/obsidian-gemini/pull/1432)
+
+Automated model-list refresh from Google's API, curated and merged by the maintainer.
+
+### [#1435 refactor(services): move findFrontmatterEndOffset to a frontmatter-offset leaf](https://github.com/allenhutchison/obsidian-gemini/pull/1435)
+
+Fixes #1417. `feature-definition.ts` — a shared leaf for the markdown-defined feature managers — was reaching back up into `skill-manager.ts` to import a 15-line, dependency-free frontmatter scanner, forcing four test files to mock an entire 491-line manager just to control one pure function. Moves the scanner verbatim to a new `frontmatter-offset.ts` leaf with a re-export from `skill-manager.ts` for backward compatibility; no behavior change.


### PR DESCRIPTION
## Summary

Automated daily-update run bundling the repo's per-day housekeeping skills for 2026-08-31.

## Changes

- **daily-changelog**: wrote `planning/changelog/2026-08-31.md` covering the day's 6 merged PRs — the prior day's daily-update PR (#1431), a retry-wrapper fix for the RAG search tool, a parent-path-derivation refactor in `file-utils.ts`, a real bug fix closing the last two gaps in the 20 MB SVG attachment budget (#1434), the automated Gemini model-list refresh, and a frontmatter-offset-scanner extraction to a leaf module.
- **audit-product-docs**: full audit of all `docs/guide/*.md`, `docs/reference/*.md`, `README.md`, and `AGENTS.md` against `src/` — settings/defaults, command IDs, tool names, loop-detection thresholds, turn-budget constants, hook safety constants, MCP timeouts, schedule-format parsing, RAG constants, attachment/SVG limits, context-compaction thresholds, tool-policy preset matrix, bundled-skills list, and the i18n roster. No drift found, no new docs warranted.

  **Flagging for maintainer attention (not a docs issue — a code bug, left unfixed per this skill's scope):** `src/main.ts` sets the default `openaiModelName` to `'gpt-5.6'`, but the curated OpenAI model registry (`src/services/openai-models-service.ts`) only recognizes `'gpt-5.6-sol'`/`'gpt-5.6-terra'`/`'gpt-5.6-luna'` — matching what `README.md` and `docs/reference/settings.md` already document as the default. Because the stored default doesn't match any known model id, a fresh OpenAI-provider install silently falls back to `UNKNOWN_MODEL_DEFAULTS` (128k context, no vision) instead of the intended flagship (922k context, vision-capable). Worth a source fix using `getDefaultModelForRole('chat', 'openai')`, the same pattern the Ollama field already uses.
- **triage-issues**: no unlabeled open issues found — all 34 open issues already carry labels. No-op.

## Screenshots / Screencast

N/A — no UI changes; this PR is changelog-only.

## Checklist

### Required

- [x] I have read and agree to the Contributing Guidelines
- [x] I have read and agree to the AI Policy
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A, this is the recurring automated daily-update run, not tied to a single issue
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — also ran `npm run lint` (0 errors, 40 pre-existing warnings) and `npm run typecheck:test`; 176 files / 3925 tests passed (one initial run hit a flaky 5s timeout in `attach-vault-file.test.ts` under parallel load — confirmed a flake by re-running that file alone and the full suite clean)
- [ ] I have tested this change on Desktop — N/A, docs/changelog-only change with no runtime code path
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A, no code changes
- [x] Documentation has been updated (if applicable) — N/A, this PR *is* the documentation/changelog update; the audit found no drift needing a fix

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude (scheduled maintainerd daily-update agent)
- [x] I have reviewed and understand all AI-generated code in this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01EhBL3rHckxwGwpGyEJVoE2)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved reliability for retrieval-augmented generation requests through retry handling.
  - Added safeguards to enforce attachment size limits for rasterized SVG files.
  - Refreshed the available Gemini model list.

- **Improvements**
  - Standardized file-path handling across the application.
  - Improved frontmatter-offset scanning for more consistent content extraction.

- **Documentation**
  - Added the August 31, 2026 daily changelog summarizing these updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->