### PR TITLE
chore(daily): 2026-09-02 daily update

### DIFF
--- a/planning/changelog/2026-09-01.md
+++ b/planning/changelog/2026-09-01.md
@@ -25,7 +25,7 @@ Fixes #1424. `sortToolCallsByPriority` enforced the reads-before-writes tool-exe
 
 ### [#1440 fix(api): unify the usageMetadata contract and plumb reasoning tokens](https://github.com/allenhutchison/obsidian-gemini/pull/1440)
 
-Fixes #1437. The token-usage wire shape was declared twice — anonymously on `ModelResponse.usageMetadata` and as a separate named interface in `context-manager.ts` — and had drifted by one field: `thoughtsTokenCount` existed only on the consumer copy, unreachable by design. Unifies both into a single `UsageMetadata` leaf in `src/api/interfaces/usage-metadata.ts` and plumbs `thoughtsTokenCount` from Gemini's SDK response through to the token readout's `TokenUsageInfo`, since reasoning tokens are billed and count toward context for thinking models. Adds a drift-guard test asserting the end-to-end consumed field set.
+Fixes #1437. The token-usage wire shape was declared twice — anonymously on `ModelResponse.usageMetadata` and as a separate named interface in `context-manager.ts` — and had drifted by one field: `thoughtsTokenCount` existed only on the consumer copy, unreachable by design. Unifies both into a single `UsageMetadata` leaf in `src/api/interfaces/usage-metadata.ts` and plumbs `thoughtsTokenCount` from Gemini's SDK response through to the token readout's `TokenUsageInfo`, since reasoning tokens are billed and included in total usage for thinking models. Adds a drift-guard test asserting the end-to-end consumed field set.
 
 ### [#1441 feat(ui): surface reasoning tokens in the token readout](https://github.com/allenhutchison/obsidian-gemini/pull/1441)
 

--- a/planning/changelog/2026-09-01.md
+++ b/planning/changelog/2026-09-01.md
@@ -1,0 +1,48 @@
+# Daily changelog — September 1, 2026
+
+**Date:** 2026-09-01
+**PRs merged:** 9
+
+---
+
+## Summary
+
+A feature-heavy day anchored by the token-usage reasoning-token pair (#1440, #1441): the shared `UsageMetadata` contract was unified and reasoning tokens plumbed end to end, then surfaced in the token readout. Two correctness fixes landed for the agent tool loop — a hardcoded tool-priority map replaced with classification-derived sorting, and a correlation-id bug that mismatched `functionResponse` pairing on the Interactions API transport. The day closed with an i18n sweep of `error-utils.ts`, its automated translation-regeneration follow-up, a dead-code deletion, and the removal of a global timer patch that had no remaining reason to exist.
+
+## What shipped
+
+### [#1436 refactor(types): delete two born-dead optional wiring fields](https://github.com/allenhutchison/obsidian-gemini/pull/1436)
+
+An `audit-architecture` sweep flagged two optional interface fields — `ModelUpdateOptions.preserveUserCustomizations` and `RagSearchResult.relevance` — that were declared but never populated or read anywhere in the repo. `knip` can't catch this class of dead surface (it resolves symbols, not per-field reachability through an object literal); both fields are deleted as a type-only, no-runtime-effect change.
+
+### [#1438 chore(daily): 2026-08-31 daily update](https://github.com/allenhutchison/obsidian-gemini/pull/1438)
+
+The automated daily-update run for 2026-08-30: wrote that day's changelog, ran a docs audit that found no drift, and a triage pass that found no unlabeled issues.
+
+### [#1439 refactor(agent): derive tool-sort priority from tool.classification](https://github.com/allenhutchison/obsidian-gemini/pull/1439)
+
+Fixes #1424. `sortToolCallsByPriority` enforced the reads-before-writes tool-execution invariant via a hand-maintained, string-keyed map of all 23 tool names — nothing compile-checked it, so a tool added without an entry silently fell to the bottom of the EXTERNAL band, ahead of `write_file` and `delete_file`, exactly the race the sort exists to prevent. Replaces the map with `classificationToPriority`, deriving priority directly from each tool's declared `ToolClassification`, and adds a `logger.warn` when the registry can't resolve a tool name.
+
+### [#1440 fix(api): unify the usageMetadata contract and plumb reasoning tokens](https://github.com/allenhutchison/obsidian-gemini/pull/1440)
+
+Fixes #1437. The token-usage wire shape was declared twice — anonymously on `ModelResponse.usageMetadata` and as a separate named interface in `context-manager.ts` — and had drifted by one field: `thoughtsTokenCount` existed only on the consumer copy, unreachable by design. Unifies both into a single `UsageMetadata` leaf in `src/api/interfaces/usage-metadata.ts` and plumbs `thoughtsTokenCount` from Gemini's SDK response through to the token readout's `TokenUsageInfo`, since reasoning tokens are billed and count toward context for thinking models. Adds a drift-guard test asserting the end-to-end consumed field set.
+
+### [#1441 feat(ui): surface reasoning tokens in the token readout](https://github.com/allenhutchison/obsidian-gemini/pull/1441)
+
+Closes the two follow-ups #1437 named on merge. The token indicator above the chat input now appends `· N reasoning` when a model reports thinking tokens (`Tokens: ~12,345 / 1M (1.2%) · 41% cached · 890 reasoning`), shown only when the provider reports the count. Separately investigated whether the context-compaction threshold needed rebalancing for thinking models and concluded no: the threshold compares prompt tokens against the input limit, and reasoning tokens are output-side, so adding them would over-count and trigger premature compaction — documented on the field's doc comment and in the settings docs rather than changed in code.
+
+### [#1443 fix(agent): carry the tool-call correlation id into functionResponse parts](https://github.com/allenhutchison/obsidian-gemini/pull/1443)
+
+Fixes #1398. The tool-call correlation `id` was read off the model response into the replayed `functionCall` part but dropped at execution, so every replayed tool turn on the Interactions API transport (the default) paired a `function_result` to its `call_id` incorrectly, falling back to matching by tool name instead. `ToolCallResultPair` now carries an optional `id`, populated on both the success and error paths of `executeToolBatch`, restoring correct pairing.
+
+### [#1444 feat(i18n): route error-utils user guidance through t()](https://github.com/allenhutchison/obsidian-gemini/pull/1444)
+
+Fixes #1332. Produced by the auto-dev pipeline from a maintainer-approved plan. `error-utils.ts` builds the actionable half of nearly every error notice the plugin shows, and none of it went through `t()` — over 20 call sites interpolated raw English into a translated notice, and five showed it as the entire notice. Adds a 32-key `error.*` i18n namespace and translates each `return` in `getErrorMessage`/`getHttpErrorMessage` in place, preserving every branch's condition and ordering; the 102 existing exact-string test assertions pass unchanged.
+
+### [#1442 chore(i18n): Update UI translations](https://github.com/allenhutchison/obsidian-gemini/pull/1442)
+
+Automated translation regeneration triggered by #1444's new `en.ts` keys landing on master.
+
+### [#1446 fix(mcp): delete the global window timer patch](https://github.com/allenhutchison/obsidian-gemini/pull/1446)
+
+Fixes #1416. `patchSetTimeoutForElectron` replaced `window.setTimeout`/`window.clearTimeout` process-wide on first MCP connect with no teardown, affecting every other plugin and Obsidian core for the rest of the session. Verified against the installed MCP SDK's source that no transport the plugin actually uses (`streamableHttp`, or the desktop-only `stdio` transport) has an unguarded `.unref()` call that the patch was protecting against, so the 46-line patch and its call site are deleted outright rather than made removable.


### PR DESCRIPTION
## Summary

Automated daily-update run bundling the repo's per-day housekeeping skills for 2026-09-01.

## Changes

- **daily-changelog**: wrote `planning/changelog/2026-09-01.md` covering the day's 9 merged PRs — the `usageMetadata` contract unification and reasoning-token plumbing/surfacing (#1440, #1441), a tool-sort-priority refactor derived from tool classification (#1439), a `functionResponse` correlation-id fix for the Interactions API transport (#1443), an i18n sweep of `error-utils.ts` (#1444) plus its automated translation regeneration (#1442), a dead-field cleanup (#1436), and removal of the global MCP window-timer patch (#1446).
- **audit-product-docs**: full audit of all `docs/guide/*.md`, `docs/reference/*.md`, `README.md`, and `AGENTS.md` against `src/` — settings/defaults, tool names, the schedule parser, hook-engine constants, MCP timeouts, RAG constants, the i18n roster, and the bundled skills list. No drift found, no new docs warranted.

  **Flagging for maintainer attention (not a docs issue — a code bug, left unfixed per this skill's scope, re-flagged from yesterday's run):** `src/main.ts` still sets the default `openaiModelName` to `'gpt-5.6'`, which isn't a recognized model id in the registry (`src/services/openai-models-service.ts`) — the docs and registry both correctly say the default is `'gpt-5.6-sol'`.
- **triage-issues**: 1 unlabeled open issue found and labeled — [#1448](https://github.com/allenhutchison/obsidian-gemini/issues/1448) (`bug` + `architecture`) — a retry-backoff cancellation bug where a cancelled stream's `complete` promise stays pending until the backoff sleep elapses.

## Screenshots / Screencast

N/A — no UI changes; this PR is changelog-only.

## Checklist

### Required

- [x] I have read and agree to the Contributing Guidelines
- [x] I have read and agree to the AI Policy
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A, this is the recurring automated daily-update run, not tied to a single issue
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — also ran `npm run lint` (0 errors, 40 pre-existing warnings) and `npm run typecheck:test`; 177 files / 3953 tests passed (one initial run hit the same flaky 5s timeout in `attach-vault-file.test.ts` under parallel load noted in yesterday's run — confirmed a flake by re-running that file alone, then the full suite clean)
- [ ] I have tested this change on Desktop — N/A, docs/changelog-only change with no runtime code path
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A, no code changes
- [x] Documentation has been updated (if applicable) — N/A, this PR *is* the documentation/changelog update
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (automated daily-update scheduled run)
- [x] I have reviewed and understand all AI-generated code in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PpJKPykFR5GfCURBg1re6Z

---
_Generated by [Claude Code](https://claude.ai/code/session_01PpJKPykFR5GfCURBg1re6Z)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Usage information now includes reasoning-token details where available.
  - Tool lists are sorted consistently for easier navigation.
  - Error messages and updated translations are available in supported languages.

- **Bug Fixes**
  - Improved accuracy when matching tool calls with their results.
  - Corrected global timer behavior.
  - Unified usage information across applicable views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->