### PR TITLE
docs(guidelines): encode the "no speculative wiring fields" rule (#1303)

### DIFF
--- a/.claude/guidelines/coding.md
+++ b/.claude/guidelines/coding.md
@@ -64,6 +64,19 @@ module both import — never import the manager back. See `invariants.md` for th
 `ToolExecutionContext.plugin` is already typed `ObsidianGemini` — use `context.plugin` directly,
 no cast.
 
+## Wiring interfaces carry only what is read
+
+When you add a field to a context, callback, or capability interface — `SendContext`
+(`agent-view-send.ts`), `UICallbacks` (`agent-view-ui.ts`), `AgentViewContext`
+(`agent-view-tools.ts`, imported by `agent-view.ts` under the alias `ToolsContext`),
+`ProviderCapabilities` (`api/providers/registry.ts`) — wire it to a consumer in the same change.
+Don't populate a field speculatively for a caller that doesn't exist yet: `npm run knip` resolves
+exported symbols, not per-field reachability through an object literal, so an unread field on a
+live interface populated at a live construction site is invisible to it. Such a field is born dead
+and stays dead with every check green — which is why making knip blocking does not close this gap.
+The rule runs in reverse too: when you remove the last reader of a field, remove the field and its
+population site with it.
+
 ## Platform guards
 
 Desktop-only APIs (Electron, MCP, Node.js) must be guarded with Obsidian's `Platform` checks


### PR DESCRIPTION
<!-- auto-dev -->
## Summary

Adds one section to `.claude/guidelines/coding.md` encoding the rule that `audit-architecture` promoted after filing the same pattern three times: a field is declared on a context/callback/capability interface and populated at its single construction site, but no consumer ever reads it — and `knip` cannot see it.

The section is placed directly after **Plugin type surface — never import `main.ts`**, which already governs how components are wired and is the section the issue nominates.

This is deliberately prose rather than tooling. The escalation the issue names — a per-field reachability check over the named wiring interfaces — is a real build with real maintenance cost, and the issue is explicit that the rule should get its chance first. Worth stating the honest limit: nothing in CI reads `coding.md`, so this rule's only enforcement is a reviewer or an audit run applying it. If a fourth instance is filed after this lands, that is the evidence prose failed, and the mechanical check should follow rather than a reword.

Produced by the auto-dev pipeline from the plan approved on #1303.

Fixes #1303

## Changes

- `.claude/guidelines/coding.md` — new section **Wiring interfaces carry only what is read**, inserted between the Plugin-type-surface and Platform-guards sections. Substance as the issue drafted it, with three deviations from the issue's literal wording, each deliberate:
  - **Interface name corrected.** The issue lists `ToolsContext` among the wiring interfaces. No interface by that name exists — it is a local import alias (`import { AgentViewTools, AgentViewContext as ToolsContext } from './agent-view-tools'`, `src/ui/agent-view/agent-view.ts:16`). The declaration is `AgentViewContext` (`src/ui/agent-view/agent-view-tools.ts:19`). The section uses the declared name and notes the alias, because the rule's value is that a reviewer or future audit can grep the named interfaces, and `ToolsContext` greps to one import line.
  - **The "why" is stated in terms of knip's resolution model** — it resolves exported symbols, not per-field reachability through an object literal — so the rule reads as a consequence rather than an assertion.
  - **The removal half is kept explicit**: when the last reader of a field goes, the field and its population site go with it.
- No other file. Per the approved plan, the rule lives only in `coding.md`; the optional `AGENTS.md` mirror was offered and not taken.

## Screenshots / Screencast

N/A — no UI change. This PR touches one Markdown guideline file and no source.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer — #1303, plan approved 2026-08-29
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [ ] I have tested this change on Desktop — N/A. Guideline prose that no code reads; there is no runnable surface to exercise. Behavioral verification is genuinely not applicable here rather than skipped.
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A. No source, no platform-sensitive API.
- [x] Documentation has been updated (if applicable) — this PR *is* the documentation change.
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (auto-dev pipeline)
- [x] I have reviewed and understand all AI-generated code in this PR

## Verification

Full pre-flight, all green:

- `npm run format-check` — Prettier covers this file (`.prettierignore` excludes only `*.hbs` and four JSON/dist paths), so this is a real gate rather than a no-op
- `npm run lint` — 0 errors (40 pre-existing warnings in unrelated test files)
- `npm run typecheck:test`
- `npm run build`
- `npm test` — 171 files, 3819 tests passed

Every symbol and path the new section cites was re-verified against `master` at `adbf1af` rather than trusted from the plan comment, since a stale citation is the exact failure mode that filed #1302:

- `SendContext` → `src/ui/agent-view/agent-view-send.ts:28`
- `UICallbacks` → `src/ui/agent-view/agent-view-ui.ts:27`
- `AgentViewContext` → `src/ui/agent-view/agent-view-tools.ts:19` (aliased `ToolsContext` at `agent-view.ts:16`)
- `ProviderCapabilities` → `src/api/providers/registry.ts:46`
- `knip.json` sets `ignoreExportsUsedInFile` for `interface`/`type`; `npm run knip` is a real script (`package.json:26`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TcD1NupMiicXs31KCrtJjG

---
_Generated by [Claude Code](https://claude.ai/code/session_01TcD1NupMiicXs31KCrtJjG)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for ensuring interface fields are connected to active consumers.
  * Clarified when unused fields and their population sites should be removed.
  * Documented a limitation in detecting unread fields within active object literals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->