### PR TITLE
fix: Prevent stale scheduled-task lifecycle writes

### DIFF
--- a/src/services/file-backed-feature-manager.ts
+++ b/src/services/file-backed-feature-manager.ts
@@ -120,8 +120,12 @@ export abstract class FileBackedFeatureManager<TDef extends FileBackedDefinition
 	 * feature folder (excluding the `Runs/` subtree), seed state for newly-seen
 	 * definitions, drop orphan state entries, and persist. Replaces the
 	 * copy-pasted `discoverHooks` / `discoverTasks` loops.
+	 *
+	 * When provided, `isCurrent` is checked before applying results from each
+	 * asynchronous parse so a superseded lifecycle cannot repopulate the maps.
 	 */
-	protected async discoverDefinitions(): Promise<void> {
+	protected async discoverDefinitions(isCurrent?: () => boolean): Promise<void> {
+		if (isCurrent && !isCurrent()) return;
 		this.definitions.clear();
 
 		const prefix = this.featureFolderPath + '/';
@@ -134,10 +138,12 @@ export abstract class FileBackedFeatureManager<TDef extends FileBackedDefinition
 		for (const file of files) {
 			try {
 				const def = await this.parseDefinitionFile(file);
+				if (isCurrent && !isCurrent()) return;
 				if (!def) continue;
 				this.definitions.set(def.slug, def);
 				this.seedDiscoveredState(def);
 			} catch (err) {
+				if (isCurrent && !isCurrent()) return;
 				this.plugin.logger.warn(
 					`${this.featureConfig.logPrefix} Failed to parse ${this.featureConfig.featureNoun} file ${file.path}:`,
 					err
@@ -176,8 +182,11 @@ export abstract class FileBackedFeatureManager<TDef extends FileBackedDefinition
 
 	// ── State persistence ────────────────────────────────────────────────────
 
-	protected async loadState(): Promise<void> {
-		this.state = await this.stateStore.load();
+	protected async loadState(isCurrent?: () => boolean): Promise<void> {
+		const state = await this.stateStore.load();
+		if (!isCurrent || isCurrent()) {
+			this.state = state;
+		}
 	}
 
 	protected async saveState(): Promise<void> {

--- a/src/services/scheduled-task-manager.ts
+++ b/src/services/scheduled-task-manager.ts
@@ -64,6 +64,8 @@ export class ScheduledTaskManager extends FileBackedFeatureManager<ScheduledTask
 	private tasks = new Map<string, ScheduledTask>();
 	private tickIntervalId: number | null = null;
 	private initialized = false;
+	/** Invalidates asynchronous handlers across initialize/destroy boundaries. */
+	private lifecycleGeneration = 0;
 	private metadataCacheHandler: ((...data: unknown[]) => unknown) | null = null;
 	private vaultCreateHandler: ((...data: unknown[]) => unknown) | null = null;
 	/** Slugs of tasks currently being submitted — prevents double-fire from tick + runNow race. */
@@ -138,13 +140,14 @@ export class ScheduledTaskManager extends FileBackedFeatureManager<ScheduledTask
 	 * with refresh: true so that historyFolder changes are picked up without
 	 * requiring a full plugin restart.
 	 *
-	 * Passing no arguments (or refresh: false) after the first successful
 	 * initialization is a no-op — this prevents the double-init that occurs
 	 * when setup() runs with layoutReady === true and onLayoutReady() fires
 	 * immediately afterwards.
 	 */
 	async initialize(options?: { refresh?: boolean }): Promise<void> {
 		if (this.initialized && !options?.refresh) return;
+		// Refresh keeps `initialized` true, so invalidate the previous lifecycle explicitly.
+		const generation = ++this.lifecycleGeneration;
 		// Cancel any 500 ms defers still waiting from a previous initialization so
 		// stale callbacks cannot fire against the freshly-loaded state.
 		this.cancelPendingDefers();
@@ -158,6 +161,11 @@ export class ScheduledTaskManager extends FileBackedFeatureManager<ScheduledTask
 		await ensureFolderExists(this.plugin.app.vault, this.runsFolder, 'scheduled task runs', this.plugin.logger);
 		await this.loadState();
 		await this.discoverDefinitions();
+
+		if (this.lifecycleGeneration !== generation) {
+			this.plugin.logger.log('[ScheduledTaskManager] Aborting superseded initialization');
+			return;
+		}
 
 		// Re-parse a task definition file whenever the metadata cache updates it
 		// (fires after Obsidian re-indexes the frontmatter, so values are current).
@@ -173,6 +181,8 @@ export class ScheduledTaskManager extends FileBackedFeatureManager<ScheduledTask
 				if (this.recentlyCreated.has(slug)) return;
 				this.parseTaskFile(file)
 					.then(async (task) => {
+						// The parse may outlive the lifecycle that started it.
+						if (generation !== this.lifecycleGeneration) return;
 						if (task) {
 							const isNew = !this.tasks.has(task.slug);
 							this.tasks.set(task.slug, task);
@@ -218,11 +228,12 @@ export class ScheduledTaskManager extends FileBackedFeatureManager<ScheduledTask
 				const timerId = window.setTimeout(() => {
 					this.pendingDefers.delete(timerId);
 					this.recentlyCreated.delete(file.basename);
-					// Guard: if the manager was destroyed or re-initialized while the
-					// defer was pending, skip the parse — state has been reset.
-					if (!this.initialized) return;
+					// A pending timer may outlive the lifecycle that scheduled it.
+					if (!this.initialized || this.lifecycleGeneration !== generation) return;
 					this.parseTaskFile(file)
 						.then(async (task) => {
+							// The parse may outlive the lifecycle that scheduled it.
+							if (this.lifecycleGeneration !== generation) return;
 							if (!task) return;
 							// Skip if createTask() already registered this task immediately.
 							if (this.tasks.has(task.slug)) return;
@@ -457,14 +468,14 @@ export class ScheduledTaskManager extends FileBackedFeatureManager<ScheduledTask
 	}
 
 	destroy(): void {
+		// Invalidate in-flight parses before clearing state.
+		this.lifecycleGeneration++;
 		if (this.tickIntervalId !== null) {
 			window.clearInterval(this.tickIntervalId);
 			this.tickIntervalId = null;
 		}
 		this.detachVaultListeners();
-		// Cancel any 500 ms defers still in flight — their callbacks check
-		// this.initialized before touching state, but clearing here is the
-		// belt-and-suspenders guarantee that no timer fires after teardown.
+		// Also stop any defer that has not fired yet.
 		this.cancelPendingDefers();
 		this.tasks.clear();
 		this.state = {};

--- a/src/services/scheduled-task-manager.ts
+++ b/src/services/scheduled-task-manager.ts
@@ -148,6 +148,7 @@ export class ScheduledTaskManager extends FileBackedFeatureManager<ScheduledTask
 		if (this.initialized && !options?.refresh) return;
 		// Refresh keeps `initialized` true, so invalidate the previous lifecycle explicitly.
 		const generation = ++this.lifecycleGeneration;
+		const isCurrent = () => this.lifecycleGeneration === generation;
 		// Cancel any 500 ms defers still waiting from a previous initialization so
 		// stale callbacks cannot fire against the freshly-loaded state.
 		this.cancelPendingDefers();
@@ -159,10 +160,12 @@ export class ScheduledTaskManager extends FileBackedFeatureManager<ScheduledTask
 
 		await ensureFolderExists(this.plugin.app.vault, this.scheduledTasksFolder, 'scheduled tasks', this.plugin.logger);
 		await ensureFolderExists(this.plugin.app.vault, this.runsFolder, 'scheduled task runs', this.plugin.logger);
-		await this.loadState();
-		await this.discoverDefinitions();
+		await this.loadState(isCurrent);
+		if (isCurrent()) {
+			await this.discoverDefinitions(isCurrent);
+		}
 
-		if (this.lifecycleGeneration !== generation) {
+		if (!isCurrent()) {
 			this.plugin.logger.log('[ScheduledTaskManager] Aborting superseded initialization');
 			return;
 		}

--- a/test/services/scheduled-task-manager.test.ts
+++ b/test/services/scheduled-task-manager.test.ts
@@ -868,6 +868,15 @@ describe('ScheduledTaskManager', () => {
 
 		it('does not register listeners when destroy() interrupts initialize()', async () => {
 			const plugin = createMockPlugin();
+			plugin.app.vault.getMarkdownFiles.mockReturnValue([
+				Object.assign(new MockTFile(), {
+					path: 'gemini-scribe/Scheduled-Tasks/stale-task.md',
+					basename: 'stale-task',
+					extension: 'md',
+				}),
+			]);
+			plugin.app.metadataCache.getFileCache.mockReturnValue({ frontmatter: { schedule: 'daily' } });
+			plugin.app.vault.read = vi.fn().mockResolvedValue('Stale prompt.');
 			plugin.app.vault.adapter.exists.mockResolvedValue(true);
 			let resolveStateRead!: (value: string) => void;
 			plugin.app.vault.adapter.read.mockReturnValue(
@@ -882,11 +891,17 @@ describe('ScheduledTaskManager', () => {
 				expect(plugin.app.vault.adapter.read).toHaveBeenCalledOnce();
 			});
 			manager.destroy();
-			resolveStateRead('{}');
+			resolveStateRead(
+				JSON.stringify({
+					'stale-task': { nextRunAt: '2026-09-04T08:00:00.000Z' },
+				})
+			);
 			await initializePromise;
 
 			expect(plugin.app.vault.on).not.toHaveBeenCalled();
 			expect(plugin.app.metadataCache.on).not.toHaveBeenCalled();
+			expect(manager.getTasks()).toEqual([]);
+			expect(manager.getState()).toEqual({});
 
 			plugin.app.vault.adapter.read.mockResolvedValue('{}');
 			await manager.initialize();

--- a/test/services/scheduled-task-manager.test.ts
+++ b/test/services/scheduled-task-manager.test.ts
@@ -747,6 +747,153 @@ describe('ScheduledTaskManager', () => {
 			// parseTaskFile (vault.read) must never have been called from the stale defer
 			expect(plugin.app.vault.read).not.toHaveBeenCalled();
 		});
+
+		it('does not admit a create event whose parse resolves after destroy()', async () => {
+			const plugin = createMockPlugin();
+			plugin.app.vault.getMarkdownFiles.mockReturnValue([]);
+			const manager = new ScheduledTaskManager(plugin);
+			await manager.initialize();
+
+			const vaultOnCalls = (plugin.app.vault.on as Mock).mock.calls;
+			const createHandler = vaultOnCalls.find(([e]: any[]) => e === 'create')?.[1] as (...a: unknown[]) => unknown;
+			const newFile = Object.assign(new MockTFile(), {
+				path: 'gemini-scribe/Scheduled-Tasks/late-task.md',
+				basename: 'late-task',
+				extension: 'md',
+			});
+			let resolveRead!: (value: string) => void;
+			plugin.app.vault.read = vi.fn().mockReturnValue(
+				new Promise<string>((resolve) => {
+					resolveRead = resolve;
+				})
+			);
+			plugin.app.metadataCache.getFileCache.mockReturnValue({ frontmatter: { schedule: 'daily' } });
+
+			vi.useFakeTimers();
+			try {
+				createHandler(newFile);
+				await vi.advanceTimersByTimeAsync(500);
+				expect(plugin.app.vault.read).toHaveBeenCalledOnce();
+				plugin.app.vault.adapter.write.mockClear();
+
+				manager.destroy();
+				resolveRead('Late prompt.');
+				await Promise.resolve();
+				await Promise.resolve();
+
+				expect(manager.getTasks()).toEqual([]);
+				expect(manager.getState()).toEqual({});
+				expect(plugin.app.vault.adapter.write).not.toHaveBeenCalled();
+			} finally {
+				vi.useRealTimers();
+				manager.destroy();
+			}
+		});
+
+		it('does not admit a create event whose parse crosses a refresh initialize()', async () => {
+			const plugin = createMockPlugin();
+			plugin.app.vault.getMarkdownFiles.mockReturnValue([]);
+			const manager = new ScheduledTaskManager(plugin);
+			await manager.initialize();
+
+			const vaultOnCalls = (plugin.app.vault.on as Mock).mock.calls;
+			const createHandler = vaultOnCalls.find(([e]: any[]) => e === 'create')?.[1] as (...a: unknown[]) => unknown;
+			const newFile = Object.assign(new MockTFile(), {
+				path: 'gemini-scribe/Scheduled-Tasks/stale-task.md',
+				basename: 'stale-task',
+				extension: 'md',
+			});
+			let resolveRead!: (value: string) => void;
+			plugin.app.vault.read = vi.fn().mockReturnValue(
+				new Promise<string>((resolve) => {
+					resolveRead = resolve;
+				})
+			);
+			plugin.app.metadataCache.getFileCache.mockReturnValue({ frontmatter: { schedule: 'daily' } });
+
+			vi.useFakeTimers();
+			try {
+				createHandler(newFile);
+				await vi.advanceTimersByTimeAsync(500);
+				expect(plugin.app.vault.read).toHaveBeenCalledOnce();
+
+				await manager.initialize({ refresh: true });
+				plugin.app.vault.adapter.write.mockClear();
+				resolveRead('Stale prompt.');
+				await Promise.resolve();
+				await Promise.resolve();
+
+				expect(manager.getTasks()).toEqual([]);
+				expect(manager.getState()).toEqual({});
+				expect(plugin.app.vault.adapter.write).not.toHaveBeenCalled();
+			} finally {
+				vi.useRealTimers();
+				manager.destroy();
+			}
+		});
+
+		it('does not apply a metadata re-parse that resolves after destroy()', async () => {
+			const plugin = createMockPlugin();
+			plugin.app.vault.getMarkdownFiles.mockReturnValue([]);
+			const manager = new ScheduledTaskManager(plugin);
+			await manager.initialize();
+
+			const cacheOnCalls = (plugin.app.metadataCache.on as Mock).mock.calls;
+			const changedHandler = cacheOnCalls.find(([e]: any[]) => e === 'changed')?.[1] as (...a: unknown[]) => unknown;
+			const changedFile = Object.assign(new MockTFile(), {
+				path: 'gemini-scribe/Scheduled-Tasks/changed-task.md',
+				basename: 'changed-task',
+				extension: 'md',
+			});
+			let resolveRead!: (value: string) => void;
+			plugin.app.vault.read = vi.fn().mockReturnValue(
+				new Promise<string>((resolve) => {
+					resolveRead = resolve;
+				})
+			);
+			plugin.app.metadataCache.getFileCache.mockReturnValue({ frontmatter: { schedule: 'daily' } });
+
+			changedHandler(changedFile);
+			expect(plugin.app.vault.read).toHaveBeenCalledOnce();
+			plugin.app.vault.adapter.write.mockClear();
+			manager.destroy();
+			resolveRead('Changed prompt.');
+			await Promise.resolve();
+			await Promise.resolve();
+
+			expect(manager.getTasks()).toEqual([]);
+			expect(manager.getState()).toEqual({});
+			expect(plugin.app.vault.adapter.write).not.toHaveBeenCalled();
+		});
+
+		it('does not register listeners when destroy() interrupts initialize()', async () => {
+			const plugin = createMockPlugin();
+			plugin.app.vault.adapter.exists.mockResolvedValue(true);
+			let resolveStateRead!: (value: string) => void;
+			plugin.app.vault.adapter.read.mockReturnValue(
+				new Promise<string>((resolve) => {
+					resolveStateRead = resolve;
+				})
+			);
+			const manager = new ScheduledTaskManager(plugin);
+
+			const initializePromise = manager.initialize();
+			await vi.waitFor(() => {
+				expect(plugin.app.vault.adapter.read).toHaveBeenCalledOnce();
+			});
+			manager.destroy();
+			resolveStateRead('{}');
+			await initializePromise;
+
+			expect(plugin.app.vault.on).not.toHaveBeenCalled();
+			expect(plugin.app.metadataCache.on).not.toHaveBeenCalled();
+
+			plugin.app.vault.adapter.read.mockResolvedValue('{}');
+			await manager.initialize();
+			expect(plugin.app.vault.on).toHaveBeenCalledOnce();
+			expect(plugin.app.metadataCache.on).toHaveBeenCalledOnce();
+			manager.destroy();
+		});
 	});
 
 	// ── Tick behaviour ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Prevent scheduled-task initialization and file parses from mutating manager state after `destroy()` or a refresh supersedes the lifecycle that started them. Lifecycle-gated state loading and definition discovery also prevent an interrupted initialization from restoring obsolete state, tasks, or listeners after teardown.

Fixes #1342

## Changes

- add a monotonic lifecycle generation to `ScheduledTaskManager`
- reject stale create-defer and metadata-cache parse continuations before they mutate tasks or persisted state
- stage sidecar loads and gate asynchronous definition discovery before applying lifecycle-local results
- abort listener registration when initialization is superseded during an await
- add deterministic regression coverage for destroy, refresh, metadata re-parse, and interrupted initialization races
- mutation-check the regressions against the pre-fix source; every guarded race fails without its corresponding lifecycle protection

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [ ] I have tested this change on Desktop — N/A: this internal millisecond-scale lifecycle race is exercised deterministically in unit tests; no UI surface changed
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — no platform-specific APIs or behavior were added
- [x] Documentation has been updated (if applicable) — N/A: internal lifecycle correctness fix with no user-facing behavior, settings, or public API changes
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

If any part of this PR was generated or assisted by AI tools, you **must** complete this section:

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: OpenAI Codex
- [ ] I have reviewed and understand all AI-generated code in this PR — maintainer review pending

## Verification

- `npm run format-check`
- `npm run lint -- --ignore-pattern '.claude/worktrees/**'` (0 errors; existing warnings only)
- `npm run build`
- `npm run typecheck:test`
- `npm test` (179 files, 4017 tests)
- `npm run lint:cycles`
- `npm run knip`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented outdated background operations from changing task data after a refresh or shutdown.
  * Improved handling of interrupted initialization so stale results and callbacks are ignored.
  * Ensured listeners are registered correctly after a subsequent initialization.

* **Tests**
  * Added coverage for interrupted initialization, delayed metadata processing, shutdown behavior, stale state updates, and listener registration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->