### PR TITLE
chore(daily): 2026-09-03 daily update

### DIFF
--- a/planning/changelog/2026-09-02.md
+++ b/planning/changelog/2026-09-02.md
@@ -1,0 +1,36 @@
+# Daily changelog — September 02, 2026
+
+**Date:** 2026-09-02
+**PRs merged:** 6
+
+---
+
+## Summary
+
+A retry-engine and frontmatter-safety day: two fixes closed out cancellation and classification bugs surfaced by yesterday's triage and refactor work, while the prior day's automated daily-update PR itself landed. The bulk of the day's other three PRs were auto-dev pipeline follow-through — unifying streaming retries with the shared retry engine, giving the two frontmatter writers one YAML quoting rule, and documenting a recurring dead-field pattern in the coding guidelines.
+
+## What shipped
+
+### [#1451 chore(daily): 2026-09-02 daily update](https://github.com/allenhutchison/obsidian-gemini/pull/1451)
+
+The automated daily-update run covering 2026-09-01: wrote `planning/changelog/2026-09-01.md` for that day's 9 merged PRs, ran a full `audit-product-docs` pass with no drift found, and had `triage-issues` label one unlabeled issue (#1448, `bug` + `architecture`) — the retry-cancellation bug fixed later today by #1453.
+
+### [#1450 refactor(services): give the frontmatter writers one YAML quoting rule](https://github.com/allenhutchison/obsidian-gemini/pull/1450)
+
+Fixes #1352. `ScheduledTaskManager` and `HookManager` each hand-rolled YAML frontmatter with different quoting conventions, so a correctness fix to one (#1347) never reached the other. Adds a shared leaf module, `src/services/yaml-scalar.ts`, and routes both writers' free-text fields through it. The real fix: `frontmatterFilter` keys and `enabledSkills` items were previously emitted with no quoting at all — a raw key containing a colon followed by a space could nest a YAML map and make the whole block unparseable, silently vanishing the hook from the manager. Falls back to double-quoted scalars for values containing control characters, since single-quoted YAML has no escape for them.
+
+### [#1447 refactor(api): route streaming retries through the shared retry engine](https://github.com/allenhutchison/obsidian-gemini/pull/1447)
+
+Fixes #1337. `RetryDecorator.generateStreamingResponse` re-implemented its own retry loop instead of using the shared `retry.ts` engine, and had drifted from it in five ways — no jitter, an uncapped exponential backoff arm, two different `RetryConfig` types, duplicate sleep helpers, and a zero-length API-provided delay being silently discarded. All were making the streaming path (every interactive agent turn) less conservative than non-streaming, which is backwards. Unifies both paths; the decorator's exported type is renamed `ApiRetryConfig` to avoid colliding with the engine's own `RetryConfig`.
+
+### [#1433 docs(guidelines): encode the "wiring interfaces carry only what is read" rule](https://github.com/allenhutchison/obsidian-gemini/pull/1433)
+
+Fixes #1303. Adds a new section to `.claude/guidelines/coding.md` documenting a pattern the `audit-architecture` skill has flagged three times in 90 days: a field declared on a context/callback/capability interface and populated at its construction site, but never read anywhere. `knip` can't catch this structurally since it resolves exported symbols, not per-field reachability through an object literal — so the rule exists to catch what tooling can't. Docs-only.
+
+### [#1453 fix(api): make the retry backoff interruptible on cancellation](https://github.com/allenhutchison/obsidian-gemini/pull/1453)
+
+Fixes #1448 (flagged by yesterday's triage run). `executeWithRetry` slept between retry attempts with a plain, non-interruptible sleep, so a cancellation arriving mid-backoff wasn't observed until the sleep elapsed — up to the 60-second delay cap introduced by #1447 earlier the same day. In practice, hitting Stop during a retry backoff on a streaming response left `stream.complete` pending, delaying cleanup and surfacing a spurious "Stream was cancelled" error notice up to ~66 seconds late. Adds `sleepInterruptibly`, which slices the backoff into 100ms polls and re-checks the existing `shouldAbort` hook between them; behavior is unchanged for any call site that doesn't pass `shouldAbort`.
+
+### [#1456 fix(mcp): derive MCP tool classification from the server's destructiveHint](https://github.com/allenhutchison/obsidian-gemini/pull/1456)
+
+Fixes #1449. `MCPToolWrapper` stamped every tool from every MCP server as `ToolClassification.EXTERNAL`, dropping the MCP spec's `annotations` field at the type boundary — so the permission system couldn't distinguish a destructive tool (e.g. `delete_file`) from a harmless one (e.g. `query`). Now maps `destructiveHint: true` to `DESTRUCTIVE` and leaves everything else `EXTERNAL`. Per the MCP spec's own warning against trusting `readOnlyHint` from untrusted servers, the mapping is deliberately stricter-only: it can promote a tool to more restrictive but never to more permissive.

--- a/test/ui/agent-view/attach-vault-file.test.ts
+++ b/test/ui/agent-view/attach-vault-file.test.ts
@@ -144,7 +144,8 @@ describe('attachVaultBinaryFile', () => {
 	it('accepts a bulky source SVG whose rasterized PNG fits the budget (no source gate) (#1434 review)', async () => {
 		// A >20 MB source SVG can rasterize to a small PNG (the rasterizer caps
 		// the canvas at 2048px); the source-byte gate must not reject it — only
-		// the converted payload counts.
+		// the converted payload counts. Building/copying the >20 MB source buffer
+		// is CPU-bound and can exceed the default 5s timeout under load; give it room.
 		const bulky = bufferOf(new Array(GEMINI_INLINE_DATA_LIMIT + 1024).fill(0x20));
 		rasterizeSvg.mockResolvedValue('AB=='); // decodes to 1 byte
 		const result = await attachVaultBinaryFile(
@@ -158,7 +159,7 @@ describe('attachVaultBinaryFile', () => {
 			expect(result.bytes).toBe(1);
 			expect(rasterizeSvg).toHaveBeenCalledWith(expect.anything(), false, GEMINI_INLINE_DATA_LIMIT);
 		}
-	});
+	}, 20000);
 
 	it('returns raster-failed when rasterization rejects', async () => {
 		rasterizeSvg.mockRejectedValue(new Error('bad svg'));


### PR DESCRIPTION
## Summary

Automated daily-update run bundling the repo's per-day housekeeping skills for 2026-09-02.

## Changes

- **daily-changelog**: wrote `planning/changelog/2026-09-02.md` covering the day's 6 merged PRs — the retry-engine cancellation and MCP tool-classification fixes (#1453, #1456), the shared-retry-engine unification for streaming (#1447), the frontmatter YAML-quoting unification across `ScheduledTaskManager`/`HookManager` (#1450), the "wiring interfaces carry only what is read" guideline (#1433), and the prior day's automated daily-update PR itself (#1451).
- **audit-product-docs**: spot-checked the docs updated alongside the day's PRs (MCP tool classification/`destructiveHint` in `docs/guide/mcp-servers.md`, retry jitter/backoff ceiling in `docs/reference/advanced-settings.md`, hook frontmatter quoting in `docs/guide/lifecycle-hooks.md`) against the current source — all already accurate. A settings-default spot-check (`maxRetries`, `initialBackoffDelay`) found no additional drift.

  **Flagging for maintainer attention (not a docs issue — a code bug, left unfixed per this skill's scope, re-flagged from the last two runs):** `src/main.ts` still sets the default `openaiModelName` to `'gpt-5.6'`, which isn't a recognized model id in the registry (`src/services/openai-models-service.ts`) — the docs and registry both correctly say the default is `'gpt-5.6-sol'`.
- **triage-issues**: no unlabeled open issues found — all 28 open issues already carry labels.

Also includes a test-infra fix found while validating this change: `test/ui/agent-view/attach-vault-file.test.ts`'s "accepts a bulky source SVG..." case was flagged as a flaky 5s timeout in each of the last two daily runs. This time it reproduced reliably (not just under parallel load) — building/copying its >20 MB source buffer consistently exceeded the default 5s timeout in this environment, and passed cleanly with more time. Gave it a 20s per-test timeout instead of continuing to re-flag it as a flake.

## Screenshots / Screencast

N/A — no UI changes.

## Checklist

### Required

- [x] I have read and agree to the Contributing Guidelines
- [x] I have read and agree to the AI Policy
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A, this is the recurring automated daily-update run, not tied to a single issue
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — also ran `npm run lint` (0 errors, 39 pre-existing warnings) and `npm run typecheck:test`; 179 files / 4013 tests passed
- [ ] I have tested this change on Desktop — N/A, changelog/docs-audit change plus a test-timeout adjustment, no runtime code path
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A, no runtime code changes
- [x] Documentation has been updated (if applicable) — N/A, this PR *is* the documentation/changelog update
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (automated daily-update scheduled run)
- [x] I have reviewed and understand all AI-generated code in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018MCehumgRz8UXxeuy4ryiA

---
_Generated by [Claude Code](https://claude.ai/code/session_018MCehumgRz8UXxeuy4ryiA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added the September 2, 2026 daily changelog covering updates to YAML quoting, streaming retries, wiring guidelines, retry interruption, and MCP tool classification.
  - Included the preceding daily update in the changelog for a more complete record of recent changes.

- **Tests**
  - Clarified payload-size budgeting for large vault-file attachments.
  - Increased the relevant test timeout to improve reliability when processing large source data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->