### PR TITLE
docs(guidelines): encode the "wiring interfaces carry only what is read" rule (#1303)

### DIFF
--- a/.claude/guidelines/coding.md
+++ b/.claude/guidelines/coding.md
@@ -64,6 +64,18 @@ module both import — never import the manager back. See `invariants.md` for th
 `ToolExecutionContext.plugin` is already typed `ObsidianGemini` — use `context.plugin` directly,
 no cast.
 
+## Wiring interfaces carry only what is read
+
+When you add a field to a context, callback, or capability interface — `SendContext`,
+`UICallbacks`, `AgentViewContext` (imported as `ToolsContext` in `agent-view.ts`),
+`ProviderCapabilities`, … — wire it to a consumer in the same change. Never populate a field
+speculatively for a caller that does not exist yet: `npm run knip` resolves exported symbols, not
+per-field reachability through an object literal, so a field whose interface and target method are
+both live is invisible to it. Such a field can be born dead and stay dead indefinitely with every
+check green. The rule runs backwards too — when you remove the last reader of a field, remove the
+field and its population site with it, or the next audit finds an unreachable branch hanging off a
+value nothing sets. Prior instances: #1298, #1300, #1301.
+
 ## Platform guards
 
 Desktop-only APIs (Electron, MCP, Node.js) must be guarded with Obsidian's `Platform` checks


### PR DESCRIPTION
<!-- auto-dev -->

## Summary

Adds one section to `.claude/guidelines/coding.md` encoding the pattern `audit-architecture` has filed three times in 90 days: a field declared on a context/callback/capability interface and populated at its single construction site, but never read by any consumer.

`npm run knip` cannot catch this class. It resolves exported symbols, not per-field reachability through an object literal, so a field whose interface and target method are both live is invisible to it — a field can be born dead and stay dead indefinitely with every check green. That is precisely why making the knip check blocking (#1294) does not close this gap, exactly as the issue argues.

The new section sits after **Plugin type surface — never import `main.ts`**, which already governs how components are wired and is the placement the issue nominates. Docs-only: no code, CI, or `knip.json` changes.

Fixes #1303

## Changes

- `.claude/guidelines/coding.md` — new section `## Wiring interfaces carry only what is read`, inserted between the Plugin-type-surface and Platform-guards sections. Substance as the issue drafted it, with three deliberate adjustments:
  - **Corrected interface name.** The issue lists `ToolsContext` among the named wiring interfaces. No such declaration exists — it is a local import alias: `import { AgentViewTools, AgentViewContext as ToolsContext } from './agent-view-tools'` (`src/ui/agent-view/agent-view.ts:16`). The real interface is `AgentViewContext` (`src/ui/agent-view/agent-view-tools.ts:19`). This matters because the rule's value is that a reviewer or future audit can grep the named interfaces, and `ToolsContext` greps to one import line. The section names the real interface and notes the alias.
  - **The *why* stated in terms of knip's resolution model**, so the rule reads as a consequence rather than an assertion.
  - **The removal half kept explicit** — when the last reader of a field goes, the field and its population site go with it. That is the half that produced #1301's 170-line unreachable modal.
- No other file. Per the approved plan, the rule is **not** mirrored into `AGENTS.md`; the maintainer approved the `coding.md`-only scope without taking the "both" option the plan offered.

## Screenshots / Screencast

N/A — no UI change. This PR touches one Markdown guideline file.

## Verification

Every symbol and path the new section cites was re-verified against this branch rather than trusted from the plan comment:

| Claim | Result |
| --- | --- |
| `SendContext` | `src/ui/agent-view/agent-view-send.ts:28` ✅ |
| `UICallbacks` | `src/ui/agent-view/agent-view-ui.ts:24` ✅ |
| `ProviderCapabilities` | `src/api/providers/registry.ts:46` ✅ |
| `AgentViewContext` | `src/ui/agent-view/agent-view-tools.ts:19` ✅ |
| `ToolsContext` is an alias, not a declaration | `agent-view.ts:16` ✅ |
| `npm run knip` is a real script | `package.json:26` ✅ |
| knip sets `ignoreExportsUsedInFile` for `interface`/`type` | `knip.json` ✅ |

Pre-flight, all green on this branch: `npm run format-check`, `npm run lint` (0 errors; 40 pre-existing warnings), `npm run build`, `npm run typecheck:test`, `npm test` (176 files, 3903 tests passed).

**Behavioral verification is genuinely N/A**, and worth naming rather than hand-waving: this is prose in a guideline file that no code reads, so there is no runnable surface to exercise. Nothing was executed and no tick is claimed for it.

## Honest limit of what this buys

The issue is candid that prose may not hold, and this PR does not oversell it: nothing in CI reads `coding.md`, so the rule's only enforcement is a reviewer or an audit run applying it. It is worth doing because the alternative on the table — a per-field reachability checker over the named wiring interfaces — is a real build with real maintenance, and the rule should get its chance first. If a fourth instance is filed after this lands, that is the evidence prose failed, and the mechanical escalation should follow rather than a fifth rewording.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer — #1303, plan approved 2026-08-29
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [ ] I have tested this change on Desktop — N/A, no runtime behavior changes; the change is one Markdown guideline file
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A, no code change and so no platform surface
- [x] Documentation has been updated (if applicable) — this PR *is* the documentation change; no user-facing behavior changed, so no `docs/` or `README.md` update is owed
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code, via the auto-dev pipeline
- [x] I have reviewed and understand all AI-generated code in this PR

---

Produced by the auto-dev pipeline from the plan approved on #1303. The pipeline never merges — merging is the maintainer's call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RN96QdSQ64V9LVzQ4JMVYf

---
_Generated by [Claude Code](https://claude.ai/code/session_01RN96QdSQ64V9LVzQ4JMVYf)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added coding guidance requiring interface fields to connect to active consumers within the same change.
  * Added guidance to remove unused fields and their population sites when their final reader is removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->