### PR TITLE
fix(agent): carry the tool-call correlation id into functionResponse parts

### DIFF
--- a/src/agent/agent-loop-helpers.ts
+++ b/src/agent/agent-loop-helpers.ts
@@ -15,11 +15,18 @@ import type { ToolResult } from '../tools/types';
  * A tool call paired with its execution result. Carries the original args
  * alongside so emitters that need both (e.g. agent event bus) get a single
  * record instead of having to zip two arrays.
+ *
+ * `id` is the model-assigned tool-call correlation id (present on Interactions
+ * `function_call` steps and OpenAI tool calls; absent on plain generateContent).
+ * Carried through so the replayed `functionResponse` part can reference the
+ * same id the `functionCall` part emitted — the Interactions API pairs a
+ * result to its call by `call_id`, and OpenAI by `tool_call_id` (#1398).
  */
 export interface ToolCallResultPair {
 	toolName: string;
 	toolArguments: Record<string, unknown>;
 	result: ToolResult;
+	id?: string;
 }
 
 /**
@@ -109,6 +116,10 @@ export function buildFunctionResponseParts(toolResults: ToolCallResultPair[]): P
 				functionResponse: {
 					name: tr.toolName,
 					response: resultWithoutInlineData,
+					// Reference the id the functionCall part emitted, so
+					// Interactions `call_id` and OpenAI `tool_call_id` pair the
+					// result to its own call rather than by name (#1398).
+					...(tr.id && { id: tr.id }),
 				},
 			},
 		];

--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -731,6 +731,9 @@ export class AgentLoop {
 					toolName: toolCall.name,
 					toolArguments: toolCall.arguments,
 					result,
+					// Carry the model-assigned correlation id so the replayed
+					// functionResponse pairs with its functionCall (#1398).
+					...(toolCall.id && { id: toolCall.id }),
 				});
 			} catch (error) {
 				plugin.logger.error(`[AgentLoop] Tool execution error for ${toolCall.name}:`, error);
@@ -742,6 +745,9 @@ export class AgentLoop {
 						success: false,
 						error: getRawErrorMessageOr(error, 'Unknown error'),
 					},
+					// Same correlation on the error path — the functionResponse
+					// still needs to pair with its functionCall (#1398).
+					...(toolCall.id && { id: toolCall.id }),
 				});
 			}
 		}

--- a/test/agent/agent-loop-helpers.test.ts
+++ b/test/agent/agent-loop-helpers.test.ts
@@ -54,6 +54,25 @@ describe('sortToolCallsByPriority', () => {
 			'delete_file',
 		]);
 	});
+
+	test('sort is stable: same-name calls keep model-emitted order within a band (#1398)', () => {
+		// Load-bearing for OpenAI's FIFO tool_call_id pairing: convertHistoryEntry
+		// pairs each id-less functionResponse with the oldest pending id for its
+		// NAME, which lines up with the calls only because same-name calls keep
+		// their relative order through the sort. An unstable comparator would
+		// mis-pair results silently — this test fails if that ever changes.
+		const resolveAllWrites = (name: string): ToolClassification | undefined =>
+			name === 'write_file' || name === 'append_content' ? ToolClassification.WRITE : undefined;
+		const calls = [
+			{ name: 'append_content', id: 'call_a1' },
+			{ name: 'write_file', id: 'call_w1' },
+			{ name: 'append_content', id: 'call_a2' },
+		];
+
+		const sorted = sortToolCallsByPriority(calls, resolveAllWrites);
+
+		expect(sorted.map((c) => c.id)).toEqual(['call_a1', 'call_w1', 'call_a2']);
+	});
 	test('all known READ-classified tools sort before any write/destructive (regression for missing custom reads)', () => {
 		const reads = [
 			'read_file',

--- a/test/api/providers/gemini/client.test.ts
+++ b/test/api/providers/gemini/client.test.ts
@@ -3,8 +3,9 @@ import { GoogleGenAI } from '@google/genai';
 import { GeminiClient } from '../../../../src/api/providers/gemini/client';
 import type { GeminiClientConfig } from '../../../../src/api/providers/gemini/config';
 import { GeminiPrompts } from '../../../../src/prompts';
-import type { ExtendedModelRequest } from '../../../../src/api/interfaces/model-api';
+import type { ExtendedModelRequest, ToolCall } from '../../../../src/api/interfaces/model-api';
 import { ModelUseCase } from '../../../../src/api/model-use-case';
+import { buildToolHistoryTurns, type ToolCallResultPair } from '../../../../src/agent/agent-loop-helpers';
 
 // Capture every call to `client.models.generateContent` so tests can assert on
 // the params (system instruction, contents, etc.) the SDK sees. vi.hoisted lets
@@ -1179,16 +1180,29 @@ describe('GeminiClient', () => {
 
 		test('replays history as typed steps incl. function call/result round-trip', async () => {
 			const client = makeInteractionsClient();
+			// Build the history the way production does — via buildToolHistoryTurns
+			// from a ToolCall + ToolCallResultPair — so this fixture cannot diverge
+			// from the shape buildFunctionResponseParts actually emits (#1398: the
+			// old hand-written Content literal carried a functionResponse.id that
+			// no production path ever produced).
+			const conversationHistory = buildToolHistoryTurns({
+				conversationHistory: [{ role: 'user', parts: [{ text: 'read foo.md' }] }],
+				userMessage: '',
+				toolCalls: [{ id: 'c1', name: 'read_file', arguments: { path: 'foo.md' } }],
+				toolResults: [
+					{
+						toolName: 'read_file',
+						toolArguments: { path: 'foo.md' },
+						result: { success: true, data: { content: 'hi' } },
+						id: 'c1',
+					},
+				],
+			});
 			await client.generateModelResponse({
 				prompt: '',
 				userMessage: 'and now?',
 				kind: 'extended',
-				conversationHistory: [
-					{ role: 'user', parts: [{ text: 'read foo.md' }] },
-					{ role: 'model', parts: [{ functionCall: { id: 'c1', name: 'read_file', args: { path: 'foo.md' } } }] },
-					{ role: 'user', parts: [{ functionResponse: { id: 'c1', name: 'read_file', response: { content: 'hi' } } }] },
-					{ role: 'model', parts: [{ text: 'foo.md says hi' }] },
-				],
+				conversationHistory,
 			});
 
 			const params = interactionsCreateMock.mock.calls[0][0];
@@ -1201,11 +1215,59 @@ describe('GeminiClient', () => {
 					name: 'read_file',
 					// Plain string, never a content array — the array form is a
 					// "multimodal function response" that Gemini 2.5 rejects with a 400.
-					result: JSON.stringify({ content: 'hi' }),
+					result: JSON.stringify({ success: true, data: { content: 'hi' } }),
 				},
-				{ type: 'model_output', content: [{ type: 'text', text: 'foo.md says hi' }] },
 				{ type: 'user_input', content: [{ type: 'text', text: 'and now?' }] },
 			]);
+		});
+
+		test('pairs function_result.call_id with function_call.id after a priority reorder (#1398)', async () => {
+			const client = makeInteractionsClient();
+			// The model emitted [delete_file, read_file]; the sort reorders to
+			// [read_file, delete_file] before execution. The replayed history
+			// must still pair each function_result with its own function_call
+			// id — this is exactly the case where name-based pairing breaks
+			// under two same-name calls or cross-name reordering.
+			const toolCalls: ToolCall[] = [
+				{ id: 'call_d1', name: 'delete_file', arguments: { path: 'a.md' } },
+				{ id: 'call_r1', name: 'read_file', arguments: { path: 'b.md' } },
+			];
+			const toolResults: ToolCallResultPair[] = [
+				{ toolName: 'read_file', toolArguments: { path: 'b.md' }, result: { success: true, data: {} }, id: 'call_r1' },
+				{
+					toolName: 'delete_file',
+					toolArguments: { path: 'a.md' },
+					result: { success: true, data: {} },
+					id: 'call_d1',
+				},
+			];
+			const conversationHistory = buildToolHistoryTurns({
+				conversationHistory: [{ role: 'user', parts: [{ text: 'read b.md then delete a.md' }] }],
+				userMessage: '',
+				toolCalls,
+				toolResults,
+			});
+			// Sanity: the call parts are in model order, responses in execution order.
+			const callParts = conversationHistory
+				.flatMap((c) => c.parts)
+				.filter((p): p is NonNullable<typeof p> => p?.functionCall !== undefined);
+			expect(callParts.map((p) => p.functionCall!.id)).toEqual(['call_d1', 'call_r1']);
+
+			await client.generateModelResponse({
+				prompt: '',
+				userMessage: 'done?',
+				kind: 'extended',
+				conversationHistory,
+			});
+
+			const params = interactionsCreateMock.mock.calls[0][0];
+			const results = params.input.filter((s: { type: string }) => s.type === 'function_result');
+			const calls = params.input.filter((s: { type: string }) => s.type === 'function_call');
+			// Every call_id references a function_call id that exists in the same input.
+			for (const r of results) {
+				expect(calls.some((c: { id?: string }) => c.id === r.call_id)).toBe(true);
+			}
+			expect(results.map((r: { call_id: string }) => r.call_id)).toEqual(['call_r1', 'call_d1']);
 		});
 
 		test('maps inline image attachments to image content items', async () => {


### PR DESCRIPTION
## Summary

Fixes #1398

The tool-call correlation `id` was plumbed in one direction only: read off the model response into the replayed `functionCall` part, then dropped at the execution boundary — `ToolCallResultPair` had no `id` field, so `buildFunctionResponseParts` could not emit one. Both readers of `functionResponse.id` (Interactions `call_id`, OpenAI `tool_call_id`) were statically dead branches, always taking their fallback.

On the **Interactions API transport — the default** (`useInteractionsApi: true`), `function_call` steps carry a real id, so every replayed tool turn mismatched:

```
function_call   { id: "call_abc123",  name: "read_file" }
function_result { call_id: "read_file", … }              ← fell back to the name
```

The Interactions API pairs a `function_result` to its `function_call` by `call_id`; every result we replayed referenced an id that appears nowhere in the `input` array. The mismatch was invisible because the one test covering `call_id` hand-built its history with an id no production path ever produced — fixed here by building the fixture the way production does.

## Changes

- `src/agent/agent-loop-helpers.ts` — `ToolCallResultPair` gains `id?: string` (documented as the model-assigned correlation id); `buildFunctionResponseParts` emits `...(tr.id && { id: tr.id })`, the same spread shape `buildFunctionCallParts` already uses on the call side.
- `src/agent/agent-loop.ts` — both `results.push` sites in `executeToolBatch` populate `id` from the `toolCall` already in scope: the success path *and* the error path (a failed tool's `functionResponse` still needs to pair with its call).
- Provider blast radius (the issue's named decision):
  - **Gemini/Interactions** (the point): `call_id` starts matching the call.
  - **OpenAI**: `client.ts:445` already handles a present `id` — deterministic pairing instead of FIFO reconstruction. Per the maintainer decision the **FIFO fallback stays**: histories whose `functionCall` was trimmed by compaction have no id to reconstruct, and pre-id legacy sessions rely on it. The **stable-sort precondition** its name-based pairing silently rests on is now pinned by a dedicated test (`sortToolCallsByPriority` must keep same-name calls in model-emitted order — an unstable comparator would mis-pair OpenAI tool results with no other signal).
  - **Ollama**: declares `functionResponse` as `{name, response}` locally and ignores extra keys — verified no-op.
- Tests: the hand-built `client.test.ts` fixture is rebuilt via `buildToolHistoryTurns` from production `ToolCall`/`ToolCallResultPair` shapes, so it cannot diverge from what `buildFunctionResponseParts` emits again (the old fixture's `functionResponse: { id: 'c1' }` was a shape production never produced — it also masked that real `ToolResult`s serialize as `{success, data}` while the fixture asserted a bare payload). New round-trip test: a batch reordered by `sortToolCallsByPriority` still pairs every `function_result.call_id` with a `function_call.id` present in the same input. New stable-sort pin in the helpers suite.

## Live-API verification

The issue asks to verify against a live Interactions call whether the mismatched `call_id` was an active or latent bug. Not performed here — it needs a live vault session with an API key; the fix is safe either way since matching ids is the documented pairing contract, and the fixture now asserts the production shape.

## Screenshots / Screencast

N/A — wire-format correctness, no UI surface.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [ ] I have tested this change on Desktop
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards)
- [x] Documentation has been updated (if applicable)
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

Notes on the unticked items:

- **Desktop testing**: not performed — the change is type-level plumbing exercised by the suite (3944 tests, including the rebuilt round-trip fixture and the new reorder/stable-sort tests); a desktop pass against a live Interactions session is the one thing unit tests can't cover (see Live-API verification above) and is worth doing on the next eval-harness run.
- **Mobile**: no platform-specific API touched.
- **Documentation**: the correlation contract is documented in the `ToolCallResultPair` doc comment where it lives; `docs/` doesn't reference the tool-call wire shape (verified by grep).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved tool-call result handling so responses remain correctly associated with the originating request, including when results are reordered.
  - Preserved the order of tool calls with matching priority and name, supporting more reliable interaction histories.
  - Enhanced Gemini interaction-history replay to retain accurate tool-call associations and function results.

- **Tests**
  - Added regression coverage for tool-call ordering and correct result correlation during history replay.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->