### PR TITLE
chore(daily): 2026-09-07 daily update

### DIFF
--- a/planning/changelog/2026-09-06.md
+++ b/planning/changelog/2026-09-06.md
@@ -1,0 +1,24 @@
+# Daily changelog — September 06, 2026
+
+**Date:** 2026-09-06
+**PRs merged:** 5
+
+---
+
+## Summary
+
+A quiet day: the previous day's automated daily-update PR merged, an `audit-architecture` sweep routed three more hand-rolled path-containment checks through the shared helper, and Dependabot landed three routine dependency bumps.
+
+## What shipped
+
+### [#1481 refactor(paths): route three hoisted-prefix containment checks through isPathInFolder](https://github.com/allenhutchison/obsidian-gemini/pull/1481)
+
+The `audit-architecture` sweep found three more sites in `scheduled-task-manager.ts` and `file-backed-feature-manager.ts` hand-rolling `path.startsWith(folder + '/')` instead of calling `isPathInFolder()` — invisible to the ESLint guard added in #1472 because the concatenation was hoisted into a `prefix` local a line earlier, so the `.startsWith()` argument was a plain identifier rather than the binary expression the rule's selector matches. Behavior-preserving: `isPathInFolder` only differs from the strict-prefix form by an added `p === f` arm that's unreachable at these call sites (file path vs. folder path). No new tests — the change is a provable no-op covered by the existing suite.
+
+### [#1483 chore(daily): 2026-09-06 daily update](https://github.com/allenhutchison/obsidian-gemini/pull/1483)
+
+The automated daily-update run for 2026-09-05: wrote that day's changelog (4 merged PRs), ran a docs audit that found no drift, and confirmed no unlabeled open issues.
+
+### Dependency bumps: #1478, #1479, #1480
+
+Dependabot bumps: `openai` 7.6.0 → 7.9.0 in the production-dependencies group, `actions/deploy-pages` 5.0.0 → 5.0.1, and a 7-package dev-dependencies group update.


### PR DESCRIPTION
## Summary

Automated daily-update run bundling the repo's per-day housekeeping skills for 2026-09-06.

## Changes

- **daily-changelog**: wrote `planning/changelog/2026-09-06.md` covering the day's 5 merged PRs — an `audit-architecture` follow-up routing three more hoisted-prefix path-containment checks through `isPathInFolder()` (#1481), the prior day's automated daily-update PR (#1483), and three Dependabot bumps (`openai` 7.6.0 → 7.9.0, `actions/deploy-pages` 5.0.0 → 5.0.1, and a 7-package dev-dependencies group update).
- **audit-product-docs**: full pass against `docs/guide/`, `docs/reference/`, `README.md`, and `AGENTS.md` — no drift found, no new docs warranted. Spot-checked settings defaults, command IDs, tool names, schedule grammar, hook defaults, agent-loop constants, MCP timeouts, the OpenAI model registry, RAG constants, and the i18n language list; all matched current `src/`. Re-confirmed (not re-fixed) the previously-flagged code bug where `src/main.ts` defaults `openaiModelName` to `'gpt-5.6'` against the registry/docs' `'gpt-5.6-sol'` — that's a code fix, out of scope for a docs-only audit.
- **triage-issues**: no unlabeled open issues found — all 30 open issues already carry labels.

This PR is documentation-only (a changelog entry). It does not implement or close any issue itself.

## Screenshots / Screencast

N/A — no UI changes.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A, this is the recurring automated daily-update run, not tied to a single issue
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — also ran `npm run lint` (0 errors, 40 pre-existing warnings), `npm run typecheck:test`, and `npm run lint:cycles`; 179 files / 4034 tests passed locally before pushing
- [ ] I have tested this change on Desktop — N/A, changelog-only change, no runtime code path
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A, no runtime code changes
- [x] Documentation has been updated (if applicable) — N/A, this PR *is* the documentation/changelog update
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (automated daily-update scheduled run)
- [x] I have reviewed and understand all AI-generated code in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kuat2Wj2hbmY7Td4swEgeZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kuat2Wj2hbmY7Td4swEgeZ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added the September 6, 2026 daily changelog.
  - Recorded recent merged updates, including path-handling improvements and dependency version updates.
  - Documented that the path-handling changes preserve existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->