### PR TITLE
refactor(paths): route three hoisted-prefix containment checks through isPathInFolder

### DIFF
--- a/src/services/file-backed-feature-manager.ts
+++ b/src/services/file-backed-feature-manager.ts
@@ -1,6 +1,7 @@
 import { normalizePath, type TFile } from 'obsidian';
 import type { ObsidianGemini } from '../types/plugin';
 import { JsonSidecarStateStore, purgeOrphanState } from './feature-definition';
+import { isPathInFolder } from '../utils/file-utils';
 
 /**
  * Minimal shape every file-backed feature definition shares: a `slug` (its
@@ -128,12 +129,12 @@ export abstract class FileBackedFeatureManager<TDef extends FileBackedDefinition
 		if (isCurrent && !isCurrent()) return;
 		this.definitions.clear();
 
-		const prefix = this.featureFolderPath + '/';
-		const runsPrefix = this.runsFolder + '/';
+		const featureFolder = this.featureFolderPath;
+		const runsFolder = this.runsFolder;
 
 		const files = this.plugin.app.vault
 			.getMarkdownFiles()
-			.filter((f) => f.path.startsWith(prefix) && !f.path.startsWith(runsPrefix));
+			.filter((f) => isPathInFolder(f.path, featureFolder) && !isPathInFolder(f.path, runsFolder));
 
 		for (const file of files) {
 			try {

--- a/src/services/scheduled-task-manager.ts
+++ b/src/services/scheduled-task-manager.ts
@@ -1,6 +1,6 @@
 import { TFile, normalizePath } from 'obsidian';
 import type { ObsidianGemini } from '../types/plugin';
-import { ensureFolderExists } from '../utils/file-utils';
+import { ensureFolderExists, isPathInFolder } from '../utils/file-utils';
 import { FeatureToolPolicy } from '../types/tool-policy';
 import { formatToolPolicyYaml } from './feature-policy-yaml';
 import { yamlScalar } from './yaml-scalar';
@@ -175,9 +175,11 @@ export class ScheduledTaskManager extends FileBackedFeatureManager<ScheduledTask
 		this.metadataCacheHandler = (...data: unknown[]) => {
 			const file = data[0];
 			if (!(file instanceof TFile)) return;
-			const prefix = this.scheduledTasksFolder + '/';
-			const runsPrefix = this.runsFolder + '/';
-			if (file.path.startsWith(prefix) && !file.path.startsWith(runsPrefix) && file.extension === 'md') {
+			if (
+				isPathInFolder(file.path, this.scheduledTasksFolder) &&
+				!isPathInFolder(file.path, this.runsFolder) &&
+				file.extension === 'md'
+			) {
 				const slug = file.basename;
 				// Skip if the vault create handler already claimed this slug — it will
 				// parse the file after its 500 ms defer, so we don't need to do it here.
@@ -219,9 +221,11 @@ export class ScheduledTaskManager extends FileBackedFeatureManager<ScheduledTask
 			const abstractFile = data[0];
 			if (!(abstractFile instanceof TFile)) return;
 			const file = abstractFile;
-			const prefix = this.scheduledTasksFolder + '/';
-			const runsPrefix = this.runsFolder + '/';
-			if (file.path.startsWith(prefix) && !file.path.startsWith(runsPrefix) && file.extension === 'md') {
+			if (
+				isPathInFolder(file.path, this.scheduledTasksFolder) &&
+				!isPathInFolder(file.path, this.runsFolder) &&
+				file.extension === 'md'
+			) {
 				// Claim the slug immediately so the metadataCache 'changed' handler
 				// (which fires before our 500 ms defer) skips this file.
 				this.recentlyCreated.add(file.basename);

--- a/test/services/scheduled-task-manager.test.ts
+++ b/test/services/scheduled-task-manager.test.ts
@@ -66,7 +66,8 @@ vi.mock('obsidian', () => ({
 }));
 
 // ensureFolderExists is a no-op in tests
-vi.mock('../../src/utils/file-utils', () => ({
+vi.mock('../../src/utils/file-utils', async (importOriginal) => ({
+	...(await importOriginal<typeof import('../../src/utils/file-utils')>()),
 	ensureFolderExists: vi.fn().mockResolvedValue(undefined),
 	ensureParentFolderExists: vi.fn().mockResolvedValue(undefined),
 }));


### PR DESCRIPTION
## Summary

`audit-architecture` nightly sweep flagged: **repo-invariant drift** in `src/services/scheduled-task-manager.ts` and `src/services/file-backed-feature-manager.ts`.

`.claude/guidelines/coding.md` (landed yesterday via #1472, closing #1402) says: "Never hand-roll `path.startsWith(folder + '/')` … call `isPathInFolder(path, folder)`." The rationale is that `isPathInFolder` is a live fix surface — #1372 changed its containment semantics and #1374/#1404 fixed a trailing-slash bug in the setting it reads — and no inline copy inherits a correction to it.

Three sites still hand-roll it. They are not sites #1472 chose to leave alone; they are sites the ESLint guard **cannot see**. `PATH_CONTAINMENT_RULE` matches `CallExpression[callee.property.name='startsWith'][arguments.0.type='BinaryExpression'][arguments.0.operator='+']`. At all three, the concatenation is hoisted a line earlier into a `prefix` local:

```ts
const prefix = this.scheduledTasksFolder + '/';
const runsPrefix = this.runsFolder + '/';
if (file.path.startsWith(prefix) && !file.path.startsWith(runsPrefix) && file.extension === 'md') {
```

so the `.startsWith()` argument is a plain `Identifier`, not a `BinaryExpression`, and the selector does not fire. `npm run lint` is green on `master` with these three present.

These sites are not *buggy* today — #1372 noted they "already anchor correctly," and that remains true. This PR is about the coupling the rule exists to remove, not about a live over-match.

**Behaviour-preserving.** `isPathInFolder(p, f)` is `p === f || p.startsWith(f + '/')` — it differs from the replaced strict-prefix form only by the added `p === f` arm. At each site the operand is a file path (from `vault.getMarkdownFiles()`, or after an `instanceof TFile` narrowing) while the argument is a folder path, so that arm is unreachable. This is the same reasoning, and the same shape of change, as the four routed sites in #1472's table.

The enforcement gap itself — that the guard misses a hoisted prefix — is filed separately as a pattern-promotion proposal rather than fixed here, since changing the selector needs its own measure-against-`src/` gate.

Fixes: n/a — found by the architecture sweep, no pre-existing issue.

## Changes

- `src/services/scheduled-task-manager.ts` — the `metadataCache` `changed` handler and the `vault` `create` handler both derive "is this a task definition file (and not run output)?" via `isPathInFolder` instead of two hoisted prefix locals. Import extended.
- `src/services/file-backed-feature-manager.ts` — `discoverDefinitions()`'s markdown filter does the same. Import added.
- `test/services/scheduled-task-manager.test.ts` — the `file-utils` module mock replaced the whole module with two functions, so `isPathInFolder` came back `undefined` and 62 tests failed with a `TypeError`. Switched to the `importOriginal` spread pattern already used by `test/services/hook-manager.test.ts:21`, which keeps the real predicate (pure string logic) and stubs only the two folder-creating helpers. No assertions changed.

No new tests: the change is a provable no-op at every site, and the three code paths are already exercised by `test/services/scheduled-task-manager.test.ts` and `test/services/hook-manager.test.ts`.

## Screenshots / Screencast

N/A — no UI surface is touched.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: filed directly by the `audit-architecture` sweep, which routes mechanical no-op findings straight to a PR. Close it if the coupling is preferred as-is at these three sites.
- [x] All CI checks pass — run locally on this head before pushing: `npm run format-check` (clean), `npm run lint` (0 errors; 40 pre-existing warnings, all in `test/`), `npm run build`, `npm run typecheck:test`, `npm run lint:cycles` (0 cycles), `npm run knip` (clean), `npm test` (179 files / 4034 tests passing)
- [ ] I have tested this change on Desktop — N/A: no runtime behaviour change reaches the plugin; the three sites are provable no-ops and are covered by the existing suite.
- [x] I have verified this change does not break Mobile — `isPathInFolder` is pure string logic; no platform-specific API is touched.
- [ ] Documentation has been updated (if applicable) — N/A: internal refactor with no user-facing behaviour or settings change. The rule this conforms to is already documented in `.claude/guidelines/coding.md`.
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (`audit-architecture` skill)
- [x] I have reviewed and understand all AI-generated code in this PR

---

_Filed by the `audit-architecture` skill._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011VrqmPCEpepBAEskXf5Zd3

---
_Generated by [Claude Code](https://claude.ai/code/session_011VrqmPCEpepBAEskXf5Zd3)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file discovery so definitions are matched only within the correct folders.
  * Improved scheduled task detection by reliably filtering Markdown task files and excluding run-related folders.
  * Fixed path handling for folders with similar names or overlapping paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->