### PR TITLE
refactor(agent-view): import ProgressState instead of re-declaring it

### DIFF
--- a/src/ui/agent-view/agent-view-tools.ts
+++ b/src/ui/agent-view/agent-view-tools.ts
@@ -9,6 +9,7 @@ import { AgentLoop, DEFAULT_INTERACTIVE_MAX_ITERATIONS } from '../../agent/agent
 import { DEFAULT_TURN_BUDGET_REMIND_AT } from '../../agent/turn-budget';
 import type { ToolCall, StreamChunk } from '../../api/interfaces/model-api';
 import { AgentViewToolDisplay } from './agent-view-tool-display';
+import type { ProgressState } from './agent-view-progress';
 import type { PerTurnContext } from './agent-view-tool-followup';
 import { buildCompactionEntry } from './compaction-notice';
 import { t } from '../../i18n';
@@ -19,7 +20,7 @@ import { t } from '../../i18n';
 export interface AgentViewContext {
 	getCurrentSession(): ChatSession | null;
 	isCancellationRequested(): boolean;
-	updateProgress(statusText: string, state?: 'thinking' | 'tool' | 'waiting' | 'streaming'): void;
+	updateProgress(statusText: string, state?: ProgressState): void;
 	hideProgress(): void;
 	displayMessage(entry: GeminiConversationEntry): Promise<void>;
 	/** Render a reasoning line into an arbitrary container (e.g. the tool group body). */

--- a/src/ui/agent-view/agent-view.ts
+++ b/src/ui/agent-view/agent-view.ts
@@ -9,7 +9,7 @@ import type { Tool, ToolResult } from '../../tools/types';
 import { HandlerPriority } from '../../types/agent-events';
 
 // Import all component modules
-import { AgentViewProgress } from './agent-view-progress';
+import { AgentViewProgress, type ProgressState } from './agent-view-progress';
 import { shouldExcludePathForPlugin } from '../../utils/file-utils';
 import { AgentViewMessages } from './agent-view-messages';
 import { AgentViewContext } from './agent-view-context';
@@ -698,8 +698,7 @@ export class AgentView extends ItemView {
 		return {
 			getCurrentSession: () => this.currentSession,
 			isCancellationRequested: () => this.send?.isCancellationRequested() ?? false,
-			updateProgress: (statusText: string, state?: 'thinking' | 'tool' | 'waiting' | 'streaming') =>
-				this.progress.update(statusText, state),
+			updateProgress: (statusText: string, state?: ProgressState) => this.progress.update(statusText, state),
 			hideProgress: () => this.progress.hide(),
 			displayMessage: (entry: GeminiConversationEntry) => this.displayMessage(entry),
 			renderReasoning: (container: HTMLElement, thoughts: string, sourcePath: string) =>


### PR DESCRIPTION
## Summary

`audit-architecture` nightly sweep flagged: **improper typing / re-listed type** in `src/ui/agent-view/agent-view-tools.ts` and `src/ui/agent-view/agent-view.ts`.

`ProgressState` (`'thinking' | 'tool' | 'waiting' | 'streaming'`) is an exported type alias in `agent-view-progress.ts`, and `AgentViewProgress.show()` / `.update()` already take it. But the two sites that plumb a progress state through the tools context spelled the union out inline instead: the `AgentViewContext.updateProgress` signature and the `createToolsContext()` literal that satisfies it.

That is quiet by construction — adding a fifth state to the alias leaves both inline copies compiling, and the tools context is then silently unable to pass the new state through. Routing both through the alias makes the compiler carry the invariant. The union is identical, so there is no behavior change.

No new issue is filed for this; it is the whole change.

## Changes

- `src/ui/agent-view/agent-view-tools.ts` — import `ProgressState` and use it in the `AgentViewContext.updateProgress` signature.
- `src/ui/agent-view/agent-view.ts` — import `ProgressState` alongside the existing `AgentViewProgress` import and use it in `createToolsContext()`.

## Screenshots / Screencast

N/A — type-only refactor, no rendered output changes.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: filed directly by the `audit-architecture` sweep, which routes mechanical fixes to a PR rather than an issue.
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — also ran `npm run lint` (0 errors; the 40 warnings are pre-existing and all in `test/`), `npm run typecheck:test`, and `npm run lint:cycles` (0 cycles).
- [ ] I have tested this change on Desktop — N/A: type-only change with no emitted-JS difference; verified by build + the full 4051-test suite.
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — no platform-specific API touched.
- [ ] Documentation has been updated (if applicable) — N/A: internal type wiring, no user-facing behavior or setting changed.
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (`audit-architecture` skill)
- [x] I have reviewed and understand all AI-generated code in this PR

---

_Filed by the `audit-architecture` skill._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C6tuBSmK4kwmpYC3XEiBaX

---
_Generated by [Claude Code](https://claude.ai/code/session_01C6tuBSmK4kwmpYC3XEiBaX)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Standardized progress state typing across agent view components.
  - Updated progress callbacks to use the shared progress state definition.
  - No visible runtime behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->