### PR TITLE
fix(mcp): derive MCP tool classification from the server's destructiveHint

### DIFF
--- a/docs/guide/mcp-servers.md
+++ b/docs/guide/mcp-servers.md
@@ -144,7 +144,7 @@ When an MCP server is connected:
 2. It queries the server for its list of tools via the MCP protocol
 3. Each tool is registered in the plugin's tool system with a namespaced name (`mcp__<server>__<tool>`)
 4. When the agent calls a tool, the plugin forwards the request to the MCP server and returns the result
-5. The confirmation flow works the same as built-in tools — untrusted tools require approval
+5. The confirmation flow works the same as built-in tools — untrusted tools require approval. Each tool's **classification** (which permission preset and safety band it lands in) defaults to _external_; if the server declares a tool with the MCP `destructiveHint` annotation, the tool is classified **destructive** and is gated (and execution-ordered) as strictly as the built-in delete tools. The plugin only ever makes MCP tools _stricter_ based on server hints — never more permissive — since those hints come from an untrusted party
 
 ## Troubleshooting
 

--- a/src/mcp/mcp-classification.ts
+++ b/src/mcp/mcp-classification.ts
@@ -1,0 +1,42 @@
+import { ToolClassification } from '../types/tool-policy';
+
+/**
+ * Tool annotations as advertised by an MCP server (`Tool.annotations` in the
+ * MCP spec, carried on `Tool` by the SDK's `ToolSchema`). All four flags are
+ * *hints* supplied by the server — the untrusted party — and the SDK's own doc
+ * block warns: "Clients should never make tool use decisions based on
+ * ToolAnnotations received from untrusted servers."
+ *
+ * A leaf module (imports nothing) so the mapper is unit-testable without an
+ * MCP client.
+ */
+export interface MCPToolAnnotations {
+	readOnlyHint?: boolean;
+	destructiveHint?: boolean;
+	idempotentHint?: boolean;
+	openWorldHint?: boolean;
+}
+
+/**
+ * Map MCP tool annotations to the plugin's ToolClassification — the axis the
+ * permission presets and the execution-sort priority both resolve on (#1449).
+ *
+ * Trust policy (maintainer decision, option (a)): only `destructiveHint` is
+ * honored, so the mapping can only ever make a tool *stricter* (EXTERNAL →
+ * DESTRUCTIVE raises confirmation in every preset and moves the tool into the
+ * correct execution-sort band behind native writes). A lying server only
+ * hurts itself. `readOnlyHint` is deliberately NOT honored: promoting a tool
+ * to READ on a server's say-so would auto-approve it under Cautious/Edit mode
+ * — the exact untrusted-hint decision the MCP spec warns against.
+ *
+ * Everything else — absent annotations, unknown shapes, false hints — maps to
+ * EXTERNAL, preserving the pre-#1449 behavior as the default. There is no
+ * under-gating path: the mapper never returns a band more permissive than
+ * EXTERNAL.
+ */
+export function classificationFromAnnotations(annotations: MCPToolAnnotations | undefined): ToolClassification {
+	if (annotations?.destructiveHint === true) {
+		return ToolClassification.DESTRUCTIVE;
+	}
+	return ToolClassification.EXTERNAL;
+}

--- a/src/mcp/mcp-tool-wrapper.ts
+++ b/src/mcp/mcp-tool-wrapper.ts
@@ -3,6 +3,7 @@ import { Tool, ToolResult, ToolExecutionContext, ToolParameterSchema } from '../
 import { ToolCategory } from '../types/agent';
 import { ToolClassification } from '../types/tool-policy';
 import { MCP_CALL_TOOL_TIMEOUT_MS } from './mcp-constants';
+import { classificationFromAnnotations, type MCPToolAnnotations } from './mcp-classification';
 import { withTimeout } from '../utils/timeout';
 import { asRecord, getRawErrorMessage } from '../utils/error-utils';
 
@@ -11,11 +12,14 @@ import { asRecord, getRawErrorMessage } from '../utils/error-utils';
  *
  * The `inputSchema` is external JSON Schema (the SDK types property values as
  * bare `object`), so `properties` values stay `unknown` and are narrowed at the
- * point of use (see `convertInputSchema`).
+ * point of use (see `convertInputSchema`). `annotations` are the server's
+ * declared hints — mapped to a classification by `classificationFromAnnotations`
+ * (destructiveHint only; see mcp-classification.ts for the trust policy).
  */
 interface MCPToolDefinition {
 	name: string;
 	description?: string;
+	annotations?: MCPToolAnnotations;
 	inputSchema?: {
 		type?: string;
 		properties?: Record<string, unknown>;
@@ -31,7 +35,8 @@ export class MCPToolWrapper implements Tool {
 	readonly name: string;
 	readonly displayName: string;
 	readonly category: string = ToolCategory.EXTERNAL_MCP;
-	readonly classification: ToolClassification = ToolClassification.EXTERNAL;
+	/** Derived from the server's destructiveHint (EXTERNAL by default) — see mcp-classification.ts */
+	readonly classification: ToolClassification;
 	readonly description: string;
 	readonly parameters: ToolParameterSchema;
 
@@ -45,6 +50,7 @@ export class MCPToolWrapper implements Tool {
 		this.displayName = `${serverName}: ${toolDef.name}`;
 		this.description = toolDef.description || `MCP tool "${toolDef.name}" from server "${serverName}"`;
 		this.parameters = convertInputSchema(toolDef.inputSchema);
+		this.classification = classificationFromAnnotations(toolDef.annotations);
 	}
 
 	async execute(params: Record<string, unknown>, _context: ToolExecutionContext): Promise<ToolResult> {

--- a/test/mcp/mcp-classification.test.ts
+++ b/test/mcp/mcp-classification.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { classificationFromAnnotations, type MCPToolAnnotations } from '../../src/mcp/mcp-classification';
+import { ToolClassification } from '../../src/types/tool-policy';
+
+describe('classificationFromAnnotations', () => {
+	it('maps destructiveHint to DESTRUCTIVE — the only honored hint (#1449)', () => {
+		const annotations: MCPToolAnnotations = {
+			destructiveHint: true,
+			readOnlyHint: false,
+			idempotentHint: false,
+			openWorldHint: true,
+		};
+		expect(classificationFromAnnotations(annotations)).toBe(ToolClassification.DESTRUCTIVE);
+	});
+
+	it('honors destructiveHint even when readOnlyHint claims the opposite', () => {
+		// A self-contradicting server: destructive wins, since the mapping can
+		// only make tools stricter.
+		expect(classificationFromAnnotations({ readOnlyHint: true, destructiveHint: true })).toBe(
+			ToolClassification.DESTRUCTIVE
+		);
+	});
+
+	it('maps readOnlyHint to EXTERNAL — never honored from an untrusted server', () => {
+		// The MCP spec's own doc block warns against making tool-use decisions
+		// from annotations received from untrusted servers; promoting to READ
+		// would auto-approve a tool under Cautious/Edit mode on a server's
+		// say-so (maintainer decision, option (a)).
+		expect(classificationFromAnnotations({ readOnlyHint: true })).toBe(ToolClassification.EXTERNAL);
+	});
+
+	it('defaults to EXTERNAL for absent annotations — preserving pre-#1449 behavior', () => {
+		expect(classificationFromAnnotations(undefined)).toBe(ToolClassification.EXTERNAL);
+		expect(classificationFromAnnotations({})).toBe(ToolClassification.EXTERNAL);
+	});
+
+	it('defaults to EXTERNAL when hints are false or unrelated', () => {
+		expect(classificationFromAnnotations({ readOnlyHint: false, destructiveHint: false })).toBe(
+			ToolClassification.EXTERNAL
+		);
+		expect(classificationFromAnnotations({ idempotentHint: true, openWorldHint: false })).toBe(
+			ToolClassification.EXTERNAL
+		);
+	});
+
+	it('never returns a band more permissive than EXTERNAL (no under-gating path)', () => {
+		const inputs: MCPToolAnnotations[] = [
+			{},
+			{ readOnlyHint: true },
+			{ idempotentHint: true },
+			{ openWorldHint: true },
+			{ readOnlyHint: true, idempotentHint: true, openWorldHint: true },
+			{ destructiveHint: false, readOnlyHint: true },
+		];
+		for (const annotations of inputs) {
+			const result = classificationFromAnnotations(annotations);
+			expect([ToolClassification.EXTERNAL, ToolClassification.DESTRUCTIVE]).toContain(result);
+		}
+	});
+});

--- a/test/mcp/mcp-tool-wrapper.test.ts
+++ b/test/mcp/mcp-tool-wrapper.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
 import { MCPToolWrapper } from '../../src/mcp/mcp-tool-wrapper';
 import { MCP_CALL_TOOL_TIMEOUT_MS } from '../../src/mcp/mcp-constants';
+import { ToolClassification } from '../../src/types/tool-policy';
 
 function makeClient(callToolImpl: () => Promise<any>) {
 	return {
@@ -69,6 +70,26 @@ describe('MCPToolWrapper', () => {
 
 			expect(result.success).toBe(false);
 			expect(result.error).toBe('bad input');
+		});
+	});
+
+	describe('classification from annotations (#1449)', () => {
+		it('derives DESTRUCTIVE from destructiveHint and EXTERNAL by default', () => {
+			const client = makeClient(() => Promise.resolve({ content: [] }));
+			const destructive = new MCPToolWrapper(client, 'srv', {
+				name: 'remove_file',
+				annotations: { destructiveHint: true },
+			});
+			const plain = new MCPToolWrapper(client, 'srv', { name: 'query' });
+			const readOnly = new MCPToolWrapper(client, 'srv', {
+				name: 'lookup',
+				annotations: { readOnlyHint: true },
+			});
+
+			expect(destructive.classification).toBe(ToolClassification.DESTRUCTIVE);
+			expect(plain.classification).toBe(ToolClassification.EXTERNAL);
+			// readOnlyHint is never honored from an untrusted server.
+			expect(readOnly.classification).toBe(ToolClassification.EXTERNAL);
 		});
 	});
 });


### PR DESCRIPTION
## Summary

Fixes #1449

`MCPToolWrapper` stamped every tool from every MCP server with `ToolClassification.EXTERNAL` as a class constant, and the hand-rolled `MCPToolDefinition` interface dropped the MCP spec's `annotations` field at the type boundary — so the permission system (and, since #1424, the execution-sort priority) could not distinguish a filesystem server's `delete_file` from a search server's `query`. The MCP spec already carries the missing fact: `Tool.annotations` ships on the SDK's `Tool` schema and servers populate it so clients can gate tools by risk — the wrapper discarded it before the constructor ever saw it.

**Maintainer decision on the issue's trust question: option (a) — honor `destructiveHint` only.** The SDK's own doc block for `ToolAnnotations` warns verbatim: *"Clients should never make tool use decisions based on ToolAnnotations received from untrusted servers."* Honoring `readOnlyHint: true` would promote a tool to READ on an untrusted server's say-so and auto-approve it under Cautious/Edit mode — the exact anti-pattern the spec warns against. Honoring `destructiveHint` only means the mapping can **never make a tool more permissive**: a lying server only hurts itself.

## Changes

- `src/mcp/mcp-classification.ts` (new leaf, imports nothing) — `classificationFromAnnotations(annotations)` maps `destructiveHint === true` → `DESTRUCTIVE`, everything else → `EXTERNAL`. There is no under-gating path: the mapper never returns a band more permissive than EXTERNAL. The trust policy and its spec citation are documented on the function.
- `src/mcp/mcp-tool-wrapper.ts` — `MCPToolDefinition` gains `annotations?: MCPToolAnnotations` (the SDK's `Tool` carries it; it was dropped at the interface boundary), and `classification` changes from a class constant to a `readonly` field assigned in the constructor from the mapper.
- `docs/guide/mcp-servers.md` — the How-It-Works flow documents the classification default and the `destructiveHint` promotion (stricter-only, per the untrusted-party caveat) in the same PR.
- Tests (+7): 6 mapper tests — `destructiveHint` honored, contradicting-hints resolve destructive, `readOnlyHint` explicitly never honored, absent/empty/false-hint defaults, and a no-under-gating sweep asserting every input maps to EXTERNAL or DESTRUCTIVE only; 1 wrapper-level test asserting the constructed tool carries the derived classification.

## What this fixes / what it deliberately doesn't

- **Fixed**: a server that declares `destructiveHint` now gets its destructive tools gated (and execution-ordered behind native writes) as strictly as built-in deletes — the post-#1424 sort-band defect for MCP writes/deletes is corrected.
- **Deliberately unchanged** (per the trust decision): Read-only-preset MCP tools still don't auto-appear (nothing new is promoted to READ), and read-only MCP tools under Edit mode still prompt. Closing *those* would require trusting an untrusted server's `readOnlyHint` (the spec-documented anti-pattern) or a per-server trust toggle — the issue's option (b), a separate feature if ever wanted.

## Screenshots / Screencast

N/A — permission/ordering semantics; no UI change (the per-tool permission UI already renders the classification; MCP tools with `destructiveHint` will now appear as destructive there).

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [ ] I have tested this change on Desktop
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards)
- [x] Documentation has been updated (if applicable)
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

Notes on the unticked items:

- **Desktop testing**: not performed — the mapper is a pure function with 6 combination tests plus a wrapper-level assertion; connect/list-tools flow is unchanged (the SDK's `Tool` object already carried `annotations` at runtime — the type just discarded it). A desktop connect against a server that declares `destructiveHint` would confirm the end-to-end gating; the unit suite covers the mapping.
- **Mobile**: no platform-specific API touched; MCP is desktop-gated already.
- **Documentation**: `docs/guide/mcp-servers.md` updated in the same PR per the repo rule (classification default + destructiveHint promotion + the stricter-only trust statement).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - MCP tools are now classified as external by default.
  - Tools with an explicit destructive hint are classified and gated as destructive.
  - Untrusted server annotations cannot make a tool less restrictive.

- **Documentation**
  - Updated MCP server guidance to explain tool classification and destructive hints.

- **Tests**
  - Added coverage for annotated, unannotated, contradictory, and unknown tool hints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->