### PR TITLE
refactor(agent): drop the reader-less AgentLoopResult.retried flag

### DIFF
--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -177,8 +177,6 @@ export interface AgentLoopResult {
 	history: Content[];
 	/** True if cancellation interrupted the loop. */
 	cancelled: boolean;
-	/** True if the empty-response retry was triggered. */
-	retried: boolean;
 	/**
 	 * True if even the retry returned empty and `markdown` is the fallback
 	 * message listing executed tools. Caller should display but not persist.
@@ -586,7 +584,6 @@ export class AgentLoop {
 					markdown: retryResponse.markdown,
 					thoughts: retryResponse.thoughts?.trim() ? retryResponse.thoughts : undefined,
 					history: updatedHistory,
-					retried: true,
 					iterations,
 				});
 			}
@@ -596,7 +593,6 @@ export class AgentLoop {
 			return this.makeResult({
 				markdown: buildEmptyResponseMessage(toolResults, plugin),
 				history: updatedHistory,
-				retried: true,
 				fellBack: true,
 				iterations,
 			});
@@ -643,7 +639,7 @@ export class AgentLoop {
 	}
 
 	/**
-	 * Assemble an {@link AgentLoopResult}, defaulting the five status flags to
+	 * Assemble an {@link AgentLoopResult}, defaulting the four status flags to
 	 * `false` so each terminal path only spells out the flags that are true for
 	 * it. Every return site — including {@link cancelledResult} and
 	 * {@link loopAbortedResult} — routes through here so the default flag block
@@ -654,7 +650,6 @@ export class AgentLoop {
 	): AgentLoopResult {
 		return {
 			cancelled: false,
-			retried: false,
 			fellBack: false,
 			exhausted: false,
 			loopAborted: false,

--- a/test/agent/agent-loop.test.ts
+++ b/test/agent/agent-loop.test.ts
@@ -373,7 +373,7 @@ describe('AgentLoop', () => {
 	});
 
 	describe('empty-response handling', () => {
-		test('retry succeeds — returns retry text and marks retried=true, fellBack=false', async () => {
+		test('retry succeeds — returns retry text and fellBack=false', async () => {
 			const plugin = buildPlugin();
 			const session = buildSession();
 			const api = makeScriptedModelApi([textResponse(''), textResponse('summary text')]);
@@ -387,7 +387,6 @@ describe('AgentLoop', () => {
 			});
 
 			expect(result.markdown).toBe('summary text');
-			expect(result.retried).toBe(true);
 			expect(result.fellBack).toBe(false);
 			expect(api.calls).toBe(2); // follow-up + retry
 		});
@@ -406,7 +405,6 @@ describe('AgentLoop', () => {
 			});
 
 			expect(result.fellBack).toBe(true);
-			expect(result.retried).toBe(true);
 			// Fallback message references the executed tool's display name
 			expect(result.markdown).toContain('read_file');
 			expect(result.markdown).toContain('completed the requested actions');
@@ -1477,7 +1475,6 @@ describe('AgentLoop', () => {
 				},
 			});
 
-			expect(result.retried).toBe(true);
 			expect(api.generateModelResponse).toHaveBeenCalledTimes(2);
 			const retryRequest = (api.generateModelResponse as Mock).mock.calls[1][0];
 			expect(retryRequest.perTurnContext).toBeUndefined();

--- a/test/services/headless-agent-turn.test.ts
+++ b/test/services/headless-agent-turn.test.ts
@@ -60,7 +60,6 @@ function successfulLoopResult(markdown = 'Tool result text.'): AgentLoopResult {
 		markdown,
 		history: [],
 		cancelled: false,
-		retried: false,
 		fellBack: false,
 		exhausted: false,
 		loopAborted: false,

--- a/test/services/hook-runner.test.ts
+++ b/test/services/hook-runner.test.ts
@@ -76,7 +76,6 @@ function successfulLoopResult(markdown = 'Done.'): AgentLoopResult {
 		markdown,
 		history: [],
 		cancelled: false,
-		retried: false,
 		fellBack: false,
 		exhausted: false,
 		loopAborted: false,

--- a/test/services/scheduled-task-runner.test.ts
+++ b/test/services/scheduled-task-runner.test.ts
@@ -57,7 +57,6 @@ function successfulLoopResult(markdown = 'Tool result text.'): AgentLoopResult {
 		markdown,
 		history: [],
 		cancelled: false,
-		retried: false,
 		fellBack: false,
 		exhausted: false,
 		loopAborted: false,


### PR DESCRIPTION
## Summary

`audit-architecture` nightly sweep flagged: **dead surface / speculative wiring** in `src/agent/agent-loop.ts`.

`AgentLoopResult.retried` is set on both empty-response-retry return paths and read by nothing in `src/`. Its four sibling status flags all have a production consumer — `cancelled`, `fellBack` and `loopAborted` in `agent-view-tools.ts`, `exhausted` in `headless-agent-turn.ts` — and `retried` was the only one with zero. That is the shape `.claude/guidelines/coding.md` ("Wiring interfaces carry only what is read") rules out, and the same class as #1436 / #1457 / #1458 / #1467.

Removing it loses no signal: the retry is still announced through the `onEmptyResponseRetry` hook and the `[AgentLoop] Model returned empty response after tool execution` warn log. The three test assertions on `result.retried` each sat next to an assertion that already proved the retry ran (`api.calls === 2`, `generateModelResponse` called twice, the retry's own markdown / `fellBack`), so dropping them leaves the retry paths covered — including the dedicated `emits onEmptyResponseRetry hook` test.

No behavior change: the field had no reader, so nothing branched on it.

Not linked to a pre-existing issue — this PR is the audit's unit of work for the finding.

## Changes

- `src/agent/agent-loop.ts` — drop `retried` from `AgentLoopResult`, from the two `makeResult` call sites that set it `true`, and from the default flag block in `makeResult` (doc comment: "five status flags" → "four").
- `test/agent/agent-loop.test.ts` — drop the three `result.retried` assertions and rename the test whose title named the flag.
- `test/services/{headless-agent-turn,hook-runner,scheduled-task-runner}.test.ts` — drop `retried: false` from the shared `AgentLoopResult` fixtures.

## Screenshots / Screencast

N/A — internal refactor with no UI surface.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: filed directly by the `audit-architecture` sweep, which routes mechanical findings to a PR rather than an issue.
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — plus `npm run lint` (0 errors), `npm run typecheck:test`, and `npm run knip`, all clean locally.
- [ ] I have tested this change on Desktop — N/A: deletion of an unread type field; no runtime path changes. Verified by the full suite (4034 tests) and the type check.
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — no platform-specific API involved.
- [ ] Documentation has been updated (if applicable) — N/A: `retried` is not named in `AGENTS.md`, `.claude/guidelines/`, or `docs/`.
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (`audit-architecture` skill)
- [x] I have reviewed and understand all AI-generated code in this PR

## Out of scope

The sibling `onEmptyResponseRetry` hook is also supplied by no caller today (only tests). Whether the agent view should surface a retry to the user, or the hook should go, is a UX call rather than dead-code cleanup, so it is deliberately left alone here.

---

_Filed by the `audit-architecture` skill._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JJs5wxYEJNmR7ir6CLTP8v

---
_Generated by [Claude Code](https://claude.ai/code/session_01JJs5wxYEJNmR7ir6CLTP8v)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Changes**
  - Removed the obsolete retry-status field from agent loop results.
  - Updated retry and fallback result handling to use the remaining status information.
  - Updated related tests and fixtures to reflect the revised result format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->