### PR TITLE
chore(daily): 2026-09-10 daily update

### DIFF
--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -11,7 +11,7 @@ The order of sections is:
 3. **Automation** — scheduled tasks, scheduler catch-up, and lifecycle hooks combined.
 4. **Vault search index** — semantic search over your vault using Google File Search.
 
-Advanced sections — Tool permissions, MCP servers, Agent config, Debug — are tagged with an **ADVANCED** pill and only appear after toggling **Show advanced settings** at the bottom of General. **Agent config** bundles four related sub-areas (Custom Prompts, API configuration, Context management, Tool loop detection) under one collapsible since they all tune how the agent talks to the model.
+Advanced sections — Tool permissions, MCP servers, Agent config, Debug — are tagged with an **ADVANCED** pill and only appear after toggling **Show advanced settings** at the bottom of General. **Agent config** bundles three related sub-areas (API configuration, Context management, Tool loop detection) under one collapsible since they all tune how the agent talks to the model.
 
 ## Table of Contents
 
@@ -19,7 +19,7 @@ The reference below groups settings by topic for lookup, which doesn't always ma
 
 - [Basic Settings](#basic-settings) (UI: _General_ — provider, API key, models, plugin state folder)
 - [Model Configuration](#model-configuration) (UI: _General_ — chat/summary/completion/image model selection)
-- [Custom Prompts](#custom-prompts) (UI: _Agent config_ — advanced)
+- [Custom Prompts](#custom-prompts) (no settings-UI section — the override is controlled entirely via prompt frontmatter)
 - [UI Settings](#ui-settings) (UI: _User experience_ — streaming, tool execution logging, diff view, identity, frontmatter key, session history)
 - [Automation Settings](#automation-settings) (UI: _Automation_ — scheduled task catch-up, lifecycle hooks toggle)
 - [Context management](#context-management) (UI: _Agent config_ — advanced)

--- a/planning/changelog/2026-09-09.md
+++ b/planning/changelog/2026-09-09.md
@@ -1,0 +1,10 @@
+# Daily changelog — September 09, 2026
+
+**Date:** 2026-09-09
+**PRs merged:** 0
+
+---
+
+## Summary
+
+No PRs merged today.


### PR DESCRIPTION
## Summary

Automated daily-update run for 2026-09-10 (America/Los_Angeles). Runs `daily-changelog`, `audit-product-docs`, and `triage-issues` in sequence and bundles anything they write into one PR.

## Changes

- **daily-changelog**: wrote `planning/changelog/2026-09-09.md` — no PRs merged on 2026-09-09 (quiet day).
- **audit-product-docs**: fixed stale drift in `docs/reference/settings.md` left over from #1477 (which removed the "Custom Prompts" system-prompt-override toggle from the Agent config settings UI): corrected "Agent config bundles four related sub-areas" to "three related sub-areas" (Custom Prompts is no longer a settings-UI section), and updated the Table of Contents entry for Custom Prompts to reflect that it's controlled entirely via prompt frontmatter now, not a UI section. No undocumented user-visible features found in the last 60 days of `src/` commits.
- **triage-issues**: no unlabeled open issues to process (0 of 31 open issues unlabeled). No changes (GitHub-only, no working-tree diff).

## Screenshots / Screencast

N/A — no UI changes.

## Checklist

### Required

- [x] I have read and agree to the Contributing Guidelines
- [x] I have read and agree to the AI Policy
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A, this is the recurring automated daily-update run, not tied to a single issue
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — ran locally pre-push: format-check, lint (0 errors, pre-existing warnings only), build, `typecheck:test`, and the full test suite (179 files / 4051 tests) all green
- [ ] I have tested this change on Desktop — N/A, doc/changelog-only change with no runtime code touched
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A, no code changes
- [x] Documentation has been updated (if applicable) — this run's entire diff is documentation (changelog entry + settings-reference drift fix)
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (scheduled daily-update agent running the maintainerd `daily-update` meta-skill)
- [x] I have reviewed and understand all AI-generated code in this PR

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014aJgLKupsnYur4kgmXoPzp

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014aJgLKupsnYur4kgmXoPzp

---
_Generated by [Claude Code](https://claude.ai/code/session_014aJgLKupsnYur4kgmXoPzp)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the settings reference to clarify that Custom Prompts are managed through prompt frontmatter rather than a settings UI section.
  * Added the September 9, 2026 daily changelog, noting that no pull requests were merged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->