### PR TITLE
refactor(api): route streaming retries through the shared retry engine

### DIFF
--- a/docs/reference/advanced-settings.md
+++ b/docs/reference/advanced-settings.md
@@ -103,6 +103,13 @@ Configure how the plugin handles API failures:
 6. Wait quadruple the delay (e.g., 4 seconds)
 7. Final attempt or success
 
+Two details apply to every wait above:
+
+- **Jitter**: up to 10% is added at random to each delay, so several requests that hit the same rate limit don't all retry at the same instant.
+- **60-second ceiling**: no single wait exceeds 60 seconds, however large the initial backoff delay is set.
+
+If the API returns its own retry hint (Google sends one with some rate-limit errors), that delay is used in place of the calculated backoff — subject to the same 60-second ceiling. Streaming and non-streaming requests follow the identical policy.
+
 ## Model Discovery
 
 Model discovery is automatic — no configuration is required. On startup, the plugin fetches the latest available Gemini models from GitHub and caches the result for 24 hours. If the fetch fails, the bundled static model list is used as a fallback.

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -383,7 +383,7 @@ Advanced settings for developers and power users. Access by clicking "Show advan
 - **Type**: Number
 - **Default**: `3`
 - **Description**: Maximum number of retry attempts when a model request fails
-- **Note**: Uses exponential backoff between retries
+- **Note**: Uses exponential backoff between retries. Applies to streaming and non-streaming requests alike, which share one retry policy.
 
 #### Initial Backoff Delay
 
@@ -391,7 +391,8 @@ Advanced settings for developers and power users. Access by clicking "Show advan
 - **Type**: Number (milliseconds)
 - **Default**: `1000`
 - **Description**: Initial delay before the first retry attempt
-- **Note**: Subsequent retries use exponential backoff (2x, 4x, 8x, etc.)
+- **Note**: Subsequent retries use exponential backoff (2x, 4x, 8x, etc.), plus up to 10% random jitter so that several clients retrying after the same rate limit don't do so in lockstep. Each wait is capped at 60 seconds, so a large initial delay cannot push a retry arbitrarily far out.
+- **Note**: When the API supplies its own retry delay (a `RetryInfo` hint on a 429), that value is used instead of the backoff — also capped at 60 seconds.
 
 ### Model Parameters
 

--- a/src/api/retry-decorator.ts
+++ b/src/api/retry-decorator.ts
@@ -13,9 +13,16 @@ import {
 	StreamingModelResponse,
 } from './interfaces/model-api';
 import { Logger } from '../utils/logger';
-import { isRetryableApiError, parseRetryDelay, executeWithRetry } from '../utils/retry';
+import { isRetryableApiError, executeWithRetry, RetryOptions } from '../utils/retry';
 
-export interface RetryConfig {
+/**
+ * Settings-shaped retry configuration for the decorator.
+ *
+ * Deliberately distinct from `RetryConfig` in `src/utils/retry.ts`: this pair mirrors the
+ * `settings.maxRetries` / `settings.initialBackoffDelay` surface, while the retry engine's
+ * config also carries the delay cap and jitter switch. The decorator translates between them.
+ */
+export interface ApiRetryConfig {
 	maxRetries: number;
 	initialBackoffDelay: number;
 }
@@ -25,29 +32,29 @@ export interface RetryConfig {
  */
 export class RetryDecorator implements ModelApi {
 	private wrappedApi: ModelApi;
-	private config: RetryConfig;
+	private config: ApiRetryConfig;
 	private logger?: Logger;
 
-	constructor(wrappedApi: ModelApi, config: RetryConfig, logger?: Logger) {
+	constructor(wrappedApi: ModelApi, config: ApiRetryConfig, logger?: Logger) {
 		this.wrappedApi = wrappedApi;
 		this.config = config;
 		this.logger = logger;
 	}
 
-	/**
-	 * Sleep for a specified number of milliseconds
-	 */
-	private sleep(ms: number): Promise<void> {
-		return new Promise((resolve) => window.setTimeout(resolve, ms));
-	}
-
-	/** Maximum delay cap when using API-provided retry delays (60 seconds) */
+	/** Maximum delay cap for retry backoff, whether API-provided or exponential (60 seconds) */
 	private static readonly MAX_API_DELAY_MS = 60000;
 
 	/**
 	 * Execute a function with retry logic and exponential backoff.
+	 *
+	 * Both the streaming and non-streaming paths funnel through here, so they share one delay
+	 * policy — jitter, the delay cap, and the API-provided-delay decision.
 	 */
-	private async executeWithRetry<T>(operation: () => Promise<T>, operationName: string): Promise<T> {
+	private async executeWithRetry<T>(
+		operation: () => Promise<T>,
+		operationName: string,
+		cancellation?: Pick<RetryOptions, 'shouldAbort' | 'abortError'>
+	): Promise<T> {
 		return executeWithRetry(
 			operation,
 			{
@@ -59,6 +66,7 @@ export class RetryDecorator implements ModelApi {
 				operationName,
 				logger: this.logger,
 				isRetryable: isRetryableApiError,
+				...cancellation,
 			}
 		);
 	}
@@ -75,6 +83,10 @@ export class RetryDecorator implements ModelApi {
 	 *
 	 * Note: Streaming retries are more complex. If a stream fails mid-stream,
 	 * we retry from the beginning. This means chunks may be duplicated.
+	 *
+	 * The retry loop itself is the shared one — cancellation is threaded through as a
+	 * `shouldAbort` hook so that this path cannot drift from the non-streaming delay policy.
+	 * `cancel()` keeps its shape: it flags the abort and reaches the in-flight stream.
 	 */
 	generateStreamingResponse(
 		request: BaseModelRequest | ExtendedModelRequest,
@@ -84,55 +96,23 @@ export class RetryDecorator implements ModelApi {
 			throw new Error('Wrapped API does not support streaming');
 		}
 
-		let currentAttempt = 0;
 		let cancelled = false;
 		let currentStream: StreamingModelResponse | null = null;
 
-		const attemptStream = async (): Promise<ModelResponse> => {
-			if (cancelled) {
-				throw new Error('Stream was cancelled');
-			}
-
-			try {
-				currentAttempt++;
+		const complete = this.executeWithRetry<ModelResponse>(
+			async () => {
 				currentStream = this.wrappedApi.generateStreamingResponse!(request, onChunk);
 				return await currentStream.complete;
-			} catch (error) {
-				if (cancelled) {
-					throw new Error('Stream was cancelled');
-				}
-
-				// Skip retry for non-retryable errors
-				if (!isRetryableApiError(error)) {
-					this.logger?.error(`Streaming failed with non-retryable error:`, error);
-					throw error;
-				}
-
-				// Check if we should retry
-				if (currentAttempt <= this.config.maxRetries) {
-					// Use API-provided retry delay if available, otherwise exponential backoff
-					const apiDelay = parseRetryDelay(error);
-					const backoffDelay = apiDelay
-						? Math.min(apiDelay, RetryDecorator.MAX_API_DELAY_MS)
-						: this.config.initialBackoffDelay * Math.pow(2, currentAttempt - 1);
-
-					this.logger?.warn(
-						`Streaming failed (attempt ${currentAttempt}/${this.config.maxRetries + 1}). ` +
-							`Retrying in ${backoffDelay}ms${apiDelay ? ' (API-provided delay)' : ''}...`,
-						error
-					);
-
-					await this.sleep(backoffDelay);
-					return attemptStream();
-				} else {
-					this.logger?.error(`Streaming failed after ${this.config.maxRetries + 1} attempts:`, error);
-					throw error;
-				}
+			},
+			'Streaming',
+			{
+				shouldAbort: () => cancelled,
+				abortError: () => new Error('Stream was cancelled'),
 			}
-		};
+		);
 
 		return {
-			complete: attemptStream(),
+			complete,
 			cancel: () => {
 				cancelled = true;
 				if (currentStream) {

--- a/src/utils/retry.ts
+++ b/src/utils/retry.ts
@@ -40,6 +40,14 @@ export interface RetryOptions {
 	logger?: Logger;
 	/** Optional function to determine if an error is retryable (default: retry all errors) */
 	isRetryable?: (error: unknown) => boolean;
+	/**
+	 * Optional cancellation hook. Checked before every attempt and again as soon as an attempt
+	 * fails, so a cancelled operation aborts without logging a spurious retry warning.
+	 * When unset, the retry loop behaves exactly as it does without cancellation support.
+	 */
+	shouldAbort?: () => boolean;
+	/** Error to throw when `shouldAbort` returns true (default: `${operationName} was cancelled`) */
+	abortError?: () => Error;
 }
 
 /**
@@ -89,13 +97,24 @@ export async function executeWithRetry<T>(
 	config: RetryConfig = DEFAULT_RETRY_CONFIG,
 	options: RetryOptions
 ): Promise<T> {
-	const { operationName, logger, isRetryable = isRetryableApiError } = options;
+	const { operationName, logger, isRetryable = isRetryableApiError, shouldAbort, abortError } = options;
+	const makeAbortError = () => abortError?.() ?? new Error(`${operationName} was cancelled`);
 	let lastError: Error | undefined;
 
 	for (let attempt = 0; attempt <= config.maxRetries; attempt++) {
+		if (shouldAbort?.()) {
+			throw makeAbortError();
+		}
+
 		try {
 			return await operation();
 		} catch (error) {
+			// An abort takes precedence over the failure it races with: report the cancellation
+			// rather than logging a retry warning for a stream the caller already gave up on.
+			if (shouldAbort?.()) {
+				throw makeAbortError();
+			}
+
 			lastError = error as Error;
 
 			// Check if error is retryable

--- a/test/api/retry-decorator.test.ts
+++ b/test/api/retry-decorator.test.ts
@@ -1,4 +1,4 @@
-import { RetryDecorator, RetryConfig } from '../../src/api/retry-decorator';
+import { RetryDecorator, ApiRetryConfig } from '../../src/api/retry-decorator';
 import { ModelApi, BaseModelRequest, ModelResponse, StreamingModelResponse } from '../../src/api/interfaces/model-api';
 import { Logger } from '../../src/utils/logger';
 
@@ -25,7 +25,7 @@ function createMockApi(responses: Array<ModelResponse | Error>): ModelApi {
 	};
 }
 
-function createRetryConfig(overrides?: Partial<RetryConfig>): RetryConfig {
+function createRetryConfig(overrides?: Partial<ApiRetryConfig>): ApiRetryConfig {
 	return {
 		maxRetries: 2,
 		initialBackoffDelay: 10, // Very short for tests
@@ -35,6 +35,31 @@ function createRetryConfig(overrides?: Partial<RetryConfig>): RetryConfig {
 
 const successResponse: ModelResponse = { markdown: 'Hello', rendered: '' };
 const dummyRequest: BaseModelRequest = { kind: 'base', prompt: 'test' };
+
+/** A retryable 429 carrying a Google `RetryInfo` detail with the given duration string. */
+function retryInfoError(retryDelay: string): Error {
+	return Object.assign(new Error('Rate limited'), {
+		status: 429,
+		details: [{ '@type': 'type.googleapis.com/google.rpc.RetryInfo', retryDelay }],
+	});
+}
+
+/**
+ * Probe whether a promise has settled, so a test can assert *when* a retry fired rather than
+ * spying on the sleep helper. The returned function reports the latest known state.
+ */
+function trackResolution(promise: Promise<unknown>): () => boolean {
+	let settled = false;
+	void promise.then(
+		() => {
+			settled = true;
+		},
+		() => {
+			settled = true;
+		}
+	);
+	return () => settled;
+}
 
 describe('RetryDecorator', () => {
 	beforeEach(() => {
@@ -200,26 +225,73 @@ describe('RetryDecorator', () => {
 		});
 
 		test('streaming API-provided delay capped at MAX_API_DELAY_MS (60000)', async () => {
-			const error = Object.assign(new Error('Rate limited'), {
-				status: 429,
-				details: [
-					{
-						'@type': 'type.googleapis.com/google.rpc.RetryInfo',
-						retryDelay: '120s',
-					},
-				],
-			});
+			const error = retryInfoError('120s');
 			const api = createMockApi([error, successResponse]);
-			const sleepSpy = vi.spyOn(RetryDecorator.prototype as any, 'sleep');
 			const decorator = new RetryDecorator(api, createRetryConfig());
 
 			const stream = decorator.generateStreamingResponse(dummyRequest, vi.fn());
-			await vi.advanceTimersByTimeAsync(70000);
-			await stream.complete;
+			const resolved = trackResolution(stream.complete);
 
 			// 120s = 120000ms should be capped to MAX_API_DELAY_MS = 60000ms
-			expect(sleepSpy).toHaveBeenCalledWith(60000);
-			sleepSpy.mockRestore();
+			await vi.advanceTimersByTimeAsync(59000);
+			expect(resolved()).toBe(false);
+			await vi.advanceTimersByTimeAsync(2000);
+			await stream.complete;
+			expect(resolved()).toBe(true);
+		});
+	});
+
+	// The streaming and non-streaming arms share one retry policy. These pin the parts of that
+	// policy the streaming arm used to lack when it hand-rolled its own loop (#1337), so the two
+	// cannot drift apart again without a test failing.
+	describe('streaming delay policy', () => {
+		test('streaming backoff carries jitter', async () => {
+			const error = Object.assign(new Error('Internal server error'), { status: 500 });
+			const api = createMockApi([error, successResponse]);
+			// 0.5 of the 10% jitter band on a 1000ms base => 1050ms, not the bare 1000ms.
+			const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0.5);
+			const decorator = new RetryDecorator(api, createRetryConfig({ initialBackoffDelay: 1000 }));
+
+			const stream = decorator.generateStreamingResponse(dummyRequest, vi.fn());
+			const resolved = trackResolution(stream.complete);
+
+			await vi.advanceTimersByTimeAsync(1000);
+			expect(resolved()).toBe(false);
+			await vi.advanceTimersByTimeAsync(100);
+			await stream.complete;
+			expect(resolved()).toBe(true);
+			randomSpy.mockRestore();
+		});
+
+		test('streaming exponential backoff is capped at MAX_API_DELAY_MS (60000)', async () => {
+			const error = Object.assign(new Error('Internal server error'), { status: 500 });
+			const api = createMockApi([error, successResponse]);
+			// No API-provided delay, so this exercises the exponential arm, which used to be
+			// unbounded on the streaming path: 100000ms must be capped to 60000ms (+ <=10% jitter).
+			const decorator = new RetryDecorator(api, createRetryConfig({ initialBackoffDelay: 100000 }));
+
+			const stream = decorator.generateStreamingResponse(dummyRequest, vi.fn());
+			const resolved = trackResolution(stream.complete);
+
+			await vi.advanceTimersByTimeAsync(59000);
+			expect(resolved()).toBe(false);
+			await vi.advanceTimersByTimeAsync(8000);
+			await stream.complete;
+			expect(resolved()).toBe(true);
+		});
+
+		test('streaming honors an API-provided delay of 0s instead of falling back to backoff', async () => {
+			const error = retryInfoError('0s');
+			const api = createMockApi([error, successResponse]);
+			// A 0ms server instruction used to be discarded as falsy, silently backing off 5s.
+			const decorator = new RetryDecorator(api, createRetryConfig({ initialBackoffDelay: 5000 }));
+
+			const stream = decorator.generateStreamingResponse(dummyRequest, vi.fn());
+			await vi.advanceTimersByTimeAsync(5);
+			const result = await stream.complete;
+
+			expect(result).toEqual(successResponse);
+			expect(api.generateStreamingResponse).toHaveBeenCalledTimes(2);
 		});
 	});
 

--- a/test/utils/retry.test.ts
+++ b/test/utils/retry.test.ts
@@ -409,5 +409,77 @@ describe('retry utilities', () => {
 			expect(result).toBe('ok');
 			expect(op).toHaveBeenCalledTimes(2);
 		});
+
+		describe('shouldAbort', () => {
+			test('aborts before the first attempt without invoking the operation', async () => {
+				const op = vi.fn().mockResolvedValue('ok');
+
+				await expect(
+					executeWithRetry(
+						op,
+						{ maxRetries: 3, initialDelayMs: 100, jitter: false },
+						{ operationName: 'cancellable', shouldAbort: () => true }
+					)
+				).rejects.toThrow('cancellable was cancelled');
+				expect(op).not.toHaveBeenCalled();
+			});
+
+			test('aborts at catch time without retrying or logging a retry warning', async () => {
+				const mockLogger = { log: vi.fn(), debug: vi.fn(), error: vi.fn(), warn: vi.fn() };
+				let cancelled = false;
+				const op = vi.fn().mockImplementation(() => {
+					// The caller cancels while the attempt is in flight
+					cancelled = true;
+					return Promise.reject(new Error('transient failure'));
+				});
+
+				const promise = executeWithRetry(
+					op,
+					{ maxRetries: 3, initialDelayMs: 100, jitter: false },
+					{
+						operationName: 'cancellable',
+						logger: mockLogger as any,
+						shouldAbort: () => cancelled,
+					}
+				);
+				const assertion = expect(promise).rejects.toThrow('cancellable was cancelled');
+				await vi.runAllTimersAsync();
+				await assertion;
+
+				expect(op).toHaveBeenCalledTimes(1);
+				expect(mockLogger.warn).not.toHaveBeenCalled();
+				expect(mockLogger.error).not.toHaveBeenCalled();
+			});
+
+			test('uses the caller-supplied abortError', async () => {
+				const op = vi.fn().mockResolvedValue('ok');
+
+				await expect(
+					executeWithRetry(
+						op,
+						{ maxRetries: 3, initialDelayMs: 100, jitter: false },
+						{
+							operationName: 'cancellable',
+							shouldAbort: () => true,
+							abortError: () => new Error('Stream was cancelled'),
+						}
+					)
+				).rejects.toThrow('Stream was cancelled');
+			});
+
+			test('a shouldAbort that never fires leaves retry behavior unchanged', async () => {
+				const op = vi.fn().mockRejectedValueOnce(new Error('fail')).mockResolvedValue('ok');
+
+				const promise = executeWithRetry(
+					op,
+					{ maxRetries: 3, initialDelayMs: 100, jitter: false },
+					{ operationName: 'cancellable', shouldAbort: () => false }
+				);
+				await vi.runAllTimersAsync();
+
+				expect(await promise).toBe('ok');
+				expect(op).toHaveBeenCalledTimes(2);
+			});
+		});
 	});
 });


### PR DESCRIPTION
## Summary

`src/utils/retry.ts` is the repo's one retry engine, but `RetryDecorator.generateStreamingResponse` never used it — its inner `attemptStream` re-implemented the whole attempt loop inline, and the two copies had drifted. The streaming path is the one every interactive agent turn goes through, so it was retrying on materially different terms than the non-streaming path with nothing in either file saying that was intended.

All five drifts named on the issue were re-verified against this branch before any code was written:

1. **No jitter** — `retry-decorator.ts:117` was a bare `initialBackoffDelay * 2^(n-1)`; `calculateDelay` adds 10%.
2. **Uncapped exponential arm** — `MAX_API_DELAY_MS` was applied to the API-provided delay only; the engine caps both arms.
3. **Two exported `RetryConfig` types** — one in each file, same name, different field name for the same value.
4. **Two `sleep` helpers** — the decorator's `window.setTimeout` one and the module-private one in `retry.ts`.
5. **A zero API delay was discarded** — the engine tests `apiDelay !== null`, the decorator tested truthiness, so a `RetryInfo` of `"0s"` was silently dropped in favour of exponential backoff on the streaming path only.

Drifts 1, 2, and 5 all made streaming **less** conservative than non-streaming, which is backwards from the only argument for giving streaming its own policy (replayed chunks make a streaming retry more costly, not less). That is why this unifies rather than documenting the divergence.

The issue filed this as an issue rather than a PR because cancellation-awareness looked like it would change a shared signature used by several call sites. It doesn't have to: the hook is **optional**, so `proxy-fetch.ts`, `grounding-tool-runner.ts`, `web-fetch-tool.ts`, `rag-vault-scanner.ts`, `deep-research.ts`, and `context-manager.ts` compile and behave identically — they simply don't pass it.

Produced by the auto-dev pipeline from the plan approved on the issue.

Fixes #1337

## Changes

- **`src/utils/retry.ts`** — `RetryOptions` gains two optional fields: `shouldAbort?: () => boolean` and `abortError?: () => Error` (default `${operationName} was cancelled`). `shouldAbort` is checked at the top of each loop iteration and as the *first* statement of the `catch`, before the retryability check, so an abort that races a failure reports the cancellation rather than logging a spurious retry warning. Both are no-ops when unset.
- **`src/api/retry-decorator.ts`** — `attemptStream` collapses into one `executeWithRetry` call whose operation assigns `currentStream` and awaits `complete`, passing `shouldAbort: () => cancelled` and an `abortError` preserving the existing `Stream was cancelled` message. The private `sleep` is deleted — the `retry.ts` one survives, and its `obsidianmd/prefer-window-timers` disable comment (shared with node-environment tests) is the reason to keep that one specifically. The exported `RetryConfig` is renamed **`ApiRetryConfig`**: it is the settings-shaped `{maxRetries, initialBackoffDelay}` pair, genuinely distinct from the engine's `{maxRetries, initialDelayMs, maxDelayMs?, jitter?}`, so a narrower name is more honest than collapsing them and forcing the settings field names to change.
- **`test/api/retry-decorator.test.ts`** — the existing `streaming retries` and `cancel() propagation` blocks are the regression net for "nothing observable changed". Adds a `streaming delay policy` block pinning the three recovered behaviours (jitter present, exponential arm capped at 60s under a large `initialBackoffDelay`, a `"0s"` API delay honored). The `MAX_API_DELAY_MS` cap test previously spied on the now-deleted `RetryDecorator.prototype.sleep`; it now asserts the same cap behaviorally against fake timers, which is what it was really trying to prove.
- **`test/utils/retry.test.ts`** — direct coverage of the new hook: abort before the first attempt never invokes the operation; abort at catch time stops retrying and logs neither `warn` nor `error`; a caller-supplied `abortError` is used; a `shouldAbort` that never fires leaves retry behavior unchanged.
- **`docs/reference/settings.md`, `docs/reference/advanced-settings.md`** — both described backoff as a plain "2x, 4x, 8x". That was already imprecise for the non-streaming path and becomes wrong by omission once streaming joins it, so both now record the 10% jitter, the 60-second ceiling, and the API-supplied-delay case.

**One deviation from the plan**, noted for the record: the plan expected a type-name update in `src/api/factory.ts`. No change was needed — `factory.ts` never imports the type by name; its four `new RetryDecorator(...)` sites pass object literals that structurally satisfy `ApiRetryConfig`. `git grep RetryConfig` confirms the only importer of the decorator's type was the test file.

### Behavior preserved

`cancel()` keeps its exact shape: it flags the abort and reaches the in-flight stream. Attempt counts (`maxRetries + 1`), the first-retry delay (`initialBackoffDelay`), and all three log messages are byte-identical, because the operation name `'Streaming'` reproduces `Streaming failed (attempt N/M)…`, `Streaming failed after N attempts:`, and `Streaming failed with non-retryable error:` verbatim.

## Screenshots / Screencast

N/A — no UI surface; this is an internal refactor of the retry loop.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer — #1337, plan approved 2026-08-29
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — run locally before pushing: `format-check` clean, `lint` 0 errors / 40 pre-existing warnings, `lint:cycles` clean, `build` clean, `typecheck:test` clean, `knip` clean, 3960 tests in 177 files passing
- [ ] I have tested this change on Desktop — see the verification note below; the observable effect is retry *timing* under real API failure, which can't be driven in the sandbox without provoking genuine 429/5xx responses
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — the change removes a `window.setTimeout` call in favour of the existing shared helper; no new platform-specific API is introduced
- [x] Documentation has been updated (if applicable) — `docs/reference/settings.md` and `docs/reference/advanced-settings.md`, as listed above
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### Verification

**Behavioral verification was not run in the sandbox**, and this states that plainly rather than claiming otherwise: the only observable effect of this change is retry timing under API failure, which needs real 429/5xx responses to exercise end-to-end.

What was done instead is what the approved plan specified — each new assertion was **mutation-checked against a deliberately broken source**, so none of them are green by accident:

| Mutation | Test that caught it |
| --- | --- |
| `jitter: false` on the shared config | `streaming backoff carries jitter` |
| `maxDelayMs` removed | `streaming exponential backoff is capped at MAX_API_DELAY_MS (60000)` |
| `apiDelay !== null` → `apiDelay` (truthiness) | `streaming honors an API-provided delay of 0s instead of falling back to backoff` |
| both `shouldAbort` checks removed | the three new abort tests, **plus** the two pre-existing `cancel()` tests |

That last row is the one worth reading: the pre-existing cancellation tests fail against the mutation too, which is the evidence that the new hook reproduces the old inline `cancelled` checks rather than merely coexisting with them.

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (auto-dev pipeline)
- [x] I have reviewed and understand all AI-generated code in this PR

<!-- auto-dev -->

https://claude.ai/code/session_017Vw9kDSaQ6r9E4ooajhiPA

---
_Generated by [Claude Code](https://claude.ai/code/session_017Vw9kDSaQ6r9E4ooajhiPA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Retry delays now include 10% random jitter and are capped at 60 seconds.
  * API-provided retry delays for rate-limit responses are honored within the same cap.
  * Streaming and non-streaming requests follow a consistent retry policy.
  * Retries can now be cancelled promptly, including during in-flight operations.

* **Documentation**
  * Updated settings and advanced settings documentation to describe retry timing, limits, and cancellation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->