### PR TITLE
fix(api): make the retry backoff interruptible on cancellation

### DIFF
--- a/src/utils/retry.ts
+++ b/src/utils/retry.ts
@@ -58,6 +58,34 @@ function sleep(ms: number): Promise<void> {
 	return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+/** How often an in-flight backoff sleep re-checks the abort hook (ms). */
+const ABORT_POLL_INTERVAL_MS = 100;
+
+/**
+ * Sleep for `ms`, but cut the wait short when `shouldAbort` turns true — a
+ * cancellation that arrives during a backoff wait rejects immediately instead
+ * of stalling until the sleep elapses (#1448). Checked via polling at
+ * ABORT_POLL_INTERVAL so the hook-based contract (a flag, not an AbortSignal)
+ * keeps working; with no `shouldAbort`, this is exactly `sleep(ms)`.
+ *
+ * Returns whether the sleep completed uninterrupted (`false` = aborted).
+ */
+async function sleepInterruptibly(ms: number, shouldAbort?: () => boolean): Promise<boolean> {
+	if (!shouldAbort || ms <= ABORT_POLL_INTERVAL_MS) {
+		await sleep(ms);
+		return true;
+	}
+
+	let elapsed = 0;
+	while (elapsed < ms) {
+		if (shouldAbort()) return false;
+		const slice = Math.min(ABORT_POLL_INTERVAL_MS, ms - elapsed);
+		await sleep(slice);
+		elapsed += slice;
+	}
+	return true;
+}
+
 /**
  * Calculate backoff delay with optional jitter
  */
@@ -140,7 +168,13 @@ export async function executeWithRetry<T>(
 				error
 			);
 
-			await sleep(backoffDelay);
+			// Cut the backoff short when cancelled: without this, a cancellation
+			// arriving during the sleep is only observed when the sleep elapses —
+			// up to the 60s delay cap — leaving the caller's promise pending and
+			// the cancellation notice delayed (#1448).
+			if (!(await sleepInterruptibly(backoffDelay, shouldAbort))) {
+				throw makeAbortError();
+			}
 		}
 	}
 

--- a/test/api/retry-decorator.test.ts
+++ b/test/api/retry-decorator.test.ts
@@ -1,5 +1,5 @@
 import { RetryDecorator, ApiRetryConfig } from '../../src/api/retry-decorator';
-import { ModelApi, BaseModelRequest, ModelResponse, StreamingModelResponse } from '../../src/api/interfaces/model-api';
+import { ModelApi, BaseModelRequest, ModelResponse } from '../../src/api/interfaces/model-api';
 import { Logger } from '../../src/utils/logger';
 
 // Minimal mock for ModelApi
@@ -341,11 +341,31 @@ describe('RetryDecorator', () => {
 			const assertion = expect(stream.complete).rejects.toThrow('Stream was cancelled');
 			// Advance past the first failure but not past the full sleep
 			await vi.advanceTimersByTimeAsync(100);
-			// Cancel during the retry sleep
+			// Cancel during the retry sleep…
 			stream.cancel();
-			// Advance past the sleep so attemptStream runs and sees cancelled=true
-			await vi.advanceTimersByTimeAsync(10000);
+			// …and the sleep must abort without its full duration elapsing:
+			// a 100ms slice re-checks the flag, so advancing one poll interval
+			// rejects. Advancing the full 5000ms backoff is NOT required.
+			await vi.advanceTimersByTimeAsync(100);
 			await assertion;
+			// The second attempt (which the old behavior needed) never ran.
+			expect(api.generateStreamingResponse).toHaveBeenCalledTimes(1);
+		});
+
+		test('cancel() during a long backoff rejects promptly, without waiting out the delay (#1448)', async () => {
+			const error = Object.assign(new Error('Internal server error'), { status: 500 });
+			const api = createMockApi([error, successResponse]);
+			const decorator = new RetryDecorator(api, createRetryConfig({ initialBackoffDelay: 30000 }));
+
+			const stream = decorator.generateStreamingResponse(dummyRequest, vi.fn());
+			const assertion = expect(stream.complete).rejects.toThrow('Stream was cancelled');
+			await vi.advanceTimersByTimeAsync(100); // first attempt fails, backoff (5000ms) scheduled
+			stream.cancel();
+			// One abort-poll interval is enough — the sleep is cut short instead of
+			// running the full backoff.
+			await vi.advanceTimersByTimeAsync(100);
+			await assertion;
+			expect(api.generateStreamingResponse).toHaveBeenCalledTimes(1);
 		});
 	});
 

--- a/test/utils/retry.test.ts
+++ b/test/utils/retry.test.ts
@@ -494,11 +494,11 @@ describe('retry utilities', () => {
 					}
 				);
 				const assertion = expect(promise).rejects.toThrow('cancellable was cancelled');
-				// First attempt fails; the 500ms backoff is scheduled.
+				// First attempt fails; the 5000ms backoff is scheduled.
 				await vi.advanceTimersByTimeAsync(0);
 				cancelled = true;
 				// One poll interval observes the cancellation — the sleep must NOT
-				// need to run its full 500ms before the abort throws.
+				// need to run its full 5000ms before the abort throws.
 				await vi.advanceTimersByTimeAsync(100);
 				await assertion;
 				expect(op).toHaveBeenCalledTimes(1);

--- a/test/utils/retry.test.ts
+++ b/test/utils/retry.test.ts
@@ -480,6 +480,65 @@ describe('retry utilities', () => {
 				expect(await promise).toBe('ok');
 				expect(op).toHaveBeenCalledTimes(2);
 			});
+
+			test('aborts during the backoff sleep, cutting the wait short (#1448)', async () => {
+				const op = vi.fn().mockRejectedValueOnce(new Error('fail')).mockResolvedValue('ok');
+				let cancelled = false;
+
+				const promise = executeWithRetry(
+					op,
+					{ maxRetries: 3, initialDelayMs: 5000, jitter: false },
+					{
+						operationName: 'cancellable',
+						shouldAbort: () => cancelled,
+					}
+				);
+				const assertion = expect(promise).rejects.toThrow('cancellable was cancelled');
+				// First attempt fails; the 500ms backoff is scheduled.
+				await vi.advanceTimersByTimeAsync(0);
+				cancelled = true;
+				// One poll interval observes the cancellation — the sleep must NOT
+				// need to run its full 500ms before the abort throws.
+				await vi.advanceTimersByTimeAsync(100);
+				await assertion;
+				expect(op).toHaveBeenCalledTimes(1);
+			});
+
+			test('a backoff that elapses without cancellation still retries normally', async () => {
+				const op = vi.fn().mockRejectedValueOnce(new Error('fail')).mockResolvedValue('ok');
+				let polls = 0;
+				const promise = executeWithRetry(
+					op,
+					{ maxRetries: 3, initialDelayMs: 300, jitter: false },
+					{
+						operationName: 'cancellable',
+						shouldAbort: () => {
+							polls++;
+							return false;
+						},
+					}
+				);
+				await vi.runAllTimersAsync();
+
+				expect(await promise).toBe('ok');
+				// The sleep was sliced into poll-interval checks, and none aborted.
+				expect(polls).toBeGreaterThanOrEqual(1);
+				expect(op).toHaveBeenCalledTimes(2);
+			});
+
+			test('a delay shorter than the poll interval sleeps uninterruptibly and unchanged', async () => {
+				const op = vi.fn().mockRejectedValueOnce(new Error('fail')).mockResolvedValue('ok');
+
+				const promise = executeWithRetry(
+					op,
+					{ maxRetries: 3, initialDelayMs: 50, jitter: false },
+					{ operationName: 'cancellable', shouldAbort: () => false }
+				);
+				await vi.runAllTimersAsync();
+
+				expect(await promise).toBe('ok');
+				expect(op).toHaveBeenCalledTimes(2);
+			});
 		});
 	});
 });


### PR DESCRIPTION
## Summary

Fixes #1448

`executeWithRetry` slept between attempts with a plain, non-interruptible sleep. The `shouldAbort` hook (#1447) was checked before each attempt and in the `catch`, but **not during the sleep** — a cancellation arriving during a backoff wait was not observed until the sleep elapsed (up to the 60s delay cap). For `RetryDecorator.generateStreamingResponse`, `cancel()` stopped the underlying stream immediately but `complete` stayed pending for the remainder of the backoff.

**Impact trace (the issue's step 1 — resolved to live, not latent):**

- `AgentView.sendMessage` awaits `stream.complete` (`agent-view-send.ts:572`); after Stop, the rejection was delayed by the remaining backoff, postponing the `finally`-block cleanup (`resetExecutionUiState` + `updateTokenUsage`) and the `sendMessage` catch — which then showed the user an **8-second error notice** (`Stream was cancelled`) for the user's own Stop action and emitted a spurious `turnError` event, all up to ~66s late at #1447's delay cap.
- The agent loop's streaming follow-up path awaits the same promise (`agent-loop.ts:503`), and the plan path gates its post-stream checks on it.

**Fix in the retry engine, driven by the existing `shouldAbort` hook** — no new option, no signature change:

- `sleepInterruptibly(ms, shouldAbort)` slices the backoff into 100ms poll intervals and re-checks the hook between slices; aborting mid-sleep throws the abort error immediately. With no `shouldAbort` (six call sites) or a delay shorter than one poll interval, it is exactly the old sleep — **zero behavior change**.
- `executeWithRetry`'s backoff line uses it; an aborted sleep throws `makeAbortError()`.
- `RetryDecorator` needs **no change**: it already passes `shouldAbort: () => cancelled`.

## Changes

- `src/utils/retry.ts` — `sleepInterruptibly` helper + the backoff line swap (described above).
- `test/api/retry-decorator.test.ts` — the pre-existing `cancel() during retry wait` test pinned the *old* delayed behavior (it advanced the full backoff before asserting); updated to assert rejection after one poll interval with the second attempt never running, plus a new long-backoff variant (30s delay, rejects after 100ms).
- `test/utils/retry.test.ts` — three engine-level tests in the `shouldAbort` describe: abort mid-sleep cuts the wait short (op called once, abort thrown); uninterrupted backoff still retries normally (poll slicing is invisible when not cancelled); sub-poll-interval delays behave exactly as before.

## Screenshots / Screencast

N/A — timing/plumbing fix; the observable difference is that the existing post-Stop error notice now appears promptly instead of up to ~66s later.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [ ] I have tested this change on Desktop
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards)
- [x] Documentation has been updated (if applicable)
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

Notes on the unticked items:

- **Desktop testing**: not performed — the timing behavior is covered by fake-timer tests that assert *when* the rejection fires (the exact gap this PR closes), and the engine's other six call sites are unchanged by construction (no `shouldAbort` → identical sleep). A desktop Stop-during-backoff test would exercise the same hook through more layers.
- **Mobile**: no platform-specific API touched.
- **Documentation**: the delay policy itself (jitter, cap, API-provided delays) is settled by #1337/#1447 and documented there; this PR changes only *when cancellation is observed*, which the `RetryOptions.shouldAbort` doc comment already describes — extended in the engine.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Retry operations now stop promptly when cancellation occurs during a backoff delay, including longer waits.
  * Canceled streaming requests no longer start an additional retry attempt.
  * Normal retry behavior remains unchanged when no cancellation occurs.

* **Tests**
  * Added coverage for cancellation during long and short retry delays, polling-based interruption, and successful uncanceled retries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->