### PR TITLE
fix: release headless and deleted sessions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,7 +62,7 @@ The plugin uses a factory pattern (`ModelClientFactory` in `src/api/factory.ts`)
    - **Reasoning persistence**: model "thinking" is stored on `GeminiConversationEntry.thoughts` and serialized as a collapsed `> [!reasoning]-` callout. Turns with a message (user prompt, final answer) carry a `## ` header + Message Info table; streamlined reasoning-only turns are just the bare `[!reasoning]` callout with no header. **Parser invariant** (`SessionHistory.parseHistoryContent`): entries are identified by their _callout_ (`[!user]`/`[!assistant]`/`[!reasoning]`), not a `## ` header, and the parser walks **every** callout in a `---`-delimited section (reasoning + tool callouts flow together with no dividers). This keeps the divider-free activity stream, headerless reasoning, and legacy per-entry files all round-tripping — preserve it, and cover format changes with old-format fixtures in `test/agent/session-history.test.ts`.
 5. **Custom Prompts** (`src/prompts/`): User-defined prompt templates stored in `[state-folder]/Prompts/`
 6. **Agent mode** (`src/agent/`, `src/tools/`): AI agent with tool calling capabilities
-   - Session management with persistent history
+   - Session management with persistent history; new session IDs use `session_<UUID>` from Web Crypto, while existing `session_id` values in saved history are preserved.
    - Tool registry and execution engine
    - Vault operations tools with permission system
    - Google Search integration (separate from function calling)

--- a/docs/guide/lifecycle-hooks.md
+++ b/docs/guide/lifecycle-hooks.md
@@ -6,6 +6,8 @@ Lifecycle Hooks let you trigger an AI agent run in response to Obsidian vault ev
 Hooks are disabled by default. Set **Enable lifecycle hooks** in plugin settings before any hook will fire. The default is off because vault events fire continuously and an unintentionally-broad hook can drain API quota quickly.
 :::
 
+Agent-task hooks release their temporary session and tool-loop tracking when the turn ends, including cancellation or failure. Interactive chat sessions remain available in the session browser.
+
 ## Overview
 
 A hook is a markdown file stored in `[state-folder]/Hooks/`. The file's frontmatter controls the trigger, filter, and action; the body is the prompt template.

--- a/docs/guide/scheduled-tasks.md
+++ b/docs/guide/scheduled-tasks.md
@@ -1,6 +1,6 @@
 # Scheduled tasks
 
-Scheduled tasks let you automate recurring AI prompts — daily summaries, weekly reports, periodic vault maintenance — without any manual intervention. Each task runs as a headless agent session and writes its output to a file in your vault.
+Scheduled tasks let you automate recurring AI prompts — daily summaries, weekly reports, periodic vault maintenance — without any manual intervention. Each task runs as a headless agent session and writes its output to a file in your vault. The temporary session and its tool-loop tracking are released after each run, including cancellation or failure; recurring runs do not retain one session per execution.
 
 ## Overview
 

--- a/src/agent/session-manager.ts
+++ b/src/agent/session-manager.ts
@@ -497,7 +497,7 @@ export class SessionManager {
 	 * Generate unique session ID
 	 */
 	private generateSessionId(): string {
-		return `session_${Date.now()}_${Math.random().toString(36).substring(2, 11)}`;
+		return `session_${crypto.randomUUID()}`;
 	}
 
 	/**

--- a/src/agent/session-manager.ts
+++ b/src/agent/session-manager.ts
@@ -123,6 +123,16 @@ export class SessionManager {
 	}
 
 	/**
+	 * Release a finished headless session or an explicitly deleted session.
+	 * This only drops in-memory state; it never deletes history files or evicts
+	 * interactive sessions when switching views.
+	 */
+	releaseSession(sessionId: string): void {
+		this.activeSessions.delete(sessionId);
+		this.plugin.toolExecutionEngine?.clearLoopDetectorSession(sessionId);
+	}
+
+	/**
 	 * Get existing session for a note (note-centric mode)
 	 */
 	async getNoteChatSession(sourceFile: TFile): Promise<ChatSession> {

--- a/src/services/headless-agent-turn.ts
+++ b/src/services/headless-agent-turn.ts
@@ -79,89 +79,94 @@ export async function runHeadlessAgentTurn(
 		requireConfirmation: [] as DestructiveAction[],
 	});
 
-	// Propagate the per-run model override so follow-up requests also use the
-	// right model via session.modelConfig.
-	if (spec.model) {
-		session.modelConfig = { model: spec.model };
-	}
+	try {
+		// Propagate the per-run model override so follow-up requests also use the
+		// right model via session.modelConfig.
+		if (spec.model) {
+			session.modelConfig = { model: spec.model };
+		}
 
-	const toolContext: ToolExecutionContext = {
-		plugin,
-		session,
-		featureToolPolicy: spec.toolPolicy,
-	};
-	const modelApi = ModelClientFactory.createChatModel(plugin);
-	// Headless runs auto-approve confirmations, so only expose tools the user
-	// explicitly opted into (APPROVE under the layered policy). ASK_USER tools
-	// are excluded — exposing them would silently bypass the user's "ask first"
-	// intent because there's no UI to ask on. To allow an ASK_USER tool in a
-	// headless run, the run's toolPolicy must explicitly upgrade it (preset or
-	// per-tool override).
-	const availableTools = plugin.toolRegistry.getAutoApprovedTools(toolContext);
-
-	// Prepend a turn preamble so the model has accurate "now" awareness.
-	const startedAt = formatLocalTimestamp(session.created);
-	const userMessage = buildTurnPreamble(formatLocalTimestamp(new Date())) + spec.prompt;
-	const model = spec.model ?? getActiveChatModel(plugin.settings);
-
-	const initialRequest: ExtendedModelRequest = {
-		kind: 'extended',
-		userMessage,
-		conversationHistory: [],
-		model,
-		temperature: plugin.settings.temperature,
-		topP: plugin.settings.topP,
-		prompt: '',
-		availableTools,
-		renderContent: false,
-		sessionStartedAt: startedAt,
-		// The model API uses projectSkills as its include-list when filtering the
-		// registered skill set. Empty list ⇒ no filter, so the run sees every
-		// available skill (matches the documented "leave blank to inherit"
-		// semantics).
-		projectSkills: spec.projectSkills?.length ? spec.projectSkills : undefined,
-	};
-
-	if (isCancelled()) return undefined;
-	const initialResponse = await modelApi.generateModelResponse(initialRequest);
-	if (isCancelled()) return undefined;
-
-	if (!initialResponse.toolCalls?.length) {
-		return initialResponse.markdown ?? '';
-	}
-
-	// Per-run override falls back to the shared headless default when unset.
-	const maxIterations = spec.maxIterations ?? DEFAULT_HEADLESS_MAX_ITERATIONS;
-	// Hand off to AgentLoop — handles thoughtSignature propagation, history
-	// construction, follow-up requests, empty-response retry, and agentEventBus
-	// events without any UI coupling.
-	const loop = new AgentLoop();
-	const result = await loop.run({
-		initialResponse,
-		initialUserMessage: userMessage,
-		initialHistory: [],
-		options: {
+		const toolContext: ToolExecutionContext = {
 			plugin,
 			session,
-			isCancelled,
-			confirmationProvider: new HeadlessConfirmationProvider(),
-			maxIterations,
 			featureToolPolicy: spec.toolPolicy,
-			headless: true,
-		},
-	});
+		};
+		const modelApi = ModelClientFactory.createChatModel(plugin);
+		// Headless runs auto-approve confirmations, so only expose tools the user
+		// explicitly opted into (APPROVE under the layered policy). ASK_USER tools
+		// are excluded — exposing them would silently bypass the user's "ask first"
+		// intent because there's no UI to ask on. To allow an ASK_USER tool in a
+		// headless run, the run's toolPolicy must explicitly upgrade it (preset or
+		// per-tool override).
+		const availableTools = plugin.toolRegistry.getAutoApprovedTools(toolContext);
 
-	if (result.cancelled) return undefined;
+		// Prepend a turn preamble so the model has accurate "now" awareness.
+		const startedAt = formatLocalTimestamp(session.created);
+		const userMessage = buildTurnPreamble(formatLocalTimestamp(new Date())) + spec.prompt;
+		const model = spec.model ?? getActiveChatModel(plugin.settings);
 
-	if (result.exhausted) {
-		// Exhaustion fires only after the soft budget's one-shot extension was
-		// also spent, so the actual iteration count exceeds the configured cap —
-		// report both.
-		throw new Error(
-			`${spec.logPrefix} ${spec.subjectNoun} "${spec.subjectName}" exhausted its tool-iteration budget ` +
-				`(cap ${maxIterations}, ran ${result.iterations}) without producing a response`
-		);
+		const initialRequest: ExtendedModelRequest = {
+			kind: 'extended',
+			userMessage,
+			conversationHistory: [],
+			model,
+			temperature: plugin.settings.temperature,
+			topP: plugin.settings.topP,
+			prompt: '',
+			availableTools,
+			renderContent: false,
+			sessionStartedAt: startedAt,
+			// The model API uses projectSkills as its include-list when filtering the
+			// registered skill set. Empty list ⇒ no filter, so the run sees every
+			// available skill (matches the documented "leave blank to inherit"
+			// semantics).
+			projectSkills: spec.projectSkills?.length ? spec.projectSkills : undefined,
+		};
+
+		if (isCancelled()) return undefined;
+		const initialResponse = await modelApi.generateModelResponse(initialRequest);
+		if (isCancelled()) return undefined;
+
+		if (!initialResponse.toolCalls?.length) {
+			return initialResponse.markdown ?? '';
+		}
+
+		// Per-run override falls back to the shared headless default when unset.
+		const maxIterations = spec.maxIterations ?? DEFAULT_HEADLESS_MAX_ITERATIONS;
+		// Hand off to AgentLoop — handles thoughtSignature propagation, history
+		// construction, follow-up requests, empty-response retry, and agentEventBus
+		// events without any UI coupling.
+		const loop = new AgentLoop();
+		const result = await loop.run({
+			initialResponse,
+			initialUserMessage: userMessage,
+			initialHistory: [],
+			options: {
+				plugin,
+				session,
+				isCancelled,
+				confirmationProvider: new HeadlessConfirmationProvider(),
+				maxIterations,
+				featureToolPolicy: spec.toolPolicy,
+				headless: true,
+			},
+		});
+
+		if (result.cancelled) return undefined;
+
+		if (result.exhausted) {
+			// Exhaustion fires only after the soft budget's one-shot extension was
+			// also spent, so the actual iteration count exceeds the configured cap —
+			// report both.
+			throw new Error(
+				`${spec.logPrefix} ${spec.subjectNoun} "${spec.subjectName}" exhausted its tool-iteration budget ` +
+					`(cap ${maxIterations}, ran ${result.iterations}) without producing a response`
+			);
+		}
+
+		return result.markdown;
+	} finally {
+		// The temporary session never escapes this turn, even on cancellation or failure.
+		plugin.sessionManager.releaseSession(session.id);
 	}
-
-	return result.markdown;
 }

--- a/src/tools/execution-engine.ts
+++ b/src/tools/execution-engine.ts
@@ -206,11 +206,11 @@ export class ToolExecutionEngine {
 	}
 
 	/**
-	 * Release per-session state for a session that is being deleted.
+	 * Release per-session state for a finished or deleted session.
 	 *
 	 * Clears the tool loop detector's recorded calls for the session so its key
 	 * does not live on for the rest of the plugin process (#1387). Called from
-	 * the session-deletion path (`SessionListModal.deleteSession`).
+	 * `SessionManager.releaseSession` after headless turns and session deletion.
 	 */
 	clearLoopDetectorSession(sessionId: string): void {
 		this.loopDetector.clearSession(sessionId);

--- a/src/ui/agent-view/session-list-modal.ts
+++ b/src/ui/agent-view/session-list-modal.ts
@@ -344,10 +344,10 @@ export class SessionListModal extends Modal {
 			const file = this.app.vault.getAbstractFileByPath(session.historyPath);
 			if (file) {
 				await this.app.fileManager.trashFile(file);
-				// Release per-session engine state (tool-loop detector records) only
+				// Release the cached session and tool-loop detector records only
 				// after the file deletion succeeded — if trashing failed the session
 				// remains, so its detection state must survive too (#1387).
-				this.plugin.toolExecutionEngine.clearLoopDetectorSession(session.id);
+				this.plugin.sessionManager.releaseSession(session.id);
 				new Notice(t('agent.sessionList.deleted', { title: session.title }));
 
 				// Reload the list and refresh filter state

--- a/test/agent/session-manager.test.ts
+++ b/test/agent/session-manager.test.ts
@@ -67,6 +67,21 @@ describe('SessionManager', () => {
 		});
 	});
 
+	it('keeps sessions distinct even when timestamps and Math.random repeat', async () => {
+		const now = vi.spyOn(Date, 'now').mockReturnValue(1788619654778);
+		const random = vi.spyOn(Math, 'random').mockReturnValue(0.5);
+		try {
+			const first = await sessionManager.createAgentSession('First');
+			const second = await sessionManager.createAgentSession('Second');
+			expect(first.id).not.toBe(second.id);
+			sessionManager.releaseSession(first.id);
+			expect(sessionManager.getSession(second.id)).toBe(second);
+		} finally {
+			now.mockRestore();
+			random.mockRestore();
+		}
+	});
+
 	describe('createAgentSession', () => {
 		it('should sanitize file names with forbidden characters', async () => {
 			const session = await sessionManager.createAgentSession('Agent: Test Mode');

--- a/test/agent/session-manager.test.ts
+++ b/test/agent/session-manager.test.ts
@@ -47,6 +47,26 @@ describe('SessionManager', () => {
 		vi.clearAllMocks();
 	});
 
+	describe('releaseSession', () => {
+		it('drops only the released session and clears its tool-loop records, even on a repeated release', async () => {
+			const clearLoopDetectorSession = vi.fn();
+			const manager = new SessionManager({ ...mockPlugin, toolExecutionEngine: { clearLoopDetectorSession } });
+			const released = await manager.createAgentSession('Released');
+			const retained = await manager.createAgentSession('Retained');
+			manager.releaseSession(released.id);
+			manager.releaseSession(released.id);
+			expect(manager.getSession(released.id)).toBeUndefined();
+			expect(manager.getSession(retained.id)).toBe(retained);
+			expect(clearLoopDetectorSession).toHaveBeenCalledWith(released.id);
+		});
+
+		it('can release a session before the tool engine is initialized', async () => {
+			const session = await sessionManager.createAgentSession('Temporary');
+			sessionManager.releaseSession(session.id);
+			expect(sessionManager.getSession(session.id)).toBeUndefined();
+		});
+	});
+
 	describe('createAgentSession', () => {
 		it('should sanitize file names with forbidden characters', async () => {
 			const session = await sessionManager.createAgentSession('Agent: Test Mode');

--- a/test/services/headless-agent-turn.test.ts
+++ b/test/services/headless-agent-turn.test.ts
@@ -2,6 +2,7 @@ import type { Mock } from 'vitest';
 import { runHeadlessAgentTurn } from '../../src/services/headless-agent-turn';
 import type { HeadlessAgentTurnSpec } from '../../src/services/headless-agent-turn';
 import type { AgentLoopResult } from '../../src/agent/agent-loop';
+import { SessionManager } from '../../src/agent/session-manager';
 import { PolicyPreset } from '../../src/types/tool-policy';
 
 // ─── Mocks ────────────────────────────────────────────────────────────────────
@@ -9,6 +10,7 @@ import { PolicyPreset } from '../../src/types/tool-policy';
 vi.mock('obsidian', () => ({
 	normalizePath: (p: string) => p,
 	TFile: class {},
+	TFolder: class {},
 }));
 
 vi.mock('../../src/utils/format-utils', () => ({
@@ -77,11 +79,13 @@ function createMockPlugin(): any {
 	return {
 		logger: { log: vi.fn(), debug: vi.fn(), error: vi.fn(), warn: vi.fn() },
 		settings: {
+			historyFolder: 'gemini-scribe',
 			chatModelName: 'plugin-default-model',
 			temperature: 1,
 			topP: 0.95,
 		},
 		sessionManager: {
+			releaseSession: vi.fn(),
 			createAgentSession: vi.fn().mockResolvedValue({
 				id: 'session-1',
 				title: 'Headless: test',
@@ -95,6 +99,7 @@ function createMockPlugin(): any {
 			getAutoApprovedTools: vi.fn().mockReturnValue(AUTO_APPROVED_TOOLS),
 		},
 		toolExecutionEngine: {
+			clearLoopDetectorSession: vi.fn(),
 			executeTool: vi.fn().mockResolvedValue({ success: true, output: 'ok' }),
 		},
 		app: { vault: {} },
@@ -125,6 +130,56 @@ describe('runHeadlessAgentTurn', () => {
 		vi.clearAllMocks();
 		(ModelClientFactory.createChatModel as Mock).mockReturnValue(createMockModelApi());
 		mockAgentLoopRun.mockResolvedValue(successfulLoopResult());
+	});
+
+	describe('temporary session lifetime', () => {
+		it.each([
+			'answer',
+			'empty answer',
+			'cancel before request',
+			'cancel after request',
+			'tool answer',
+			'loop cancellation',
+			'exhaustion',
+			'request error',
+			'loop error',
+			'setup error',
+		])('releases only the temporary session after %s', async (outcome) => {
+			const plugin = createMockPlugin();
+			const manager = new SessionManager(plugin);
+			plugin.sessionManager = manager;
+			const existing = await manager.createAgentSession('Interactive session');
+			const createSession = vi.spyOn(manager, 'createAgentSession');
+			const modelApi = createMockModelApi(outcome === 'empty answer' ? '' : 'Answer');
+			(ModelClientFactory.createChatModel as Mock).mockReturnValue(modelApi);
+			if (['tool answer', 'loop cancellation', 'exhaustion', 'loop error'].includes(outcome)) {
+				modelApi.generateModelResponse.mockResolvedValue({ markdown: '', toolCalls: [{ name: 'read_file' }] });
+			}
+			if (outcome === 'loop cancellation')
+				mockAgentLoopRun.mockResolvedValue({ ...successfulLoopResult(), cancelled: true });
+			if (outcome === 'exhaustion') mockAgentLoopRun.mockResolvedValue({ ...successfulLoopResult(), exhausted: true });
+			if (outcome === 'request error') modelApi.generateModelResponse.mockRejectedValue(new Error('request failed'));
+			if (outcome === 'loop error') mockAgentLoopRun.mockRejectedValue(new Error('loop failed'));
+			if (outcome === 'setup error')
+				plugin.toolRegistry.getAutoApprovedTools.mockImplementation(() => {
+					throw new Error('setup failed');
+				});
+			let checks = 0;
+			const turn = runHeadlessAgentTurn(
+				plugin,
+				makeSpec(),
+				() => outcome === 'cancel before request' || (outcome === 'cancel after request' && checks++ > 0)
+			);
+			if (['exhaustion', 'request error', 'loop error', 'setup error'].includes(outcome)) {
+				await expect(turn).rejects.toThrow(outcome === 'exhaustion' ? 'exhausted' : 'failed');
+			} else {
+				await turn;
+			}
+			const temporary = await createSession.mock.results[0].value;
+			expect(manager.getSession(temporary.id)).toBeUndefined();
+			expect(manager.getSession(existing.id)).toBe(existing);
+			expect(plugin.toolExecutionEngine.clearLoopDetectorSession).toHaveBeenCalledExactlyOnceWith(temporary.id);
+		});
 	});
 
 	describe('missing agent services', () => {

--- a/test/services/hook-runner.test.ts
+++ b/test/services/hook-runner.test.ts
@@ -137,6 +137,7 @@ function createMockPlugin(opts: { existingPaths?: string[]; createBehaviour?: Va
 			topP: 0.95,
 		},
 		sessionManager: {
+			releaseSession: vi.fn(),
 			createAgentSession: vi.fn().mockResolvedValue({
 				id: 'session-1',
 				title: 'Hook: test-hook',

--- a/test/services/scheduled-task-runner.test.ts
+++ b/test/services/scheduled-task-runner.test.ts
@@ -74,6 +74,7 @@ function createMockPlugin(vaultFiles: Record<string, string> = {}): any {
 			topP: 0.95,
 		},
 		sessionManager: {
+			releaseSession: vi.fn(),
 			createAgentSession: vi.fn().mockResolvedValue({
 				id: 'session-1',
 				title: 'Scheduled: test-task',

--- a/test/ui/agent-view/session-list-confirm.test.ts
+++ b/test/ui/agent-view/session-list-confirm.test.ts
@@ -97,7 +97,7 @@ interface Harness {
 	trashFile: ReturnType<typeof vi.fn>;
 	onSelect: ReturnType<typeof vi.fn>;
 	onDelete: ReturnType<typeof vi.fn>;
-	clearLoopDetectorSession: ReturnType<typeof vi.fn>;
+	releaseSession: ReturnType<typeof vi.fn>;
 	contentEl: HTMLElement;
 }
 
@@ -121,11 +121,11 @@ async function openModal(sessions: ChatSession[]): Promise<Harness> {
 		fileManager: { trashFile },
 	} as unknown as App;
 
-	const clearLoopDetectorSession = vi.fn();
+	const releaseSession = vi.fn();
 	const plugin = {
 		settings: { historyFolder: 'gemini-scribe' },
-		toolExecutionEngine: { clearLoopDetectorSession },
 		sessionManager: {
+			releaseSession,
 			loadSession: vi.fn((path: string) => Promise.resolve(sessions.find((s) => s.historyPath === path) ?? null)),
 			createAgentSession: vi.fn(),
 		},
@@ -138,7 +138,7 @@ async function openModal(sessions: ChatSession[]): Promise<Harness> {
 	const modal = new SessionListModal(app, plugin, { onSelect, onDelete }, null);
 	await modal.onOpen();
 
-	return { modal, trashFile, onSelect, onDelete, clearLoopDetectorSession, contentEl: (modal as any).contentEl };
+	return { modal, trashFile, onSelect, onDelete, releaseSession, contentEl: (modal as any).contentEl };
 }
 
 /** The rendered rows, in display order. */
@@ -197,16 +197,16 @@ describe('SessionListModal inline delete confirmation', () => {
 		}
 	});
 
-	it('releases the tool-loop detector records when the session is deleted (#1387)', async () => {
-		const { contentEl, clearLoopDetectorSession } = await openModal([makeSession('a', 'Alpha')]);
+	it('releases the cached session and tool-loop records when the session is deleted (#1460)', async () => {
+		const { contentEl, releaseSession } = await openModal([makeSession('a', 'Alpha')]);
 		const row = rows(contentEl)[0];
 		click(deleteButton(row));
 		click(confirmButton(row)!);
-		await vi.waitFor(() => expect(clearLoopDetectorSession).toHaveBeenCalledWith('a'));
+		await vi.waitFor(() => expect(releaseSession).toHaveBeenCalledWith('a'));
 	});
 
-	it('does not release loop-detector state when trashing fails (#1387 review regression)', async () => {
-		const { contentEl, trashFile, clearLoopDetectorSession } = await openModal([makeSession('a', 'Alpha')]);
+	it('does not release session state when trashing fails (#1387 review regression)', async () => {
+		const { contentEl, trashFile, releaseSession } = await openModal([makeSession('a', 'Alpha')]);
 		trashFile.mockRejectedValueOnce(new Error('trash failed'));
 		const row = rows(contentEl)[0];
 		click(deleteButton(row));
@@ -214,16 +214,16 @@ describe('SessionListModal inline delete confirmation', () => {
 		await vi.waitFor(() => expect(trashFile).toHaveBeenCalled());
 		// Give the rejected promise a tick to surface in deleteSession's catch.
 		await new Promise((resolve) => window.setTimeout(resolve, 0));
-		expect(clearLoopDetectorSession).not.toHaveBeenCalled();
+		expect(releaseSession).not.toHaveBeenCalled();
 	});
 
-	it('does not release loop-detector state when cancelled (#1387)', async () => {
-		const { contentEl, clearLoopDetectorSession } = await openModal([makeSession('a', 'Alpha')]);
+	it('does not release session state when cancelled (#1387)', async () => {
+		const { contentEl, releaseSession } = await openModal([makeSession('a', 'Alpha')]);
 		const row = rows(contentEl)[0];
 		click(deleteButton(row));
 		click(cancelButton(row)!);
 		await new Promise((resolve) => window.setTimeout(resolve, 0));
-		expect(clearLoopDetectorSession).not.toHaveBeenCalled();
+		expect(releaseSession).not.toHaveBeenCalled();
 	});
 
 	it('deletes only after the confirm button is clicked', async () => {


### PR DESCRIPTION
## Summary

Every scheduled task or agent hook retained its temporary session until plugin unload. Release that session and its tool-loop tracking after the turn completes, including cancellation and failure. Explicitly deleted chat sessions are also removed from the in-memory cache after successful trashing.

Fixes #1460

## Changes

- Add `SessionManager.releaseSession` and call it from a `finally` around the complete headless turn.
- Route successful session deletion through the same release method; preserve state if trashing fails.
- Generate new session IDs with Web Crypto UUIDs after CodeQL identified the previous `Math.random()` suffix as insecure once IDs became release keys; saved historical IDs remain valid.
- Keep interactive session caching and persisted history unchanged.
- Document temporary-session cleanup in the scheduled-task and lifecycle-hook guides.

Validation: all 4,047 tests in 179 files pass, plus format, lint, build, test typecheck, docs build, cycle detection, and Knip. Lint has 39 existing warnings and no errors. The new tests failed before the fix and cover ten headless exit paths using the real session manager, preserving an existing interactive session while releasing the temporary session. Deletion cancellation, trash failure, and session-ID uniqueness under repeated timestamps and `Math.random()` values remain covered.

Live Obsidian/eval checks were deferred at the maintainer's direction on 2026-09-06. All GitHub checks are green, and CodeRabbit approved the final head with no actionable comments.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [x] This PR is linked to an approved issue where the approach was discussed with a maintainer — batch approved in the maintainer's interactive session.
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — full local and GitHub checks pass, including the corrected CodeQL check.
- [ ] I have tested this change on Desktop — deferred at the maintainer's direction; covered by unit and GitHub CI checks.
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards) — no platform-specific APIs added; live mobile checks were deferred.
- [x] Documentation has been updated (if applicable)
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: OpenAI Codex
- [x] I have reviewed and understand all AI-generated code in this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Temporary sessions created for automated tasks are now released after completion, cancellation, failure, or exhaustion.
  * Session identifiers now use more reliable unique UUIDs for new sessions.
  * Deleting a session also clears its associated temporary tracking state.

* **Documentation**
  * Clarified session lifecycle and cleanup behavior for scheduled tasks, lifecycle hooks, and agent mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
