### PR TITLE
chore(daily): 2026-09-03 daily update

### DIFF
--- a/planning/changelog/2026-09-03.md
+++ b/planning/changelog/2026-09-03.md
@@ -1,0 +1,28 @@
+# Daily changelog — September 03, 2026
+
+**Date:** 2026-09-03
+**PRs merged:** 4
+
+---
+
+## Summary
+
+A quiet day dominated by cleanup: the prior day's automated daily-update PR landed, alongside two more `audit-architecture` dead-field deletions continuing the "wiring interfaces carry only what is read" pattern, and one real correctness fix closing a scheduled-task lifecycle race.
+
+## What shipped
+
+### [#1462 fix: Prevent stale scheduled-task lifecycle writes](https://github.com/allenhutchison/obsidian-gemini/pull/1462)
+
+Fixes #1342. `ScheduledTaskManager` initialization and metadata-cache parse continuations could still mutate manager state after `destroy()` or a refresh superseded the lifecycle that started them. Adds a monotonic lifecycle generation to the manager, rejects stale create-defer and parse continuations before they touch tasks or persisted state, stages sidecar loads and gates asynchronous definition discovery behind the current lifecycle, and aborts listener registration if initialization is superseded mid-await. Backed by deterministic regression coverage that was mutation-checked against the pre-fix source, so each guarded race actually fails without its corresponding protection.
+
+### [#1461 chore(daily): 2026-09-03 daily update](https://github.com/allenhutchison/obsidian-gemini/pull/1461)
+
+The automated daily-update run covering 2026-09-02: wrote `planning/changelog/2026-09-02.md` for that day's 6 merged PRs, ran `audit-product-docs` with no drift found (re-flagging, for the third run in a row, that `src/main.ts`'s default `openaiModelName` of `'gpt-5.6'` is not a recognized model id — the registry and docs both say `'gpt-5.6-sol'`), and had `triage-issues` find no unlabeled issues. Also fixed a genuinely flaky test — `attach-vault-file.test.ts`'s large-SVG case — by giving it a 20s timeout instead of continuing to re-flag it.
+
+### [#1458 refactor(models): remove the unread GeminiModel.supportsTools field](https://github.com/allenhutchison/obsidian-gemini/pull/1458)
+
+Filed by the `audit-architecture` nightly sweep. `GeminiModel.supportsTools` was declared on the interface and set to `true` by both dynamic model-list services, but no code path read it — tool exposure is decided entirely by the tool registry and layered tool policy, never by model metadata. The static `GEMINI_MODELS` table never populated it either, so the field was inconsistently set as well as dead. Deletes the declaration, both producers, and the test assertions that only echoed the value back.
+
+### [#1457 refactor(agent): remove the unread AgentContext character caps](https://github.com/allenhutchison/obsidian-gemini/pull/1457)
+
+Filed by the `audit-architecture` nightly sweep. `AgentContext.maxContextChars` and `maxCharsPerFile` were declared on the interface, populated by both `DEFAULT_CONTEXTS` presets, and parsed back out of session frontmatter — but nothing ever read either value, since context budgeting in this plugin is token-based and lives entirely in `ContextManager`. Nothing wrote the corresponding frontmatter keys either, so the parse arm was reading data the plugin never produced. Removes both fields and the frontmatter parse lines that fed them; a session note carrying the keys keeps them as inert frontmatter, same as any other unrecognized key.


### PR DESCRIPTION
## Summary

Automated daily-update run bundling the repo's per-day housekeeping skills for 2026-09-03.

## Changes

- **daily-changelog**: wrote `planning/changelog/2026-09-03.md` covering the day's 4 merged PRs — the scheduled-task lifecycle race fix (#1462), the prior day's automated daily-update PR (#1461), and two `audit-architecture` dead-field deletions (#1458, #1457).
- **audit-product-docs**: full pass against `docs/guide/`, `docs/reference/`, `README.md`, and `AGENTS.md` — no drift found and no new docs warranted. Spot-checked the docs for recent internal changes (#1462, #1458, #1457) and confirmed none of them touch a documented surface. Left the known `openaiModelName` default mismatch (`src/main.ts` sets `'gpt-5.6'` vs. the registry/docs' `'gpt-5.6-sol'`) un-touched — it's a code bug already flagged to the maintainer in prior runs, out of this skill's scope.
- **triage-issues**: no unlabeled open issues found — all 29 open issues already carry labels.

## Screenshots / Screencast

N/A — no UI changes.

## Checklist

### Required

- [x] I have read and agree to the Contributing Guidelines
- [x] I have read and agree to the AI Policy
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A, this is the recurring automated daily-update run, not tied to a single issue
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — also ran `npm run lint` (0 errors, 39 pre-existing warnings) and `npm run typecheck:test`; 179 files / 4017 tests passed
- [ ] I have tested this change on Desktop — N/A, changelog-only change, no runtime code path
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A, no runtime code changes
- [x] Documentation has been updated (if applicable) — N/A, this PR *is* the documentation/changelog update
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (automated daily-update scheduled run)
- [x] I have reviewed and understand all AI-generated code in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fc6yVyYm44WSwveJ91gSvT

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fc6yVyYm44WSwveJ91gSvT)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added the September 3, 2026 daily changelog.
  - Documented a fix for a scheduled-task lifecycle race condition.
  - Recorded the previous day’s automated update.
  - Documented removal of unused model capability metadata and agent context character-limit settings, including related frontmatter parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->