### PR TITLE
chore(daily): 2026-09-11 daily update

### DIFF
--- a/planning/changelog/2026-09-11.md
+++ b/planning/changelog/2026-09-11.md
@@ -1,0 +1,36 @@
+# Daily changelog — September 11, 2026
+
+**Date:** 2026-09-11
+**PRs merged:** 6
+
+---
+
+## Summary
+
+A backlog-clearing day: three queued daily-update PRs (#1494, #1498, #1501, covering September 8–10) landed together along with two `audit-architecture` fixes and a dependency bump. The more notable fix restores the streaming setting's effect on agent follow-up responses after tool calls.
+
+## What shipped
+
+### [#1492 refactor(agent-view): import ProgressState instead of re-declaring it](https://github.com/allenhutchison/obsidian-gemini/pull/1492)
+
+`audit-architecture` flagged that `agent-view-tools.ts` and `agent-view.ts` each spelled out the `ProgressState` union inline instead of importing the existing type alias, so a future added state would silently fail to propagate through the tools context. Routes both sites through the shared alias; no behavior change.
+
+### [#1494 chore(daily): 2026-09-09 daily update](https://github.com/allenhutchison/obsidian-gemini/pull/1494)
+
+Automated daily-update run: wrote the September 8 changelog and confirmed no documentation drift or unlabeled issues.
+
+### [#1495 chore(deps): bump hono from 4.13.1 to 4.13.7](https://github.com/allenhutchison/obsidian-gemini/pull/1495)
+
+Dependency bump pulling in several upstream security fixes (JSX unescaped-string XSS, a query-parser fragment-boundary issue, an incomplete `toSSG()` path-containment fix, and unbounded nesting in `parseBody()`). Contributed by @dependabot[bot].
+
+### [#1496 fix(agent-view): honour the streaming toggle on post-tool follow-ups](https://github.com/allenhutchison/obsidian-gemini/pull/1496)
+
+Another `audit-architecture` find: `settings.streamingEnabled` only gated the _initial_ model request, so turning streaming off still left post-tool follow-up responses — where most agent-mode output comes from — streaming. `AgentLoop` picks its streaming branch based solely on whether `onFollowUpChunk` is supplied, so the fix withholds that hook (and `onFollowUpStreamReady`) when the setting is off, falling back to the existing non-streaming display path.
+
+### [#1498 chore(daily): 2026-09-10 daily update](https://github.com/allenhutchison/obsidian-gemini/pull/1498)
+
+Automated daily-update run: wrote the September 9 changelog (quiet day, no PRs) and fixed stale settings-reference drift left over from the earlier removal of the Custom Prompts settings-UI toggle.
+
+### [#1501 chore(daily): 2026-09-11 daily update](https://github.com/allenhutchison/obsidian-gemini/pull/1501)
+
+Automated daily-update run: wrote the September 10 changelog (also quiet) and independently reapplied the same settings-reference drift fix, since master hadn't yet picked up #1498's version when this branch was cut — the PR body flagged the resulting trivial conflict ahead of merge.


### PR DESCRIPTION
## Summary

Automated daily-update run for 2026-09-11 (America/Los_Angeles). Runs `daily-changelog`, `audit-product-docs`, and `triage-issues` in sequence and bundles anything they write into one PR.

## Changes

- **daily-changelog**: wrote `planning/changelog/2026-09-11.md` covering the day's 6 merged PRs — a backlog-clearing batch: three queued daily-update PRs (#1494, #1498, #1501, covering September 8–10), two `audit-architecture` fixes (#1492 a `ProgressState` typing cleanup, #1496 a fix restoring the streaming setting's effect on agent follow-up responses after tool calls), and a dependency bump (#1495, hono, pulling in several upstream security fixes).
- **audit-product-docs**: full pass against `docs/guide/`, `docs/reference/`, `README.md`, and `AGENTS.md`. Spot-checked the two areas touched by yesterday's PRs (the streaming-toggle scope note in `docs/reference/settings.md` from #1496, and the reasoning-token readout) against the current source — both already accurate. No drift found and no new docs warranted.
- **triage-issues**: no unlabeled open issues found (0 of 34 open issues unlabeled).

This PR is documentation-only (a changelog entry). It does not implement or close any issue itself.

## Screenshots / Screencast

N/A — no UI changes.

## Checklist

### Required

- [x] I have read and agree to the Contributing Guidelines
- [x] I have read and agree to the AI Policy
- [ ] This PR is linked to an approved issue where the approach was discussed with a maintainer — N/A, this is the recurring automated daily-update run, not tied to a single issue
- [x] All CI checks pass (`npm test`, `npm run build`, `npm run format-check`) — also ran `npm run lint` (0 errors, 40 pre-existing warnings) and `npm run typecheck:test`; 180 files / 4056 tests passed locally before pushing
- [ ] I have tested this change on Desktop — N/A, changelog-only change, no runtime code path
- [ ] I have verified this change does not break Mobile (or includes appropriate platform guards) — N/A, no runtime code changes
- [x] Documentation has been updated (if applicable) — N/A, this PR *is* the documentation/changelog update
- [x] I understand that I must address all review comments from CodeRabbit and maintainers, or this PR may be closed

### AI-Generated Code

- [x] This PR includes AI-generated or AI-assisted code
- [x] AI tool(s) used: Claude Code (scheduled daily-update agent running the maintainerd `daily-update` meta-skill)
- [x] I have reviewed and understand all AI-generated code in this PR

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AYLqDE5ETHz8H9zbTRAdfX

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AYLqDE5ETHz8H9zbTRAdfX

---
_Generated by [Claude Code](https://claude.ai/code/session_01AYLqDE5ETHz8H9zbTRAdfX)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added the September 11, 2026 changelog with a summary of recent updates and fixes.

- **Bug Fixes**
  - Recorded upstream security fixes.
  - Restored streaming-toggle behavior for agent follow-ups.
  - Corrected inconsistencies in settings references.
  - Documented improvements to shared progress-state handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->