### PR TITLE
fix(agent-view): honour the streaming toggle on post-tool follow-ups

### DIFF
--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -232,6 +232,8 @@ See the [Custom Prompts Guide](/guide/custom-prompts) for detailed instructions.
 - **Type**: Boolean
 - **Default**: `true`
 - **Description**: Enable streaming responses in the chat interface for a more interactive experience
+- **Scope**: Covers every model response in an agent turn — the first one and each follow-up the model
+  produces after running tools
 - **Note**: When disabled, full responses are displayed at once
 
 ### Log Tool Execution to Session History

--- a/src/ui/agent-view/agent-view-tools.ts
+++ b/src/ui/agent-view/agent-view-tools.ts
@@ -6,6 +6,7 @@ import { GeminiConversationEntry } from '../../types/conversation';
 import { IConfirmationProvider, IToolHostView, ToolResult } from '../../tools/types';
 import { CustomPrompt } from '../../prompts/types';
 import { AgentLoop, DEFAULT_INTERACTIVE_MAX_ITERATIONS } from '../../agent/agent-loop';
+import type { AgentLoopHooks } from '../../agent/agent-loop';
 import { DEFAULT_TURN_BUDGET_REMIND_AT } from '../../agent/turn-budget';
 import type { ToolCall, StreamChunk } from '../../api/interfaces/model-api';
 import { AgentViewToolDisplay } from './agent-view-tool-display';
@@ -178,27 +179,7 @@ export class AgentViewTools {
 						onFollowUpRequestStart: () => {
 							this.context.updateProgress(this.thinkingLabel(), 'thinking');
 						},
-						onFollowUpChunk: (chunk: StreamChunk) => {
-							if (!chunk.text) return;
-							if (!this.streamingFollowUpContainer) {
-								// Only create a container once there's actual (non-whitespace) text
-								// to show — intermediate tool-continuation turns that produce no
-								// text must not spawn an empty streaming bubble.
-								if (!chunk.text.trim()) return;
-								this.streamingFollowUpContainer = this.context.createFollowUpStream?.() ?? null;
-								this.context.updateProgress(t('agent.progress.generating'), 'streaming');
-							}
-							if (!this.streamingFollowUpContainer) return;
-							const contentDiv = this.streamingFollowUpContainer.querySelector('.gemini-agent-message-content');
-							if (contentDiv) {
-								contentDiv.appendChild(contentDiv.ownerDocument.createTextNode(chunk.text));
-							}
-						},
-						onFollowUpStreamReady: (stream) => {
-							// Route the live follow-up stream to the view's Stop target so
-							// pressing Stop cancels token generation immediately.
-							this.context.registerFollowUpStream?.(stream);
-						},
+						...this.followUpStreamingHooks(),
 						onModelReasoning: async (thoughts) => {
 							// Reasoning the model produced before deciding to call the
 							// next tool batch — render it as a row inside the current tool
@@ -291,6 +272,45 @@ export class AgentViewTools {
 			this.streamingFollowUpContainer = null;
 			this.context.hideProgress();
 		}
+	}
+
+	/**
+	 * The two AgentLoop hooks that opt a turn into a streamed follow-up response,
+	 * or an empty object when the user has turned streaming off.
+	 *
+	 * `AgentLoop` selects its streaming branch purely from the presence of
+	 * `onFollowUpChunk`, so withholding these hooks is what routes follow-ups
+	 * through the non-streaming call — which is how the "Enable streaming"
+	 * setting reaches the responses that come back after a tool batch. The
+	 * initial request is gated on the same setting in `agent-view-send.ts`; the
+	 * gate was missing here, so an agent turn that called tools still streamed
+	 * every one of its responses with the toggle off.
+	 */
+	private followUpStreamingHooks(): Pick<AgentLoopHooks, 'onFollowUpChunk' | 'onFollowUpStreamReady'> {
+		if (this.plugin.settings.streamingEnabled === false) return {};
+		return {
+			onFollowUpChunk: (chunk: StreamChunk) => {
+				if (!chunk.text) return;
+				if (!this.streamingFollowUpContainer) {
+					// Only create a container once there's actual (non-whitespace) text
+					// to show — intermediate tool-continuation turns that produce no
+					// text must not spawn an empty streaming bubble.
+					if (!chunk.text.trim()) return;
+					this.streamingFollowUpContainer = this.context.createFollowUpStream?.() ?? null;
+					this.context.updateProgress(t('agent.progress.generating'), 'streaming');
+				}
+				if (!this.streamingFollowUpContainer) return;
+				const contentDiv = this.streamingFollowUpContainer.querySelector('.gemini-agent-message-content');
+				if (contentDiv) {
+					contentDiv.appendChild(contentDiv.ownerDocument.createTextNode(chunk.text));
+				}
+			},
+			onFollowUpStreamReady: (stream) => {
+				// Route the live follow-up stream to the view's Stop target so
+				// pressing Stop cancels token generation immediately.
+				this.context.registerFollowUpStream?.(stream);
+			},
+		};
 	}
 
 	/**

--- a/test/ui/agent-view/agent-view-tools-streaming.test.ts
+++ b/test/ui/agent-view/agent-view-tools-streaming.test.ts
@@ -1,0 +1,77 @@
+import { describe, test, expect, vi } from 'vitest';
+import { AgentViewTools } from '../../../src/ui/agent-view/agent-view-tools';
+import type { StreamChunk } from '../../../src/api/interfaces/model-api';
+
+// `AgentLoop` picks its streaming follow-up branch purely from the presence of
+// the `onFollowUpChunk` hook, so the "Enable streaming" setting can only reach
+// post-tool responses by withholding the hooks. These tests drive that decision
+// directly: constructing the full adapter would need a live view + chat DOM,
+// and the branch under test is a pure function of the setting.
+// The members below are private on AgentViewTools, so the probe is typed as a
+// standalone shape rather than an intersection with the class (intersecting a
+// private member reduces the type to `never`).
+interface ToolsProbe {
+	plugin: unknown;
+	context: unknown;
+	streamingFollowUpContainer: HTMLElement | null;
+	followUpStreamingHooks(): Record<string, unknown>;
+}
+
+function makeTools(streamingEnabled: boolean | undefined) {
+	const tools = Object.create(AgentViewTools.prototype) as ToolsProbe;
+	const registerFollowUpStream = vi.fn();
+	const createFollowUpStream = vi.fn().mockReturnValue(null);
+	const updateProgress = vi.fn();
+	tools.plugin = { settings: { streamingEnabled } };
+	tools.context = { registerFollowUpStream, createFollowUpStream, updateProgress };
+	tools.streamingFollowUpContainer = null;
+	return { tools, registerFollowUpStream, createFollowUpStream, updateProgress };
+}
+
+describe('AgentViewTools.followUpStreamingHooks — honours the streaming setting', () => {
+	test('streaming on: supplies both follow-up streaming hooks', () => {
+		const { tools } = makeTools(true);
+		const hooks = tools.followUpStreamingHooks();
+
+		expect(typeof hooks.onFollowUpChunk).toBe('function');
+		expect(typeof hooks.onFollowUpStreamReady).toBe('function');
+	});
+
+	test('streaming off: supplies neither, so AgentLoop takes its non-streaming branch', () => {
+		const { tools } = makeTools(false);
+		const hooks = tools.followUpStreamingHooks();
+
+		// Presence is the signal AgentLoop reads — an explicit `undefined` value
+		// would still be an own key, so assert the keys are absent entirely.
+		expect(Object.keys(hooks)).toEqual([]);
+		expect('onFollowUpChunk' in hooks).toBe(false);
+		expect('onFollowUpStreamReady' in hooks).toBe(false);
+	});
+
+	test('setting absent (pre-migration data): defaults to streaming, matching the initial request', () => {
+		const { tools } = makeTools(undefined);
+		const hooks = tools.followUpStreamingHooks();
+
+		expect(typeof hooks.onFollowUpChunk).toBe('function');
+	});
+
+	test('the supplied onFollowUpStreamReady still routes the stream to the Stop target', () => {
+		const { tools, registerFollowUpStream } = makeTools(true);
+		const hooks = tools.followUpStreamingHooks();
+		const stream = { cancel: vi.fn() };
+
+		(hooks.onFollowUpStreamReady as (s: unknown) => void)(stream);
+		expect(registerFollowUpStream).toHaveBeenCalledWith(stream);
+	});
+
+	test('the supplied onFollowUpChunk ignores whitespace-only text before opening a container', () => {
+		const { tools, createFollowUpStream } = makeTools(true);
+		const hooks = tools.followUpStreamingHooks();
+
+		(hooks.onFollowUpChunk as (c: StreamChunk) => void)({ text: '   ' });
+		expect(createFollowUpStream).not.toHaveBeenCalled();
+
+		(hooks.onFollowUpChunk as (c: StreamChunk) => void)({ text: 'answer' });
+		expect(createFollowUpStream).toHaveBeenCalled();
+	});
+});

--- a/test/ui/agent-view/agent-view-tools-streaming.test.ts
+++ b/test/ui/agent-view/agent-view-tools-streaming.test.ts
@@ -17,6 +17,16 @@ interface ToolsProbe {
 	followUpStreamingHooks(): Record<string, unknown>;
 }
 
+/**
+ * Build an `AgentViewTools` probe with `settings.streamingEnabled` set to the
+ * given value and the three context callbacks the streaming hooks touch stubbed.
+ * The instance is created off the prototype so no chat container, view, or DOM
+ * is needed — `followUpStreamingHooks` reads only the setting and `context`.
+ *
+ * @param streamingEnabled - Value for `plugin.settings.streamingEnabled`;
+ *   `undefined` models a settings object saved before the toggle existed.
+ * @returns The probe plus the stub callbacks, for asserting what the hooks call.
+ */
 function makeTools(streamingEnabled: boolean | undefined) {
 	const tools = Object.create(AgentViewTools.prototype) as ToolsProbe;
 	const registerFollowUpStream = vi.fn();


### PR DESCRIPTION
## Summary

`audit-architecture` nightly sweep flagged: **repo-invariant drift (half-plumbed setting)** in `src/ui/agent-view/agent-view-tools.ts`.

`AgentLoop` selects its streaming follow-up branch purely from the presence of the `onFollowUpChunk` hook (`src/agent/agent-loop.ts:482`), and `AgentViewTools` supplied that hook unconditionally. `settings.streamingEnabled` was read only on the *initial* request (`agent-view-send.ts:111` and `:524`), so a user who turned "Enable streaming" off got a non-streamed first response and then a streamed one after every tool batch — which is where most of the visible output in agent mode comes from.

The fix moves the two follow-up streaming hooks (`onFollowUpChunk`, `onFollowUpStreamReady`) behind the same setting. Withholding them is the only way to reach the decision, because presence — not value — is what `AgentLoop` reads. With the toggle off, follow-ups take the existing `generateModelResponse` branch and land on the `displayMessage` path that already runs when no streaming container was opened, so no new rendering path is introduced. Behaviour with streaming on is unchanged: the hook bodies moved verbatim.

Layering is unchanged too — the gate lives in the UI adapter, not in `AgentLoop`, which keeps the engine UI-agnostic and reads no settings of its own. Headless callers never passed these hooks and are unaffected.

## Changes

- `src/ui/agent-view/agent-view-tools.ts` — extract `onFollowUpChunk` / `onFollowUpStreamReady` into a private `followUpStreamingHooks()` that returns `{}` when `settings.streamingEnabled === false`, and spread it into the `AgentLoop` hooks.
- `test/ui/agent-view/agent-view-tools-streaming.test.ts` — new: asserts both hooks are present when streaming is on, absent (no own keys) when off, present when the setting is missing, and that the supplied hooks still register the Stop target and skip whitespace-only chunks.
- `docs/reference/settings.md` — note that `streamingEnabled` covers every model response in an agent turn, including post-tool follow-ups.

## Screenshots / Screencast

N/A — no visual change. With streaming on the rendering is byte-identical; with streaming off the response arrives as one already-rendered message via the existing non-streaming path.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A: filed directly by the `audit-architecture` sweep as a mechanical, in-scope fix; no issue was opened for it.
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — also `npm run lint` (0 errors), `npm run typecheck:test`, `npm run knip`, `npm run lint:cycles`. Full suite: 180 files / 4056 tests passing.
- [ ] I have tested this change on Desktop — not run in a live vault; covered by unit tests over the hook-selection branch instead.
- [x] I have verified this change does not break Mobile (or includes appropriate platform guards) — no platform-specific API is touched; the change is a settings read and an object spread.
- [x] Documentation has been updated (if applicable)
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (`audit-architecture` skill)
- [x] I have reviewed and understand all AI-generated code in this PR

---

_Filed by the `audit-architecture` skill._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ert6JnTCx5sSCUC6MJ1XxJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ert6JnTCx5sSCUC6MJ1XxJ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Follow-up responses after tool execution now respect the streaming setting. Disabling streaming uses the standard non-streaming response path.
  - Streaming remains enabled by default when no setting is specified.
  - Streaming output continues to filter whitespace before displaying content and supports cancellation correctly.

- **Documentation**
  - Clarified that streaming applies to every model response during an agent turn, including follow-up responses after tool execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->