### PR TITLE
chore(daily): 2026-09-11 daily update

### DIFF
--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -19,7 +19,7 @@ The reference below groups settings by topic for lookup, which doesn't always ma
 
 - [Basic Settings](#basic-settings) (UI: _General_ — provider, API key, models, plugin state folder)
 - [Model Configuration](#model-configuration) (UI: _General_ — chat/summary/completion/image model selection)
-- [Custom Prompts](#custom-prompts) (controlled entirely via prompt frontmatter — no dedicated settings-UI section)
+- [Custom Prompts](#custom-prompts) (prompt behavior is configured via prompt frontmatter; prompt selection happens in the session settings modal — no dedicated settings-UI section)
 - [UI Settings](#ui-settings) (UI: _User experience_ — streaming, tool execution logging, diff view, identity, frontmatter key, session history)
 - [Automation Settings](#automation-settings) (UI: _Automation_ — scheduled task catch-up, lifecycle hooks toggle)
 - [Context management](#context-management) (UI: _Agent config_ — advanced)

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -11,7 +11,7 @@ The order of sections is:
 3. **Automation** — scheduled tasks, scheduler catch-up, and lifecycle hooks combined.
 4. **Vault search index** — semantic search over your vault using Google File Search.
 
-Advanced sections — Tool permissions, MCP servers, Agent config, Debug — are tagged with an **ADVANCED** pill and only appear after toggling **Show advanced settings** at the bottom of General. **Agent config** bundles four related sub-areas (Custom Prompts, API configuration, Context management, Tool loop detection) under one collapsible since they all tune how the agent talks to the model.
+Advanced sections — Tool permissions, MCP servers, Agent config, Debug — are tagged with an **ADVANCED** pill and only appear after toggling **Show advanced settings** at the bottom of General. **Agent config** bundles three related sub-areas (API configuration, Context management, Tool loop detection) under one collapsible since they all tune how the agent talks to the model.
 
 ## Table of Contents
 
@@ -19,7 +19,7 @@ The reference below groups settings by topic for lookup, which doesn't always ma
 
 - [Basic Settings](#basic-settings) (UI: _General_ — provider, API key, models, plugin state folder)
 - [Model Configuration](#model-configuration) (UI: _General_ — chat/summary/completion/image model selection)
-- [Custom Prompts](#custom-prompts) (UI: _Agent config_ — advanced)
+- [Custom Prompts](#custom-prompts) (controlled entirely via prompt frontmatter — no dedicated settings-UI section)
 - [UI Settings](#ui-settings) (UI: _User experience_ — streaming, tool execution logging, diff view, identity, frontmatter key, session history)
 - [Automation Settings](#automation-settings) (UI: _Automation_ — scheduled task catch-up, lifecycle hooks toggle)
 - [Context management](#context-management) (UI: _Agent config_ — advanced)

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -19,7 +19,7 @@ The reference below groups settings by topic for lookup, which doesn't always ma
 
 - [Basic Settings](#basic-settings) (UI: _General_ — provider, API key, models, plugin state folder)
 - [Model Configuration](#model-configuration) (UI: _General_ — chat/summary/completion/image model selection)
-- [Custom Prompts](#custom-prompts) (controlled entirely via prompt frontmatter — no dedicated settings-UI section)\
+- [Custom Prompts](#custom-prompts) (controlled entirely via prompt frontmatter — no dedicated settings-UI section)
 - [UI Settings](#ui-settings) (UI: _User experience_ — streaming, tool execution logging, diff view, identity, frontmatter key, session history)
 - [Automation Settings](#automation-settings) (UI: _Automation_ — scheduled task catch-up, lifecycle hooks toggle)
 - [Context management](#context-management) (UI: _Agent config_ — advanced)

--- a/planning/changelog/2026-09-10.md
+++ b/planning/changelog/2026-09-10.md
@@ -1,0 +1,10 @@
+# Daily changelog — September 10, 2026
+
+**Date:** 2026-09-10
+**PRs merged:** 0
+
+---
+
+## Summary
+
+Quiet day — no PRs merged.


### PR DESCRIPTION
## Summary

Automated daily-update run for 2026-09-11 (America/Los_Angeles). Runs `daily-changelog`, `audit-product-docs`, and `triage-issues` in sequence and bundles anything they write into one PR.

## Changes

- **daily-changelog**: wrote `planning/changelog/2026-09-10.md` — no PRs merged on 2026-09-10 (quiet day).
- **audit-product-docs**: fixed stale drift in `docs/reference/settings.md` left over from #1477 (which removed the "Custom Prompts" system-prompt-override toggle from the Agent config settings UI): corrected "Agent config bundles four related sub-areas" to "three related sub-areas" (API configuration, Context management, Tool loop detection — confirmed against `src/ui/settings-agent-config.ts`'s three section headings), and updated the Table of Contents entry for Custom Prompts to say it's controlled entirely via prompt frontmatter, not a settings-UI section. Re-confirmed (not re-fixed) the pre-existing, previously-flagged code bug where `src/main.ts` defaults `openaiModelName` to a model id (`gpt-5.6`) that isn't in the OpenAI model registry — a code fix, out of scope for a docs-only audit; it self-heals via a runtime migration and the docs already document the effective default (`gpt-5.6-sol`).
- **triage-issues**: no unlabeled open issues found (0 of 33 open issues unlabeled).

Note: two earlier automated daily-update PRs (#1494 for 2026-09-09, #1498 for 2026-09-10) are still open and unmerged, each already containing a changelog entry and, in #1498's case, the same settings.md drift fix applied independently here (master hadn't picked it up yet). Merging either of those first will produce a trivial conflict on that one line with this PR — worth a look before merging all three.

This PR is documentation-only (a changelog entry and a doc-drift fix). It does not implement or close any issue itself.

## Screenshots / Screencast

N/A — no UI changes.

## Checklist

### Required

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [AI Policy](../AI_POLICY.md)
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A, this is the recurring automated daily-update run, not tied to a single issue
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — also ran `npm run lint` (0 errors, 40 pre-existing warnings) and `npm run typecheck:test`; 179 files / 4051 tests passed locally before pushing
- [ ] I have tested this change on Desktop — N/A, changelog/docs-only change, no runtime code path
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A, no runtime code changes
- [x] Documentation has been updated (if applicable) — N/A, this PR *is* the documentation/changelog update
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (scheduled daily-update agent running the maintainerd `daily-update` meta-skill)
- [x] I have reviewed and understand all AI-generated code in this PR

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QvjcPY4jLYv4ypUTkuRHXL

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QvjcPY4jLYv4ypUTkuRHXL

---
_Generated by [Claude Code](https://claude.ai/code/session_01QvjcPY4jLYv4ypUTkuRHXL)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified that prompt frontmatter configures custom prompt behavior, while prompt selection remains available in the session settings modal.
  - Added the September 10, 2026 daily changelog, recording zero merged pull requests and a quiet day.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->