### PR TITLE
refactor(agent): remove the unread AgentContext character caps

### DIFF
--- a/src/agent/session-manager.ts
+++ b/src/agent/session-manager.ts
@@ -429,8 +429,6 @@ export class SessionManager {
 			contextFiles,
 			toolPolicy: parseSessionToolPolicy(frontmatter, DEFAULT_CONTEXTS.NOTE_CHAT.toolPolicy),
 			requireConfirmation,
-			maxContextChars: typeof frontmatter.max_context_chars === 'number' ? frontmatter.max_context_chars : undefined,
-			maxCharsPerFile: typeof frontmatter.max_chars_per_file === 'number' ? frontmatter.max_chars_per_file : undefined,
 		};
 	}
 

--- a/src/types/agent.ts
+++ b/src/types/agent.ts
@@ -42,12 +42,6 @@ export interface AgentContext {
 
 	/** Actions that require user confirmation */
 	requireConfirmation: DestructiveAction[];
-
-	/** Maximum total characters to include from context files */
-	maxContextChars?: number;
-
-	/** Maximum characters per individual file */
-	maxCharsPerFile?: number;
 }
 
 /**
@@ -160,8 +154,6 @@ export const DEFAULT_CONTEXTS = {
 		// are filtered out of the registry.
 		toolPolicy: { preset: PolicyPreset.READ_ONLY },
 		requireConfirmation: [],
-		maxContextChars: 50000,
-		maxCharsPerFile: 10000,
 	} as Omit<AgentContext, 'contextFiles'>,
 
 	AGENT_SESSION: {
@@ -176,8 +168,6 @@ export const DEFAULT_CONTEXTS = {
 			DestructiveAction.DELETE_FILES,
 			DestructiveAction.EXTERNAL_API_CALLS,
 		],
-		maxContextChars: 100000,
-		maxCharsPerFile: 15000,
 	} as AgentContext,
 } as const;
 


### PR DESCRIPTION
## Summary

`audit-architecture` nightly sweep flagged: **dead wiring field** in `src/types/agent.ts`.

`AgentContext.maxContextChars` and `AgentContext.maxCharsPerFile` are declared on the interface, populated by **both** `DEFAULT_CONTEXTS` presets (`NOTE_CHAT`: 50000/10000, `AGENT_SESSION`: 100000/15000), and parsed back out of session frontmatter (`max_context_chars` / `max_chars_per_file`) in `SessionManager.parseContextFromFrontmatter` — and **no code path reads either one**. `grep -rw maxContextChars src` returns only the declaration, the two preset populations, and the frontmatter parse; there are no test references at all. Context budgeting in this plugin is token-based and lives in `ContextManager`; nothing consults a character cap.

Nothing writes those frontmatter keys either, so the parse arm was a read path for data the plugin never produced. Removing the fields is a no-op at runtime — a session note that happens to carry the keys simply keeps them as inert frontmatter, exactly as it does today for any unrecognised key.

This is the "Wiring interfaces carry only what is read" rule in `.claude/guidelines/coding.md`: `npm run knip` resolves exported symbols, not per-field reachability through an object literal, so both the interface and the populating code are live and a dead field survives every check indefinitely.

No linked issue — this was found by the nightly sweep rather than filed first.

## Changes

- `src/types/agent.ts` — drop the `maxContextChars` / `maxCharsPerFile` declarations from `AgentContext` and their populations in the `NOTE_CHAT` and `AGENT_SESSION` presets.
- `src/agent/session-manager.ts` — drop the two frontmatter parse lines that fed them.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: filed directly by the `audit-architecture` sweep as a mechanical, no-behaviour-change deletion. Close it if you'd rather keep the fields for a planned consumer.
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — plus `npm run lint` (0 errors) and `npm run typecheck:test`; 4013 tests across 179 files pass.
- [ ] I have tested this change on Desktop — N/A: pure type/dead-field deletion with no reachable runtime behaviour; covered by the full suite.
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A: no platform-specific API touched.
- [ ] Documentation has been updated (if applicable) — N/A: neither field is mentioned anywhere in `docs/`, `README.md`, or `src/i18n/en.ts`; there was no user-facing surface to document.
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (`audit-architecture` skill)
- [x] I have reviewed and understand all AI-generated code in this PR

---

_Filed by the `audit-architecture` skill._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CkcXnTDoz8Tw8nWpXvhoUc

---
_Generated by [Claude Code](https://claude.ai/code/session_01CkcXnTDoz8Tw8nWpXvhoUc)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed support for restoring and configuring maximum context and per-file character limits in agent sessions.
  * Other session context, tool policy, and confirmation settings continue to be loaded as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->