### PR TITLE
feat(i18n): route error-utils user guidance through t()

### DIFF
--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -3752,6 +3752,154 @@ export const en = {
 		context:
 			'Synthetic user message automatically sent after the user approves a plan, triggering the agent execution loop. Not user-typed.',
 	},
+
+	// Model API error guidance (src/utils/error-utils.ts). These sentences are shown to users —
+	// sometimes interpolated into a longer notice, sometimes as the entire notice. Several are
+	// near-identical in English, so each context names the condition that produces it.
+	'error.unknown': {
+		message: 'An unknown error occurred',
+		context: 'Shown when the failure carried no error value at all (null/undefined).',
+	},
+	'error.openaiInvalidKey': {
+		message: 'Invalid OpenAI API key. Please check the API key in Settings → Gemini Scribe.',
+		context:
+			'HTTP 401 from an OpenAI-compatible provider. "Gemini Scribe" is the plugin name and stays untranslated; "Settings" is Obsidian\'s settings window.',
+	},
+	'error.modelNotOnEndpoint': {
+		message: 'Model not available on this endpoint. Please check your model settings or the configured base URL.',
+		context:
+			'HTTP 404 from an OpenAI-compatible provider: the server is reachable but does not serve the selected model. "Base URL" is the server address the user configured.',
+	},
+	'error.serverUnreachable': {
+		message:
+			'Could not connect to the model server. If you configured a custom base URL (LM Studio, MLX, etc.), make sure the server is running and the base URL in settings is correct.',
+		context:
+			'The OpenAI-compatible client could not open a connection at all. "LM Studio" and "MLX" are product names and stay untranslated.',
+	},
+	'error.invalidApiKey': {
+		message: 'Invalid API key. Please check your model provider credentials in settings.',
+		context: 'The provider rejected the configured API key. Generic across providers.',
+	},
+	'error.authFailed': {
+		message:
+			'Authentication failed. Please verify your model provider credentials and that your account has access to this model.',
+		context:
+			'The credentials were accepted but the account lacks permission for this model (forbidden/unauthorized), as opposed to the key itself being invalid.',
+	},
+	'error.quotaExhausted': {
+		message:
+			'Free-tier quota exhausted for this model. Try switching to a different model (e.g., Gemini Flash) or enable billing in Google AI Studio.',
+		context:
+			'Permanent quota exhaustion — retrying will not help. "Gemini Flash" and "Google AI Studio" are product names and stay untranslated.',
+	},
+	'error.rateLimit': {
+		message: 'API rate limit exceeded. Please wait a moment and try again.',
+		context: 'Transient rate limiting, detected from the error message rather than an HTTP status code.',
+	},
+	'error.ollamaModelNotPulled': {
+		message: 'Ollama model not pulled. Run: ollama pull {model}',
+		context:
+			'The local Ollama server does not have the model downloaded yet. "ollama pull {model}" is a shell command and must stay verbatim; {model} is the model name.',
+	},
+	'error.modelNotAvailable': {
+		message: 'The selected model is not available. Please check your model settings.',
+		context: 'The provider reported the model does not exist, with no provider-specific remedy to offer.',
+	},
+	'error.ollamaUnreachable': {
+		message:
+			'Could not connect to the Ollama daemon. Make sure `ollama serve` is running and the base URL in settings is correct.',
+		context:
+			'A network failure that looks like it targeted a local Ollama endpoint. "ollama serve" is a shell command and must stay verbatim.',
+	},
+	'error.network': {
+		message: 'Network error: Unable to reach the model API. Please check your connection.',
+		context: 'A generic connectivity failure that was not attributable to a specific provider.',
+	},
+	'error.timeout': {
+		message: 'Request timed out. The API took too long to respond. Please try again.',
+		context: 'The request was abandoned after the provider took too long, detected from the error message.',
+	},
+	'error.serviceUnavailable': {
+		message: 'The model API is temporarily unavailable. Please try again later.',
+		context: 'A provider-side outage detected from the error message rather than an HTTP status code.',
+	},
+	'error.safetyBlocked': {
+		message: 'Content was blocked by safety filters. Please rephrase your request.',
+		context: "The provider's content-safety filters rejected the request or the response.",
+	},
+	'error.tokenLimit': {
+		message: 'Request exceeds token limit. Please reduce the length of your message or conversation history.',
+		context:
+			'The prompt plus conversation history exceeded the model\'s context window. "Token" is the standard LLM unit of text.',
+	},
+	'error.apiPrefix': {
+		message: 'API error: {message}',
+		context:
+			'Wrapper around a provider error we could not classify. {message} is the provider\'s own text and arrives in English; only the "API error" prefix is translated.',
+	},
+	'error.communicationFailed': {
+		message: 'An error occurred while communicating with the model API',
+		context: 'Fallback for an error object that carried no usable message at all.',
+	},
+	'error.unknownCommunication': {
+		message: 'An unknown error occurred while communicating with the model API',
+		context: 'Last-resort fallback when nothing about the error value could be interpreted.',
+	},
+	'error.http.badRequest': {
+		message: 'Bad request: The API request was invalid. Please check your message and try again.',
+		context: 'HTTP 400 from the model API.',
+	},
+	'error.http.unauthorized': {
+		message: 'Authentication failed: Invalid API key. Please check your model provider credentials in settings.',
+		context: 'HTTP 401 from the model API.',
+	},
+	'error.http.forbidden': {
+		message: 'Access forbidden: The model provider denied access to this model or feature.',
+		context: 'HTTP 403 from the model API.',
+	},
+	'error.http.notFound': {
+		message: 'Model not found: The selected model is not available. Please check your model settings.',
+		context: 'HTTP 404 from the model API.',
+	},
+	'error.http.rateLimit': {
+		message: 'Rate limit exceeded: Too many requests. Please wait a moment and try again.',
+		context: 'HTTP 429 from the model API, for transient rate limiting rather than exhausted quota.',
+	},
+	'error.http.serverError': {
+		message: 'Server error: The model API encountered an internal error. Please try again later.',
+		context: 'HTTP 500 from the model API.',
+	},
+	'error.http.serviceUnavailable': {
+		message: 'Service unavailable: The model API is temporarily down. Please try again later.',
+		context: 'HTTP 503 from the model API.',
+	},
+	'error.http.gatewayTimeout': {
+		message: 'Gateway timeout: The API request took too long. Please try again.',
+		context: 'HTTP 504 from the model API.',
+	},
+	'error.http.serverErrorWithCode': {
+		message: 'Server error ({statusCode}): The model API is experiencing issues. Please try again later.',
+		context: 'Any other 5xx status. {statusCode} is the numeric HTTP status code.',
+	},
+	'error.http.clientErrorWithCode': {
+		message: 'Client error ({statusCode}): {message}',
+		context:
+			"Any other 4xx status where the provider supplied detail text. {statusCode} is the numeric HTTP status; {message} is the provider's own text and arrives in English.",
+	},
+	'error.http.clientErrorWithCodeNoDetail': {
+		message: 'Client error ({statusCode}): Please check your request and try again.',
+		context:
+			'Any other 4xx status where the provider supplied no detail text. {statusCode} is the numeric HTTP status.',
+	},
+	'error.http.genericWithCode': {
+		message: 'HTTP error {statusCode}: {message}',
+		context:
+			"A non-4xx, non-5xx status carrying detail text. {statusCode} is the numeric HTTP status; {message} is the provider's own text and arrives in English.",
+	},
+	'error.http.genericWithCodeNoDetail': {
+		message: 'HTTP error {statusCode}: An unexpected error occurred.',
+		context: 'A non-4xx, non-5xx status with no detail text. {statusCode} is the numeric HTTP status.',
+	},
 } as const satisfies Record<string, SourceString>;
 
 export type TranslationKey = keyof typeof en;

--- a/src/utils/error-utils.ts
+++ b/src/utils/error-utils.ts
@@ -4,7 +4,14 @@
  * Raw extraction (no translation): `getRawErrorMessage` — `Error` → `.message`, everything else → `String(error)`.
  * Raw extraction with an explicit fallback: `getRawErrorMessageOr` — `Error` → `.message`, everything else → the supplied fallback.
  * User-facing translation (maps provider quirks to friendly guidance): `getErrorMessage`.
+ *
+ * The guidance `getErrorMessage`/`getHttpErrorMessage` return is UI prose — it is interpolated into
+ * localized `Notice` templates and, at five call sites, *is* the whole notice — so every sentence
+ * they return goes through `t()` under the `error.*` namespace. The raw helpers above stay
+ * untranslated by design: their output is provider text bound for logs and persisted sidecars.
  */
+
+import { t } from '../i18n';
 
 /**
  * Coerce an unknown value to a string-keyed record for safe property probing.
@@ -190,7 +197,7 @@ export function getRawErrorMessageOr(error: unknown, fallback: string): string {
 export function getErrorMessage(error: unknown): string {
 	// Handle null/undefined
 	if (!error) {
-		return 'An unknown error occurred';
+		return t('error.unknown');
 	}
 
 	// Convert to Error object if it's a string
@@ -214,10 +221,10 @@ export function getErrorMessage(error: unknown): string {
 		if (isOpenAIApiError(asRecord(error))) {
 			const statusCode = extractStatusCode(error);
 			if (statusCode === 401) {
-				return 'Invalid OpenAI API key. Please check the API key in Settings → Gemini Scribe.';
+				return t('error.openaiInvalidKey');
 			}
 			if (statusCode === 404) {
-				return 'Model not available on this endpoint. Please check your model settings or the configured base URL.';
+				return t('error.modelNotOnEndpoint');
 			}
 		}
 
@@ -230,7 +237,7 @@ export function getErrorMessage(error: unknown): string {
 		// carry one) rather than an SDK class import, for the same reason as
 		// `isOpenAIApiError` above.
 		if (message === 'Connection error.' && extractStatusCode(error) === null) {
-			return 'Could not connect to the model server. If you configured a custom base URL (LM Studio, MLX, etc.), make sure the server is running and the base URL in settings is correct.';
+			return t('error.serverUnreachable');
 		}
 
 		// API key errors
@@ -239,7 +246,7 @@ export function getErrorMessage(error: unknown): string {
 			messageLower.includes('api_key') ||
 			messageLower.includes('invalid_api_key')
 		) {
-			return 'Invalid API key. Please check your model provider credentials in settings.';
+			return t('error.invalidApiKey');
 		}
 
 		// Authentication/permission errors
@@ -248,7 +255,7 @@ export function getErrorMessage(error: unknown): string {
 			messageLower.includes('forbidden') ||
 			messageLower.includes('unauthorized')
 		) {
-			return 'Authentication failed. Please verify your model provider credentials and that your account has access to this model.';
+			return t('error.authFailed');
 		}
 
 		// Rate limiting — distinguish transient from permanent quota exhaustion
@@ -258,9 +265,9 @@ export function getErrorMessage(error: unknown): string {
 			messageLower.includes('resource_exhausted')
 		) {
 			if (isQuotaExhausted(error)) {
-				return 'Free-tier quota exhausted for this model. Try switching to a different model (e.g., Gemini Flash) or enable billing in Google AI Studio.';
+				return t('error.quotaExhausted');
 			}
-			return 'API rate limit exceeded. Please wait a moment and try again.';
+			return t('error.rateLimit');
 		}
 
 		// Model not found
@@ -274,9 +281,9 @@ export function getErrorMessage(error: unknown): string {
 				// (e.g. `model 'llama3.2' not found, try pulling it first`).
 				const match = error.message.match(/model\s+["']?([\w./:-]+)["']?/i);
 				const modelName = match ? match[1] : 'this model';
-				return `Ollama model not pulled. Run: ollama pull ${modelName}`;
+				return t('error.ollamaModelNotPulled', { model: modelName });
 			}
-			return 'The selected model is not available. Please check your model settings.';
+			return t('error.modelNotAvailable');
 		}
 
 		// Network errors. Match the specific fetch-failure phrasings — "Failed to
@@ -299,14 +306,14 @@ export function getErrorMessage(error: unknown): string {
 			const looksLikeOllamaEndpoint =
 				/(?:^|[\s(/])(?:https?:\/\/)?(?:localhost|127\.0\.0\.1|\[::1\]|[\w.-]+):11434\b/.test(messageLower);
 			if (messageLower.includes('ollama') || looksLikeOllamaEndpoint) {
-				return 'Could not connect to the Ollama daemon. Make sure `ollama serve` is running and the base URL in settings is correct.';
+				return t('error.ollamaUnreachable');
 			}
-			return 'Network error: Unable to reach the model API. Please check your connection.';
+			return t('error.network');
 		}
 
 		// Timeout errors
 		if (messageLower.includes('timeout') || messageLower.includes('timed out')) {
-			return 'Request timed out. The API took too long to respond. Please try again.';
+			return t('error.timeout');
 		}
 
 		// Service unavailable
@@ -316,12 +323,12 @@ export function getErrorMessage(error: unknown): string {
 		// that isn't happening. Genuine 503s are still covered by the HTTP
 		// status-code path in getHttpErrorMessage.
 		if (messageLower.includes('unavailable')) {
-			return 'The model API is temporarily unavailable. Please try again later.';
+			return t('error.serviceUnavailable');
 		}
 
 		// Content filtering/safety
 		if (messageLower.includes('safety') || messageLower.includes('blocked')) {
-			return 'Content was blocked by safety filters. Please rephrase your request.';
+			return t('error.safetyBlocked');
 		}
 
 		// HTTP status code mapping runs after the message-based checks above so
@@ -338,16 +345,16 @@ export function getErrorMessage(error: unknown): string {
 			messageLower.includes('too long') ||
 			messageLower.includes('max tokens')
 		) {
-			return 'Request exceeds token limit. Please reduce the length of your message or conversation history.';
+			return t('error.tokenLimit');
 		}
 
 		// If we have a message, return it
 		if (message) {
-			return `API error: ${message}`;
+			return t('error.apiPrefix', { message });
 		}
 
 		// Fallback for Error objects without useful message
-		return 'An error occurred while communicating with the model API';
+		return t('error.communicationFailed');
 	}
 
 	// Handle objects with error information
@@ -364,7 +371,7 @@ export function getErrorMessage(error: unknown): string {
 		if (err.message) {
 			// If the message is a string, process it as an error message with prefix
 			if (typeof err.message === 'string') {
-				return `API error: ${err.message}`;
+				return t('error.apiPrefix', { message: err.message });
 			}
 			// Otherwise recurse (could be nested error object)
 			return getErrorMessage(err.message);
@@ -375,7 +382,7 @@ export function getErrorMessage(error: unknown): string {
 		if (nestedError.message) {
 			// Process nested error message
 			if (typeof nestedError.message === 'string') {
-				return `API error: ${nestedError.message}`;
+				return t('error.apiPrefix', { message: nestedError.message });
 			}
 			return getErrorMessage(nestedError.message);
 		}
@@ -384,7 +391,7 @@ export function getErrorMessage(error: unknown): string {
 		try {
 			const errorStr = JSON.stringify(err);
 			if (errorStr !== '{}') {
-				return `API error: ${errorStr}`;
+				return t('error.apiPrefix', { message: errorStr });
 			}
 		} catch {
 			// JSON.stringify failed, continue to fallback
@@ -392,7 +399,7 @@ export function getErrorMessage(error: unknown): string {
 	}
 
 	// Final fallback
-	return 'An unknown error occurred while communicating with the model API';
+	return t('error.unknownCommunication');
 }
 
 /**
@@ -457,32 +464,36 @@ function getHttpErrorMessage(statusCode: number, error: unknown): string {
 
 	switch (statusCode) {
 		case 400:
-			return 'Bad request: The API request was invalid. Please check your message and try again.';
+			return t('error.http.badRequest');
 		case 401:
-			return 'Authentication failed: Invalid API key. Please check your model provider credentials in settings.';
+			return t('error.http.unauthorized');
 		case 403:
-			return 'Access forbidden: The model provider denied access to this model or feature.';
+			return t('error.http.forbidden');
 		case 404:
-			return 'Model not found: The selected model is not available. Please check your model settings.';
+			return t('error.http.notFound');
 		case 429:
 			if (isQuotaExhausted(error)) {
-				return 'Free-tier quota exhausted for this model. Try switching to a different model (e.g., Gemini Flash) or enable billing in Google AI Studio.';
+				return t('error.quotaExhausted');
 			}
-			return 'Rate limit exceeded: Too many requests. Please wait a moment and try again.';
+			return t('error.http.rateLimit');
 		case 500:
-			return 'Server error: The model API encountered an internal error. Please try again later.';
+			return t('error.http.serverError');
 		case 503:
-			return 'Service unavailable: The model API is temporarily down. Please try again later.';
+			return t('error.http.serviceUnavailable');
 		case 504:
-			return 'Gateway timeout: The API request took too long. Please try again.';
+			return t('error.http.gatewayTimeout');
 		default:
 			if (statusCode >= 500) {
-				return `Server error (${statusCode}): The model API is experiencing issues. Please try again later.`;
+				return t('error.http.serverErrorWithCode', { statusCode });
 			}
 			if (statusCode >= 400) {
-				return `Client error (${statusCode}): ${errorMessage || 'Please check your request and try again.'}`;
+				return errorMessage
+					? t('error.http.clientErrorWithCode', { statusCode, message: errorMessage })
+					: t('error.http.clientErrorWithCodeNoDetail', { statusCode });
 			}
-			return `HTTP error ${statusCode}: ${errorMessage || 'An unexpected error occurred.'}`;
+			return errorMessage
+				? t('error.http.genericWithCode', { statusCode, message: errorMessage })
+				: t('error.http.genericWithCodeNoDetail', { statusCode });
 	}
 }
 

--- a/test/utils/error-utils.test.ts
+++ b/test/utils/error-utils.test.ts
@@ -1,3 +1,5 @@
+import { getLanguage } from 'obsidian';
+import { locales } from '../../src/i18n';
 import {
 	getErrorMessage,
 	getRawErrorMessage,
@@ -665,6 +667,70 @@ describe('error-utils', () => {
 		test('returns short messages unchanged', () => {
 			expect(truncateStoredError('Disk full')).toBe('Disk full');
 			expect(truncateStoredError('')).toBe('');
+		});
+	});
+
+	// Every assertion above resolves through `t()` already — `__mocks__/obsidian.js` stubs
+	// `getLanguage()` to 'en', so the English source string comes back and the exact-string
+	// expectations keep their original meaning. These cases cover what that setup cannot show:
+	// that the returns are genuinely keyed lookups rather than English literals, and that the
+	// placeholders survive the move into `en.ts`.
+	describe('localization', () => {
+		const RU_KEYS = ['error.timeout', 'error.ollamaModelNotPulled', 'error.http.serverErrorWithCode'] as const;
+
+		afterEach(() => {
+			vi.mocked(getLanguage).mockReturnValue('en');
+			for (const key of RU_KEYS) delete locales.ru[key];
+		});
+
+		test('resolves through the active locale rather than returning English literals', () => {
+			locales.ru['error.timeout'] = 'Время ожидания запроса истекло.';
+			vi.mocked(getLanguage).mockReturnValue('ru');
+
+			expect(getErrorMessage(new Error('Request timed out'))).toBe('Время ожидания запроса истекло.');
+		});
+
+		test('falls back to English for a key the active locale has not translated yet', () => {
+			// The `Update UI translations` workflow regenerates language files only after `en.ts`
+			// lands on master, so a newly added key is missing from every locale in the meantime.
+			vi.mocked(getLanguage).mockReturnValue('ru');
+
+			expect(getErrorMessage(new Error('Request timed out'))).toBe(
+				'Request timed out. The API took too long to respond. Please try again.'
+			);
+		});
+
+		test('interpolates the Ollama model name into the translated pull hint', () => {
+			locales.ru['error.ollamaModelNotPulled'] = 'Модель Ollama не загружена. Выполните: ollama pull {model}';
+			vi.mocked(getLanguage).mockReturnValue('ru');
+
+			const error = new Error("model 'llama3.2' not found, try pulling it first");
+			expect(getErrorMessage(error)).toBe('Модель Ollama не загружена. Выполните: ollama pull llama3.2');
+		});
+
+		test('interpolates the status code into the translated 5xx fallback', () => {
+			locales.ru['error.http.serverErrorWithCode'] = 'Ошибка сервера ({statusCode}). Повторите попытку позже.';
+			vi.mocked(getLanguage).mockReturnValue('ru');
+
+			expect(getErrorMessage({ status: 502 })).toBe('Ошибка сервера (502). Повторите попытку позже.');
+		});
+
+		test('interpolates the status code and provider detail into the 4xx fallback', () => {
+			expect(getErrorMessage({ status: 422, message: 'Unprocessable payload' })).toBe(
+				'Client error (422): Unprocessable payload'
+			);
+		});
+
+		test('uses the detail-free 4xx fallback when the provider supplied no message', () => {
+			expect(getErrorMessage({ status: 422 })).toBe('Client error (422): Please check your request and try again.');
+		});
+
+		test('interpolates the status code and provider detail into the non-4xx/5xx fallback', () => {
+			expect(getErrorMessage({ status: 302, message: 'Found elsewhere' })).toBe('HTTP error 302: Found elsewhere');
+		});
+
+		test('uses the detail-free fallback for a non-4xx/5xx status with no message', () => {
+			expect(getErrorMessage({ status: 302 })).toBe('HTTP error 302: An unexpected error occurred.');
 		});
 	});
 });


### PR DESCRIPTION
## Summary

`src/utils/error-utils.ts` builds the actionable, user-facing half of nearly every error the plugin shows — "Invalid API key. Please check your model provider credentials in settings.", "Ollama model not pulled. Run: ollama pull llama3.2" — and none of it went through `t()`. Over 20 call sites interpolate `getErrorMessage(error)` into an already-translated `Notice` template, and five more (`rag-sync-queue.ts:276`, `rag-vault-scanner.ts:565`, `rewrite-selection.ts:82` and `:134`, `agent-view-send.ts:713`) show it as the *entire* notice, so a non-English user got a half-translated string.

This is strictly "same branches, translated returns", as the approved plan scopes it: a 32-key `error.*` namespace is added to `src/i18n/en.ts`, and each literal `return` in `getErrorMessage` / `getHttpErrorMessage` becomes a `t()` lookup. Every branch condition, its guard, and its **position in the ordering-sensitive ladder are byte-identical** — the ordering comments at `:203`, `:229`, `:294`, `:313`, `:326` document arms that must win over later ones, so the diff reads as "left-hand sides untouched, right-hand sides swapped". Every resolved English string is unchanged, which is why the 102 pre-existing exact-string assertions in `test/utils/error-utils.test.ts` pass with **zero edits**.

Because `t()` translates the helper itself, all five raw-notice call sites are localized without touching a single caller — the issue's "consider a wrapper template for `rag-sync-queue`" bullet is deliberately not taken, since wrapper templates would be five caller changes that buy nothing once the helper is translated.

Produced by the auto-dev pipeline from the plan approved on the issue.

Fixes #1332

## Changes

- **`src/i18n/en.ts`** — new `error.*` namespace, 32 keys, each with a `context` naming the condition that triggers it (several are near-identical in English, and translators need the disambiguation). Placeholders: `{model}` for the Ollama pull hint, `{statusCode}` / `{message}` for the HTTP fallbacks, `{message}` for the `API error:` wrapper. `"Free-tier quota exhausted…"` appears verbatim in both `getErrorMessage`'s rate-limit arm and `getHttpErrorMessage`'s 429 arm, so it is one shared key (`error.quotaExhausted`) rather than two.
- **`src/utils/error-utils.ts`** — adds `import { t } from '../i18n'`; 22 returns translated in `getErrorMessage`, 10 in `getHttpErrorMessage`. The file header now records *why* the raw helpers stay untranslated while these do not.
- **`test/utils/error-utils.test.ts`** — additive only (+8 cases). Existing assertions untouched.

Two notes on judgement calls inside the plan's scope:

- **The passthrough shapes the issue flagged for a decision** are translated as wrappers, per the plan's recommendation and the approval: `API error: {message}`, `Server error ({statusCode}): …`, `Client error ({statusCode}): {message}`, `HTTP error {statusCode}: {message}`. The interpolated `{message}` is provider English either way; leaving the wrappers English would have meant the *only* untranslated fragments were the generic catch-alls users hit most often.
- **The two detail-carrying HTTP fallbacks gained a paired detail-free key** (`error.http.clientErrorWithCodeNoDetail`, `error.http.genericWithCodeNoDetail`) instead of interpolating an English fragment (`'Please check your request and try again.'`) into a translated wrapper. A translator sees a whole sentence in both cases rather than a wrapper with a hole an English fragment falls into. Output is byte-identical to the previous `${errorMessage || '…'}` shape either way.

**Deliberately untouched:** `getErrorMessage:197` (`typeof error === 'string'` → the caller's own string passing through, not our prose), `getRawErrorMessage` / `getRawErrorMessageOr` / `truncateStoredError` (provider text verbatim, bound for logs and persisted sidecars), and the `if` ladder's structure — restructuring it is a fair separate discussion, but mixing a refactor into a string-extraction pass makes the diff unreviewable.

**Two safety checks, both clean.** Nothing localized leaks into vault-persisted state: `failure-pause-tracker.ts:125` persists `lastError` via the *raw* helper, so that path stays untranslated; `background-task-manager.ts:193` holds `task.error` in memory only. And no `===` comparison against `getErrorMessage` output exists anywhere in `src/` or `test/`. The `getShortErrorMessage` coordination risk the plan raised (it split this output on `/[:.]/`, which would have become locale-dependent) is moot — #1331 has since merged and the function is gone.

Per-language files are **not** hand-written here; the `Update UI translations` workflow regenerates them once `en.ts` lands on master. `test/i18n/locales.test.ts` asserts one-directionally (a locale may only contain keys that exist in `en.ts`, not the reverse), so `en.ts` landing ahead of them is green, and `t()` falls back to English in the meantime.

## Screenshots / Screencast

N/A — no UI surface changes. The rendered strings are byte-identical in English; the change is which lookup produces them.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer — #1332, plan approved 2026-08-29
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — run locally before pushing: `format-check` clean, `lint` 0 errors / 40 pre-existing warnings, `lint:cycles` 0 circular deps, `build` clean, `typecheck:test` clean, `knip` clean, 3950 tests in 177 files passing
- [ ] I have tested this change on Desktop — not run in the sandbox (no Obsidian runtime available). Behavioral verification here is string resolution, which the added locale-flipped unit tests exercise directly and more precisely than reading a notice: they seed a `ru` entry, flip the `getLanguage` mock, and assert the translated string comes back with its placeholders interpolated. The English-output equivalence is covered by the 102 unchanged exact-string assertions.
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — no platform-specific API is touched; `src/i18n` is already loaded on every platform
- [x] Documentation has been updated (if applicable) — no doc change needed, and that is a real answer rather than a skipped box: `README.md:335` and `docs/guide/faq.md:163` **already** state that notices are translated. That claim was false for the error half; this change makes the existing documentation true.
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (auto-dev pipeline)
- [x] I have reviewed and understand all AI-generated code in this PR

<!-- auto-dev -->

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013fpTyRUpJe2RFp2ptfqyMw

---
_Generated by [Claude Code](https://claude.ai/code/session_013fpTyRUpJe2RFp2ptfqyMw)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added localized guidance for model, provider, network, quota, timeout, safety, token, and HTTP errors.
  * Error messages now support translated text with relevant details such as model names and status information.
  * Added English fallback messaging when translations are unavailable.

* **Bug Fixes**
  * Improved consistency and clarity of user-facing error messages across supported failure scenarios.

* **Tests**
  * Added coverage for locale selection, fallback behavior, and dynamic error details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->