### PR TITLE
chore(daily): 2026-09-04 daily update

### DIFF
--- a/planning/changelog/2026-09-04.md
+++ b/planning/changelog/2026-09-04.md
@@ -1,0 +1,46 @@
+# Daily changelog — September 04, 2026
+
+**Date:** 2026-09-04
+**PRs merged:** 6
+
+---
+
+## Summary
+
+A cleanup-heavy day: five internal refactors from the `auto-dev` pipeline and `audit-architecture` sweep landed back-to-back, plus the automated daily-update PR for the previous day. The most consequential change tightens `deep_research`'s output-path validation to match `generate_image`'s stricter rules.
+
+## What shipped
+
+### [#1470 chore(daily): 2026-09-03 daily update](https://github.com/allenhutchison/obsidian-gemini/pull/1470)
+
+The automated daily-update run for 2026-09-03: wrote that day's changelog (4 merged PRs), ran a docs audit that found no drift, and confirmed no unlabeled open issues.
+
+### [#1467 refactor(rag): drop the unread IndexedFileEntry.resourceName field](https://github.com/allenhutchison/obsidian-gemini/pull/1467)
+
+The `audit-architecture` nightly sweep flagged `IndexedFileEntry.resourceName` as a dead wiring field — populated at every cache-write site but read by nothing, and mislabeled (it actually held a File Search store name, not a per-file resource name). Removed from the type and its three write sites; a new test confirms existing on-disk caches carrying the old field still load without a version-reset warning.
+
+### [#1466 refactor(utils): give the two background-output validators one write-path policy](https://github.com/allenhutchison/obsidian-gemini/pull/1466)
+
+`DeepResearch` and `ImageGenerationService` each had their own near-identical "may I write this generated artifact here?" validator, and they'd already drifted — `generate_image` rejected vault-escaping (`..`) and blank/directory-only paths, `deep_research` didn't. Both now route through one `validateGeneratedOutputPath` helper in `src/utils/file-utils.ts`, so `deep_research`'s output path is now held to the same reject set as `generate_image`.
+
+Fixes #1401.
+
+### [#1465 refactor(agent-view): decompose createInputArea into wiring helpers](https://github.com/allenhutchison/obsidian-gemini/pull/1465)
+
+Split the 509-line `createInputArea()` — the longest method in the codebase — into focused private helpers for keyboard handling, drag-and-drop, paste, and the send button, taking the body down to 52 lines. Pure code motion with an unchanged test suite plus 3 new direct cases for the extracted drop-target collector.
+
+The PR flags that a live-vault behavioral pass (drag/drop, paste, `@`/`/` triggers) hasn't been run — the sandbox has no Obsidian runtime — so that verification is still outstanding.
+
+Refs #1396 (one slice of a larger decomposition tracked there).
+
+### [#1464 refactor(projects): collapse the three parse-and-cache blocks into one helper](https://github.com/allenhutchison/obsidian-gemini/pull/1464)
+
+`ProjectManager` ran the same parse-then-cache-then-warn logic in three methods, and the warning messages had already drifted to two different prefixes. Extracted a private `cacheParsedProject()` helper and standardized the log prefix across all three call sites.
+
+Refs #1369, entry 1 of 5 (the other four stay tracked on the issue per the maintainer's scoped approval).
+
+### [#1463 refactor: delete the unreachable public API barrel](https://github.com/allenhutchison/obsidian-gemini/pull/1463)
+
+`src/index.ts` re-exported roughly 60 symbols as a "public API," but the package isn't published and nothing imports the barrel — its only effect was making `knip`'s dead-export detection treat every named symbol as reachable, undermining the CI-blocking check added by #1294. Deleted the barrel along with the now-visibly-dead symbols it had been hiding (two orphan provider barrels, a handful of unused interfaces). Verified via byte-identical build output between `master` and the branch.
+
+Fixes #1356.


### PR DESCRIPTION
## Summary

Automated daily-update run bundling the repo's per-day housekeeping skills for 2026-09-04.

## Changes

- **daily-changelog**: wrote `planning/changelog/2026-09-04.md` covering the day's 6 merged PRs — five internal refactors (the `auto-dev` pipeline's API-barrel deletion #1463, `ProjectManager` parse/cache dedup #1464, `createInputArea` decomposition #1465, and the deep-research/image-gen output-path validator unification #1466) plus an `audit-architecture` dead-field removal (#1467) and the prior day's automated daily-update PR (#1470). Issue #1401 (already closed, via #1466 merging the day before) is mentioned in the changelog entry for context only.
- **audit-product-docs**: full pass against `docs/guide/`, `docs/reference/`, `README.md`, and `AGENTS.md` — no drift found, no new docs warranted. Re-confirmed (not re-fixed) the previously-flagged code bug where `src/main.ts` defaults `openaiModelName` to `'gpt-5.6'` against the registry/docs' `'gpt-5.6-sol'` — that's a code fix, out of scope for a docs-only audit.
- **triage-issues**: no unlabeled open issues found — all 28 open issues already carry labels.

This PR is documentation-only (a changelog entry). It does not implement or close any issue itself.

## Screenshots / Screencast

N/A — no UI changes.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A, this is the recurring automated daily-update run, not tied to a single issue
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — also ran `npm run lint` (0 errors, 39 pre-existing warnings) and `npm run typecheck:test`; 179 files / 4034 tests passed
- [ ] I have tested this change on Desktop — N/A, changelog-only change, no runtime code path
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A, no runtime code changes
- [x] Documentation has been updated (if applicable) — N/A, this PR *is* the documentation/changelog update
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (automated daily-update scheduled run)
- [x] I have reviewed and understand all AI-generated code in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TQw1raUjqCNW1a19oVtvzL