### PR TITLE
refactor(utils): give the two background-output validators one write-path policy (#1401)

### DIFF
--- a/docs/guide/deep-research.md
+++ b/docs/guide/deep-research.md
@@ -96,6 +96,7 @@ When you specify an output file:
 - A `.md` extension is added automatically if missing
 - The file is added to your current session context, so the agent can reference the findings in follow-up messages
 - Protected folders (Obsidian's configuration folder — `.obsidian` by default, or a renamed one — and the plugin state folder) cannot be used as output paths
+- The path must name a file inside your vault: a blank path, or one that escapes the vault with `..`, is rejected
 
 ## How It Differs from Google Search
 
@@ -155,6 +156,7 @@ Deep Research is inherently slow — it's performing thorough multi-source inves
 The research succeeded but saving failed. Check that:
 
 - The output path isn't in a protected folder (Obsidian's configuration folder — `.obsidian` by default, or a renamed one — or the plugin state folder)
+- The output path names a file inside the vault — a blank path, or one containing `..`, is rejected
 - You have write permissions to the target directory
 - The research results are still available in the chat — you can copy them manually
 

--- a/src/services/deep-research.ts
+++ b/src/services/deep-research.ts
@@ -1,6 +1,6 @@
-import { TFile, normalizePath } from 'obsidian';
+import { TFile } from 'obsidian';
 import type { ObsidianGemini } from '../types/plugin';
-import { isPathInFolder } from '../utils/file-utils';
+import { validateGeneratedOutputPath } from '../utils/file-utils';
 import type { Interactions } from '@google/genai';
 // The `/research` subpath is built-in-free (no fs/path/crypto), unlike the
 // barrel — import from it so this module stays mobile-safe at load (#1154).
@@ -341,38 +341,29 @@ export class DeepResearchService {
 	/**
 	 * Validate and normalize the output file path.
 	 * Throws an error if the path is inside a protected system folder.
+	 *
+	 * The policy itself lives in `validateGeneratedOutputPath` and is shared with
+	 * the image-generation write path (#1401) — this method only supplies the
+	 * report-specific error wording.
 	 */
 	private validateAndNormalizeFilePath(rawFilePath: string): string {
-		// Normalize the path using Obsidian's normalizePath (handles slashes, removes redundant separators)
-		const normalizedPath = normalizePath(rawFilePath);
-
-		// The Obsidian configuration directory (default `.obsidian`, but the user
-		// may have renamed it) must never be written to. Root-anchored, matching
-		// the image-generation write-path validator.
 		const configDir = this.plugin.app.vault.configDir;
-		if (isPathInFolder(normalizedPath, configDir)) {
-			throw new Error(
-				`Cannot write report to protected system folder: "${configDir}". Please choose a different output location.`
-			);
-		}
-
-		// Check if path is inside the plugin's history folder (or is the folder itself).
-		// Background-Tasks/ is the one allowed subfolder — it is the canonical output
-		// location for background and scheduled-task outputs.
 		const historyFolder = this.plugin.settings.historyFolder;
-		if (historyFolder) {
-			const normalizedHistoryFolder = normalizePath(historyFolder);
-			const backgroundTasksFolder = normalizePath(`${normalizedHistoryFolder}/Background-Tasks`);
-			const insideStateFolder = isPathInFolder(normalizedPath, normalizedHistoryFolder);
-			const insideBackgroundTasks = normalizedPath.startsWith(backgroundTasksFolder + '/');
-			if (insideStateFolder && !insideBackgroundTasks) {
-				throw new Error(
-					`Cannot write report to plugin state folder: "${historyFolder}". Please choose a different output location.`
-				);
-			}
-		}
 
-		return normalizedPath;
+		return validateGeneratedOutputPath(rawFilePath, {
+			configDir,
+			historyFolder,
+			allowedSubfolder: 'Background-Tasks',
+			messages: {
+				'missing-filename': (path) => `Cannot write report to a folder path: "${path}". Please include a filename.`,
+				'vault-escape': (path) =>
+					`Cannot write report outside the vault: "${path}". Please choose a path inside the vault.`,
+				'config-folder': () =>
+					`Cannot write report to protected system folder: "${configDir}". Please choose a different output location.`,
+				'state-folder': () =>
+					`Cannot write report to plugin state folder: "${historyFolder}". Please choose a different output location.`,
+			},
+		});
 	}
 
 	/**

--- a/src/services/image-generation.ts
+++ b/src/services/image-generation.ts
@@ -3,7 +3,7 @@ import { Notice, App, MarkdownView, Modal, Setting, TextAreaComponent, TFile, no
 import { BaseModelRequest, GeminiClient, ModelClientFactory } from '../api';
 import { GeminiPrompts } from '../prompts';
 import { getErrorMessage, getRawErrorMessageOr } from '../utils/error-utils';
-import { ensureParentFolderExists, isPathInFolder } from '../utils/file-utils';
+import { ensureParentFolderExists, validateGeneratedOutputPath } from '../utils/file-utils';
 import { t } from '../i18n';
 
 export class ImageGeneration {
@@ -258,48 +258,31 @@ export class ImageGeneration {
 	 * Always returns a path ending with ".png" since the code always writes PNG bytes.
 	 */
 	private validateOutputPath(outputPath: string): string {
-		const normalized = normalizePath(outputPath);
-
-		// Reject directory-only paths (empty or trailing slash)
-		if (!normalized || normalized.endsWith('/')) {
-			throw new Error(`Output path must include a filename: "${outputPath}"`);
-		}
-
-		// Reject vault-escaping paths (normalizePath does not resolve ..)
-		if (normalized.startsWith('..') || normalized.split('/').includes('..')) {
-			throw new Error(`Output path escapes the vault: "${outputPath}"`);
-		}
-
-		// Reject paths inside the Obsidian configuration directory (default
-		// `.obsidian`, but the user may have renamed it). Root-anchored, matching
-		// deep-research's write-path validator.
-		if (isPathInFolder(normalized, this.plugin.app.vault.configDir)) {
-			throw new Error(`Output path cannot be inside the Obsidian configuration folder: "${outputPath}"`);
-		}
-
-		// Always ensure the file ends with .png — the code always writes PNG bytes.
-		// Rewrite extension before the state-folder check so the validated path
-		// matches what will actually be written (e.g. "Background-Tasks" bare →
-		// "Background-Tasks.png", which is outside the allowed subfolder).
-		const dotIndex = normalized.lastIndexOf('.');
-		const slashIndex = normalized.lastIndexOf('/');
-		const hasExtension = dotIndex > slashIndex + 1;
-		const normalizedFilePath = hasExtension ? normalized.slice(0, dotIndex) + '.png' : normalized + '.png';
-
-		// Reject paths inside the plugin state folder, except for the canonical
-		// Background-Tasks/ subfolder which is the designated output location.
-		const historyFolder = this.plugin.settings.historyFolder;
-		if (historyFolder) {
-			const normalizedHistoryFolder = normalizePath(historyFolder);
-			const backgroundTasksFolder = normalizePath(`${normalizedHistoryFolder}/Background-Tasks`);
-			const insideStateFolder = isPathInFolder(normalizedFilePath, normalizedHistoryFolder);
-			const insideBackgroundTasks = normalizedFilePath.startsWith(backgroundTasksFolder + '/');
-			if (insideStateFolder && !insideBackgroundTasks) {
-				throw new Error(`Output path cannot be inside the plugin state folder: "${outputPath}"`);
-			}
-		}
-
-		return normalizedFilePath;
+		// The reject set is shared with deep-research's write path via
+		// `validateGeneratedOutputPath` (#1401); the `.png` rewrite below is the
+		// only part that is genuinely this validator's own.
+		return validateGeneratedOutputPath(outputPath, {
+			configDir: this.plugin.app.vault.configDir,
+			historyFolder: this.plugin.settings.historyFolder,
+			allowedSubfolder: 'Background-Tasks',
+			// Always ensure the file ends with .png — the code always writes PNG
+			// bytes. The helper applies this before the state-folder check so the
+			// validated path matches what will actually be written (e.g. a bare
+			// "Background-Tasks" → "Background-Tasks.png", which is outside the
+			// allowed subfolder and must still be rejected).
+			rewriteFileName: (normalized) => {
+				const dotIndex = normalized.lastIndexOf('.');
+				const slashIndex = normalized.lastIndexOf('/');
+				const hasExtension = dotIndex > slashIndex + 1;
+				return hasExtension ? normalized.slice(0, dotIndex) + '.png' : normalized + '.png';
+			},
+			messages: {
+				'missing-filename': (path) => `Output path must include a filename: "${path}"`,
+				'vault-escape': (path) => `Output path escapes the vault: "${path}"`,
+				'config-folder': (path) => `Output path cannot be inside the Obsidian configuration folder: "${path}"`,
+				'state-folder': (path) => `Output path cannot be inside the plugin state folder: "${path}"`,
+			},
+		});
 	}
 
 	/**

--- a/src/utils/file-utils.ts
+++ b/src/utils/file-utils.ts
@@ -29,6 +29,101 @@ export function isPathInFolder(path: string, folder: string): boolean {
 }
 
 /**
+ * The distinct ways a generated-output path can be rejected.
+ *
+ * Callers supply their own wording for each one, so the *policy* lives here
+ * while the error text stays specific to what is being written (a research
+ * report, a generated image, …).
+ */
+export type GeneratedOutputPathViolation = 'missing-filename' | 'vault-escape' | 'config-folder' | 'state-folder';
+
+/**
+ * Options for {@link validateGeneratedOutputPath}.
+ */
+export interface GeneratedOutputPathOptions {
+	/** The vault's configuration directory (`vault.configDir`). Never writable. */
+	configDir: string;
+	/** The plugin state folder (`settings.historyFolder`); skipped when unset. */
+	historyFolder?: string;
+	/** The one subfolder of `historyFolder` that generated output may be written to. */
+	allowedSubfolder: string;
+	/**
+	 * Optional filename rewrite, applied *after* the config-folder check and
+	 * *before* the state-folder check. The ordering is load-bearing: a rewrite
+	 * changes the path that actually gets written, so the state-folder check has
+	 * to see the rewritten path (a bare `Background-Tasks` rewritten to
+	 * `Background-Tasks.png` is outside the allowed subfolder and must be
+	 * rejected). The rewritten path is what this function returns.
+	 */
+	rewriteFileName?: (normalizedPath: string) => string;
+	/**
+	 * Error message factories keyed by violation, each receiving the caller's
+	 * raw (un-normalized) path. Required in full so that adding a violation
+	 * fails to compile until every caller has wording for it — the reject set
+	 * cannot silently drift between callers again (#1401).
+	 */
+	messages: Record<GeneratedOutputPathViolation, (rawPath: string) => string>;
+}
+
+/**
+ * Validate and normalize a vault path that the plugin is about to write
+ * generated output to (a deep-research report, a generated image, …).
+ *
+ * This is the single source of truth for the "may I write this generated
+ * artifact here?" policy, which is deliberately *not* the same as the agent
+ * vault tools' blanket exclusion (`shouldExcludePathForPlugin`): generated
+ * output is allowed into one carve-out subfolder of the plugin state folder,
+ * because that subfolder is its canonical home.
+ *
+ * The reject set, in order: empty/directory-only paths, vault-escaping paths,
+ * the Obsidian configuration directory, and the plugin state folder except
+ * `allowedSubfolder`. These paths come from agent-supplied tool parameters, so
+ * every caller wants the same guards — previously each validator carried its
+ * own fork and they had already drifted apart.
+ *
+ * @param rawPath - The caller-supplied, un-normalized path
+ * @param options - Policy inputs and per-violation error wording
+ * @returns The normalized path (after `rewriteFileName`, when supplied)
+ * @throws Error built by the matching `options.messages` factory
+ */
+export function validateGeneratedOutputPath(rawPath: string, options: GeneratedOutputPathOptions): string {
+	const { configDir, historyFolder, allowedSubfolder, rewriteFileName, messages } = options;
+	const normalized = normalizePath(rawPath);
+
+	// Reject directory-only paths (empty, or a bare/trailing slash).
+	if (!normalized || normalized.endsWith('/')) {
+		throw new Error(messages['missing-filename'](rawPath));
+	}
+
+	// Reject vault-escaping paths — normalizePath does not resolve `..`.
+	if (normalized.startsWith('..') || normalized.split('/').includes('..')) {
+		throw new Error(messages['vault-escape'](rawPath));
+	}
+
+	// The Obsidian configuration directory (default `.obsidian`, but the user
+	// may have renamed it) must never be written to. Root-anchored.
+	if (isPathInFolder(normalized, configDir)) {
+		throw new Error(messages['config-folder'](rawPath));
+	}
+
+	const finalPath = rewriteFileName ? rewriteFileName(normalized) : normalized;
+
+	// The plugin state folder is off limits except for the one subfolder that is
+	// the canonical output location for background and scheduled-task output.
+	if (historyFolder) {
+		const normalizedHistoryFolder = normalizePath(historyFolder);
+		const allowedFolder = normalizePath(`${normalizedHistoryFolder}/${allowedSubfolder}`);
+		const insideStateFolder = isPathInFolder(finalPath, normalizedHistoryFolder);
+		const insideAllowedSubfolder = finalPath.startsWith(allowedFolder + '/');
+		if (insideStateFolder && !insideAllowedSubfolder) {
+			throw new Error(messages['state-folder'](rawPath));
+		}
+	}
+
+	return finalPath;
+}
+
+/**
  * Check if a file or folder path should be excluded from selection or operations.
  * This excludes:
  * - Files/folders within the specified exclude folder (e.g., plugin state folder)

--- a/test/services/deep-research.test.ts
+++ b/test/services/deep-research.test.ts
@@ -518,6 +518,26 @@ describe('DeepResearchService', () => {
 		it('allows arbitrary paths outside the state folder', () => {
 			expect(validate('Notes/foo.md')).toBe('Notes/foo.md');
 		});
+
+		// #1401: these three guards used to exist only on the image-generation
+		// side of the same policy. Both validators now share one helper, and
+		// these cases mirror test/services/image-generation.test.ts so the pair
+		// cannot silently diverge again.
+		it('rejects vault-escaping paths', () => {
+			expect(() => validate('../outside.md')).toThrow(/outside the vault/);
+			expect(() => validate('Notes/../../outside.md')).toThrow(/outside the vault/);
+		});
+
+		it('rejects empty paths', () => {
+			// normalizePath maps blank input to the vault root '/', which carries
+			// no filename to write to.
+			expect(() => validate('   ')).toThrow(/include a filename/);
+			expect(() => validate('')).toThrow(/include a filename/);
+		});
+
+		it('rejects the bare config folder as well as paths under it', () => {
+			expect(() => validate('.obsidian')).toThrow(/protected system folder/);
+		});
 	});
 
 	describe('proxyFetch injection into the interactions client', () => {

--- a/test/utils/file-utils.test.ts
+++ b/test/utils/file-utils.test.ts
@@ -8,7 +8,9 @@ import {
 	getFileName,
 	getParentPath,
 	isPathInFolder,
+	validateGeneratedOutputPath,
 } from '../../src/utils/file-utils';
+import type { GeneratedOutputPathOptions } from '../../src/utils/file-utils';
 import { TFile, TFolder, Vault, Notice, normalizePath } from 'obsidian';
 
 describe('file-utils', () => {
@@ -385,6 +387,81 @@ describe('file-utils', () => {
 			await expect(
 				ensureParentFolderExists(mockVault as unknown as Vault, 'a/b/out.md', 'image output folder')
 			).rejects.toThrow('Failed to create folder "a/b" (image output folder): Disk full');
+		});
+	});
+
+	// #1401: the write-path policy shared by deep-research and image-generation.
+	// Each reject arm is asserted here once, so the two callers only have to
+	// cover their own wording and their own extras (e.g. the .png rewrite).
+	describe('validateGeneratedOutputPath', () => {
+		const messages = {
+			'missing-filename': (p: string) => `missing-filename:${p}`,
+			'vault-escape': (p: string) => `vault-escape:${p}`,
+			'config-folder': (p: string) => `config-folder:${p}`,
+			'state-folder': (p: string) => `state-folder:${p}`,
+		};
+		const options: GeneratedOutputPathOptions = {
+			configDir: '.obsidian',
+			historyFolder: 'gemini-scribe',
+			allowedSubfolder: 'Background-Tasks',
+			messages,
+		};
+		const validate = (path: string, overrides: Partial<GeneratedOutputPathOptions> = {}): string =>
+			validateGeneratedOutputPath(path, { ...options, ...overrides });
+
+		it('returns the normalized path for an ordinary vault path', () => {
+			expect(validate('Notes//foo.md')).toBe('Notes/foo.md');
+		});
+
+		it('allows the allowed subfolder under the state folder', () => {
+			expect(validate('gemini-scribe/Background-Tasks/out.md')).toBe('gemini-scribe/Background-Tasks/out.md');
+		});
+
+		it('rejects empty and blank paths', () => {
+			expect(() => validate('')).toThrow('missing-filename:');
+			expect(() => validate('   ')).toThrow('missing-filename:');
+		});
+
+		it('rejects vault-escaping paths', () => {
+			expect(() => validate('../outside.md')).toThrow('vault-escape:../outside.md');
+			expect(() => validate('Notes/../../outside.md')).toThrow('vault-escape:');
+		});
+
+		it('rejects the config folder itself and paths beneath it', () => {
+			expect(() => validate('.obsidian')).toThrow('config-folder:.obsidian');
+			expect(() => validate('.obsidian/snippets/x.md')).toThrow('config-folder:');
+		});
+
+		it('rejects the bare state folder and its other subfolders', () => {
+			expect(() => validate('gemini-scribe')).toThrow('state-folder:gemini-scribe');
+			expect(() => validate('gemini-scribe/Skills/x.md')).toThrow('state-folder:');
+		});
+
+		it('does not treat a sibling-prefixed folder as the allowed subfolder', () => {
+			expect(() => validate('gemini-scribe/Background-Tasks-Other/x.md')).toThrow('state-folder:');
+		});
+
+		it('does not over-match a folder that merely shares the state folder prefix', () => {
+			expect(validate('gemini-scribe-backup/x.md')).toBe('gemini-scribe-backup/x.md');
+		});
+
+		it('skips the state-folder check when no history folder is configured', () => {
+			expect(validate('gemini-scribe/Skills/x.md', { historyFolder: undefined })).toBe('gemini-scribe/Skills/x.md');
+		});
+
+		it('applies rewriteFileName after the config check and before the state-folder check', () => {
+			const rewriteFileName = (p: string) => `${p}.png`;
+
+			// The rewritten path is what gets returned...
+			expect(validate('Notes/img', { rewriteFileName })).toBe('Notes/img.png');
+
+			// ...and what the state-folder check sees: a bare allowed-subfolder
+			// path becomes a file directly under the state folder, so it is
+			// rejected rather than slipping through as the subfolder itself.
+			expect(() => validate('gemini-scribe/Background-Tasks', { rewriteFileName })).toThrow('state-folder:');
+
+			// The config-folder check still runs against the pre-rewrite path.
+			expect(() => validate('.obsidian/x', { rewriteFileName })).toThrow('config-folder:');
 		});
 	});
 });


### PR DESCRIPTION
<!-- auto-dev -->

## Summary

`DeepResearch.validateAndNormalizeFilePath` and `ImageGenerationService.validateOutputPath` were near-verbatim forks of one "may I write this generated artifact here?" policy — same `Background-Tasks/` carve-out, same state-folder rejection, with only local variable names and error strings differing. The coupling was documented in prose on both sides ("matching deep-research's write-path validator" / "matching the image-generation write-path validator"), which is a comment doing a shared helper's job.

The fork had already drifted: image-generation rejected vault-escaping (`..`) and directory-only paths; deep-research rejected neither, despite both taking their output path from an agent-supplied tool parameter (`deep_research`'s `outputFile`, `generate_image`'s `outputPath`) at identical trust levels.

This lifts the whole policy into one helper and routes both validators through it, so the reject set and the carve-out live in exactly one place.

Fixes #1401

## Changes

- **`src/utils/file-utils.ts`** — adds `validateGeneratedOutputPath(rawPath, options)`, the single source of truth for the generated-output write policy. Reject set, in order: empty/directory-only path, vault-escaping `..`, the Obsidian config directory, and the plugin state folder except `allowedSubfolder`. Returns the normalized path or throws. Deliberately distinct from `shouldExcludePathForPlugin`, whose blanket exclusion (no carve-out) remains correct for the agent vault tools.
- **`src/services/deep-research.ts`** — `validateAndNormalizeFilePath` delegates to the helper, keeping its report-specific error wording.
- **`src/services/image-generation.ts`** — `validateOutputPath` keeps only what is genuinely its own: the `.png` extension rewrite. It is passed as `rewriteFileName` and the helper applies it **after** the config-folder check and **before** the state-folder check, preserving the load-bearing ordering (a bare `Background-Tasks` becomes `Background-Tasks.png`, which is outside the allowed subfolder and must still be rejected).
- Error wording stays per-caller via a required `messages` record keyed by violation. Requiring it in full is the mechanical guard: adding a violation fails to compile until every caller supplies wording for it, so the reject set cannot silently diverge again.
- **`test/utils/file-utils.test.ts`** — direct coverage of the helper: every reject arm, the carve-out, the `path === folder` case, sibling-prefix over-match (`gemini-scribe-backup`, `Background-Tasks-Other`), the unset-history-folder case, and the `rewriteFileName` ordering.
- **`test/services/deep-research.test.ts`** — mirrors the image-generation path assertions for the guards deep-research newly adopts.
- **`docs/guide/deep-research.md`** — the two places that enumerate rejected output paths now mention the vault-escape and blank-path rejections.

### The behaviour change, called out

Per the approved plan's explicit decision (approved as posted, guards included): **`deep_research` now rejects vault-escaping and blank output paths**, matching `generate_image`. This tightens the reject set for a user-visible tool parameter; it does not widen what either tool accepts.

The plan also asked what Obsidian's `vault.create()` actually does with a `../`-bearing path. **This could not be verified in the pipeline sandbox** — there is no live vault here, and the `obsidian` typings document no `..` handling either way (`DataAdapter` only says paths should be passed through `normalizePath`, which explicitly does not resolve `..`). So the guard is landing as defence-in-depth and consistency, not on a demonstrated escape. Worth a maintainer eye if you want the stronger claim.

## Screenshots / Screencast

Not applicable — internal refactor with no UI surface.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`)
- [ ] I have tested this change on Desktop — **not done**: behavioral verification of `deep_research` / `generate_image` end-to-end needs a live Obsidian instance and an API key, which the pipeline sandbox does not have. Pre-flight and unit coverage only; the validators' behaviour is pinned by the tests above, but no tool was actually run.
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — no new platform-specific APIs; the helper is pure string work over `normalizePath`.
- [x] Documentation has been updated (if applicable)
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (auto-dev pipeline)
- [x] I have reviewed and understand all AI-generated code in this PR

## Test plan

Full pre-flight, all green:

- `npm run format-check` — clean
- `npm run lint` — 0 errors (39 pre-existing warnings, all `no-nodejs-modules` in unrelated test files)
- `npm run build` — clean
- `npm run typecheck:test` — clean
- `npm test` — 4030 tests / 179 files passing
- `npm run lint:cycles` — no circular dependencies

Behavioral verification was **not** run in the sandbox, for the reason given above.

---

Produced by the auto-dev pipeline from the approved plan on #1401.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169NLDxWxg3YmtewAx161CT

---
_Generated by [Claude Code](https://claude.ai/code/session_0169NLDxWxg3YmtewAx161CT)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation for generated research and image output paths.
  - Blank paths, paths outside the vault, and protected configuration or plugin folders are now rejected.
  - Output paths can still use permitted subfolders, including supported history locations.
  - Path normalization and filename handling are applied consistently across generated outputs.

- **Documentation**
  - Updated the Deep Research guide and troubleshooting guidance to explain valid output path requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->