### PR TITLE
docs(guidelines): encode the no-speculative-wiring-fields rule (#1303) [DUPLICATE of merged #1433 — please close]

### DIFF
--- a/.claude/guidelines/coding.md
+++ b/.claude/guidelines/coding.md
@@ -64,6 +64,18 @@ module both import — never import the manager back. See `invariants.md` for th
 `ToolExecutionContext.plugin` is already typed `ObsidianGemini` — use `context.plugin` directly,
 no cast.
 
+## Wiring interfaces carry only what is read
+
+When you add a field to a context, callback, or capability interface (`SendContext`,
+`UICallbacks`, `AgentViewContext` — imported as `ToolsContext` in `agent-view.ts` —
+`ProviderCapabilities`, …), wire it to a consumer in the same change. Don't populate a field
+speculatively for a future caller: `npm run knip` resolves exported symbols, not per-field
+reachability through an object literal, so an unread field on a live interface populated at a live
+construction site is invisible to it — born dead, and still dead with every check green
+(#1298, #1300, #1301). The removal half matters as much: when the last reader of a field goes,
+delete the field and its population site with it, or whatever they reached becomes unreachable and
+stays (that is how #1301 kept a 170-line modal no caller could open).
+
 ## Platform guards
 
 Desktop-only APIs (Electron, MCP, Node.js) must be guarded with Obsidian's `Platform` checks


### PR DESCRIPTION
<!-- auto-dev -->
> **Do not review this PR. It is a duplicate and should be closed.**
>
> The rule this PR adds was already landed on `master` by **#1433**, which merged at 2026-09-02 17:17 UTC — roughly fifteen minutes before the tick that opened this one began. The two changes edit the same section of the same file, so this branch now conflicts with `master` and has nothing left to contribute. The auto-dev pipeline cannot close a PR (that is one of its hard prohibitions), so this needs a maintainer's click. Original description preserved below for the record.

## Why this happened

The tick's Step 0 state gather returned stale data on two independent channels:

- `git fetch origin --prune` followed by `git reset --hard origin/master` put the sandbox on `adbf1af`. `master` was already at `b533b6c` (which contains #1433).
- The closed-PR listing, requested newest-updated-first, returned nothing more recent than 2026-08-29 — so #1433, closed and merged that same hour, was absent from it.

Neither channel showed the merge, and issue #1303 still carried `auto:in-progress` with no discoverable PR (#1433's branch, `auto/issue-1303-wiring-fields-rule`, had been deleted on merge). Under the pipeline's orphan rule that reads exactly like a crashed build from a previous tick, so this tick reclaimed the issue and rebuilt it. The reclaim logic behaved correctly on the inputs it had; the inputs were wrong.

The gap worth noting: the orphan check keys on branch-prefix and open-PR discovery, and a merged PR whose branch is gone leaves no trace it can see. Issue #1303 has now been reconciled — `auto:in-progress` removed, merged PR linked.

---

## Summary

Adds one section to `.claude/guidelines/coding.md` encoding the rule #1303 proposes: a field added to a context/callback/capability interface must be wired to a consumer in the same change.

The rule is worth writing down because it names a gap that is structural, not incidental. `npm run knip` resolves exported symbols, not per-field reachability through an object literal — and `knip.json` sets `ignoreExportsUsedInFile` for `interface`/`type`. So an unread field on a live interface, populated at a live construction site, is invisible to knip by construction. It can be born dead and stay dead with every check green, which is exactly why making the knip check blocking (#1294) does not close this class. Three instances in 90 days: #1298 (`ProviderCapabilities`), #1300 (`SendContext`), #1301 (`UICallbacks`, whose unread `showFilePicker` left a 170-line modal no caller could open).

Built from the plan approved on #1303. Produced by the auto-dev pipeline.

## Changes

- `.claude/guidelines/coding.md` — new section **Wiring interfaces carry only what is read**, inserted between *Plugin type surface — never import `main.ts`* and *Platform guards*.

Every symbol and path the section cites was re-verified against `adbf1af`: `SendContext` (`agent-view-send.ts:28`), `UICallbacks` (`agent-view-ui.ts:27`), `ProviderCapabilities` (`registry.ts:46`), `AgentViewContext` (`agent-view-tools.ts:19`), the `ToolsContext` alias, `npm run knip` (`package.json:26`), and `ignoreExportsUsedInFile` in `knip.json`.

Pre-flight was green locally before pushing: `format-check` clean, `lint` 0 errors / 40 pre-existing warnings, `build` green, `typecheck:test` green, 3819 tests across 171 files. None of that changes the conclusion — the work was already done by #1433, whose wording is materially equivalent and is the version that should stand.

## Screenshots / Screencast

N/A — no UI surface.

## Checklist

Left unticked deliberately. This PR should not merge on any checklist; it duplicates merged work.

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (auto-dev pipeline)
- [x] I have reviewed and understand all AI-generated code in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018MuNd5Ys9qefjPVnbn3iGz