### PR TITLE
fix(agent-view): anchor the dropped-file vault-root check to a folder boundary

### DIFF
--- a/src/ui/agent-view/agent-view-ui.ts
+++ b/src/ui/agent-view/agent-view-ui.ts
@@ -2,7 +2,7 @@ import { App, Menu, TFile, TFolder, Notice, setIcon, setTooltip } from 'obsidian
 import type { ObsidianGemini } from '../../types/plugin';
 import { ChatSession } from '../../types/agent';
 import { insertTextAtCursor, moveCursorToEnd, execContextCommand } from '../../utils/dom-context';
-import { shouldExcludePathForPlugin } from '../../utils/file-utils';
+import { isPathInFolder, shouldExcludePathForPlugin } from '../../utils/file-utils';
 import { renameSessionHistoryFile } from '../../agent/session-rename';
 import { collectFilesFromFolder } from '../../utils/folder-walk';
 import {
@@ -510,8 +510,10 @@ export class AgentViewUI {
 			if (adapter && 'basePath' in adapter) {
 				const basePath = (adapter as { basePath: string }).basePath;
 				// Normalize slashes for cross-platform consistency (Windows backslashes vs POSIX)
-				// Using explicit replace instead of normalizePath which is intended for vault-relative paths
-				const normalizedBase = basePath.replace(/\\/g, '/');
+				// Using explicit replace instead of normalizePath which is intended for vault-relative paths.
+				// Any trailing separator is stripped so the containment check below sees a bare folder
+				// path — isPathInFolder appends its own '/' and matches nothing when given one (#1374).
+				const normalizedBase = basePath.replace(/\\/g, '/').replace(/\/+$/, '');
 
 				for (const file of Array.from(e.dataTransfer.files)) {
 					// `.path` is an Electron extension on File that provides the full filesystem path
@@ -520,7 +522,10 @@ export class AgentViewUI {
 					if (rawPath && typeof rawPath === 'string') {
 						const normalizedRaw = rawPath.replace(/\\/g, '/');
 
-						if (normalizedRaw.startsWith(normalizedBase)) {
+						// Root-anchored: a bare startsWith also matched sibling folders that merely
+						// share the prefix (a drop from `<vault>-backup/Archive/a.md` resolved to the
+						// vault's own `Archive/a.md`).
+						if (isPathInFolder(normalizedRaw, normalizedBase)) {
 							let relPath = normalizedRaw.substring(normalizedBase.length);
 							if (relPath.startsWith('/')) relPath = relPath.substring(1);
 

--- a/test/ui/agent-view-ui.test.ts
+++ b/test/ui/agent-view-ui.test.ts
@@ -14,7 +14,13 @@ vi.mock('../../src/ui/agent-view/session-list-modal');
 vi.mock('../../src/ui/agent-view/file-mention-modal');
 vi.mock('../../src/ui/agent-view/session-settings-modal');
 vi.mock('../../src/utils/dom-context');
-vi.mock('../../src/utils/file-utils');
+// Only the plugin-aware exclusion predicate is stubbed; the pure path helpers
+// (isPathInFolder, …) keep their real implementations so containment behaviour
+// is exercised rather than mocked away.
+vi.mock('../../src/utils/file-utils', async (importOriginal) => ({
+	...(await importOriginal<typeof import('../../src/utils/file-utils')>()),
+	shouldExcludePathForPlugin: vi.fn(),
+}));
 
 // Mock external ESM dependencies
 vi.mock('@allenhutchison/gemini-utils/research', () => ({
@@ -229,6 +235,41 @@ describe('AgentViewUI', () => {
 			// .md is classified as TEXT → handleDroppedFiles
 			expect(callbacks.handleDroppedFiles).toHaveBeenCalledWith([mockFile]);
 			expect(app.vault.getAbstractFileByPath).toHaveBeenCalledWith('folder/note.md');
+		});
+
+		it('should ignore drops from a sibling folder that shares the vault path prefix', async () => {
+			const mockFile = {
+				path: 'Archive/note.md',
+				extension: 'md',
+			} as unknown as TFile;
+			Object.setPrototypeOf(mockFile, TFile.prototype);
+
+			// The vault happens to contain the same relative path, so an unanchored
+			// prefix check would resolve the external file to this vault file.
+			(app.vault.getAbstractFileByPath as Mock).mockReturnValue(mockFile);
+
+			// `/Users/test/vault-backup` shares the `/Users/test/vault` prefix but is a
+			// different folder entirely.
+			const droppedFile = {
+				path: '/Users/test/vault-backup/Archive/note.md',
+				name: 'note.md',
+			};
+
+			const dataTransfer = {
+				files: [droppedFile],
+				types: ['Files'],
+				// Nothing resolves, so the handler falls through to the text-link branch.
+				getData: vi.fn(() => ''),
+			};
+			Object.defineProperty(dataTransfer.files, 'length', { value: 1 });
+			(dataTransfer.files as any)[Symbol.iterator] = function* () {
+				yield droppedFile;
+			};
+
+			await triggerDrop(dataTransfer);
+
+			expect(app.vault.getAbstractFileByPath).not.toHaveBeenCalled();
+			expect(callbacks.handleDroppedFiles).not.toHaveBeenCalled();
 		});
 
 		it('should normalize Windows paths correctly', async () => {


### PR DESCRIPTION
## Summary

`audit-architecture` nightly sweep flagged: **path-containment drift** in `src/ui/agent-view/agent-view-ui.ts`.

The Electron file-drop path decided whether a dropped OS file lives inside the vault with a bare prefix test:

```ts
const normalizedBase = basePath.replace(/\\/g, '/');
...
if (normalizedRaw.startsWith(normalizedBase)) {
    let relPath = normalizedRaw.substring(normalizedBase.length);
```

With no separator anchor, a sibling directory that merely shares the vault's path prefix passes. Dropping `<vault>-backup/Archive/a.md` onto a vault at `<vault>` yields `relPath = "Archive/a.md"`, which `resolvePath()` then resolves against the vault — so when the vault happens to contain `Archive/a.md`, the agent silently attaches the wrong file instead of ignoring an out-of-vault drop.

The fix routes the check through `isPathInFolder()` in `src/utils/file-utils.ts`, the predicate `.claude/guidelines/coding.md` designates as the single source of truth for path containment. This is a pure narrowing: the equal-path case behaves as before (`relPath` becomes empty and resolves to nothing), and only genuine sibling-prefix matches are now rejected.

Not a duplicate of the two path-containment items already open: #1481 fixed three *hoisted* `folder + '/'` prefixes and did not touch this file, and #1482 is about widening the `PATH_CONTAINMENT_RULE` ESLint selector to catch that hoisted form. This site has no `+ '/'` at all, so neither the shipped selector nor the widened one proposed in #1482 would flag it — it is an unanchored check, which is a correctness bug rather than a style deviation.

Filed as a PR rather than an issue because the fix is four lines in one file with no design decision attached.

## Changes

- `src/ui/agent-view/agent-view-ui.ts` — replace the bare `startsWith` vault-root test with `isPathInFolder()`; strip any trailing separator from the normalized base path first, since the helper appends its own and matches nothing when handed one (#1374).
- `test/ui/agent-view-ui.test.ts` — add a regression test for a drop from a sibling folder sharing the vault prefix, in a case where the vault does contain the same relative path. Narrow the blanket `vi.mock('../../src/utils/file-utils')` to stub only `shouldExcludePathForPlugin`: the automock replaced the pure path helpers with undefined-returning stubs, which would have made the new containment check vacuously false and silently voided the test.

## Screenshots / Screencast

N/A — no visual change; this alters which file a drop resolves to, not how anything renders.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: opened directly by the `audit-architecture` sweep, whose routing rule sends mechanical, single-file fixes to a PR rather than an issue.
- [x] All CI checks pass — verified locally before pushing: `npm run format-check`, `npm run lint` (0 errors), `npm run build`, `npm run typecheck:test`, `npm test` (4035 tests, 179 files).
- [ ] I have tested this change on Desktop — not verified in a live vault; the drop path needs Electron's `File.path` extension, which the unit test simulates. Covered by the new regression test plus the 28 existing drop-handling tests.
- [x] I have verified this change does not break Mobile — `isPathInFolder` is a pure string predicate with no platform-specific API; the branch it guards is already behind an Electron-only `basePath`/`File.path` check.
- [ ] Documentation has been updated — N/A: internal correctness fix; no documented behavior changes (the drag-and-drop guide describes in-vault drops, which are unaffected).
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (`audit-architecture` skill)
- [x] I have reviewed and understand all AI-generated code in this PR

---

_Filed by the `audit-architecture` skill._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0173W3WLQycabiMwMXv18Pah

---
_Generated by [Claude Code](https://claude.ai/code/session_0173W3WLQycabiMwMXv18Pah)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed file drop handling for folders with similar path prefixes, preventing files outside the vault from being incorrectly accepted.
  - Ensured only files within the configured vault location are processed.

- **Tests**
  - Added coverage for rejecting files from sibling folders that share the vault’s path prefix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->