### PR TITLE
feat(ui): surface reasoning tokens in the token readout

### DIFF
--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -330,8 +330,8 @@ Advanced settings for developers and power users. Access by clicking "Show advan
 - **Type**: Boolean
 - **Default**: `false`
 - **Description**: Display estimated token count in the agent input area
-- **Display format**: `Tokens: ~N / M (X%)` showing total prompt tokens, model limit, and percentage used. When part of the prompt was served from Gemini's cache, an additional `· Y% cached` suffix appears
-- **How it works**: Token counts update live after each API response, including during tool call chains. Gemini's implicit caching means repeated content (system prompt, tool definitions) is often served from cache — the cached percentage rewards stable prefixes (system prompt, pinned history)
+- **Display format**: `Tokens: ~N / M (X%)` showing total prompt tokens, model limit, and percentage used. When part of the prompt was served from Gemini's cache, an additional `· Y% cached` suffix appears; when the model reports its reasoning (thinking) token count for the last response, a `· Z reasoning` suffix appears. Both suffixes can appear together
+- **How it works**: Token counts update live after each API response, including during tool call chains. Gemini's implicit caching means repeated content (system prompt, tool definitions) is often served from cache — the cached percentage rewards stable prefixes (system prompt, pinned history). The reasoning count appears only for models that report thinking tokens (Gemini thinking models); reasoning tokens are output-side and included in the response's total, so they don't count against the context window the percentage measures
 - **Visual indicators**:
   - Normal (muted text) — well under threshold
   - Yellow — approaching compaction threshold (≥80% of threshold)

--- a/src/api/interfaces/usage-metadata.ts
+++ b/src/api/interfaces/usage-metadata.ts
@@ -28,6 +28,13 @@ export interface UsageMetadata {
 	 * omit it, which is honest rather than zero. Included in
 	 * `totalTokenCount` either way, so the aggregate is correct regardless;
 	 * this field attributes the reasoning share of it.
+	 *
+	 * Calibration note (#1437 follow-up): reasoning tokens are output-side and
+	 * occupy no context-window space on subsequent requests — reasoning
+	 * persisted back into history returns as ordinary prompt text, already
+	 * counted inside `promptTokenCount`. The compaction threshold correctly
+	 * stays prompt-based; adding this field to that comparison would
+	 * over-count and trigger premature compaction.
 	 */
 	thoughtsTokenCount?: number;
 }

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -2190,6 +2190,16 @@ export const en = {
 		context:
 			'Token usage indicator variant when part of the prompt was served from cache. {cached} is the cached percentage. Keep the middle-dot separator.',
 	},
+	'agent.tokens.usageThoughts': {
+		message: 'Tokens: ~{used} / {limit} ({percent}%) · {thoughts} reasoning',
+		context:
+			'Token usage indicator variant when the model reports reasoning (thinking) tokens for the last response. {thoughts} is the formatted reasoning-token count. Keep the middle-dot separator.',
+	},
+	'agent.tokens.usageCachedThoughts': {
+		message: 'Tokens: ~{used} / {limit} ({percent}%) · {cached}% cached · {thoughts} reasoning',
+		context:
+			'Token usage indicator variant when the prompt was partly served from cache AND the model reported reasoning tokens. {cached} is the cached percentage, {thoughts} the formatted reasoning-token count. Keep the middle-dot separators.',
+	},
 	'agent.empty.example.findTagged': {
 		message: 'Find all notes tagged with #important',
 		context:

--- a/src/ui/agent-view/agent-view.ts
+++ b/src/ui/agent-view/agent-view.ts
@@ -2,6 +2,7 @@ import { ItemView, MarkdownView, Platform, WorkspaceLeaf, TFile, Notice } from '
 import { getActiveChatModel } from '../../models';
 import { ChatSession, SessionModelConfig } from '../../types/agent';
 import { isSameSession } from './session-identity';
+import { formatTokenUsageLine } from './token-usage-format';
 import { GeminiConversationEntry } from '../../types/conversation';
 import type { ObsidianGemini } from '../../types/plugin';
 import type { Tool, ToolResult } from '../../tools/types';
@@ -806,20 +807,7 @@ export class AgentView extends ItemView {
 			this.tokenUsageContainer.empty();
 
 			const tokenText = this.tokenUsageContainer.createSpan({ cls: 'gemini-agent-token-text' });
-			const usageVars = {
-				used: usage.estimatedTokens.toLocaleString(),
-				limit: usage.inputTokenLimit.toLocaleString(),
-				percent: usage.percentUsed,
-			};
-			if (usage.cachedTokens > 0 && usage.estimatedTokens > 0) {
-				// Cached ratio reflects how much of the current prompt was served
-				// from Gemini's implicit/explicit cache — a positive signal that
-				// rewards stable prefixes (system prompt, pinned history).
-				const cachedPercent = Math.round((usage.cachedTokens / usage.estimatedTokens) * 100);
-				tokenText.textContent = t('agent.tokens.usageCached', { ...usageVars, cached: cachedPercent });
-			} else {
-				tokenText.textContent = t('agent.tokens.usage', usageVars);
-			}
+			tokenText.textContent = formatTokenUsageLine(usage);
 
 			// Add warning class if approaching threshold
 			const threshold = this.plugin.settings.contextCompactionThreshold;

--- a/src/ui/agent-view/token-usage-format.ts
+++ b/src/ui/agent-view/token-usage-format.ts
@@ -1,0 +1,45 @@
+import { t } from '../../i18n';
+import type { TokenUsageInfo } from '../../services/context-manager';
+
+/**
+ * Build the token-readout line for the agent view's usage indicator.
+ *
+ * Extracted from AgentView.updateTokenUsage (#1437 follow-up) so the
+ * segment-selection logic — which optional segments (cached, reasoning)
+ * appear, and with what values — is unit-testable without scaffolding the
+ * full view. Rendering is a plain string; the caller puts it in the span.
+ *
+ * Segments appear only when the provider actually reported them:
+ * - cached: positive cachedTokens against a positive prompt estimate
+ *   (how much of the prompt the implicit/explicit cache served — a
+ *   positive signal that rewards stable prefixes);
+ * - reasoning (thoughtsTokens): present only on providers that report
+ *   thinking-token counts (Gemini thinking models); absent elsewhere is
+ *   honest rather than zero.
+ */
+export function formatTokenUsageLine(usage: TokenUsageInfo): string {
+	const usageVars = {
+		used: usage.estimatedTokens.toLocaleString(),
+		limit: usage.inputTokenLimit.toLocaleString(),
+		percent: usage.percentUsed,
+	};
+	const hasCached = usage.cachedTokens > 0 && usage.estimatedTokens > 0;
+	const hasThoughts = usage.thoughtsTokens !== undefined && usage.thoughtsTokens > 0;
+	if (hasCached && hasThoughts) {
+		const cachedPercent = Math.round((usage.cachedTokens / usage.estimatedTokens) * 100);
+		return t('agent.tokens.usageCachedThoughts', {
+			...usageVars,
+			cached: cachedPercent,
+			thoughts: usage.thoughtsTokens!.toLocaleString(),
+		});
+	} else if (hasCached) {
+		const cachedPercent = Math.round((usage.cachedTokens / usage.estimatedTokens) * 100);
+		return t('agent.tokens.usageCached', { ...usageVars, cached: cachedPercent });
+	} else if (hasThoughts) {
+		return t('agent.tokens.usageThoughts', {
+			...usageVars,
+			thoughts: usage.thoughtsTokens!.toLocaleString(),
+		});
+	}
+	return t('agent.tokens.usage', usageVars);
+}

--- a/test/ui/agent-view/token-usage-format.test.ts
+++ b/test/ui/agent-view/token-usage-format.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { formatTokenUsageLine } from '../../../src/ui/agent-view/token-usage-format';
+import type { TokenUsageInfo } from '../../../src/services/context-manager';
+
+function usage(overrides: Partial<TokenUsageInfo> = {}): TokenUsageInfo {
+	return {
+		estimatedTokens: 12_345,
+		inputTokenLimit: 1_000_000,
+		percentUsed: 1.2,
+		cachedTokens: 0,
+		...overrides,
+	};
+}
+
+describe('formatTokenUsageLine', () => {
+	it('renders the base line when neither cached nor reasoning tokens are reported', () => {
+		expect(formatTokenUsageLine(usage())).toBe('Tokens: ~12,345 / 1,000,000 (1.2%)');
+	});
+
+	it('appends the cached segment when part of the prompt was served from cache', () => {
+		// 5000 of 12,345 prompt tokens served from cache → 41%
+		expect(formatTokenUsageLine(usage({ cachedTokens: 5_000 }))).toBe(
+			'Tokens: ~12,345 / 1,000,000 (1.2%) · 41% cached'
+		);
+	});
+
+	it('appends the reasoning segment when the model reports thinking tokens (#1437 follow-up)', () => {
+		expect(formatTokenUsageLine(usage({ thoughtsTokens: 890 }))).toBe(
+			'Tokens: ~12,345 / 1,000,000 (1.2%) · 890 reasoning'
+		);
+	});
+
+	it('combines cached and reasoning segments when both are present', () => {
+		expect(formatTokenUsageLine(usage({ cachedTokens: 5_000, thoughtsTokens: 890 }))).toBe(
+			'Tokens: ~12,345 / 1,000,000 (1.2%) · 41% cached · 890 reasoning'
+		);
+	});
+
+	it('formats the reasoning count with locale grouping', () => {
+		expect(formatTokenUsageLine(usage({ thoughtsTokens: 12_345 }))).toContain('· 12,345 reasoning');
+	});
+
+	it('omits the reasoning segment when the provider reports zero thinking tokens', () => {
+		// A thinking model that didn't think this turn — 0 is "no reasoning",
+		// not "zero tokens of reasoning worth surfacing".
+		expect(formatTokenUsageLine(usage({ thoughtsTokens: 0 }))).toBe('Tokens: ~12,345 / 1,000,000 (1.2%)');
+	});
+
+	it('omits the reasoning segment when the provider does not report the field at all', () => {
+		// Ollama / OpenAI: the field is undefined, not zero.
+		expect(formatTokenUsageLine(usage())).toBe('Tokens: ~12,345 / 1,000,000 (1.2%)');
+	});
+
+	it('omits the cached segment when cached tokens are zero', () => {
+		expect(formatTokenUsageLine(usage({ cachedTokens: 0 }))).toBe('Tokens: ~12,345 / 1,000,000 (1.2%)');
+	});
+});


### PR DESCRIPTION
## Summary

Closes the two follow-ups #1437 named when it merged.

**1. Surface reasoning tokens in the token readout.** #1437 plumbed `thoughtsTokenCount` to `TokenUsageInfo.thoughtsTokens` but no consumer rendered it. The token indicator above the chat input now appends `· N reasoning` when the model reports thinking tokens — present only when the provider reports the count (Gemini thinking models; Ollama/OpenAI omit the field, which stays hidden rather than showing a misleading 0), and combined with the existing `· Y% cached` segment when both appear. This is user-visible: `Tokens: ~12,345 / 1M (1.2%) · 41% cached · 890 reasoning`.

**2. Compaction threshold: investigated, correctly calibrated, no code change.** #1437 conditioned this follow-up on "if plumbing reasoning tokens shows the threshold is mis-calibrated for thinking models." It is not: the threshold compares **prompt tokens against the input limit**, and reasoning tokens are **output-side** — they occupy no context-window space on subsequent requests. Reasoning persisted back into history returns as ordinary prompt text, already counted inside `promptTokenCount`. Adding `thoughtsTokenCount` to the comparison would over-count and trigger premature compaction. The conclusion is recorded in the `UsageMetadata.thoughtsTokenCount` doc comment (with the reasoning, so the next auditor doesn't re-derive it) and reflected in the setting docs.

## Changes

- `src/ui/agent-view/token-usage-format.ts` (new leaf, following the `compaction-notice`/`session-identity` pattern) — `formatTokenUsageLine(usage)` owns the segment selection: base / cached / reasoning / cached+reasoning. Extracted from `AgentView.updateTokenUsage`, which previously had no test coverage (only a mocked context stub); the view method becomes two lines.
- `src/ui/agent-view/agent-view.ts` — `updateTokenUsage` renders via the leaf; the inline branch ladder is gone (net −14 lines).
- `src/i18n/en.ts` — two new keys, `agent.tokens.usageThoughts` and `agent.tokens.usageCachedThoughts`, alongside the existing pair. Per-language files regenerate automatically when `en.ts` lands on master (the `Update UI translations` workflow); until then `t()` falls back to English.
- `src/api/interfaces/usage-metadata.ts` — the `thoughtsTokenCount` doc comment gains the calibration note (compaction stays prompt-based; adding this field there would over-count).
- `docs/reference/settings.md` — the `showTokenUsage` setting's display-format and how-it-works entries document the reasoning segment, when it appears, and that reasoning tokens don't count against the measured window.
- `test/ui/agent-view/token-usage-format.test.ts` (new) — 8 tests: all four segment combinations, locale-grouped formatting, and the two honest-absence cases (zero reasoning reported by a thinking model; field undefined for Ollama/OpenAI).

## Screenshots / Screencast

Not attached — the change is one text span whose exact content is pinned by the unit tests above (`Tokens: ~12,345 / 1,000,000 (1.2%) · 41% cached · 890 reasoning`); happy to attach a vault screenshot on request.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [ ] I have tested this change on Desktop
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards)
- [x] Documentation has been updated (if applicable)
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

Notes on the unticked items:

- **Desktop testing**: not performed — the rendering is a pure string function fully covered by unit tests (8 cases including every segment combination), driven from data #1437 already lands in production paths. A desktop pass would confirm the span visually; attaching a screenshot on request.
- **Mobile**: no platform-specific API; the span inherits existing readout styling.
- **Documentation**: `showTokenUsage` in `docs/reference/settings.md` updated (display format + how-it-works) — this is the documented surface for the readout; the calibration note lives in the type doc comment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Token usage indicators now show reasoning-token counts when available.
  * Cached-token percentages and reasoning-token counts are displayed together when applicable.
  * Zero or unavailable token details are omitted for clearer reporting.

* **Documentation**
  * Clarified how reasoning tokens contribute to token usage and context-window calculations.
  * Documented how persisted reasoning is counted in conversation history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->