### PR TITLE
fix(mcp): delete the global window timer patch

### DIFF
--- a/src/mcp/mcp-manager.ts
+++ b/src/mcp/mcp-manager.ts
@@ -44,63 +44,6 @@ function describeConnectionTarget(config: MCPServerConfig, useHttp: boolean): st
 type MCPTransport = StdioClientTransportType | StreamableHTTPClientTransport;
 
 /**
- * Patch the global setTimeout to return objects with .unref() in Electron's renderer.
- *
- * The MCP SDK internally calls setTimeout(...).unref(), which works in Node.js
- * (where setTimeout returns a Timeout object) but fails in Electron's renderer
- * (where setTimeout returns a number, like in browsers).
- *
- * This polyfill wraps the return value so .unref() is a safe no-op.
- */
-function patchSetTimeoutForElectron(): void {
-	const origSetTimeout = window.setTimeout.bind(window);
-	if (typeof origSetTimeout === 'function') {
-		// Test if unref already works (true Node.js environment)
-		const testTimer = origSetTimeout(() => {}, 0);
-		if (typeof (testTimer as unknown as { unref?: unknown }).unref === 'function') {
-			// Already has .unref() — no patch needed
-			window.clearTimeout(testTimer);
-			return;
-		}
-		window.clearTimeout(testTimer);
-
-		// Patch: wrap return value to add .unref() and .ref() as no-ops. The wrapper
-		// deliberately does not match the native `number` return type, so the
-		// assignment is bridged through `unknown` — a genuine monkey-patch boundary.
-		window.setTimeout = function patchedSetTimeout(
-			callback: (...args: unknown[]) => void,
-			ms?: number,
-			...args: unknown[]
-		) {
-			const id = origSetTimeout(callback, ms, ...args);
-			return {
-				[Symbol.toPrimitive]() {
-					return id;
-				},
-				unref() {
-					return this;
-				},
-				ref() {
-					return this;
-				},
-				// Preserve the raw id so clearTimeout still works
-				__timerId: id,
-			};
-		} as unknown as typeof window.setTimeout;
-
-		// Also patch clearTimeout to handle our wrapper objects
-		const origClearTimeout = window.clearTimeout.bind(window);
-		window.clearTimeout = function patchedClearTimeout(id?: unknown): void {
-			if (id && typeof id === 'object' && '__timerId' in id) {
-				origClearTimeout((id as { __timerId?: number }).__timerId);
-			} else {
-				origClearTimeout(id as number | undefined);
-			}
-		};
-	}
-}
-
-/**
  * Runtime connection info for an MCP server
  */
 interface ServerConnection {
@@ -498,9 +441,6 @@ export class MCPManager {
 		config: MCPServerConfig
 	): Promise<{ client: Client; transport: MCPTransport }> {
 		const useHttp = isHttpTransport(config);
-
-		// Patch setTimeout for Electron compatibility before any MCP SDK calls
-		patchSetTimeoutForElectron();
 
 		let transport: MCPTransport;
 		let authProvider: ObsidianOAuthClientProvider | undefined;

--- a/test/mcp/mcp-manager.test.ts
+++ b/test/mcp/mcp-manager.test.ts
@@ -176,6 +176,36 @@ describe('MCPManager', () => {
 			await expect(manager.connectServer(config)).rejects.toThrow('HTTP transport requires a URL');
 		});
 
+		it('leaves window.setTimeout and window.clearTimeout untouched across connect cycles (#1416)', async () => {
+			// Regression guard for the old patchSetTimeoutForElectron: it used to
+			// replace the global timer functions on the first MCP connect and
+			// never restore them, so every setTimeout in the app returned a
+			// wrapper object instead of a numeric id for the rest of the
+			// session. The patch is gone (#1416); these asserts pin that
+			// connect/disconnect cycles leave the globals identity-unchanged.
+			const setTimeoutBefore = window.setTimeout;
+			const clearTimeoutBefore = window.clearTimeout;
+			mockListTools.mockResolvedValueOnce({ tools: [{ name: 'test_tool' }] });
+
+			await manager.connectServer(createHttpConfig());
+			await manager.disconnectAll();
+			mockListTools.mockResolvedValueOnce({ tools: [] });
+			await manager.connectServer(createStdioConfig());
+
+			expect(window.setTimeout).toBe(setTimeoutBefore);
+			expect(window.clearTimeout).toBe(clearTimeoutBefore);
+			// The timer globals still behave natively: the id they return
+			// round-trips through clearTimeout. Deliberate real-timer use: the
+			// subject under test IS the timer identity, not the timing — the
+			// timer is cleared synchronously and never awaited. The id's type
+			// (number in a browser, Node Timeout object in this jsdom/vitest
+			// environment) is exactly what the old patch used to rewrite; the
+			// guarantee being pinned is identity of the functions, not the id
+			// representation.
+			const id = window.setTimeout(() => {}, 0);
+			window.clearTimeout(id);
+		});
+
 		it('should block stdio on mobile', async () => {
 			const originalIsMobile = Platform.isMobile;
 			try {


### PR DESCRIPTION
## Summary

Fixes #1416

`patchSetTimeoutForElectron` replaced `window.setTimeout`/`window.clearTimeout` process-wide on the first MCP connect and never restored them: every `setTimeout` call in the Obsidian window — core, every other installed plugin, this plugin — returned a wrapper **object** instead of a timer id, and the patch had no teardown: disabling the plugin, toggling `mcpEnabled` off, or a settings-triggered reload all left it installed for the rest of the session with no owner. This is the exact anti-pattern the repo's own Logger exists to avoid ("so it doesn't conflict with other plugins").

**Strategy (the issue's fork): delete the patch entirely** rather than make it removable/reference-counted. The SDK source evidence says it protects nothing the plugin's transports actually need.

## Why deletion is correct (the issue's live-verification question, answered from the SDK source)

The issue asked to "confirm on a current Electron/Obsidian build whether the patch is still needed." The installed SDK (1.30.0 — current latest, verified against `npm view`) answers it directly:

- **`.unref()` is called in exactly two client-side places**, both in `client/stdio.js` `close()` — inside a `Promise.race` with a 2s close timeout, i.e. process teardown.
- **`shared/protocol.js`** — the hot path that runs every request timeout — calls `setTimeout`/`clearTimeout` and **never `.unref()`**.
- **`client/streamableHttp.js`** — the HTTP transport the plugin actually uses for HTTP servers — has zero `.unref()` calls.
- **The stdio transport cannot run in an Electron renderer anyway**: it spawns a process via `cross-spawn` → `child_process`, Node-only (the plugin already gates stdio as desktop-only, and desktop plugins run with Node available — where the patch's own probe `typeof testTimer.unref === 'function'` short-circuited it to a no-op).
- Where the SDK tolerates unref-less timers, it guards itself: `server/sseKeepAlive.js` uses `timer.unref?.()`.

So the patch either did nothing (Node-flavored runtime) or replaced the window's timer functions to guard a code path the plugin can't reach. The issue's option (1) asked whether the SDK exposes a timer seam for the patch to be replaced by — none is needed: no unguarded `.unref()` remains on any transport path the plugin uses. If a **future** SDK version adds an unguarded `.unref()` on a supported transport, the scoped fix is wrapping that one call site, not the window globals.

## Changes

- `src/mcp/mcp-manager.ts` — `patchSetTimeoutForElectron()` (46 lines) and its call site in `createTransportAndConnect` deleted. Net −60 lines. No other MCP behavior touched (out-of-scope items respected: transport selection, OAuth, file split all untouched).
- `test/mcp/mcp-manager.test.ts` — regression test: connect (HTTP) → disconnectAll → connect (stdio) → assert `window.setTimeout`/`window.clearTimeout` are **identity-equal** to the pre-cycle references, and the returned id round-trips through `clearTimeout`. Pins the invariant so a future global-patch regression fails here.

**Test-environment note:** jsdom/vitest timers return Node `Timeout` objects (`typeof 'object'`), browsers return numbers — the id's *representation* was exactly what the old patch rewrote, and it varies by runtime. The test therefore asserts **function identity** (the real invariant), not id representation; a comment in the test records why.

## Screenshots / Screencast

N/A — removal of a global side effect; the MCP user-facing surface (connect, tool listing, OAuth) is unchanged and covered by the existing 44-test suite.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [ ] I have tested this change on Desktop
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards)
- [x] Documentation has been updated (if applicable)
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

Notes on the unticked items:

- **Desktop testing**: the issue's live-verification item is answered from the installed SDK source (1.30.0 — current latest, matching `package.json`) rather than a live vault: the `.unref()` census above is exhaustive (grep over `node_modules/@modelcontextprotocol/sdk/dist/esm/`). A desktop MCP smoke test would only re-confirm that connect/list-tools work — covered by the 44-test MCPManager suite. Worth a real stdio-server connect during the next eval-harness run for belt and braces.
- **Mobile**: stdio stays mobile-blocked exactly as before (`Platform.isMobile` gates unchanged); HTTP transport unaffected.
- **Documentation**: no docs reference the timer patch (verified by grep over `docs/`); the rationale lives in the commit and the regression test's comments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MCP connection stability by preserving the browser’s native timer behavior during HTTP and stdio connection cycles.
  * Prevented timer functions from being unexpectedly replaced or altered after connecting and disconnecting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->