### PR TITLE
refactor(models): remove the unread GeminiModel.supportsTools field

### DIFF
--- a/src/models.ts
+++ b/src/models.ts
@@ -17,8 +17,6 @@ export interface GeminiModel {
 	maxTemperature?: number;
 	/** Provider that serves this model. Omitted entries are treated as 'gemini' for backward compat. */
 	provider?: ModelProvider;
-	/** Whether the model is known to support function/tool calling. Defaults to true for Gemini, varies for Ollama. */
-	supportsTools?: boolean;
 	/** Whether the model supports image input (vision). */
 	supportsVision?: boolean;
 	/** Context window in tokens (used for compaction thresholds). */

--- a/src/services/ollama-models-service.ts
+++ b/src/services/ollama-models-service.ts
@@ -339,7 +339,6 @@ export class OllamaModelsService {
 			value: name,
 			label: this.formatLabel(m),
 			provider: 'ollama',
-			supportsTools: true,
 			supportsVision: isVision,
 			...(contextWindow && { contextWindow }),
 			...(m.remote_host && { remoteHost: m.remote_host }),

--- a/src/services/openai-models-service.ts
+++ b/src/services/openai-models-service.ts
@@ -157,7 +157,6 @@ export class OpenAIModelsService {
 			value: id,
 			label: id,
 			provider: 'openai',
-			supportsTools: true,
 			supportsVision: meta.supportsVision,
 			contextWindow: meta.contextWindow,
 			...(meta.defaultForRoles && { defaultForRoles: [...meta.defaultForRoles] }),

--- a/test/services/ollama-models-service.test.ts
+++ b/test/services/ollama-models-service.test.ts
@@ -45,7 +45,6 @@ describe('OllamaModelsService', () => {
 			value: 'llama3.2:3b',
 			label: 'llama3.2:3b (3.2B)',
 			provider: 'ollama',
-			supportsTools: true,
 			defaultForRoles: ['completions'], // 3b matches the small-model heuristic
 		});
 		// Vision detection

--- a/test/services/openai-models-service.test.ts
+++ b/test/services/openai-models-service.test.ts
@@ -31,7 +31,6 @@ describe('OpenAIModelsService', () => {
 		expect(models[0]).toMatchObject({
 			value: 'gpt-5.6-sol',
 			provider: 'openai',
-			supportsTools: true,
 			supportsVision: true,
 			contextWindow: 922_000,
 			defaultForRoles: ['chat'],
@@ -50,7 +49,6 @@ describe('OpenAIModelsService', () => {
 			expect.objectContaining({
 				value: 'some-custom-local-model',
 				provider: 'openai',
-				supportsTools: true,
 				supportsVision: false,
 				contextWindow: 128_000,
 			}),


### PR DESCRIPTION
## Summary

`audit-architecture` nightly sweep flagged: **dead wiring field** in `src/models.ts`.

`GeminiModel.supportsTools` is declared on the interface and set to `true` by the two dynamic model-list services (`OpenAIModelsService.toGeminiModel`, `OllamaModelsService`), but **no code path reads it**. Tool exposure is decided by the tool registry and the layered tool policy (`ToolPolicySettings` / `FeatureToolPolicy`), never by model metadata.

Two details make it worth deleting rather than keeping:

- The static `GEMINI_MODELS` table never set it, so the field was inconsistently populated as well as unread — a future consumer reading it would have silently treated every Gemini model as `undefined`.
- Its doc comment ("Defaults to true for Gemini, varies for Ollama") describes behaviour that was never implemented: both producers hardcode `true`.

The only references outside the declaration were the three test assertions echoing back the value the service had just been told to produce; those are removed with it.

This is the "Wiring interfaces carry only what is read" rule in `.claude/guidelines/coding.md`: `npm run knip` resolves exported symbols, not per-field reachability, so an unread field on a live interface survives every check.

No linked issue — this was found by the nightly sweep rather than filed first.

## Changes

- `src/models.ts` — drop the `supportsTools` declaration from `GeminiModel`.
- `src/services/openai-models-service.ts` — drop its population in `toGeminiModel`.
- `src/services/ollama-models-service.ts` — drop its population.
- `test/services/openai-models-service.test.ts`, `test/services/ollama-models-service.test.ts` — drop the three assertions on the removed field.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: filed directly by the `audit-architecture` sweep as a mechanical, no-behaviour-change deletion. Close it if the field is being held for a planned tool-capability gate.
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — plus `npm run lint` (0 errors) and `npm run typecheck:test`; 4013 tests across 179 files pass.
- [ ] I have tested this change on Desktop — N/A: unread field deletion with no reachable runtime behaviour; the two model-list services are covered by their existing tests.
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A: no platform-specific API touched.
- [ ] Documentation has been updated (if applicable) — N/A: the field is not mentioned in `docs/`, `README.md`, or any settings surface.
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (`audit-architecture` skill)
- [x] I have reviewed and understand all AI-generated code in this PR

---

_Filed by the `audit-architecture` skill._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CkcXnTDoz8Tw8nWpXvhoUc

---
_Generated by [Claude Code](https://claude.ai/code/session_01CkcXnTDoz8Tw8nWpXvhoUc)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected model capability metadata so Gemini, Ollama, and OpenAI models no longer advertise tool support.
  * Preserved existing vision support, context-window details, provider information, and role metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->