### PR TITLE
refactor(projects): collapse the three parse-and-cache blocks into one helper

### DIFF
--- a/src/services/project-manager.ts
+++ b/src/services/project-manager.ts
@@ -36,14 +36,7 @@ export class ProjectManager {
 		const files = this.plugin.app.vault.getMarkdownFiles();
 		for (const file of files) {
 			if (this.isProjectFile(file)) {
-				try {
-					const project = await this.parseProjectFile(file);
-					if (project) {
-						this.projectCache.set(file.path, project);
-					}
-				} catch (error) {
-					this.plugin.logger.warn(`Failed to parse project at ${file.path}:`, error);
-				}
+				await this.cacheParsedProject(file);
 			}
 		}
 
@@ -72,16 +65,7 @@ export class ProjectManager {
 		const file = this.plugin.app.vault.getAbstractFileByPath(filePath);
 		if (!(file instanceof TFile)) return null;
 
-		try {
-			const project = await this.parseProjectFile(file);
-			if (project) {
-				this.projectCache.set(filePath, project);
-			}
-			return project;
-		} catch (error) {
-			this.plugin.logger.warn(`ProjectManager: Failed to parse project at ${filePath}:`, error);
-			return null;
-		}
+		return this.cacheParsedProject(file, filePath);
 	}
 
 	/**
@@ -318,6 +302,30 @@ Add your project instructions here. This text will be injected into the agent's 
 
 	// --- Private helpers ---
 
+	/**
+	 * Parse a project file and cache it on success, warning (not throwing) on failure.
+	 *
+	 * The three call sites differ only in the cache key: `getProject` keys on the
+	 * caller-supplied path and uses the return value, while the vault-scan and
+	 * file-change paths key on `file.path` and ignore it.
+	 *
+	 * @param file The project file to parse.
+	 * @param cacheKey Cache key to store the parsed project under; defaults to `file.path`.
+	 * @returns The parsed project, or `null` if the file isn't a project or parsing failed.
+	 */
+	private async cacheParsedProject(file: TFile, cacheKey: string = file.path): Promise<Project | null> {
+		try {
+			const project = await this.parseProjectFile(file);
+			if (project) {
+				this.projectCache.set(cacheKey, project);
+			}
+			return project;
+		} catch (error) {
+			this.plugin.logger.warn(`ProjectManager: Failed to parse project at ${cacheKey}:`, error);
+			return null;
+		}
+	}
+
 	private scheduleRefresh(file: TFile): void {
 		this.cancelPendingRefresh(file.path);
 		const timer = window.setTimeout(() => {
@@ -412,14 +420,7 @@ Add your project instructions here. This text will be injected into the agent's 
 
 	private async onFileCreateOrModify(file: TFile): Promise<void> {
 		if (this.isProjectFile(file)) {
-			try {
-				const project = await this.parseProjectFile(file);
-				if (project) {
-					this.projectCache.set(file.path, project);
-				}
-			} catch (error) {
-				this.plugin.logger.warn(`ProjectManager: Failed to parse project at ${file.path}:`, error);
-			}
+			await this.cacheParsedProject(file);
 		} else {
 			// Tag may have been removed — evict if cached
 			this.projectCache.delete(file.path);

--- a/test/services/project-manager.test.ts
+++ b/test/services/project-manager.test.ts
@@ -107,7 +107,12 @@ describe('ProjectManager', () => {
 			await manager.initialize();
 
 			expect(manager.discoverProjects()).toHaveLength(0);
-			expect(mockPlugin.logger.warn).toHaveBeenCalled();
+			// The scan path must use the same `ProjectManager:` prefix as the other
+			// parse-failure sites — it used to warn without it (#1369).
+			expect(mockPlugin.logger.warn).toHaveBeenCalledWith(
+				'ProjectManager: Failed to parse project at bad/Bad.md:',
+				expect.any(Error)
+			);
 		});
 	});
 


### PR DESCRIPTION
<!-- auto-dev -->

## Summary

`ProjectManager` ran the same parse → cache-on-success → warn-on-failure block in three methods, and the copies had already drifted: `initialize` warned `Failed to parse project at …` while `getProject` and `onFileCreateOrModify` warned `ProjectManager: Failed to parse project at …`. The same failure therefore logged under two different prefixes depending on which path hit it, which is exactly the drift the audit predicted.

This extracts a private `cacheParsedProject(file, cacheKey = file.path)` and standardizes the warning on the prefixed form that matches the rest of the file's logging.

Refs #1369 — **entry 1 only**, deliberately not `Fixes`.

**Scope / deviation note:** #1369 lists five independent entries and says "File one sub-issue per entry — don't bundle them into one PR." The approved plan scoped this PR to entry 1, and the maintainer's approval reads "Approved for entry 1 only… The other four entries stay tracked on the issue." So this PR uses `Refs #1369` rather than the pipeline's usual `Fixes #<N>`: an auto-close on merge would take entries 2–5 down with it. #1369 stays open after this merges.

Produced by the auto-dev pipeline from the approved plan on #1369.

## Changes

- `src/services/project-manager.ts` — add a private `cacheParsedProject(file: TFile, cacheKey = file.path): Promise<Project | null>` that parses, caches on success, warns and returns `null` on failure. Call it from all three sites: `initialize` and `onFileCreateOrModify` ignore the return; `getProject` returns it directly (it keys the cache on its `filePath` argument, which is what the `cacheKey` parameter is for).
- Standardize the parse-failure warning on `ProjectManager: Failed to parse project at ${cacheKey}:`. This is the entry's correctness half — the `initialize` site's unprefixed message is the odd one out and made the debug log hard to grep.
- `test/services/project-manager.test.ts` — tighten the existing malformed-frontmatter assertion on the `initialize` path from a bare `toHaveBeenCalled()` to the exact prefixed message. Without it the prefix fix is untested: the suite's other assertion is `stringContaining('Failed to parse project')`, which both spellings satisfy.

Net effect is three `try`/`catch` blocks collapsing to one. No new module — the helper is private to the file, as the issue's "Proposed unit of work" specifies.

**Naming correction for the record:** the issue calls the second site the `refreshProject`/`filePath` variant. There is no `refreshProject` method on `master`; that block lives inside `getProject`. Same code, different method name.

## Screenshots / Screencast

N/A — internal refactor, no UI surface.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer — #1369, plan approved 2026-08-29
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — run locally: `format-check` clean, `lint` 0 errors (39 pre-existing warnings, none in the touched files), `build` clean, `typecheck:test` clean, `lint:cycles` clean, `npm test` 4017 passed / 179 files
- [ ] I have tested this change on Desktop — **not run.** Pure internal refactor with no runnable surface (no command, no UI, no endpoint); the only observable difference is a debug-log prefix. The unit tests are the verification, as the approved plan stated up front. Behavioral verification was not run in the sandbox — flagging rather than claiming it.
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — no platform-specific API touched; the change is a local extraction within existing code paths.
- [ ] Documentation has been updated (if applicable) — **N/A.** Internal refactor: no user-facing behavior, no settings, no public surface. The one observable difference is a debug-log prefix, which no guide documents.
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (auto-dev pipeline)
- [x] I have reviewed and understand all AI-generated code in this PR

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XFhRtvhWmHSor51YngyhHz

---
_Generated by [Claude Code](https://claude.ai/code/session_01XFhRtvhWmHSor51YngyhHz)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of projects with malformed front matter during initialization and refresh.
  * Warnings now provide clearer, more consistent details when project parsing fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->