### PR TITLE
chore(daily): 2026-09-09 daily update

### DIFF
--- a/planning/changelog/2026-09-08.md
+++ b/planning/changelog/2026-09-08.md
@@ -1,0 +1,40 @@
+# Daily changelog — September 08, 2026
+
+**Date:** 2026-09-08
+**PRs merged:** 7
+
+---
+
+## Summary
+
+A backlog-clearing day: the maintainer batch-merged two pending automated daily-update PRs alongside two real fixes (a headless-session leak and a dead settings toggle), an `audit-architecture` fix for an unanchored vault-root path check, and the two weekly automated bot PRs (Gemini model list, UI translations).
+
+## What shipped
+
+### [#1491 chore(daily): 2026-09-08 daily update](https://github.com/allenhutchison/obsidian-gemini/pull/1491)
+
+The automated daily-update run covering 2026-09-07: wrote that day's changelog (a quiet day, no PRs merged), ran a docs audit that found no drift, and confirmed no unlabeled open issues.
+
+### [#1489 fix(agent-view): anchor the dropped-file vault-root check to a folder boundary](https://github.com/allenhutchison/obsidian-gemini/pull/1489)
+
+The Electron file-drop handler in `agent-view-ui.ts` decided whether a dropped OS file lives inside the vault with a bare `startsWith` prefix check and no separator anchor, so a sibling directory merely sharing the vault's path prefix (e.g. `<vault>-backup/Archive/a.md` against a vault at `<vault>`) could resolve to an in-vault file of the same relative path and get silently attached instead of rejected. The fix routes the check through the shared `isPathInFolder()` helper, per the repo's path-containment invariant. Filed directly as a PR by the `audit-architecture` sweep since the fix was a self-contained, four-line, single-file change.
+
+### [#1486 chore(daily): 2026-09-07 daily update](https://github.com/allenhutchison/obsidian-gemini/pull/1486)
+
+The automated daily-update run covering 2026-09-06: wrote that day's changelog (5 merged PRs), ran a docs audit that found no drift, and confirmed no unlabeled open issues. Re-confirmed (not re-fixed) a previously-flagged code bug where `main.ts` defaults `openaiModelName` to a model ID that doesn't match the registry — a code fix, out of scope for the docs-only audit.
+
+### [#1476 fix: release headless and deleted sessions](https://github.com/allenhutchison/obsidian-gemini/pull/1476)
+
+Every scheduled task or agent hook retained its temporary session until plugin unload, since nothing released it after the turn completed. Adds `SessionManager.releaseSession`, called from a `finally` around the headless turn (covering cancellation and failure too), and routes explicit session deletion through the same release path. Also switches new session IDs to Web Crypto UUIDs after CodeQL flagged the old `Math.random()` suffix as insecure now that IDs double as release keys; existing saved session IDs remain valid. Fixes #1460.
+
+### [#1477 fix: remove ineffective system prompt override toggle](https://github.com/allenhutchison/obsidian-gemini/pull/1477)
+
+Removes the "Allow system prompt override" settings toggle and its now-empty Custom Prompts heading — the toggle never actually did anything; the prompt's own `override_system_prompt` frontmatter field was already the sole control. Prunes the corresponding i18n keys across all 20 shipped translations and updates README, the settings reference, and the custom-prompts guide. Fixes #1468.
+
+### [#1487 chore: Update available Gemini models](https://github.com/allenhutchison/obsidian-gemini/pull/1487)
+
+Weekly automated model-list refresh from Google's API.
+
+### [#1488 chore(i18n): Update UI translations](https://github.com/allenhutchison/obsidian-gemini/pull/1488)
+
+Automated regeneration of `src/i18n/` translations for keys whose English source changed since the last run — largely picking up the string removals from #1477.


### PR DESCRIPTION
## Summary

Automated daily-update run for 2026-09-09 (America/Los_Angeles). Runs `daily-changelog`, `audit-product-docs`, and `triage-issues` in sequence and bundles anything they write into one PR.

## Changes

- **daily-changelog**: wrote `planning/changelog/2026-09-08.md` covering the day's 7 merged PRs — two automated daily-update PRs (#1491, #1486) that had been queued and were batch-merged this day, a headless-session cleanup fix (#1476), removal of an ineffective settings toggle (#1477), an `audit-architecture` fix for an unanchored vault-root path check (#1489), and the two weekly automated bot PRs (Gemini model list refresh #1487, UI translation regeneration #1488).
- **audit-product-docs**: full pass against `docs/guide/`, `docs/reference/`, `README.md`, and `AGENTS.md`, with focused checks on the docs touched by the prior day's PRs (removed settings toggle, session-release lifecycle, model list). No drift found and no new docs warranted. Re-confirmed (not re-fixed) the pre-existing, previously-flagged code bug where `src/main.ts` defaults `openaiModelName` to a model id (`gpt-5.6`) that isn't in the OpenAI model registry — a code fix, out of scope for a docs-only audit; it self-heals via a runtime migration and the docs already document the effective default.
- **triage-issues**: no unlabeled open issues found.

Note: `.claude/maintainerd.json` points `paths.prTemplate` at `.github/PULL_REQUEST_TEMPLATE.md`, but that file doesn't exist in this repo (no git history for it either) — this body falls back to the generic Summary/Changes/Checklist structure per the `create-pr` skill's documented fallback, matching the shape used by prior daily-update PRs. Worth a `/bootstrap` re-run or a config fix to point at a real template (or `null`) if that's intentional.

This PR is documentation-only (a changelog entry). It does not implement or close any issue itself.

## Screenshots / Screencast

N/A — no UI changes.

## Checklist

### Required

- [x] I have read and agree to the Contributing Guidelines
- [x] I have read and agree to the AI Policy
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A, this is the recurring automated daily-update run, not tied to a single issue
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — also ran `npm run lint` (0 errors, 40 pre-existing warnings) and `npm run typecheck:test`; 179 files / 4051 tests passed locally before pushing
- [ ] I have tested this change on Desktop — N/A, changelog-only change, no runtime code path
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A, no runtime code changes
- [x] Documentation has been updated (if applicable) — N/A, this PR *is* the documentation/changelog update
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (scheduled daily-update agent running the maintainerd `daily-update` meta-skill)
- [x] I have reviewed and understand all AI-generated code in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018cBmY86NFpP23FRApSoh3q

---
_Generated by [Claude Code](https://claude.ai/code/session_018cBmY86NFpP23FRApSoh3q)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added the September 8, 2026 daily changelog.
  - Documented recent updates covering path-containment safeguards, session cleanup, session identifier changes, system-prompt setting changes, Gemini model updates, and refreshed UI translations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->