### PR TITLE
refactor(agent): derive tool-sort priority from tool.classification

### DIFF
--- a/src/agent/agent-loop-helpers.ts
+++ b/src/agent/agent-loop-helpers.ts
@@ -1,5 +1,6 @@
 import type { Content, Part } from '@google/genai';
 import type { ToolCall } from '../api/interfaces/model-api';
+import { ToolClassification } from '../types/tool-policy';
 import type { ToolResult } from '../tools/types';
 
 /**
@@ -22,67 +23,49 @@ export interface ToolCallResultPair {
 }
 
 /**
- * Tool execution priority. Reads run before writes, writes before deletes —
- * so a model that emits "delete A" and "read A" in the same response can't
- * lose data to the race. Lower number = earlier execution.
- *
- * Grouped by classification (band gaps make it obvious where a new tool slots
- * in by category): READS 1–19, EXTERNAL 20–29, WRITES 30–39, DESTRUCTIVE 40+.
- * Unknown tools fall to the END of the EXTERNAL band (29) — safer than after
- * deletes, since most unknown tools added later will be reads or writes, and
- * if it really is destructive the explicit entry should be added.
- *
- * When adding a new tool, add it here too. Any READ-classified tool MUST sort
- * before write_file (30) to satisfy the reads-before-writes invariant.
+ * Execution-priority band for a tool classification. Reads run before
+ * external calls, external before writes, writes before deletes — so a model
+ * that emits "delete A" and "read A" in the same response can't lose data to
+ * the race (#1424). The band is derived from the classification every tool
+ * already declares, so a new tool can't silently sort into the wrong band.
+ * Lower number = earlier execution.
  */
-const TOOL_PRIORITY: Record<string, number> = {
-	// ── READS (1–19) ────────────────────────────────────────────────────────
-	read_file: 1,
-	list_files: 2,
-	find_files_by_name: 3,
-	find_files_by_content: 4,
-	get_workspace_state: 5,
-	read_memory: 6,
-	recall_sessions: 7,
-	vault_semantic_search: 8,
-	activate_skill: 9,
-	// ── EXTERNAL (20–29) ────────────────────────────────────────────────────
-	google_search: 20,
-	fetch_url: 21,
-	deep_research: 22,
-	google_maps: 23,
-	// ── WRITES (30–39) ──────────────────────────────────────────────────────
-	write_file: 30,
-	create_folder: 31,
-	update_frontmatter: 32,
-	append_content: 33,
-	update_memory: 34,
-	create_skill: 35,
-	edit_skill: 36,
-	generate_image: 37,
-	// ── DESTRUCTIVE (40+) ───────────────────────────────────────────────────
-	move_file: 40,
-	delete_file: 41,
-};
-
-/**
- * Default priority for tools not in TOOL_PRIORITY — bottom of the EXTERNAL
- * band so unknowns run after all known reads but before any known writes or
- * destructive operations. Conservative choice: if a future tool is added but
- * its priority entry is forgotten, it still won't race destructive ops.
- */
-const UNKNOWN_TOOL_PRIORITY = 29;
+export function classificationToPriority(c: ToolClassification): number {
+	switch (c) {
+		case ToolClassification.READ:
+			return 10;
+		case ToolClassification.EXTERNAL:
+			return 20;
+		case ToolClassification.WRITE:
+			return 30;
+		case ToolClassification.DESTRUCTIVE:
+			return 40;
+	}
+}
 
 /**
  * Sort tool calls so reads execute before writes/deletes.
- * Stable: equal-priority calls retain their original relative order.
+ *
+ * Priority comes from each tool's declared classification via `resolve`; the
+ * map is injected so this module stays pure and registry-free. Within a band
+ * the sort is stable — calls keep the model's emitted order — which is safe:
+ * cross-tool ordering inside a band (e.g. a write's parent folder) is handled
+ * by the tools themselves, not by sort order. A name the resolver can't
+ * resolve falls to the END of the EXTERNAL band (29) — after all known reads,
+ * before any known write/destructive — the same conservative fallback the old
+ * hand-maintained map used.
  */
-export function sortToolCallsByPriority<T extends { name: string }>(toolCalls: T[]): T[] {
-	return [...toolCalls].sort((a, b) => {
-		const pa = TOOL_PRIORITY[a.name] ?? UNKNOWN_TOOL_PRIORITY;
-		const pb = TOOL_PRIORITY[b.name] ?? UNKNOWN_TOOL_PRIORITY;
-		return pa - pb;
-	});
+export function sortToolCallsByPriority<T extends { name: string }>(
+	toolCalls: T[],
+	resolve: (name: string) => ToolClassification | undefined
+): T[] {
+	return [...toolCalls].sort((a, b) => resolvePriority(a.name, resolve) - resolvePriority(b.name, resolve));
+}
+
+/** Band for a resolvable name; the EXTERNAL-band fallback (29) otherwise. */
+function resolvePriority(name: string, resolve: (name: string) => ToolClassification | undefined): number {
+	const classification = resolve(name);
+	return classification === undefined ? 29 : classificationToPriority(classification);
 }
 
 /**

--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -343,8 +343,19 @@ export class AgentLoop {
 				}
 			}
 
-			// Sort and execute this batch
-			const sortedToolCalls = sortToolCallsByPriority(currentToolCalls);
+			// Sort and execute this batch. Priority comes from each tool's declared
+			// classification (#1424); a name missing from the registry sorts into the
+			// EXTERNAL fallback band and is logged so a missing registration
+			// surfaces instead of silently mis-sorting.
+			const unresolvable = new Set<string>();
+			const sortedToolCalls = sortToolCallsByPriority(currentToolCalls, (name) => {
+				const classification = plugin.toolRegistry?.getTool(name)?.classification;
+				if (classification === undefined) unresolvable.add(name);
+				return classification;
+			});
+			for (const name of unresolvable) {
+				plugin.logger.warn(`[AgentLoop] Tool "${name}" is not in the registry; sorting it before writes.`);
+			}
 			await this.safeHook('onToolBatchStart', plugin, () => hooks?.onToolBatchStart?.(sortedToolCalls, iterations));
 			iterations++;
 			const toolResults = await this.executeToolBatch(sortedToolCalls, toolContext, options);

--- a/test/agent/agent-loop-helpers.test.ts
+++ b/test/agent/agent-loop-helpers.test.ts
@@ -1,5 +1,6 @@
 import {
 	sortToolCallsByPriority,
+	classificationToPriority,
 	buildFunctionCallParts,
 	buildFunctionResponseParts,
 	buildToolHistoryTurns,
@@ -9,14 +10,27 @@ import {
 	DEFAULT_TOOL_RESPONSE_TRUNCATE_BYTES,
 	ToolCallResultPair,
 } from '../../src/agent/agent-loop-helpers';
+import { ToolClassification } from '../../src/types/tool-policy';
 import type { ToolCall } from '../../src/api/interfaces/model-api';
+
+/** The registry-style resolver production callers pass: name → classification. */
+const resolve = (name: string): ToolClassification | undefined =>
+	({
+		read_file: ToolClassification.READ,
+		list_files: ToolClassification.READ,
+		delete_file: ToolClassification.DESTRUCTIVE,
+		write_file: ToolClassification.WRITE,
+		mystery_tool: undefined,
+		another_unknown: undefined,
+	})[name];
 
 describe('sortToolCallsByPriority', () => {
 	test('orders reads before writes and deletes', () => {
 		const calls = [{ name: 'delete_file' }, { name: 'write_file' }, { name: 'read_file' }, { name: 'list_files' }];
 
-		const sorted = sortToolCallsByPriority(calls);
+		const sorted = sortToolCallsByPriority(calls, resolve);
 
+		// Stable within the read band: model-emitted order (read_file before list_files) is kept.
 		expect(sorted.map((c) => c.name)).toEqual(['read_file', 'list_files', 'write_file', 'delete_file']);
 	});
 
@@ -29,7 +43,7 @@ describe('sortToolCallsByPriority', () => {
 			{ name: 'another_unknown' },
 		];
 
-		const sorted = sortToolCallsByPriority(calls);
+		const sorted = sortToolCallsByPriority(calls, resolve);
 
 		// Reads first, then unknowns (stable order between them), then writes, then destructive
 		expect(sorted.map((c) => c.name)).toEqual([
@@ -40,7 +54,6 @@ describe('sortToolCallsByPriority', () => {
 			'delete_file',
 		]);
 	});
-
 	test('all known READ-classified tools sort before any write/destructive (regression for missing custom reads)', () => {
 		const reads = [
 			'read_file',
@@ -55,10 +68,20 @@ describe('sortToolCallsByPriority', () => {
 		];
 		const writes = ['write_file', 'create_folder', 'update_frontmatter', 'append_content', 'update_memory'];
 		const destructive = ['move_file', 'delete_file'];
+		// Every name resolves to its declared classification — a registry-style
+		// resolver built from ToolClassification directly, no hand-written map.
+		const registryResolve = (name: string): ToolClassification | undefined =>
+			reads.includes(name)
+				? ToolClassification.READ
+				: writes.includes(name)
+					? ToolClassification.WRITE
+					: destructive.includes(name)
+						? ToolClassification.DESTRUCTIVE
+						: undefined;
 
 		// Interleave: every read alternated with a delete — sort must still pull all reads first
 		const interleaved = reads.flatMap((r) => [{ name: 'delete_file' }, { name: r }]);
-		const sorted = sortToolCallsByPriority(interleaved);
+		const sorted = sortToolCallsByPriority(interleaved, registryResolve);
 
 		// First N positions must all be the reads (any order); after that, no read may appear.
 		const firstN = sorted.slice(0, reads.length).map((c) => c.name);
@@ -73,6 +96,25 @@ describe('sortToolCallsByPriority', () => {
 		expect(restNames.some((n) => reads.includes(n))).toBe(false);
 	});
 
+	test('a DESTRUCTIVE tool absent from any hardcoded list still sorts after every write (#1424)', () => {
+		// The case the old hand-maintained map could not express: a new
+		// destructive tool needs no map entry — its declared classification
+		// puts it in the destructive band on its own.
+		const resolveNew = (name: string): ToolClassification | undefined =>
+			name === 'shred_vault'
+				? ToolClassification.DESTRUCTIVE
+				: name === 'write_file'
+					? ToolClassification.WRITE
+					: name === 'read_file'
+						? ToolClassification.READ
+						: undefined;
+		const calls = [{ name: 'shred_vault' }, { name: 'write_file' }, { name: 'read_file' }];
+
+		const sorted = sortToolCallsByPriority(calls, resolveNew);
+
+		expect(sorted.map((c) => c.name)).toEqual(['read_file', 'write_file', 'shred_vault']);
+	});
+
 	test('preserves relative order for equal-priority calls', () => {
 		const calls = [
 			{ name: 'read_file', tag: 'a' },
@@ -80,7 +122,7 @@ describe('sortToolCallsByPriority', () => {
 			{ name: 'read_file', tag: 'c' },
 		];
 
-		const sorted = sortToolCallsByPriority(calls);
+		const sorted = sortToolCallsByPriority(calls, resolve);
 
 		expect(sorted.map((c) => c.tag)).toEqual(['a', 'b', 'c']);
 	});
@@ -89,13 +131,27 @@ describe('sortToolCallsByPriority', () => {
 		const calls = [{ name: 'delete_file' }, { name: 'read_file' }];
 		const original = [...calls];
 
-		sortToolCallsByPriority(calls);
+		sortToolCallsByPriority(calls, resolve);
 
 		expect(calls).toEqual(original);
 	});
 
 	test('handles empty array', () => {
-		expect(sortToolCallsByPriority([])).toEqual([]);
+		expect(sortToolCallsByPriority([], resolve)).toEqual([]);
+	});
+});
+
+describe('classificationToPriority', () => {
+	test('bands read < external < write < destructive', () => {
+		expect(classificationToPriority(ToolClassification.READ)).toBeLessThan(
+			classificationToPriority(ToolClassification.EXTERNAL)
+		);
+		expect(classificationToPriority(ToolClassification.EXTERNAL)).toBeLessThan(
+			classificationToPriority(ToolClassification.WRITE)
+		);
+		expect(classificationToPriority(ToolClassification.WRITE)).toBeLessThan(
+			classificationToPriority(ToolClassification.DESTRUCTIVE)
+		);
 	});
 });
 

--- a/test/agent/agent-loop.test.ts
+++ b/test/agent/agent-loop.test.ts
@@ -1,4 +1,5 @@
 import type { Mock } from 'vitest';
+import { ToolClassification } from '../../src/types/tool-policy';
 import { AgentLoop } from '../../src/agent/agent-loop';
 import type {
 	ToolCall,
@@ -21,11 +22,24 @@ const confirmationProvider: IConfirmationProvider = {
 // Build a minimal plugin stub with just enough surface for AgentLoop and the
 // followup helpers to walk through. Each test customises only what it cares about.
 function buildPlugin(overrides: any = {}) {
+	// Classifications mirror the real registry so the classification-derived
+	// tool sort (#1424) behaves identically to production in these tests.
+	const classifications: Record<string, ToolClassification> = {
+		read_file: ToolClassification.READ,
+		list_files: ToolClassification.READ,
+		get_workspace_state: ToolClassification.READ,
+		write_file: ToolClassification.WRITE,
+		create_folder: ToolClassification.WRITE,
+		delete_file: ToolClassification.DESTRUCTIVE,
+		move_file: ToolClassification.DESTRUCTIVE,
+		google_search: ToolClassification.EXTERNAL,
+	};
 	const toolRegistry = {
 		getTool: vi.fn().mockImplementation(function (name: string) {
 			return {
 				name,
 				displayName: name,
+				classification: classifications[name],
 			};
 		}),
 		getEnabledTools: vi.fn().mockReturnValue([]),


### PR DESCRIPTION
## Summary

Fixes #1424

`sortToolCallsByPriority` enforced the reads-before-writes invariant via `TOOL_PRIORITY` — a hand-maintained, string-keyed map of all 23 tool names whose four band comments (`READS 1–19`, `EXTERNAL 20–29`, `WRITES 30–39`, `DESTRUCTIVE 40+`) restated the four `ToolClassification` values every tool already declares. Nothing compile-checked the map: a tool added without an entry silently fell to `UNKNOWN_TOOL_PRIORITY = 29` — the bottom of the EXTERNAL band — sorting a new WRITE or DESTRUCTIVE tool *before* `write_file` (30) and `delete_file` (41), exactly the race the sort exists to prevent. The source comment acknowledged the gap ("the explicit entry should be added"); this makes the gap unexpressable instead.

## Changes

- `src/agent/agent-loop-helpers.ts` — `TOOL_PRIORITY` (23 entries) and `UNKNOWN_TOOL_PRIORITY` deleted. New exported `classificationToPriority(c)` maps the four bands (READ=10, EXTERNAL=20, WRITE=30, DESTRUCTIVE=40); `sortToolCallsByPriority(calls, resolve)` takes an injected `name → ToolClassification | undefined` resolver, keeping the module pure and registry-free (the issue's named constraint). Unresolvable names keep the old conservative fallback — end of the EXTERNAL band, after all known reads, before any known write.
- `src/agent/agent-loop.ts` — the sole caller passes `plugin.toolRegistry.getTool(name)?.classification` and `logger.warn`s any name the registry can't resolve, so a missing registration surfaces instead of silently mis-sorting. This is the "louder than today" fallback the issue asked for.
- Tests:
  - `test/agent/agent-loop-helpers.test.ts` — all six sort tests pass a registry-style resolver; new test for the case the old map **cannot express**: a DESTRUCTIVE tool absent from any hardcoded list still sorts after every write, purely from its declared classification. New `classificationToPriority` band-ordering test.
  - `test/agent/agent-loop.test.ts` — the `buildPlugin` `getTool` stub now returns each tool's real classification (without it, every name resolved to `undefined` and the sort degraded to a no-op — caught by the existing `tool sorting` tests, which pass unchanged otherwise).

## Behavioral note

Intra-band ordering changes from the hand map's arbitrary total order (`read_file` before `list_files`, etc.) to the model's emitted order (the sort is stable). I verified no load-bearing intra-band dependency exists: cross-tool ordering inside a band — e.g. a write's target parent folder — is handled by the tools themselves (`ensureParentFolderExists` in the write tools, `fileManager.renameFile` in move), not by sort order. Band-level behavior, the actual invariant, is unchanged and now derived from the source of truth.

## Screenshots / Screencast

N/A — internal refactor; no user-visible surface (the only observable change is a new developer-facing warn log for unregistered tool names).

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [ ] I have tested this change on Desktop
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards)
- [x] Documentation has been updated (if applicable)
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

Notes on the unticked items:

- **Desktop testing**: not performed — the sort is fully covered by the unit suites (46 helper tests + 45 loop tests, including the reads-before-writes invariant tests that caught the stub-classification gap during development); the agent eval harness (`npm run eval`) exercises the full tool loop against a live vault if you want a deeper pass before merging.
- **Mobile**: no platform-specific API touched.
- **Documentation**: no docs reference `TOOL_PRIORITY` or the sort (verified by grep over `docs/`); the invariant is documented in the code comments, which moved with the code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Tool actions are now ordered according to their safety classification.
  * Read operations are prioritized before external, write, and destructive operations.
  * Unrecognized tools receive a safe fallback priority and generate a warning.
  * Ordering remains stable and supports newly introduced tool classifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->