### PR TITLE
refactor(rag): drop the unread IndexedFileEntry.resourceName field

### DIFF
--- a/src/services/rag-sync-queue.ts
+++ b/src/services/rag-sync-queue.ts
@@ -234,7 +234,6 @@ export class RagSyncQueue {
 								await fileUploader.uploadContent(content, storeName);
 								if (this.ragCache.cache) {
 									this.ragCache.cache.files[file.path] = {
-										resourceName: storeName,
 										contentHash: content.hash,
 										lastIndexed: Date.now(),
 									};

--- a/src/services/rag-types.ts
+++ b/src/services/rag-types.ts
@@ -3,7 +3,6 @@
  */
 // knip:keep — Intentional public API structurally consumed by RagIndexCache.files
 export interface IndexedFileEntry {
-	resourceName: string; // Gemini file resource name
 	contentHash: string; // SHA-256 hash for reliable change detection
 	lastIndexed: number; // Timestamp
 }

--- a/src/services/rag-vault-scanner.ts
+++ b/src/services/rag-vault-scanner.ts
@@ -467,7 +467,6 @@ export class RagVaultScanner {
 						if (this.ragCache.cache && event.currentFile && vaultAdapter) {
 							const contentHash = await vaultAdapter.computeHash(event.currentFile);
 							this.ragCache.cache.files[event.currentFile] = {
-								resourceName: storeName, // Store name as reference (individual doc names not available)
 								contentHash,
 								lastIndexed: Date.now(),
 							};
@@ -501,7 +500,6 @@ export class RagVaultScanner {
 						) {
 							const contentHash = await vaultAdapter.computeHash(event.currentFile);
 							this.ragCache.cache.files[event.currentFile] = {
-								resourceName: storeName,
 								contentHash,
 								lastIndexed: Date.now(),
 							};

--- a/test/services/rag-cache.test.ts
+++ b/test/services/rag-cache.test.ts
@@ -90,7 +90,7 @@ describe('RagCache', () => {
 				storeName: 'test-store',
 				lastSync: 1234567890,
 				files: {
-					'test.md': { resourceName: 'res1', contentHash: 'hash1', lastIndexed: 1234567890 },
+					'test.md': { contentHash: 'hash1', lastIndexed: 1234567890 },
 				},
 			};
 
@@ -155,7 +155,7 @@ describe('RagCache', () => {
 				storeName: 'test-store',
 				lastSync: 1234567890,
 				files: {
-					'test.md': { resourceName: 'res1', contentHash: 'hash1', lastIndexed: 1234567890 },
+					'test.md': { contentHash: 'hash1', lastIndexed: 1234567890 },
 				},
 			};
 			mockPlugin.app.vault.getAbstractFileByPath.mockReturnValue(createMockTFile('cache.json'));
@@ -232,8 +232,8 @@ describe('RagCache', () => {
 				storeName: 'test',
 				lastSync: 0,
 				files: {
-					'a.md': { resourceName: 'r1', contentHash: 'h1', lastIndexed: 0 },
-					'b.md': { resourceName: 'r2', contentHash: 'h2', lastIndexed: 0 },
+					'a.md': { contentHash: 'h1', lastIndexed: 0 },
+					'b.md': { contentHash: 'h2', lastIndexed: 0 },
 				},
 			};
 

--- a/test/services/rag-cache.test.ts
+++ b/test/services/rag-cache.test.ts
@@ -126,6 +126,7 @@ describe('RagCache', () => {
 			expect(mockPlugin.logger.warn).not.toHaveBeenCalled();
 			expect(cache.indexedCount).toBe(1);
 			expect(cache.cache?.storeName).toBe('test-store');
+			expect(cache.cache?.lastSync).toBe(1234567890);
 			expect(cache.cache?.files['test.md']).toEqual(
 				expect.objectContaining({ contentHash: 'hash1', lastIndexed: 1234567890 })
 			);

--- a/test/services/rag-cache.test.ts
+++ b/test/services/rag-cache.test.ts
@@ -103,6 +103,34 @@ describe('RagCache', () => {
 			expect(cache.indexedCount).toBe(1);
 		});
 
+		it('should load a legacy cache whose entries still carry the removed resourceName key', async () => {
+			// Caches written before `IndexedFileEntry.resourceName` was removed still
+			// carry that key on disk. loadCache validates only `version`, so such a
+			// file must load as-is — no reset, no re-index — with the fields that are
+			// still read intact. Written as raw JSON because the extra key is exactly
+			// what the current type no longer permits.
+			const legacyCacheJson = JSON.stringify({
+				version: '1.0',
+				storeName: 'test-store',
+				lastSync: 1234567890,
+				files: {
+					'test.md': { resourceName: 'test-store', contentHash: 'hash1', lastIndexed: 1234567890 },
+				},
+			});
+
+			mockPlugin.app.vault.getAbstractFileByPath.mockReturnValue(createMockTFile('cache.json'));
+			mockPlugin.app.vault.read.mockResolvedValue(legacyCacheJson);
+
+			await cache.loadCache();
+
+			expect(mockPlugin.logger.warn).not.toHaveBeenCalled();
+			expect(cache.indexedCount).toBe(1);
+			expect(cache.cache?.storeName).toBe('test-store');
+			expect(cache.cache?.files['test.md']).toEqual(
+				expect.objectContaining({ contentHash: 'hash1', lastIndexed: 1234567890 })
+			);
+		});
+
 		it('should fall back to adapter.read when file exists on disk but not in metadata', async () => {
 			const cacheData = {
 				version: '1.0',

--- a/test/services/rag-indexing.test.ts
+++ b/test/services/rag-indexing.test.ts
@@ -516,7 +516,7 @@ describe('RagIndexingService', () => {
 				storeName: 'test-store',
 				lastSync: 1234567890,
 				files: {
-					'file1.md': { resourceName: 'res1', contentHash: 'hash1', lastIndexed: 1234567890 },
+					'file1.md': { contentHash: 'hash1', lastIndexed: 1234567890 },
 				},
 			};
 
@@ -721,7 +721,7 @@ describe('RagIndexingService', () => {
 					storeName: 'test-store',
 					lastSync: 1234567890,
 					files: {
-						'test.md': { resourceName: 'res1', contentHash: 'hash1', lastIndexed: 1234567890 },
+						'test.md': { contentHash: 'hash1', lastIndexed: 1234567890 },
 					},
 				};
 
@@ -980,7 +980,7 @@ describe('RagIndexingService', () => {
 				lastSync: Date.now(),
 				indexingInProgress: false,
 				files: {
-					'note.md': { resourceName: 'res1', contentHash: 'h1', lastIndexed: Date.now() },
+					'note.md': { contentHash: 'h1', lastIndexed: Date.now() },
 				},
 			};
 			getRagCache(service).indexedCount = 1;
@@ -1002,7 +1002,7 @@ describe('RagIndexingService', () => {
 				storeName: 'test-store',
 				lastSync: Date.now(),
 				indexingInProgress: true,
-				files: { 'note.md': { resourceName: 'res1', contentHash: 'h1', lastIndexed: Date.now() } },
+				files: { 'note.md': { contentHash: 'h1', lastIndexed: Date.now() } },
 			};
 			getRagCache(service).indexedCount = 1;
 
@@ -1188,7 +1188,7 @@ describe('RagIndexingService', () => {
 				storeName: 'test-store',
 				lastSync: 1000,
 				files: {
-					'a.md': { resourceName: 'r1', contentHash: 'h1', lastIndexed: 1000 },
+					'a.md': { contentHash: 'h1', lastIndexed: 1000 },
 				},
 			};
 
@@ -1230,9 +1230,9 @@ describe('RagIndexingService', () => {
 				storeName: 'test-store',
 				lastSync: 1000,
 				files: {
-					'old.md': { resourceName: 'r1', contentHash: 'h1', lastIndexed: 100 },
-					'new.md': { resourceName: 'r2', contentHash: 'h2', lastIndexed: 300 },
-					'mid.md': { resourceName: 'r3', contentHash: 'h3', lastIndexed: 200 },
+					'old.md': { contentHash: 'h1', lastIndexed: 100 },
+					'new.md': { contentHash: 'h2', lastIndexed: 300 },
+					'mid.md': { contentHash: 'h3', lastIndexed: 200 },
 				},
 			};
 			cache.indexedCount = 3;

--- a/test/services/rag-sync-queue.test.ts
+++ b/test/services/rag-sync-queue.test.ts
@@ -493,7 +493,6 @@ describe('RagSyncQueue', () => {
 		describe('delete change', () => {
 			it('should call deleteFile and reset changesSinceLastSave on success', async () => {
 				mockCache.cache.files['notes/test.md'] = {
-					resourceName: 'test-store',
 					contentHash: 'hash123',
 					lastIndexed: Date.now(),
 				};
@@ -714,12 +713,10 @@ describe('RagSyncQueue', () => {
 
 		it('should remove file from cache, update indexedCount, save, and return true', async () => {
 			mockCache.cache.files['notes/test.md'] = {
-				resourceName: 'test-store',
 				contentHash: 'hash123',
 				lastIndexed: Date.now(),
 			};
 			mockCache.cache.files['notes/other.md'] = {
-				resourceName: 'test-store',
 				contentHash: 'hash456',
 				lastIndexed: Date.now(),
 			};
@@ -734,7 +731,6 @@ describe('RagSyncQueue', () => {
 
 		it('should log error and return false when saveCache throws', async () => {
 			mockCache.cache.files['notes/test.md'] = {
-				resourceName: 'test-store',
 				contentHash: 'hash123',
 				lastIndexed: Date.now(),
 			};

--- a/test/services/rag-vault-scanner.test.ts
+++ b/test/services/rag-vault-scanner.test.ts
@@ -670,7 +670,6 @@ describe('RagVaultScanner', () => {
 			// Cache should contain the file entry with computed hash
 			expect(ragCache.cache.files['note.md']).toEqual(
 				expect.objectContaining({
-					resourceName: 'test-store',
 					contentHash: 'abc123',
 				})
 			);
@@ -720,7 +719,6 @@ describe('RagVaultScanner', () => {
 			expect(scanner.getRunningSkipped()).toBe(1);
 			expect(ragCache.cache.files['cached.md']).toEqual(
 				expect.objectContaining({
-					resourceName: 'test-store',
 					contentHash: 'skip-hash',
 				})
 			);
@@ -735,7 +733,6 @@ describe('RagVaultScanner', () => {
 				cacheData: {
 					files: {
 						'already-cached.md': {
-							resourceName: 'test-store',
 							contentHash: 'original-hash',
 							lastIndexed: 1000,
 						},


### PR DESCRIPTION
## Summary

`audit-architecture` nightly sweep flagged: **dead wiring field** in `src/services/rag-types.ts`.

`IndexedFileEntry.resourceName` is populated at all three cache-write sites and read by nothing — no production code, no test assertion beyond the fixtures that set it. It is the exact shape `.claude/guidelines/coding.md` describes under "Wiring interfaces carry only what is read": knip resolves exported symbols, not per-field reachability through an object literal, so both `IndexedFileEntry` and `RagIndexCache.files` stay live and the field survives every green check.

It is also actively misleading. The declaration comments it as "Gemini file resource name", but every write stores `storeName` — the File Search *store*, not a per-file resource. `rag-vault-scanner.ts` says so inline: `// Store name as reference (individual doc names not available)`. Anyone reaching for it later would get the wrong value.

Removal is behaviour-preserving for existing installs: `RagCache.loadCache` validates only `version` and then casts (`parsed as unknown as RagIndexCache`), so an existing `rag-index-cache.json` carrying the extra key still parses and nothing re-indexes. `CACHE_VERSION` is deliberately left alone — bumping it would discard every user's index for a field nobody reads. That compatibility claim is now covered by a test (see below), added in response to CodeRabbit's review.

No issue is linked: this was found by the nightly architecture sweep rather than filed first.

## Changes

- `src/services/rag-types.ts` — remove `resourceName` from `IndexedFileEntry`.
- `src/services/rag-sync-queue.ts` — drop the field from the incremental-sync cache write.
- `src/services/rag-vault-scanner.ts` — drop it from the `file_indexed` and `file_skipped` cache writes.
- `test/services/rag-{cache,indexing,sync-queue,vault-scanner}.test.ts` — drop it from cache fixtures, and from the two `expect.objectContaining` assertions in the scanner tests that checked it.
- `test/services/rag-cache.test.ts` — **add** a legacy-cache case: loads raw JSON still carrying `resourceName` and asserts no version-reset warning fired, the entry was counted, and `contentHash`/`lastIndexed` survived. Written as raw JSON because the extra key is exactly what the current type no longer permits.

## Screenshots / Screencast

N/A — internal refactor, no UI surface.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: opened directly by the `audit-architecture` sweep, which routes mechanical fixes to a PR and judgment calls to an issue.
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — plus `npm run lint` (0 errors, 39 pre-existing warnings, none in the touched files) and `npm run typecheck:test`. Full suite: 179 files / 4018 tests passing.
- [ ] I have tested this change on Desktop — not run in a live vault. The change deletes a field with no reader; the RAG paths it touches are covered by the four test files above, and the legacy-cache load path now has its own case.
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — no platform-specific API involved.
- [ ] Documentation has been updated (if applicable) — N/A: `resourceName` appears nowhere in `docs/` or `README.md`; the cache file's internal shape is not a documented surface.
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code
- [x] I have reviewed and understand all AI-generated code in this PR

---

_Filed by the `audit-architecture` skill._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EU9gDxWgNNTwnHZ1SZw8t6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cached file metadata now retains only content hashes and indexing timestamps.
  * File indexing, synchronization, and scanning use the simplified cache records.
  * Existing cache data containing legacy metadata continues to load without warnings while preserving supported information and indexed counts.

* **Tests**
  * Updated cache, indexing, synchronization, and scanning coverage for the revised metadata format and legacy cache compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->